### PR TITLE
Fixes bug: Operations won't expand in Swagger UI

### DIFF
--- a/library/Swagger/Swagger.php
+++ b/library/Swagger/Swagger.php
@@ -490,7 +490,7 @@ class Swagger implements \Serializable
                     );
                 }                
                 $api = array('path' => '/resources/'
-                    . str_replace('/', '-', ltrim($val['resourcePath'], '/')) . '.json');
+                    . str_replace('/', '-', ltrim($val['resourcePath'], '/')) . '.{format}');
                 foreach ($val['apis'] as $v) {
                     if (isset($api['path']) && isset($v['description'])) {
                         $api['description'] = $v['description'];


### PR DESCRIPTION
The API resource path in api-docs.json must have {format} as extension instead of hardcoded "json".
