### PR TITLE
import Logger and use Logger::notice instead of undefined Logger::log

### DIFF
--- a/library/Swagger/Annotations/Resource.php
+++ b/library/Swagger/Annotations/Resource.php
@@ -22,6 +22,7 @@ namespace Swagger\Annotations;
  * @subpackage
  */
 use Doctrine\Common\Annotations\AnnotationException;
+use Swagger\Logger;
 
 /**
  * @package
@@ -98,7 +99,7 @@ class Resource extends AbstractAnnotation
             }
         }
         if (count($apis) == 0) {
-            Logger::log(new AnnotationException('Resource "'.$this->basePath.'" doesn\'t have any valid api calls'));
+            Logger::notice(new AnnotationException('Resource "'.$this->basePath.'" doesn\'t have any valid api calls'));
             return false;
         }
         $this->apis = $apis;


### PR DESCRIPTION
since `Logger` is not yet imported, this causes an error - additionally, `Swagger\Logger` has no `log` method, therefore using `notice`
