### PR TITLE
Adding allowMultiple field to Parameter

### DIFF
--- a/library/Swagger/Annotations/Parameter.php
+++ b/library/Swagger/Annotations/Parameter.php
@@ -63,6 +63,14 @@ class Parameter extends DataType
      * @var bool
      */
     public $required;
+    
+    /**
+     * Another way to allow multiple values for a "query" parameter. 
+     * If used, the query parameter may accept comma-separated values. 
+     * The field may be used only if paramType is "query", "header" or "path".
+     * @var bool
+     */
+    public $allowMultiple;
 
     public function __construct(array $values = array())
     {


### PR DESCRIPTION
According to Swagger spec it should be possible to list parameter's values.
See https://github.com/wordnik/swagger-spec/blob/master/versions/1.2.md#524-parameter-object

If one generates swagger json from code right now there is a warning:

```
[INFO] Skipping unsupported property: "allowMultiple" for @Swagger\Annotations\Parameter, expecting "paramType", "name", "type", "required", "description", "format", "items", "uniqueItems", "minimum", "maximum", "enum", "defaultValue", "_partialId", "_partials", "_context" in 
```

Adding this public field to Parameter's Annotation solves this issue. Generated client application (using swagger-ui) works fine.
