### PR TITLE
GetResourceList standardisation, GetResource salization

### DIFF
--- a/library/Swagger/Swagger.php
+++ b/library/Swagger/Swagger.php
@@ -345,7 +345,7 @@ class Swagger implements \Serializable
                         'apis' => array()
                     );
                 }
-                $path = '/resources/'.str_replace('/', '-', ltrim($resource->resourcePath, '/')).'.{format}';
+                $path = '/'.str_replace('/', '-', ltrim($resource->resourcePath, '/'));
                 $result['apis'][] = array(
                     'path' => $path,
                     'description' => $resource->apis[0]->description
@@ -498,6 +498,7 @@ class Swagger implements \Serializable
     /**
      * @param $resourceName
      * @param bool $prettyPrint
+     * @param bool $serialize
      * @return bool|mixed|null|string
      */
     public function getResource($resourceName, $prettyPrint = true, $serialize = true)
@@ -515,7 +516,14 @@ class Swagger implements \Serializable
             array_multisort($paths, SORT_ASC, $apis);
 
             $resource->apis = $apis;
-            return $this->jsonEncode($resource, $prettyPrint);
+
+            // Return the resource itself if serialize is not requested
+            if ($serialize) {
+                return $this->jsonEncode($resource, $prettyPrint);
+            }
+
+            return $resource;
+
         }
         Logger::warning('Resource "'.$resourceName.'" not found, try "'.implode('", "', $this->getResourceNames()).'"');
         return false;


### PR DESCRIPTION
Removes "/resources/" prefix and ".{format}" suffix from the getResourceList() returned resource paths. This allows Swagger to use data from getResourceList as an index of available resources, and auto-crawl the list successfully.

For comparison, see the demo index: http://petstore.swagger.wordnik.com/api/api-docs
This refers to the resourced http://petstore.swagger.wordnik.com/api/api-docs/users which is auto-crawled as a result.
## 

Also adds usage of the $serialize argument in getResource() to return the resource rather than the JSON document. Useful for frameworks that want to encode their own documents.
