### PR TITLE
fix typo on bootstrap option

### DIFF
--- a/bin/swagger
+++ b/bin/swagger
@@ -142,7 +142,7 @@ EOF;
     }
     if ($options['bootstrap']) {
         /* @var  \Composer\Autoload\ClassLoader $loader */
-        foreach (explode(',', $option['bootstrap']) as $incPath) {
+        foreach (explode(',', $options['bootstrap']) as $incPath) {
             @list($namespace, $inclusionPath) = explode(':', $incPath);
             $loader->add($namespace, array($inclusionPath ? : '.'));
             if (!$inclusionPath && is_file($incPath)) {


### PR DESCRIPTION
using undefined variable `$option` causes Warning: Illegal string offset 'bootstrap'
