### PR TITLE
Fixing documentation so that examples don't break if used, case of classes was wrong

### DIFF
--- a/annotations.html
+++ b/annotations.html
@@ -169,7 +169,7 @@ Types Supported: <tt class="docutils literal"><span class="pre">LIST</span></tt>
 <span class="sd"> * @SWG\Api(</span>
 <span class="sd"> *   path=&quot;/pet.{format}/{petId}&quot;,</span>
 <span class="sd"> *   description=&quot;Operations about pets&quot;,</span>
-<span class="sd"> *   @SWG\Operations(@SWG\operation(@SWG\parameters(@SWG\Parameter(...)),</span>
+<span class="sd"> *   @SWG\Operations(@SWG\Operation(@SWG\parameters(@SWG\Parameter(...)),</span>
 <span class="sd"> *       @SWG\ErrorResponses(</span>
 <span class="sd"> *          @SWG\ErrorResponse(@SWG\errorResponse(...)</span>
 <span class="sd"> *       )</span>

--- a/docs/annotations.rst
+++ b/docs/annotations.rst
@@ -121,7 +121,7 @@ Api
      * @SWG\Api(
      *   path="/pet.{format}/{petId}",
      *   description="Operations about pets",
-     *   @SWG\Operations(@SWG\operation(@SWG\parameters(@SWG\Parameter(...)),
+     *   @SWG\Operations(@SWG\Operation(@SWG\Parameters(@SWG\Parameter(...)),
      *       @SWG\ErrorResponses(
      *          @SWG\ErrorResponse(@SWG\errorResponse(...)
      *       )
@@ -196,7 +196,7 @@ ErrorResponses
     use Swagger\Annotations as SWG;
 
     /**
-     * @SWG\ErrorResponses(@SWG\errorResponse(...)[ @SWG\errorResponse(...), ])
+     * @SWG\ErrorResponses(@SWG\ErrorResponse(...)[ @SWG\ErrorResponse(...), ])
      */
 
 **Derived JSON**


### PR DESCRIPTION
In the documentation annotations.rst the some of the cases of the @SWG\types was wrong.

eg  
`@SWG\allowableValues(valueType="LIST",values="['available', 'pending', 'sold']")`

was changed to 
`@SWG\AllowableValues(valueType="LIST",values="['available', 'pending', 'sold']")`

So that most autoloads don't break.
It would have worked fine on windows but borked on *nix
