### PR TITLE
use always project-path, instead of project-dir

### DIFF
--- a/bin/swagger
+++ b/bin/swagger
@@ -40,7 +40,7 @@ EOT
 $shortopts = 'fp:hvo:i:e:';
 
 $longopts = array(
-    'project-dir:',
+    'project-path:',
     'exclude-path:',
     'include-path:',
     'output-dir',
@@ -108,13 +108,13 @@ EOF;
             }
         }
     }
-    if (!isset($options['p']) && !isset($options['project-dir'])) {
-        throw new RuntimeException('--project-dir must be provided');
+    if (!isset($options['p']) && !isset($options['project-path'])) {
+        throw new RuntimeException('--project-path must be provided');
     } else {
-        if (isset($options['project-dir'])
-            && !empty($options['project-dir'])
+        if (isset($options['project-path'])
+            && !empty($options['project-path'])
         ) {
-            $projectPath = $options['project-dir'];
+            $projectPath = $options['project-path'];
         } else {
             $projectPath = $options['p'];
         }


### PR DESCRIPTION
usage tells you

```
Usage: swagger --project-path PATH [--output-path PATH]...

  -p, --project-path     Path containing the php files with Swagger annotations
```

if you go with `--project-path` you'll get an error which is telling you, that `--project-dir must be provided`. since we have everything ending on `path` i changed all the occurrences of `project-dir` into `project-path`
