### PR TITLE
Fixed bug that uses Doctrine parser

### DIFF
--- a/library/Swagger/Parser.php
+++ b/library/Swagger/Parser.php
@@ -332,15 +332,17 @@ class Parser
             foreach ($this->processors as $processor) {
                 $processor->process($annotation, $context);
             }
-            if ($annotation->hasPartialId()) {
-                if ($this->hasPartial($annotation->_partialId)) {
-                    Logger::notice('partial="' . $annotation->_partialId . '" is not unique. another was found in ' . $annotation->_context);
+            if ($annotation instanceof AbstractAnnotation) {
+                if ($annotation->hasPartialId()) {
+                    if ($this->hasPartial($annotation->_partialId)) {
+                        Logger::notice('partial="' . $annotation->_partialId . '" is not unique. another was found in ' . $annotation->_context);
+                    }
+                    $this->setPartial($annotation->_partialId, $annotation);
+                } elseif ($annotation instanceof Resource) {
+                    $this->resources[] = $annotation;
+                } elseif ($annotation instanceof Model) {
+                    $this->models[] = $annotation;
                 }
-                $this->setPartial($annotation->_partialId, $annotation);
-            } elseif ($annotation instanceof Resource) {
-                $this->resources[] = $annotation;
-            } elseif ($annotation instanceof Model) {
-                $this->models[] = $annotation;
             }
         }
         return $annotations;


### PR DESCRIPTION
when using this property use_simple_annotation_reader=false with doctrine and swagger.
the docparser returns all annotations which swagger in return uses to  call the method: 'hasPartialId'.
Incase with for example a doctrine annotation this fails because this is not an instance of Swagger\Annotations\AbstractAnnotation.
