### PR TITLE
Added support for Multiple @SWG\Operation() inside a @SWG\Operations

### DIFF
--- a/library/Swagger/Swagger.php
+++ b/library/Swagger/Swagger.php
@@ -166,7 +166,11 @@ class Swagger implements \Serializable
                 } else {
                     $apis = array_pop($apis);
                     $op = array_pop($apis['operations'])->toArray();
-                    $result[$apis['path']][] = $op;
+					if (key($op) === 0) {
+						$result[$apis['path']] = $op;
+					} else {
+						$result[$apis['path']][] = $op;
+					}
                 }
             }
         }


### PR DESCRIPTION
Fixes an issue which caused Swagger to generate an array in an array:
{ path: "/users", operations: [ [ { nickname:"index", … } ] ] }
Instead of the correct:
{ path: "/users", operations: [ { nickname:"index", … } ] }

Example docblock:

``` php
/**
 * @SWG\Api(
 *   path="/users",
 *   @SWG\Operations(
 *     @SWG\Operation(
 *       nickname="index",
 *       summary="Retrieve all users",
 *       httpMethod="GET",
 *       responseClass="User"
 *     ),
 *     @SWG\Operation(
 *       nickname="index",
 *       summary="Create user",
 *       httpMethod="POST",
 *       responseClass="User",
 *       @SWG\Parameter(name="email",dataType="String"),
 *       @SWG\Parameter(name="phone",dataType="String")
 *     )
 *   )
 * )
 */
function index() {
}
```
