### PR TITLE
fix missing Model issue when using items in operation

### DIFF
--- a/library/Swagger/Swagger.php
+++ b/library/Swagger/Swagger.php
@@ -222,6 +222,15 @@ class Swagger
                     if ($model) {
                         $models[] = $model;
                     }
+
+                    // check for items
+                    if ($operation->items) {
+                        $model = $this->resolveModel($operation->items->type);
+                        if ($model) {
+                            $models[] = $model;
+                        }
+                    }
+
                     foreach ($operation->parameters as $parameter) {
                         $model = $this->resolveModel($parameter->type);
                         if ($model) {


### PR DESCRIPTION
e.g.
@SWG\Operations(
  @SWG\Operation(
     method="GET",
     type="array",
     items="$ref:Pet"
  )
)
