### PR TITLE
Remove basePath from resource list

### DIFF
--- a/library/Swagger/Swagger.php
+++ b/library/Swagger/Swagger.php
@@ -129,7 +129,7 @@ class Swagger
         } else {
             $result = array();
         }
-        foreach (array('basePath', 'apiVersion', 'swaggerVersion') as $key) {
+        foreach (array('apiVersion', 'swaggerVersion') as $key) {
             if (array_key_exists($key, $result) === false) {
                 $result[$key] = $options[$key];
             }
@@ -152,9 +152,6 @@ class Swagger
                 unset($api['description']);
             }
             $result['apis'][] = $api;
-        }
-        if ($result['basePath'] === null) {
-            unset($result['basePath']);
         }
         if ($this->info !== null) {
             $result['info'] = $this->info;
@@ -295,7 +292,7 @@ class Swagger
                 }
                 $this->authorizations[$authorization->type] = $authorization;
             }
-            
+
         }
         foreach ($parser->getResources() as $resource) {
             if (array_key_exists($resource->resourcePath, $this->registry)) {


### PR DESCRIPTION
basePath is not a valid element in the resource list, and it causes
swagger-ui to load the wrong paths from the backend, in effect breaking
the entire service.

See this for a related issue: https://github.com/swagger-api/swagger-ui/issues/490