### PR TITLE
fix to parse out a namespace in the first line of the file and use that in class names

### DIFF
--- a/library/Swagger/Swagger.php
+++ b/library/Swagger/Swagger.php
@@ -200,15 +200,37 @@ class Swagger
         if(file_exists($filename)){
             $tokens = token_get_all(file_get_contents($filename));
             $count = count($tokens);
+            $ns = $this->_getNamespace($filename);
+
             for ($i = 2; $i < $count; $i++) {
                 if ($tokens[$i - 2][0] == T_CLASS &&
                     $tokens[$i - 1][0] == T_WHITESPACE &&
                     $tokens[$i][0] == T_STRING) {
-                    $classes[] = $tokens[$i][1];
+                    $classes[] = $ns . $tokens[$i][1];
                 }
             }
         }
         return $classes;
+    }
+    /**
+     *
+     * @param string $filename
+     */
+    protected function _getNamespace($filename) {
+        $ns = '\\';
+        if(file_exists($filename)){
+            $tokens = token_get_all(file_get_contents($filename));
+            $count = count($tokens);
+            if ($tokens[1][0] == T_NAMESPACE) {
+                $i = 3;
+                while ($tokens[$i][2] == 2) {
+                    $ns .= $tokens[$i][1];
+                    $i++;
+                }
+            }
+            $ns .= '\\';
+        }
+        return $ns;
     }
     /**
      *


### PR DESCRIPTION
because if you're using a file with namespaces it does this:

PHP Fatal error:  Uncaught exception 'ReflectionException' with message 'Class <classname> does not exist' in <somepath>vendor/zircote/swagger-php/library/Swagger/Swagger.php:239
