### PR TITLE
Fix partial_id

### DIFF
--- a/_sources/partials.txt
+++ b/_sources/partials.txt
@@ -7,14 +7,14 @@ To avoid duplication swagger-php introduces partials.
 Defining a partial
 ******************
 
-Any swagger annotation can become a partial by addding the property "partial_id".
+Any swagger annotation can become a partial by addding the property "partial".
 
 
 .. code-block:: php
 
   /**
    * @SWG\Parameter(partial="path_id", name="id", paramType="path", type="integer")
-   * @SWG\ResponseMessage(partial_id="error404", code=404, message="Entity not found")
+   * @SWG\ResponseMessage(partial="error404", code=404, message="Entity not found")
    */
 
 Using a partial

--- a/docs/partials.rst
+++ b/docs/partials.rst
@@ -7,14 +7,14 @@ To avoid duplication swagger-php introduces partials.
 Defining a partial
 ******************
 
-Any swagger annotation can become a partial by addding the property "partial_id".
+Any swagger annotation can become a partial by addding the property "partial".
 
 
 .. code-block:: php
 
   /**
    * @SWG\Parameter(partial="path_id", name="id", paramType="path", type="integer")
-   * @SWG\ResponseMessage(partial_id="error404", code=404, message="Entity not found")
+   * @SWG\ResponseMessage(partial="error404", code=404, message="Entity not found")
    */
 
 Using a partial

--- a/partials.html
+++ b/partials.html
@@ -57,10 +57,10 @@
 <p>To avoid duplication swagger-php introduces partials.</p>
 <div class="section" id="defining-a-partial">
 <h2>Defining a partial<a class="headerlink" href="#defining-a-partial" title="Permalink to this headline">¶</a></h2>
-<p>Any swagger annotation can become a partial by addding the property &#8220;partial_id&#8221;.</p>
+<p>Any swagger annotation can become a partial by addding the property &#8220;partial&#8221;.</p>
 <div class="highlight-php"><div class="highlight"><pre><span class="sd">/**</span>
 <span class="sd"> * @SWG\Parameter(partial=&quot;path_id&quot;, name=&quot;id&quot;, paramType=&quot;path&quot;, type=&quot;integer&quot;)</span>
-<span class="sd"> * @SWG\ResponseMessage(partial_id=&quot;error404&quot;, code=404, message=&quot;Entity not found&quot;)</span>
+<span class="sd"> * @SWG\ResponseMessage(partial=&quot;error404&quot;, code=404, message=&quot;Entity not found&quot;)</span>
 <span class="sd"> */</span>
 </pre></div>
 </div>


### PR DESCRIPTION
Changed gh-pages to show that the property to make an annotation become a partial is *partial*, not *partial_id*