### PR TITLE
Fix handling of jsonEncode prettyPrint flag

### DIFF
--- a/library/Swagger/Swagger.php
+++ b/library/Swagger/Swagger.php
@@ -521,7 +521,12 @@ class Swagger implements \Serializable
     {
         $data = self::export($resource);
         if (version_compare(PHP_VERSION, '5.4', '>=')) {
-            return json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+            $options = JSON_UNESCAPED_SLASHES;
+            if ($prettyPrint) {
+                $options |= JSON_PRETTY_PRINT;
+            }
+
+            return json_encode($data, $options);
         } else {
             $json = str_replace('\/', '/', json_encode($data));
         }

--- a/tests/SwaggerTests/SwaggerTest.php
+++ b/tests/SwaggerTests/SwaggerTest.php
@@ -177,4 +177,22 @@ class SwaggerTest extends \PHPUnit_Framework_TestCase
         $expectedResource = json_decode(file_get_contents($path . '/logs.json'), true);
         $this->assertEquals($expectedResource, Swagger::export($swagger->registry['/logs']));
     }
+
+    /**
+     * Verify that the jsonEncode method respects the prettyPrint flag.  This test assumes that JSON is considered
+     * "prettyPrint" if it consists of more than one line.
+     *
+     * @covers Swagger\Swagger::jsonEncode
+     */
+    public function testJsonEncodePrettyPrint() {
+        $swagger = new Swagger();
+
+        $data = json_decode(file_get_contents(__DIR__ . '/Fixtures/api-docs.json'), true);
+
+        $prettyJson = $swagger->jsonEncode($data, true);
+        $this->assertNotCount(1, explode("\n", $prettyJson));
+
+        $flatJson = $swagger->jsonEncode($data, false);
+        $this->assertCount(1, explode("\n", $flatJson));
+    }
 }


### PR DESCRIPTION
I noticed that in PHP 5.4+, the jsonEncode method does not respect the prettyPrint flag.  This commit updates the logic to respect that flag.  I also added tests to prove it works and prevent future regressions.
