### PR TITLE
accept paramType=form on properties

### DIFF
--- a/library/Swagger/Annotations/Parameter.php
+++ b/library/Swagger/Annotations/Parameter.php
@@ -83,8 +83,8 @@ class Parameter extends AbstractAnnotation
     {
         parent::__construct($values);
         Swagger::checkDataType($this->dataType);
-        if ($this->paramType && !in_array($this->paramType, array('path', 'query', 'body', 'header'))) {
-            Logger::warning('Unexpected paramType "'.$this->paramType.'", expecting "path", "query", "body" or "header" in '.AbstractAnnotation::$context);
+        if ($this->paramType && !in_array($this->paramType, array('path', 'query', 'body', 'header', 'form'))) {
+            Logger::warning('Unexpected paramType "'.$this->paramType.'", expecting "path", "query", "body", "header" or "form" in '.AbstractAnnotation::$context);
         }
     }
 


### PR DESCRIPTION
fehguy commented on https://github.com/wordnik/swagger-core/issues/107#issuecomment-12976087 that now (as in 3 months ago) `paramType=form` is supported, to execute normal POST-Request (up until then the only way was one big field containing the complete json/xml-structure the server should have expected)

w/o this PR the generated resource files do contain the defined paramType, but you'll get this warning:
    `[WARN] Unexpected paramType "form", expecting "path", "query", "body" or "header" in Controller->method(...) in ./Controller.php on line 1`
