### PR TITLE
Enhance generated files w/ static data?

### DIFF
--- a/bin/swagger
+++ b/bin/swagger
@@ -48,6 +48,7 @@ try {
         'default-base-path' => null,
         'default-api-version' => null,
         'default-swagger-version' => '1.2',
+        'api-doc-template' => null,
         'version' => false,
         'suffix' => '.{format}',
         'help' => false,
@@ -70,6 +71,7 @@ try {
         'default-base-path',
         'default-api-version',
         'default-swagger-version',
+        'api-doc-template',
     );
     $paths = array();
     // Parse cli arguments
@@ -124,6 +126,7 @@ Usage: swagger /path/to/project [--output /path/to/docs] ...
   --default-base-path        Provide a default basePath for the resources
   --default-api-version      Provide a default apiVersion for the resources
   --default-swagger-version  Provide a default swaggerVersion for the resources
+  --api-doc-template         Provide a template for the resource listing
 
   -v, --version       Swagger-PHP version
   -h, --help          This help message
@@ -164,6 +167,25 @@ EOF;
     }
     $outputPath = rtrim($options['output'], '\\//').DIRECTORY_SEPARATOR; // Force a trailing slash
 
+    if ($options['api-doc-template']) {
+
+        if (!file_exists($options['api-doc-template'])) {
+            throw new RuntimeException('Template "'.$options['api-doc-template'].'" does not exist');
+        }
+
+        if (!is_readable($options['api-doc-template'])) {
+            throw new RuntimeException('Template "'.$options['api-doc-template'].'" is not readable');
+        }
+
+        $template = json_decode(file_get_contents($options['api-doc-template']), true);
+        if ($error = json_last_error()) {
+            throw new RuntimeException('Template "'.$options['api-doc-template'].'" does contain invalid json');
+        }
+
+        $options['api-doc-template'] = $template;
+        
+    }
+
     \Swagger\Logger::getInstance()->log = function ($entry, $type) {
         $type = $type === E_USER_NOTICE ? 'INFO' : 'WARN';
         if ($entry instanceof Exception) {
@@ -179,6 +201,7 @@ EOF;
         'basePath' => $options['url'],
         'apiVersion' => $options['default-api-version'],
         'swaggerVersion' => $options['default-swagger-version'],
+        'template' => $options['api-doc-template'] ?: array()
     );
     $resourceOptions = array(
         'output' => 'json',

--- a/library/Swagger/Swagger.php
+++ b/library/Swagger/Swagger.php
@@ -98,13 +98,15 @@ class Swagger
             'swaggerVersion' => '1.2',
             'output' => 'array',
             'json_pretty_print' => true, // for outputtype 'json'
+            'template' => array(),
         ));
-        $result = array(
-            'basePath' => $options['basePath'],
-            'apiVersion' => $options['apiVersion'],
-            'swaggerVersion' => $options['swaggerVersion'],
-            'apis' => array()
-        );
+
+        $result = $options['template'];
+        $result['basePath'] = $options['basePath'];
+        $result['apiVersion'] = $options['apiVersion'];
+        $result['swaggerVersion'] = $options['swaggerVersion'];
+        $result['apis'] = array();
+
         foreach ($this->registry as $resource) {
             if ($resource->swaggerVersion > $result['swaggerVersion']) {
                 $result['swaggerVersion'] = $resource->swaggerVersion;


### PR DESCRIPTION
To provide a bit context: Swagger allows to include a `info`-key in the resource-listing, which gets display on top of the actual listing ([api-docs](http://petstore.swagger.wordnik.com/api/api-docs), [petstore](http://petstore.swagger.wordnik.com/))

that could be useful when you'd like to show some information, for example:
- which credentials to use for Authentication (given you are on a test-instance and that gets resetted once a while, but the fixtures are available all the time)
- the app contains a decision-matrix which decides based on several properties what the result looks like. and you could include those information there.

long story short: that would be nice, but i don't like to see that stuff cluttering my code. rather i'd like to see the possibility to include that stuff, from a static source or something like that.

probably i'm having a clear picture in mind but wasn't able to express it that clearly. if that's the case, please let me know and i'll elaborate a bit more.

WDYT?
