### PR TITLE
Nicer paths for resource files and BC

### DIFF
--- a/bin/swagger
+++ b/bin/swagger
@@ -129,7 +129,7 @@ EOF;
     $output = array();
     foreach ($swagger->getResourceNames() as $resourceName) {
         $json = $swagger->getResource($resourceName, $prettyPrint);
-        $resourceName = str_replace('/', null, $resourceName);
+        $resourceName = str_replace('/', '-', ltrim($resourceName, '/'));
         $output[$resourceName] = $json;
     }
     if ($output) {


### PR DESCRIPTION
Nicer paths for resource files and backwards compatability for earlier swagger-php versions.

A resource name for path "/foo/bar" must not become "foobar", but "foo-bar" instead to define hierarchy.
