### PR TITLE
Command line flags now always override defaults.

### DIFF
--- a/library/Swagger/Swagger.php
+++ b/library/Swagger/Swagger.php
@@ -150,13 +150,13 @@ class Swagger
         }
         $resource = $this->registry[$resourceName];
         // Apply defaults
-        if ($resource->basePath === null) {
+        if (!empty($options['defaultBasePath'])) {
             $resource->basePath = $options['defaultBasePath'];
         }
-        if ($resource->apiVersion === null) {
+        if (!empty($options['defaultApiVersion'])) {
             $resource->apiVersion = $options['defaultApiVersion'];
         }
-        if ($resource->swaggerVersion === null) {
+        if (!empty($options['defaultSwaggerVersion'])) {
             $resource->swaggerVersion = $options['defaultSwaggerVersion'];
         }
         // Sort operation paths alphabetically with shortest first


### PR DESCRIPTION
This allows for the basePath, swaggerVersion and apiVersion
to be overridden on development with a different base url
that on production.
