### PR TITLE
mv {tests/,}phpunit.xml{,.dist}

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ php:
   - 5.3
   - 5.4
 
-script: phpunit -c tests/phpunit.xml
+script: phpunit

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="./bootstrap.php"
+<phpunit bootstrap="./tests/bootstrap.php"
          colors="false"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="false"
@@ -6,7 +6,7 @@
          stopOnFailure="false"
          syntaxCheck="true">
     <testsuite name="Swagger Library Test Suite">
-        <directory>SwaggerTests</directory>
+        <directory>tests/SwaggerTests</directory>
     </testsuite>
     <logging>
         <!--<log type="coverage-text" target="php://stdout"-->
@@ -18,13 +18,13 @@
     </logging>
     <filter>
         <blacklist>
-            <directory suffix=".php">../</directory>
+            <directory suffix=".php">./</directory>
         </blacklist>
         <whitelist>
-            <directory suffix=".php">../library/Swagger</directory>
+            <directory suffix=".php">./library/Swagger</directory>
             <exclude>
-                <directory suffix=".phtml">../</directory>
-                <file>./bootstrap.php</file>
+                <directory suffix=".phtml">./</directory>
+                <file>./tests/bootstrap.php</file>
             </exclude>
         </whitelist>
     </filter>


### PR DESCRIPTION
running the tests is a bit difficult since you have to specify the `-c` parameter to reference `tests/phpunit.xml`. from the phpunit docs:

```
If phpunit.xml or phpunit.xml.dist (in that order) exist in the current working directory and
--configuration is not used, the configuration will be automatically read from that file.
```

with the patch, it would just be `composer install && phpunit` to get it up and running :)
