### PR TITLE
allow exception instead of code and reason for ErrorResponse

### DIFF
--- a/library/Swagger/Annotations/ErrorResponse.php
+++ b/library/Swagger/Annotations/ErrorResponse.php
@@ -45,6 +45,14 @@ class ErrorResponse extends AbstractAnnotation
 
     public function __construct(array $values = array())
     {
+        if( isset( $values['exception'] ) )
+        {
+          $exception = new $values['exception'];
+          unset( $values['exception'] );
+          $values['code'] = $exception->getCode();
+          $values['reason'] = $exception->getMessage();
+        }
+        
         parent::__construct($values);
         if ($this->code !== null) {
             $this->code = (int) $this->code;


### PR DESCRIPTION
Just a quick thought, mainly about DRY. `ErrorResponse` accepts `code` and `reason` which i would have to specify directly in the DocBlock. we're using Exceptions and have therefore to write the same things at least twice .. and like always, chances are, that one gets lost :/

what i imagine would be something like this:

```
/**
 * ...
 *   @Swagger\Annotations\ErrorResponse( code="403", reason="Object is not assigned to your account" ),
 *   @Swagger\Annotations\ErrorResponse( exception="Project\Domain\Exception\ObjectNotFoundException" )
 * ...
 */
```

which allows you to specify an Exception instead of plain text. The included change is really simple, right now missing additional `instanceof` checks and things like this - just wanted to know if you think it's worth to work on :)
