### PR TITLE
Change coding style to match PSR-2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,5 +34,10 @@
     },
     "require-dev": {
         "zendframework/zend-form": "~2.3"
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "SwaggerTests\\": "tests/"
+        }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="tests/bootstrap.php"
+<phpunit bootstrap="vendor/autoload.php"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"

--- a/src/Annotations/AbstractAnnotation.php
+++ b/src/Annotations/AbstractAnnotation.php
@@ -16,7 +16,8 @@ use Swagger\Parser;
 /**
  * The swagger annotation base class.
  */
-abstract class AbstractAnnotation implements JsonSerializable {
+abstract class AbstractAnnotation implements JsonSerializable
+{
 
     /**
      * Allows extensions to the Swagger Schema.
@@ -79,11 +80,12 @@ abstract class AbstractAnnotation implements JsonSerializable {
     /**
      * @param array $properties
      */
-    public function __construct($properties) {
+    public function __construct($properties)
+    {
         if (isset($properties['_context'])) {
             $this->_context = $properties['_context'];
             unset($properties['_context']);
-        } else if (Parser::$context) {
+        } elseif (Parser::$context) {
             $this->_context = Parser::$context;
         } else {
             $this->_context = Context::detect(1);
@@ -115,12 +117,14 @@ abstract class AbstractAnnotation implements JsonSerializable {
         }
     }
 
-    public function __get($property) {
+    public function __get($property)
+    {
         $properties = get_object_vars($this);
         Logger::notice('Property "' . $property . '" doesn\'t exist in a ' . $this->identity() . ', exising properties: "' . implode('", "', array_keys($properties)) . '" in ' . $this->_context);
     }
 
-    public function __set($property, $value) {
+    public function __set($property, $value)
+    {
         $fields = get_object_vars($this);
         foreach (static::$_blacklist as $_property) {
             unset($fields[$_property]);
@@ -135,7 +139,8 @@ abstract class AbstractAnnotation implements JsonSerializable {
      *
      * @param AbstractAnnotation[] $annotations
      */
-    public function merge(Array $annotations) {
+    public function merge(Array $annotations)
+    {
         foreach ($annotations as $annotation) {
             $found = false;
             foreach (static::$_nested as $class => $property) {
@@ -166,7 +171,8 @@ abstract class AbstractAnnotation implements JsonSerializable {
      *
      * @param object $object
      */
-    public function mergeProperties($object) {
+    public function mergeProperties($object)
+    {
         $defaultValues = get_class_vars(get_class($this));
         $currentValues = get_object_vars($this);
         foreach ($object as $property => $value) {
@@ -196,11 +202,13 @@ abstract class AbstractAnnotation implements JsonSerializable {
         }
     }
 
-    public function __toString() {
+    public function __toString()
+    {
         return json_encode($this, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
     }
 
-    public function __debugInfo() {
+    public function __debugInfo()
+    {
         $properties = [];
         foreach (get_object_vars($this) as $property => $value) {
             if ($value !== UNDEFINED) {
@@ -214,7 +222,8 @@ abstract class AbstractAnnotation implements JsonSerializable {
      * Customize the way json_encode() renders the annotations.
      * @return array
      */
-    public function jsonSerialize() {
+    public function jsonSerialize()
+    {
         $data = new stdClass();
         // Strip undefined and null values.
         $classVars = get_class_vars(get_class($this));
@@ -274,7 +283,8 @@ abstract class AbstractAnnotation implements JsonSerializable {
      * @return boolean
      * @throws Exception
      */
-    public function validate($skip = []) {
+    public function validate($skip = [])
+    {
         if (in_array($this, $skip, true)) {
             return true;
         }
@@ -375,7 +385,8 @@ abstract class AbstractAnnotation implements JsonSerializable {
      * @param array [$skip] Array with objects which are already validated
      * @return boolean
      */
-    private static function _validate($fields, $skip) {
+    private static function _validate($fields, $skip)
+    {
         $valid = true;
         if (is_object($fields)) {
             if (in_array($fields, $skip, true)) {
@@ -407,7 +418,8 @@ abstract class AbstractAnnotation implements JsonSerializable {
      * Example: "@SWG\Get(path="/pets")"
      * @return string
      */
-    public function identity() {
+    public function identity()
+    {
         return $this->_identity([]);
     }
 
@@ -416,7 +428,8 @@ abstract class AbstractAnnotation implements JsonSerializable {
      * @param array $properties
      * @return string
      */
-    protected function _identity($properties) {
+    protected function _identity($properties)
+    {
         $fields = [];
         foreach ($properties as $property) {
             $value = $this->$property;
@@ -427,8 +440,9 @@ abstract class AbstractAnnotation implements JsonSerializable {
         return '@' . str_replace('Swagger\\Annotations\\', 'SWG\\', get_class($this)) . '(' . implode(',', $fields) . ')';
     }
 
-    private function validateType($type, $value) {
-        if (substr($type, 0, 1) === '[' && substr($type, -1) === ']') { // Array of a specified type? 
+    private function validateType($type, $value)
+    {
+        if (substr($type, 0, 1) === '[' && substr($type, -1) === ']') { // Array of a specified type?
             if ($this->validateType('array', $value) === false) {
                 return false;
             }
@@ -474,5 +488,4 @@ abstract class AbstractAnnotation implements JsonSerializable {
                 throw new Exception('Invalid type "' . $type . '"');
         }
     }
-
 }

--- a/src/Annotations/Contact.php
+++ b/src/Annotations/Contact.php
@@ -12,7 +12,8 @@ namespace Swagger\Annotations;
  *
  * A Swagger "Contact Object": https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#contactObject
  */
-class Contact extends AbstractAnnotation {
+class Contact extends AbstractAnnotation
+{
 
     /**
      * The identifying name of the contact person/organization.
@@ -43,5 +44,4 @@ class Contact extends AbstractAnnotation {
     public static $_parents = [
         'Swagger\Annotations\Info'
     ];
-
 }

--- a/src/Annotations/Definition.php
+++ b/src/Annotations/Definition.php
@@ -9,7 +9,8 @@ namespace Swagger\Annotations;
 /**
  * @Annotation
  */
-class Definition extends Schema {
+class Definition extends Schema
+{
 
     /**
      * The key into Swagger->definitions array.
@@ -29,5 +30,4 @@ class Definition extends Schema {
         'Swagger\Annotations\Definition',
         'Swagger\Annotations\Property',
     ];
-
 }

--- a/src/Annotations/Delete.php
+++ b/src/Annotations/Delete.php
@@ -9,7 +9,8 @@ namespace Swagger\Annotations;
 /**
  * @Annotation
  */
-class Delete extends Operation {
+class Delete extends Operation
+{
 
     /** @inheritdoc */
     public $method = 'delete';
@@ -18,5 +19,4 @@ class Delete extends Operation {
     public static $_parents = [
         'Swagger\Annotations\Path'
     ];
-
 }

--- a/src/Annotations/ExternalDocumentation.php
+++ b/src/Annotations/ExternalDocumentation.php
@@ -12,7 +12,8 @@ namespace Swagger\Annotations;
  *
  * A Swagger "External Documentation Object":  * https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#external-documentation-object
  */
-class ExternalDocumentation extends AbstractAnnotation {
+class ExternalDocumentation extends AbstractAnnotation
+{
 
     /**
      * A short description of the target documentation. GFM syntax can be used for rich text representation.
@@ -49,5 +50,4 @@ class ExternalDocumentation extends AbstractAnnotation {
         'Swagger\Annotations\Delete',
         'Swagger\Annotations\Patch',
     ];
-
 }

--- a/src/Annotations/Get.php
+++ b/src/Annotations/Get.php
@@ -9,7 +9,8 @@ namespace Swagger\Annotations;
 /**
  * @Annotation
  */
-class Get extends Operation {
+class Get extends Operation
+{
 
     /** @inheritdoc */
     public $method = 'get';
@@ -18,5 +19,4 @@ class Get extends Operation {
     public static $_parents = [
         'Swagger\Annotations\Path'
     ];
-
 }

--- a/src/Annotations/Header.php
+++ b/src/Annotations/Header.php
@@ -11,7 +11,8 @@ namespace Swagger\Annotations;
  *
  * A Swagger "Header Object" https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#headerObject
  */
-class Header extends AbstractAnnotation {
+class Header extends AbstractAnnotation
+{
 
     /**
      * @var string
@@ -150,5 +151,4 @@ class Header extends AbstractAnnotation {
     public static $_parents = [
         'Swagger\Annotations\Response'
     ];
-
 }

--- a/src/Annotations/Info.php
+++ b/src/Annotations/Info.php
@@ -11,7 +11,8 @@ namespace Swagger\Annotations;
  *
  * A Swagger "Info Object":  https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#infoObject
  */
-class Info extends AbstractAnnotation {
+class Info extends AbstractAnnotation
+{
 
     /**
      * The title of the application.
@@ -69,5 +70,4 @@ class Info extends AbstractAnnotation {
     public static $_parents = [
         'Swagger\Annotations\Swagger'
     ];
-
 }

--- a/src/Annotations/Items.php
+++ b/src/Annotations/Items.php
@@ -14,7 +14,8 @@ use Swagger\Logger;
  *
  * A Swagger "Items Object": https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#itemsObject
  */
-class Items extends AbstractAnnotation {
+class Items extends AbstractAnnotation
+{
 
     /**
      * $ref See http://json-schema.org/latest/json-schema-core.html#rfc.section.7
@@ -158,7 +159,8 @@ class Items extends AbstractAnnotation {
         'Swagger\Annotations\Items'
     ];
 
-    public function validate($skip = []) {
+    public function validate($skip = [])
+    {
         if (in_array($this, $skip, true)) {
             return true;
         }
@@ -169,5 +171,4 @@ class Items extends AbstractAnnotation {
         }
         return $valid;
     }
-
 }

--- a/src/Annotations/License.php
+++ b/src/Annotations/License.php
@@ -12,7 +12,8 @@ namespace Swagger\Annotations;
  *
  * A Swagger "License Object": https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#licenseObject
  */
-class License extends AbstractAnnotation {
+class License extends AbstractAnnotation
+{
 
     /**
      * The license name used for the API.
@@ -39,5 +40,4 @@ class License extends AbstractAnnotation {
     public static $_parents = [
         'Swagger\Annotations\Info'
     ];
-
 }

--- a/src/Annotations/Operation.php
+++ b/src/Annotations/Operation.php
@@ -14,7 +14,8 @@ use Swagger\Logger;
  *
  * A Swagger "Operation Object": https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#operationObject
  */
-abstract class Operation extends AbstractAnnotation {
+abstract class Operation extends AbstractAnnotation
+{
 
     /**
      * key in the Swagger "Paths Object" for this operation
@@ -142,14 +143,16 @@ abstract class Operation extends AbstractAnnotation {
     ];
 
     /** @inheritdoc */
-    public function jsonSerialize() {
+    public function jsonSerialize()
+    {
         $data = parent::jsonSerialize();
         unset($data->method);
         unset($data->path);
         return $data;
     }
 
-    public function validate($skip = array()) {
+    public function validate($skip = array())
+    {
         if (in_array($this, $skip, true)) {
             return true;
         }
@@ -163,5 +166,4 @@ abstract class Operation extends AbstractAnnotation {
         }
         return $valid;
     }
-
 }

--- a/src/Annotations/Parameter.php
+++ b/src/Annotations/Parameter.php
@@ -14,7 +14,8 @@ use \Swagger\Logger;
  *
  * A Swagger "Parameter Object": https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#parameterObject
  */
-class Parameter extends AbstractAnnotation {
+class Parameter extends AbstractAnnotation
+{
 
     /**
      * $ref See http://json-schema.org/latest/json-schema-core.html#rfc.section.7
@@ -201,7 +202,8 @@ class Parameter extends AbstractAnnotation {
         'Swagger\Annotations\Swagger'
     ];
 
-    public function validate($skip = []) {
+    public function validate($skip = [])
+    {
         if (in_array($this, $skip, true)) {
             return true;
         }
@@ -230,8 +232,8 @@ class Parameter extends AbstractAnnotation {
     }
 
     /** @inheritdoc */
-    public function identity() {
+    public function identity()
+    {
         return parent::_identity(['name', 'in']);
     }
-
 }

--- a/src/Annotations/Patch.php
+++ b/src/Annotations/Patch.php
@@ -9,7 +9,8 @@ namespace Swagger\Annotations;
 /**
  * @Annotation
  */
-class Patch extends Operation {
+class Patch extends Operation
+{
 
     /** @inheritdoc */
     public $method = 'patch';
@@ -18,5 +19,4 @@ class Patch extends Operation {
     public static $_parents = [
         'Swagger\Annotations\Path'
     ];
-
 }

--- a/src/Annotations/Path.php
+++ b/src/Annotations/Path.php
@@ -14,7 +14,8 @@ namespace Swagger\Annotations;
  *
  * A Swagger "Path Item Object": https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#path-item-object-
  */
-class Path extends AbstractAnnotation {
+class Path extends AbstractAnnotation
+{
 
     /**
      * key in the Swagger "Paths Object" for this path.
@@ -89,5 +90,4 @@ class Path extends AbstractAnnotation {
     public static $_parents = [
         'Swagger\Annotations\Swagger'
     ];
-
 }

--- a/src/Annotations/Post.php
+++ b/src/Annotations/Post.php
@@ -9,7 +9,8 @@ namespace Swagger\Annotations;
 /**
  * @Annotation
  */
-class Post extends Operation {
+class Post extends Operation
+{
 
     /** @inheritdoc */
     public $method = 'post';
@@ -18,5 +19,4 @@ class Post extends Operation {
     public static $_parents = [
         'Swagger\Annotations\Path'
     ];
-
 }

--- a/src/Annotations/Property.php
+++ b/src/Annotations/Property.php
@@ -9,7 +9,8 @@ namespace Swagger\Annotations;
 /**
  * @Annotation
  */
-class Property extends Schema {
+class Property extends Schema
+{
 
     /**
      * The key into Schema->properties array.
@@ -23,5 +24,4 @@ class Property extends Schema {
         'Swagger\Annotations\Schema',
         'Swagger\Annotations\Property',
     ];
-
 }

--- a/src/Annotations/Put.php
+++ b/src/Annotations/Put.php
@@ -9,7 +9,8 @@ namespace Swagger\Annotations;
 /**
  * @Annotation
  */
-class Put extends Operation {
+class Put extends Operation
+{
 
     /** @inheritdoc */
     public $method = 'put';
@@ -18,5 +19,4 @@ class Put extends Operation {
     public static $_parents = [
         'Swagger\Annotations\Path'
     ];
-
 }

--- a/src/Annotations/Response.php
+++ b/src/Annotations/Response.php
@@ -11,7 +11,8 @@ namespace Swagger\Annotations;
  *
  * A Swagger "Response Object": https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#responseObject
  */
-class Response extends AbstractAnnotation {
+class Response extends AbstractAnnotation
+{
 
     /**
      * $ref See http://json-schema.org/latest/json-schema-core.html#rfc.section.7
@@ -21,8 +22,8 @@ class Response extends AbstractAnnotation {
 
     /**
      * The key into Operations->responses array.
-     * 
-     * @var string a HTTP Status Code or "default" 
+     *
+     * @var string a HTTP Status Code or "default"
      */
     public $response;
 
@@ -74,5 +75,4 @@ class Response extends AbstractAnnotation {
         'Swagger\Annotations\Delete',
         'Swagger\Annotations\Swagger'
     ];
-
 }

--- a/src/Annotations/Schema.php
+++ b/src/Annotations/Schema.php
@@ -18,7 +18,8 @@ namespace Swagger\Annotations;
  * A Swagger "Schema Object": https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#schemaObject
  * JSON Schema: http://json-schema.org/latest/json-schema-validation.html
  */
-class Schema extends AbstractAnnotation {
+class Schema extends AbstractAnnotation
+{
 
     /**
      * $ref See http://json-schema.org/latest/json-schema-core.html#rfc.section.7
@@ -212,7 +213,7 @@ class Schema extends AbstractAnnotation {
 
     /**
      * An instance validates successfully against this property if it validates successfully against exactly one schema defined by this property's value.
-     * @var type 
+     * @var type
      */
     public $oneOf;
 
@@ -272,5 +273,4 @@ class Schema extends AbstractAnnotation {
         'Swagger\Annotations\Response',
         'Swagger\Annotations\Parameter',
     ];
-
 }

--- a/src/Annotations/SecurityScheme.php
+++ b/src/Annotations/SecurityScheme.php
@@ -10,7 +10,8 @@ namespace Swagger\Annotations;
  * @Annotation
  * A Swagger "Security Scheme Object": https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#securitySchemeObject
  */
-class SecurityScheme extends AbstractAnnotation {
+class SecurityScheme extends AbstractAnnotation
+{
 
     /**
      * The key into Swagger->securityDefinitions array.
@@ -43,8 +44,8 @@ class SecurityScheme extends AbstractAnnotation {
     public $in;
 
     /**
-     * The flow used by the OAuth2 security scheme. 
-     * @var 
+     * The flow used by the OAuth2 security scheme.
+     * @var
      */
     public $flow;
 
@@ -82,5 +83,4 @@ class SecurityScheme extends AbstractAnnotation {
     public static $_parents = [
         'Swagger\Annotations\Swagger',
     ];
-
 }

--- a/src/Annotations/Swagger.php
+++ b/src/Annotations/Swagger.php
@@ -16,7 +16,8 @@ use Symfony\Component\Finder\Finder;
  *
  * A Swagger "Swagger Object": https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#swagger-object-
  */
-class Swagger extends AbstractAnnotation {
+class Swagger extends AbstractAnnotation
+{
 
     /**
      * Specifies the Swagger Specification version being used. It can be used by the Swagger UI and other clients to interpret the API listing.
@@ -139,7 +140,8 @@ class Swagger extends AbstractAnnotation {
      * @param string|array $exclude
      * @throws Exception
      */
-    public function crawl($directory, $exclude = null) {
+    public function crawl($directory, $exclude = null)
+    {
         // Setup Finder
         if (is_object($directory)) {
             $finder = $directory;
@@ -179,10 +181,10 @@ class Swagger extends AbstractAnnotation {
      * @param string $filename
      * @throws Exception
      */
-    public function saveAs($filename) {
+    public function saveAs($filename)
+    {
         if (file_put_contents($filename, $this) === false) {
             throw new Exception('Failed to saveAs("' . $filename . '")');
         }
     }
-
 }

--- a/src/Annotations/Tag.php
+++ b/src/Annotations/Tag.php
@@ -11,7 +11,8 @@ namespace Swagger\Annotations;
  *
  * A Swagger "Tag Object":  https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#tagObject
  */
-class Tag extends AbstractAnnotation {
+class Tag extends AbstractAnnotation
+{
 
     /**
      * The name of the tag.
@@ -49,5 +50,4 @@ class Tag extends AbstractAnnotation {
     public static $_nested = [
         'Swagger\Annotations\ExternalDocumentation' => 'externalDocs'
     ];
-
 }

--- a/src/Annotations/Xml.php
+++ b/src/Annotations/Xml.php
@@ -11,7 +11,8 @@ namespace Swagger\Annotations;
  *
  * A Swagger "XML Object": https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#xmlObject
  */
-class Xml extends AbstractAnnotation {
+class Xml extends AbstractAnnotation
+{
 
     /**
      * Replaces the name of the element/attribute used for the described schema property. When defined within the Items Object (items), it will affect the name of the individual XML elements within the list. When defined alongside type being array (outside the items), it will affect the wrapping element and only if wrapped is true. If wrapped is false, it will be ignored.
@@ -58,5 +59,4 @@ class Xml extends AbstractAnnotation {
         'Swagger\Annotations\Property',
         'Swagger\Annotations\Definition'
     ];
-
 }

--- a/src/Context.php
+++ b/src/Context.php
@@ -33,7 +33,8 @@ namespace Swagger;
  * @property string $property
  * @property Annotations\AbstractAnnotation[] $annotations
  */
-class Context {
+class Context
+{
 
     /**
      * Prototypical inheritance for properties.
@@ -45,7 +46,8 @@ class Context {
      * @param array $properties new properties for this context.
      * @param Context $parent The parent context
      */
-    public function __construct($properties = [], $parent = null) {
+    public function __construct($properties = [], $parent = null)
+    {
         foreach ($properties as $property => $value) {
             $this->$property = $value;
         }
@@ -58,7 +60,8 @@ class Context {
      * @param string $type Example: $c->is('method') or $c->is('class')
      * @return bool
      */
-    public function is($type) {
+    public function is($type)
+    {
         return property_exists($this, $type);
     }
 
@@ -68,7 +71,8 @@ class Context {
      * @param string $property
      * @return boolean|\Swagger\Context
      */
-    public function with($property) {
+    public function with($property)
+    {
         if (property_exists($this, $property)) {
             return $this;
         }
@@ -81,7 +85,8 @@ class Context {
     /**
      * @return \Swagger\Context
      */
-    public function getRootContext() {
+    public function getRootContext()
+    {
         if ($this->_parent) {
             return $this->_parent->getRootContext();
         }
@@ -93,7 +98,8 @@ class Context {
      *
      * @return string Example: "file1.php on line 12"
      */
-    public function getDebugLocation() {
+    public function getDebugLocation()
+    {
         $location = '';
         if ($this->class && ($this->method || $this->property)) {
             $location .= $this->fullyQualifiedName($this->class);
@@ -127,25 +133,29 @@ class Context {
      * @param string $property
      * @return mixed
      */
-    public function __get($property) {
+    public function __get($property)
+    {
         if ($this->_parent) {
             return $this->_parent->$property;
         }
         return null;
     }
 
-    public function __toString() {
+    public function __toString()
+    {
         return $this->getDebugLocation();
     }
 
-    public function __debugInfo() {
+    public function __debugInfo()
+    {
         return ['-' => $this->getDebugLocation()];
     }
 
     /**
      * @return string|null
      */
-    public function extractDescription() {
+    public function extractDescription()
+    {
         $lines = explode("\n", $this->comment);
         unset($lines[0]);
         $description = '';
@@ -171,7 +181,8 @@ class Context {
      * @param int $index
      * @return \Swagger\Context
      */
-    static public function detect($index = 0) {
+    public static function detect($index = 0)
+    {
         $context = new Context();
         $backtrace = debug_backtrace();
         $position = $backtrace[$index];
@@ -205,7 +216,8 @@ class Context {
      * @param string $class  The class name
      * @return string
      */
-    public function fullyQualifiedName($class) {
+    public function fullyQualifiedName($class)
+    {
         if ($this->namespace) {
             $namespace = str_replace('\\\\', '\\', '\\' . $this->namespace . '\\');
         } else {
@@ -240,5 +252,4 @@ class Context {
         }
         return $namespace . $class;
     }
-
 }

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -12,7 +12,8 @@ use Exception;
 /**
  * Logger reports the parser and validation messages.
  */
-class Logger {
+class Logger
+{
 
     /**
      * Singleton
@@ -25,7 +26,8 @@ class Logger {
      */
     public $log;
 
-    protected function __construct() {
+    protected function __construct()
+    {
         /**
          * @param \Exception|string $entry
          * @param int $type Error type
@@ -41,7 +43,8 @@ class Logger {
     /**
      * @return Logger
      */
-    public static function getInstance() {
+    public static function getInstance()
+    {
         if (self::$instance === null) {
             self::$instance = new Logger();
         }
@@ -52,7 +55,8 @@ class Logger {
      * Log a Swagger warning.
      * @param Exception|string $entry
      */
-    public static function warning($entry) {
+    public static function warning($entry)
+    {
         call_user_func(self::getInstance()->log, $entry, E_USER_WARNING);
     }
 
@@ -60,8 +64,8 @@ class Logger {
      * Log a Swagger notice.
      * @param Exception|string $entry
      */
-    public static function notice($entry) {
+    public static function notice($entry)
+    {
         call_user_func(self::getInstance()->log, $entry, E_USER_NOTICE);
     }
-
 }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -30,7 +30,8 @@ AnnotationRegistry::registerLoader(function ($class) {
 /**
  * Swagger\Parser extracts swagger-php annotations from php code.
  */
-class Parser {
+class Parser
+{
 
     /**
      * List of namespaces that should be detected by the doctrine annotation parser.
@@ -52,7 +53,8 @@ class Parser {
     /**
      * @param string $filename
      */
-    public function __construct($filename = null) {
+    public function __construct($filename = null)
+    {
         if ($filename !== null) {
             $this->parseFile($filename);
         }
@@ -64,7 +66,8 @@ class Parser {
      * @param string $filename Path to a php file.
      * @return AbstractAnnotation[]
      */
-    public function parseFile($filename) {
+    public function parseFile($filename)
+    {
         $tokens = token_get_all(file_get_contents($filename));
         return $this->parseTokens($tokens, new Context(['filename' => $filename]));
     }
@@ -76,7 +79,8 @@ class Parser {
      * @param Context $context The original location of the contents.
      * @return AbstractAnnotation[]
      */
-    public function parseContents($contents, $context) {
+    public function parseContents($contents, $context)
+    {
         $tokens = token_get_all($contents);
         return $this->parseTokens($tokens, $context);
     }
@@ -88,7 +92,8 @@ class Parser {
      * @param Context $parseContext
      * @return AbstractAnnotation[]
      */
-    protected function parseTokens($tokens, $parseContext) {
+    protected function parseTokens($tokens, $parseContext)
+    {
         $this->docParser = new DocParser();
         $this->docParser->setIgnoreNotImportedAnnotations(true);
 
@@ -232,13 +237,13 @@ class Parser {
      * @param Context $context
      * @return string|array The next token (or false)
      */
-    private function nextToken(&$tokens, $context) {
+    private function nextToken(&$tokens, $context)
+    {
         $token = next($tokens);
         if ($token[0] === T_WHITESPACE) {
             return $this->nextToken($tokens, $context);
         }
         if ($token[0] === T_COMMENT) {
-
             $pos = strpos($token[1], '@SWG\\');
             if ($pos) {
                 $line = $context->line ? $context->line + $token[2] : $token[2];
@@ -250,7 +255,8 @@ class Parser {
         return $token;
     }
 
-    private function parseNamespace(&$tokens, &$token, $parseContext) {
+    private function parseNamespace(&$tokens, &$token, $parseContext)
+    {
         $namespace = '';
         while ($token !== false) {
             $token = $this->nextToken($tokens, $parseContext);
@@ -262,7 +268,8 @@ class Parser {
         return $namespace;
     }
 
-    private function parseUseStatement(&$tokens, &$token, $parseContext) {
+    private function parseUseStatement(&$tokens, &$token, $parseContext)
+    {
         $class = '';
         $alias = '';
         $statements = [];
@@ -273,17 +280,17 @@ class Parser {
             if (!$explicitAlias && $isNameToken) {
                 $class .= $token[1];
                 $alias = $token[1];
-            } else if ($explicitAlias && $isNameToken) {
+            } elseif ($explicitAlias && $isNameToken) {
                 $alias .= $token[1];
-            } else if ($token[0] === T_AS) {
+            } elseif ($token[0] === T_AS) {
                 $explicitAlias = true;
                 $alias = '';
-            } else if ($token === ',') {
+            } elseif ($token === ',') {
                 $statements[$alias] = $class;
                 $class = '';
                 $alias = '';
                 $explicitAlias = false;
-            } else if ($token === ';') {
+            } elseif ($token === ';') {
                 $statements[$alias] = $class;
                 break;
             } else {
@@ -300,7 +307,8 @@ class Parser {
      * @param  AbstractAnnotation[] $annotations
      * @return AbstractAnnotation[]
      */
-    protected function parseContext($context, &$annotations) {
+    protected function parseContext($context, &$annotations)
+    {
         try {
             self::$context = $context;
             if ($context->is('annotations') === false) {
@@ -333,5 +341,4 @@ class Parser {
         }
         return $annotations;
     }
-
 }

--- a/src/Processing.php
+++ b/src/Processing.php
@@ -18,13 +18,15 @@ use Swagger\Processors\MergeSwagger;
 /**
  * Registry for the post-processing operations.
  */
-class Processing {
+class Processing
+{
 
     /**
-     * Apply all processors 
+     * Apply all processors
      * @param Swagger $swagger
      */
-    static function process($swagger) {
+    public static function process($swagger)
+    {
         foreach (self::processors() as $processor) {
             $processor($swagger);
         }
@@ -39,7 +41,8 @@ class Processing {
      * Get direct access to the processors array.
      * @return array reference
      */
-    static function &processors() {
+    public static function &processors()
+    {
         if (!self::$processors) {
             // Add default processors.
             self::$processors = [
@@ -57,7 +60,8 @@ class Processing {
      * Register a processor
      * @param Closure $processor
      */
-    static function register($processor) {
+    public static function register($processor)
+    {
         array_push(self::processors(), $processor);
     }
     
@@ -65,7 +69,8 @@ class Processing {
      * Unregister a processor
      * @param Closure $processor
      */
-    static function unregister($processor) {
+    public static function unregister($processor)
+    {
         $processors = &self::processors();
         $key = array_search($processor, $processors, true);
         if ($key === false) {
@@ -73,5 +78,4 @@ class Processing {
         }
         unset($processors[$key]);
     }
-
 }

--- a/src/Processors/AugmentParameter.php
+++ b/src/Processors/AugmentParameter.php
@@ -11,9 +11,11 @@ use Swagger\Annotations\Swagger;
 /**
  * Use the parameter->name as keyfield (parameter->parameter) when used in swagger object.
  */
-class AugmentParameter {
+class AugmentParameter
+{
 
-    public function __invoke(Swagger $swagger) {
+    public function __invoke(Swagger $swagger)
+    {
         if ($swagger->parameters) {
             $keys = [];
             $parametersWithoutKey = [];
@@ -32,5 +34,4 @@ class AugmentParameter {
             }
         }
     }
-
 }

--- a/src/Processors/BuildPaths.php
+++ b/src/Processors/BuildPaths.php
@@ -15,9 +15,11 @@ use Swagger\Context;
 /**
  * Build the swagger->paths using the detected @SWG\Path and @SWG\Operations (like @SWG\Get, @SWG\Post, etc)
  */
-class BuildPaths {
+class BuildPaths
+{
 
-    public function __invoke(Swagger $swagger) {
+    public function __invoke(Swagger $swagger)
+    {
         $paths = [];
         // Merge @SWG\Paths with the same path.
         foreach ($swagger->paths as $annotation) {
@@ -45,5 +47,4 @@ class BuildPaths {
         }
         $swagger->paths = array_values($paths);
     }
-
 }

--- a/src/Processors/ClassProperties.php
+++ b/src/Processors/ClassProperties.php
@@ -15,9 +15,10 @@ use Swagger\Context;
 /**
  * Use the property context to extract useful information and inject that into the annotation.
  */
-class ClassProperties {
+class ClassProperties
+{
 
-    static $types = [
+    public static $types = [
         'array' => 'array',
         'byte' => ['string', 'byte'],
         'boolean' => 'boolean',
@@ -35,7 +36,8 @@ class ClassProperties {
         'object' => 'object'
     ];
 
-    public function __invoke(Swagger $swagger) {
+    public function __invoke(Swagger $swagger)
+    {
         $refs = [];
         // Use the class names for @SWG\Definition()
         foreach ($swagger->definitions as $definition) {
@@ -85,7 +87,8 @@ class ClassProperties {
      * @param Property $annotation
      * @param array $refs
      */
-    public function processProperty($annotation, $refs) {
+    public function processProperty($annotation, $refs)
+    {
         $context = $annotation->_context;
         // Use the property names for @SWG\Property()
         if ($annotation->property === null) {
@@ -130,5 +133,4 @@ class ClassProperties {
             $annotation->description = $context->extractDescription();
         }
     }
-
 }

--- a/src/Processors/InheritProperties.php
+++ b/src/Processors/InheritProperties.php
@@ -13,9 +13,11 @@ use Swagger\Annotations\Definition;
 /**
  * Copy the annotated properties from parent classes;
  */
-class InheritProperties {
+class InheritProperties
+{
 
-    public function __invoke(Swagger $swagger) {
+    public function __invoke(Swagger $swagger)
+    {
         $children = $this->getChildren($swagger);
         $definitions = $this->getDefinitions($swagger);
 
@@ -51,7 +53,8 @@ class InheritProperties {
      * @param Swagger $swagger
      * @return array '\Namespace\ClassName' => SWG\Definition
      */
-    public function getDefinitions($swagger) {
+    public function getDefinitions($swagger)
+    {
         $definitions = [];
         foreach ($swagger->definitions as $definition) {
             if ($definition->_context->is('class')) {
@@ -65,7 +68,8 @@ class InheritProperties {
      * @param Swagger $swagger
      * @return array '\namespace\ParentClass' => ['\namespace\Child', 'Child2']
      */
-    public function getChildren($swagger) {
+    public function getChildren($swagger)
+    {
         $extends = []; // '\namespace\class' => '\namespace\parent'
         foreach ($swagger->definitions as $definition) {
             $context = $definition->_context;
@@ -95,7 +99,8 @@ class InheritProperties {
      * @param array $extends '\namespace\class' => '\namespace\parent'
      * @return array
      */
-    private function getChildrenFor($class, $extends) {
+    private function getChildrenFor($class, $extends)
+    {
         $children = [];
         foreach ($extends as $child => $parent) {
             if ($parent === $class) { // A direct descendant?
@@ -107,11 +112,12 @@ class InheritProperties {
     }
 
     /**
-     * 
+     *
      * @param Definition $definition
      * @param Property[] $properties
      */
-    private function mergeProperties($definition, $properties) {
+    private function mergeProperties($definition, $properties)
+    {
         if ($definition->properties === null) {
             $definition->properties = $properties;
             return;
@@ -128,5 +134,4 @@ class InheritProperties {
             }
         }
     }
-
 }

--- a/src/Processors/MergeSwagger.php
+++ b/src/Processors/MergeSwagger.php
@@ -11,9 +11,11 @@ use Swagger\Annotations\Swagger;
 /**
  * Merge all @SWG\Swagger annotations into one.
  */
-class MergeSwagger {
+class MergeSwagger
+{
 
-    public function __invoke(Swagger $swagger) {
+    public function __invoke(Swagger $swagger)
+    {
         $unmerged = $swagger->_unmerged;
         foreach ($swagger->_unmerged as $i => $annotation) {
             if ($annotation instanceof Swagger) {
@@ -33,5 +35,4 @@ class MergeSwagger {
         }
         $swagger->_unmerged = array_values($unmerged);
     }
-
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -23,7 +23,8 @@ define('Swagger\Processors\UNDEFINED', UNDEFINED);
  * @param string|array $exclude
  * @return Swagger
  */
-function scan($directory, $exclude = null) {
+function scan($directory, $exclude = null)
+{
     $swagger = new Swagger([
         '_context' => Context::detect(1)
     ]);

--- a/tests/AbstractAnnotationTest.php
+++ b/tests/AbstractAnnotationTest.php
@@ -6,28 +6,33 @@
 
 namespace SwaggerTests;
 
-class AbstractAnnotationTest extends SwaggerTestCase {
+class AbstractAnnotationTest extends SwaggerTestCase
+{
 
-    function testVendorFields() {
+    public function testVendorFields()
+    {
         $annotations = $this->parseComment('@SWG\Get(x={"internal-id": 123})');
         $output = $annotations[0]->jsonSerialize();
         $prefixedProperty = 'x-internal-id';
         $this->assertSame(123, $output->$prefixedProperty);
     }
 
-    function testInvalidField() {
+    public function testInvalidField()
+    {
         $this->assertSwaggerLogEntryStartsWith('Unexpected field "doesnot" for @SWG\Get(), expecting');
         $this->parseComment('@SWG\Get(doesnot="exist")');
     }
 
-    function testUmergedAnnotation() {
+    public function testUmergedAnnotation()
+    {
         $swagger = $this->createSwaggerWithInfo();
         $swagger->merge($this->parseComment('@SWG\Items()'));
         $this->assertSwaggerLogEntryStartsWith('Unexpected @SWG\Items(), expected to be inside @SWG\\');
         $swagger->validate();
     }
 
-    function testConflictedNesting() {
+    public function testConflictedNesting()
+    {
         $comment = <<<END
 @SWG\Info(
     title="Info only has one contact field..",
@@ -41,7 +46,8 @@ END;
         $annotations[0]->validate();
     }
 
-    function testKey() {
+    public function testKey()
+    {
         $comment = <<<END
 @SWG\Response(
     @SWG\Header(header="X-CSRF-Token",description="Token to prevent Cross Site Request Forgery")
@@ -51,7 +57,8 @@ END;
         $this->assertEquals('{"headers":{"X-CSRF-Token":{"description":"Token to prevent Cross Site Request Forgery"}}}', json_encode($annotations[0]));
     }
 
-    function testConflictingKey() {
+    public function testConflictingKey()
+    {
         $comment = <<<END
 @SWG\Response(
     description="The headers in response must have unique header values",
@@ -64,7 +71,8 @@ END;
         $annotations[0]->validate();
     }
 
-    function testRequiredFields() {
+    public function testRequiredFields()
+    {
         $annotations = $this->parseComment('@SWG\Info()');
         $info = $annotations[0];
         $this->assertSwaggerLogEntryStartsWith('Missing required field "title" for @SWG\Info() in ');
@@ -72,12 +80,13 @@ END;
         $info->validate();
     }
 
-    function testTypeValidation() {
+    public function testTypeValidation()
+    {
         $comment = <<<END
 @SWG\Parameter(
-    name=123, 
-    type="strig", 
-    in="dunno", 
+    name=123,
+    type="strig",
+    in="dunno",
     required="maybe",
     maximum="twentytwo"
 )
@@ -91,5 +100,4 @@ END;
         $this->assertSwaggerLogEntryStartsWith('@SWG\Parameter(name=123,in="dunno")->type must be "string", "number", "integer", "boolean", "array", "file" when @SWG\Parameter()->in != "body" in ');
         $parameter->validate();
     }
-
 }

--- a/tests/AugmentParameterTest.php
+++ b/tests/AugmentParameterTest.php
@@ -6,12 +6,13 @@
 
 namespace SwaggerTests;
 
-class AugmentParameterTest extends SwaggerTestCase {
+class AugmentParameterTest extends SwaggerTestCase
+{
 
-    function testAugmentParameter() {
+    public function testAugmentParameter()
+    {
         $swagger = \Swagger\scan(__DIR__ . '/Fixtures/UsingRefs.php');
         $this->assertCount(1, $swagger->parameters, 'Swagger contains 1 reusable parameter specification');
         $this->assertEquals('ItemName', $swagger->parameters[0]->parameter, 'When no @SWG\Parameter()->parameter is specified, use @SWG\Parameter()->name');
     }
-
 }

--- a/tests/BuildPathsTest.php
+++ b/tests/BuildPathsTest.php
@@ -12,9 +12,11 @@ use Swagger\Annotations\Path;
 use Swagger\Annotations\Get;
 use Swagger\Annotations\Post;
 
-class BuildPathsTest extends SwaggerTestCase {
+class BuildPathsTest extends SwaggerTestCase
+{
 
-    function testMergePathsWithSamePath() {
+    public function testMergePathsWithSamePath()
+    {
         $swagger = new Swagger([]);
         $swagger->paths = [
             new Path(['path' => '/comments']),
@@ -26,7 +28,8 @@ class BuildPathsTest extends SwaggerTestCase {
         $this->assertSame('/comments', $swagger->paths[0]->path);
     }
 
-    function testMergeOperationsWithSamePath() {
+    public function testMergeOperationsWithSamePath()
+    {
         $swagger = new Swagger([]);
         $swagger->_unmerged = [
             new Get(['path' => '/comments']),
@@ -42,5 +45,4 @@ class BuildPathsTest extends SwaggerTestCase {
         $this->assertInstanceOf('\Swagger\Annotations\Post', $path->post);
         $this->assertNull($path->put);
     }
-
 }

--- a/tests/ClassPropertiesTest.php
+++ b/tests/ClassPropertiesTest.php
@@ -9,9 +9,11 @@ namespace SwaggerTests;
 use Swagger\Annotations\Swagger;
 use Swagger\Processors\ClassProperties;
 
-class ClassPropertiesTest extends SwaggerTestCase {
+class ClassPropertiesTest extends SwaggerTestCase
+{
 
-    function testClassPropertiesProcessor() {
+    public function testClassPropertiesProcessor()
+    {
         $processor = new ClassProperties();
         $swagger = new Swagger([]);
         $swagger->crawl(__DIR__ . '/Fixtures/Customer.php');
@@ -41,5 +43,4 @@ class ClassPropertiesTest extends SwaggerTestCase {
         $this->assertSame('array', $friends->type);
         $this->assertSame('#/definitions/Customer', $friends->items->ref);
     }
-
 }

--- a/tests/CommandlineInterfaceTest.php
+++ b/tests/CommandlineInterfaceTest.php
@@ -6,16 +6,19 @@
 
 namespace SwaggerTests;
 
-class CommandlineInterfaceTest extends SwaggerTestCase {
+class CommandlineInterfaceTest extends SwaggerTestCase
+{
 
-    protected function setUp() {
+    protected function setUp()
+    {
         if (defined('HHVM_VERSION')) {
             $this->markTestSkipped();
         }
         parent::setUp();
     }
 
-    public function testStdout() {
+    public function testStdout()
+    {
         exec(__DIR__ . '/../bin/swagger --stdout ' . escapeshellarg(__DIR__ . '/../Examples/swagger-spec/petstore-simple') . ' 2> /dev/null', $output, $retval);
         $this->assertSame(0, $retval);
         $json = json_decode(implode("\n", $output));
@@ -23,7 +26,8 @@ class CommandlineInterfaceTest extends SwaggerTestCase {
         $this->compareOutput($json);
     }
 
-    public function testOutputTofile() {
+    public function testOutputTofile()
+    {
         $filename = sys_get_temp_dir() . '/swagger-php-clitest.json';
         exec(__DIR__ . '/../bin/swagger -o ' . escapeshellarg($filename) . ' ' . escapeshellarg(__DIR__ . '/../Examples/swagger-spec/petstore-simple') . ' 2> /dev/null', $output, $retval);
         $this->assertSame(0, $retval);
@@ -35,11 +39,11 @@ class CommandlineInterfaceTest extends SwaggerTestCase {
         $this->compareOutput($json);
     }
 
-    private function compareOutput($actual) {
+    private function compareOutput($actual)
+    {
         $expected = json_decode(file_get_contents(__DIR__ . '/ExamplesOutput/petstore-simple.json'));
         $expectedJson = json_encode($this->sorted($expected, 'petstore-simple.json'), JSON_PRETTY_PRINT);
         $actualJson = json_encode($this->sorted($actual, 'Swagger CLI'), JSON_PRETTY_PRINT);
         $this->assertEquals($expectedJson, $actualJson);
     }
-
 }

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -8,9 +8,11 @@ namespace SwaggerTests;
 
 use Swagger\Context;
 
-class ContextTest extends SwaggerTestCase {
+class ContextTest extends SwaggerTestCase
+{
 
-    function testDetect() {
+    public function testDetect()
+    {
         $context = Context::detect();
         $line = __LINE__ - 1;
         $this->assertSame('ContextTest', $context->class);
@@ -22,10 +24,11 @@ class ContextTest extends SwaggerTestCase {
 //        $this->assertCount(1, $context->uses); // Context::detect() doesn't pick up USE statements (yet)
     }
 
-    function testFullyQualifiedName() {
+    public function testFullyQualifiedName()
+    {
         $swagger = \Swagger\scan(__DIR__ . '/Fixtures/Customer.php');
         $context = $swagger->definitions[0]->_context;
-        // resolve with namespace 
+        // resolve with namespace
         $this->assertSame('\FullyQualified', $context->fullyQualifiedName('\FullyQualified'));
         $this->assertSame('\SwaggerFixures\Unqualified', $context->fullyQualifiedName('Unqualified'));
         $this->assertSame('\SwaggerFixures\Namespace\Qualified', $context->fullyQualifiedName('Namespace\Qualified'));
@@ -37,5 +40,4 @@ class ContextTest extends SwaggerTestCase {
         $this->assertSame('\Swagger\Parser', $context->fullyQualifiedName('SwgParser'));
         $this->assertSame('\Swagger\Annotations\QualifiedAlias', $context->fullyQualifiedName('SWG\QualifiedAlias'));
     }
-
 }

--- a/tests/ExamplesTest.php
+++ b/tests/ExamplesTest.php
@@ -6,7 +6,8 @@
 
 namespace SwaggerTests;
 
-class ExamplesTest extends SwaggerTestCase {
+class ExamplesTest extends SwaggerTestCase
+{
 
     /**
      * Test the processed Examples against json files in ExamplesOutput.
@@ -15,7 +16,8 @@ class ExamplesTest extends SwaggerTestCase {
      * @param string $example Example path
      * @param string $output Expected output (path to a json file)
      */
-    public function testExample($example, $output) {
+    public function testExample($example, $output)
+    {
         $swagger = \Swagger\scan(__DIR__ . '/../Examples/' . $example);
 //        die((string) $swagger);
         $this->assertSwaggerEqualsFile(__DIR__ . '/ExamplesOutput/' . $output, $swagger);
@@ -25,7 +27,8 @@ class ExamplesTest extends SwaggerTestCase {
      * dataProvider for testExample
      * @return array
      */
-    public function getExamples() {
+    public function getExamples()
+    {
         return [
             ['petstore.swagger.io', 'petstore.swagger.io.json'],
             ['swagger-spec/petstore', 'petstore.json'],
@@ -33,5 +36,4 @@ class ExamplesTest extends SwaggerTestCase {
             ['swagger-spec/petstore-with-external-docs', 'petstore-with-external-docs.json'],
         ];
     }
-
 }

--- a/tests/Fixtures/Child.php
+++ b/tests/Fixtures/Child.php
@@ -1,15 +1,16 @@
 <?php
 
 namespace AnotherNamespace;
+
 /**
  * @SWG\Definition()
  */
-class Child extends \SwaggerFixtures\Parent {
+class Child extends \SwaggerFixtures\Parent
+{
 
     /**
      * @var bool
      * @SWG\Property()
      */
     public $isBaby;
-
 }

--- a/tests/Fixtures/Customer.php
+++ b/tests/Fixtures/Customer.php
@@ -10,7 +10,8 @@ use Swagger\Annotations as SWG;
  * @SWG\Info(title="Fixture for ClassPropertiesTest", version="test")
  * @SWG\Definition()
  */
-class Customer {
+class Customer
+{
     
     /**
      * The firstname of the customer.
@@ -46,7 +47,8 @@ class Customer {
     /**
      * for ContextTest
      */
-    function testResolvingFullyQualifiedNames() {
+    public function testResolvingFullyQualifiedNames()
+    {
         $test = new SwgParser();
         $test2 = new Parser();
         $test3 = new SWG\Contact();

--- a/tests/Fixtures/GrandParent.php
+++ b/tests/Fixtures/GrandParent.php
@@ -1,11 +1,12 @@
 <?php
 namespace SwaggerFixtures;
-class GrandParent {
 
-	/**
-	 * @SWG\Property(property="lastname");
-	 * @var string
-	 */
-	public $lastname;
+class GrandParent
+{
 
+    /**
+     * @SWG\Property(property="lastname");
+     * @var string
+     */
+    public $lastname;
 }

--- a/tests/Fixtures/ThirdPartyAnnotations.php
+++ b/tests/Fixtures/ThirdPartyAnnotations.php
@@ -1,5 +1,6 @@
 <?php
 namespace SwaggerFixtures;
+
 /**
  * @SWG\Info(title="Fixture for ParserTest", version="test")
  * Based on the examplefrom http://framework.zend.com/manual/current/en/modules/zend.form.quick-start.html
@@ -35,7 +36,7 @@ class ThirdPartyAnnotations
     /**
      * @SWG\Get(path="api/3rd-party", @SWG\Response(response="200", description="a response"))
      */
-    function methodWithSwaggerAnnotation() {
-        
+    public function methodWithSwaggerAnnotation()
+    {
     }
 }

--- a/tests/Fixtures/UsingRefs.php
+++ b/tests/Fixtures/UsingRefs.php
@@ -2,7 +2,8 @@
 /**
  * @SWG\Info(title="Using a parameter definition", version="unittest")
  */
-class UsingRefs {
+class UsingRefs
+{
 
     /**
      * @SWG\Get(
@@ -12,18 +13,17 @@ class UsingRefs {
      *   @SWG\Response(response="default", ref="#/responses/Item")
      * )
      */
-    function getProtectedItem() {
-        
+    public function getProtectedItem()
+    {
     }
-
 }
 
 /**
  * @SWG\Parameter(
  *   name="ItemName",
- *   in="path", 
+ *   in="path",
  *   type="string",
- *   required=true, 
+ *   required=true,
  *   description="protected item name",
  *   maxLength=256
  * )

--- a/tests/InheritPropertiesTest.php
+++ b/tests/InheritPropertiesTest.php
@@ -9,9 +9,11 @@ namespace SwaggerTests;
 use Swagger\Processors\InheritProperties;
 use Swagger\Processors\ClassProperties;
 
-class InheritPropertiesTest extends SwaggerTestCase {
+class InheritPropertiesTest extends SwaggerTestCase
+{
 
-    function testGetChildren() {
+    public function testGetChildren()
+    {
         $processor = new InheritProperties();
         $swagger = $this->createSwaggerWithInfo();
         $swagger->crawl([
@@ -26,7 +28,8 @@ class InheritPropertiesTest extends SwaggerTestCase {
         $this->assertSame($children['\\SwaggerFixtures\\GrandParent'], ['\\SwaggerFixtures\\Parent', '\\AnotherNamespace\\Child']);
     }
 
-    function testInheritWithoutClassProperties() {
+    public function testInheritWithoutClassProperties()
+    {
         $swagger = $this->createSwaggerWithInfo();
         $swagger->crawl([
             __DIR__ . '/Fixtures/Child.php',
@@ -45,7 +48,8 @@ class InheritPropertiesTest extends SwaggerTestCase {
         $this->assertCount(1, $childDefinition->properties); // Inherited 1 property, but couldn't inherit the property from Parent because it didn't have a name, also missing its own isBaby property.
     }
 
-    function detestInheritProcessor() {
+    public function detestInheritProcessor()
+    {
         $swagger = $this->createSwaggerWithInfo();
         $swagger->crawl([
             __DIR__ . '/Fixtures/GrandParent.php',
@@ -67,5 +71,4 @@ class InheritPropertiesTest extends SwaggerTestCase {
         $this->assertCount(2, $parentDefinition->properties);
         $swagger->validate();
     }
-
 }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -9,9 +9,11 @@ namespace SwaggerTests;
 use Swagger\Context;
 use Swagger\Parser;
 
-class ParserTest extends SwaggerTestCase {
+class ParserTest extends SwaggerTestCase
+{
 
-    function testParseContents() {
+    public function testParseContents()
+    {
         $annotations = $this->parseComment('@SWG\Parameter(description="This is my parameter")');
         $this->assertInternalType('array', $annotations);
         $parameter = $annotations[0];
@@ -19,13 +21,15 @@ class ParserTest extends SwaggerTestCase {
         $this->assertSame('This is my parameter', $parameter->description);
     }
 
-    function testWrongCommentType() {
+    public function testWrongCommentType()
+    {
         $parser = new Parser();
         $this->assertSwaggerLogEntryStartsWith('Annotations are only parsed inside `/**` DocBlocks');
         $parser->parseContents("<?php\n/*\n * @SWG\Parameter() */", Context::detect());
     }
 
-    function testThirdPartyAnnotations() {
+    public function testThirdPartyAnnotations()
+    {
         Parser::$whitelist = ['Swagger\\Annotations\\'];
         $parser = new Parser();
         $annotations = $parser->parseFile(__DIR__ . '/Fixtures/ThirdPartyAnnotations.php');
@@ -38,15 +42,16 @@ class ParserTest extends SwaggerTestCase {
         $this->assertCount(10, $swagger->_unmerged);
     }
 
-    function testIndentationCorrection() {
+    public function testIndentationCorrection()
+    {
         $parser = new Parser();
         $annotations = $parser->parseFile(__DIR__ . '/Fixtures/routes.php');
         $this->assertCount(2, $annotations);
     }
 
-    function testDeprecatedAnnotationWarning() {
+    public function testDeprecatedAnnotationWarning()
+    {
         $this->assertSwaggerLogEntryStartsWith('The annotation @SWG\\Resource() is deprecated.');
         $annotations = $this->parseComment('@SWG\Resource()');
     }
-
 }

--- a/tests/ProcessingTest.php
+++ b/tests/ProcessingTest.php
@@ -9,9 +9,11 @@ namespace SwaggerTests;
 use Swagger\Annotations\Swagger;
 use Swagger\Processing;
 
-class ProcessingTest extends SwaggerTestCase {
+class ProcessingTest extends SwaggerTestCase
+{
 
-    function testRegister() {
+    public function testRegister()
+    {
         $counter = 0;
         $swagger = $this->createSwaggerWithInfo();
         Processing::process($swagger);
@@ -26,5 +28,4 @@ class ProcessingTest extends SwaggerTestCase {
         Processing::process($swagger);
         $this->assertSame(1, $counter);
     }
-
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -6,13 +6,13 @@
 
 namespace SwaggerTests;
 
+class ResponseTest extends SwaggerTestCase
+{
 
-class ResponseTest extends SwaggerTestCase {
-
-    function testMisspelledDefault() {
+    public function testMisspelledDefault()
+    {
         $annotations = $this->parseComment('@SWG\Get(@SWG\Response(response="Default", description="description"))');
         $this->assertSwaggerLogEntryStartsWith('Invalid value "Default" for @SWG\Response()->response, expecting "default" or a HTTP Status Code in ');
         $annotations[0]->validate();
     }
-
 }

--- a/tests/SwaggerTestCase.php
+++ b/tests/SwaggerTestCase.php
@@ -16,7 +16,8 @@ use Swagger\Context;
 use Swagger\Logger;
 use Swagger\Parser;
 
-class SwaggerTestCase extends PHPUnit_Framework_TestCase {
+class SwaggerTestCase extends PHPUnit_Framework_TestCase
+{
 
     /**
      * @var array
@@ -34,7 +35,8 @@ class SwaggerTestCase extends PHPUnit_Framework_TestCase {
      * @param Swagger $actualSwagger
      * @param string $message
      */
-    public function assertSwaggerEqualsFile($expectedFile, $actualSwagger, $message = '') {
+    public function assertSwaggerEqualsFile($expectedFile, $actualSwagger, $message = '')
+    {
         $expected = json_decode(file_get_contents($expectedFile));
         $error = json_last_error();
         if ($error !== JSON_ERROR_NONE) {
@@ -50,26 +52,30 @@ class SwaggerTestCase extends PHPUnit_Framework_TestCase {
         $this->assertEquals($expectedJson, $actualJson, $message);
     }
 
-    public function assertSwaggerLog($expectedEntry, $expectedType, $message = '') {
+    public function assertSwaggerLog($expectedEntry, $expectedType, $message = '')
+    {
         $this->expectedLogMessages[] = function ($actualEntry, $actualType) use ($expectedEntry, $expectedType, $message) {
             $this->assertSame($expectedEntry, $actualEntry, $message);
             $this->assertSame($expectedType, $actualType, $message);
         };
     }
 
-    public function assertSwaggerLogType($expectedType, $message = '') {
+    public function assertSwaggerLogType($expectedType, $message = '')
+    {
         $this->expectedLogMessages[] = function ($entry, $actualType) use ($expectedType, $message) {
             $this->assertSame($expectedType, $actualType, $message);
         };
     }
 
-    public function assertSwaggerLogEntry($expectedEntry, $message = '') {
+    public function assertSwaggerLogEntry($expectedEntry, $message = '')
+    {
         $this->expectedLogMessages[] = function ($actualEntry, $type) use ($expectedEntry, $message) {
             $this->assertSame($expectedEntry, $actualEntry, $message);
         };
     }
 
-    public function assertSwaggerLogEntryStartsWith($entryPrefix, $message = '') {
+    public function assertSwaggerLogEntryStartsWith($entryPrefix, $message = '')
+    {
         $this->expectedLogMessages[] = function ($entry, $type) use ($entryPrefix, $message) {
             if ($entry instanceof Exception) {
                 $entry = $entry->getMessage();
@@ -78,7 +84,8 @@ class SwaggerTestCase extends PHPUnit_Framework_TestCase {
         };
     }
 
-    protected function setUp() {
+    protected function setUp()
+    {
         $this->expectedLogMessages = [];
         $this->originalLogger = Logger::getInstance()->log;
         Logger::getInstance()->log = function ($entry, $type) {
@@ -100,7 +107,8 @@ class SwaggerTestCase extends PHPUnit_Framework_TestCase {
         parent::setUp();
     }
 
-    protected function tearDown() {
+    protected function tearDown()
+    {
         $this->assertCount(0, $this->expectedLogMessages, count($this->expectedLogMessages) . ' Swagger\Logger messages were not triggered');
         Logger::getInstance()->log = $this->originalLogger;
         parent::tearDown();
@@ -111,7 +119,8 @@ class SwaggerTestCase extends PHPUnit_Framework_TestCase {
      * @param string $comment Contents of a comment block
      * @return AbstractAnnotation[]
      */
-    protected function parseComment($comment) {
+    protected function parseComment($comment)
+    {
         $parser = new Parser();
         $context = Context::detect(1);
         $context->line -= 2; // correct generated lines: "<?php\n" and "/**\n"
@@ -122,7 +131,8 @@ class SwaggerTestCase extends PHPUnit_Framework_TestCase {
      * Create a Swagger object with Info.
      * (So it will pass validation.)
      */
-    protected function createSwaggerWithInfo() {
+    protected function createSwaggerWithInfo()
+    {
         $swagger = new Swagger([
             'info' => new \Swagger\Annotations\Info([
                 'title' => 'Swagger-PHP Test-API',
@@ -141,7 +151,8 @@ class SwaggerTestCase extends PHPUnit_Framework_TestCase {
      * @param string   $origin
      * @return stdClass The sorted object
      */
-    protected function sorted(stdClass $object, $origin = 'unknown') {
+    protected function sorted(stdClass $object, $origin = 'unknown')
+    {
         static $sortMap = null;
         if ($sortMap === null) {
             $sortMap = [
@@ -196,5 +207,4 @@ class SwaggerTestCase extends PHPUnit_Framework_TestCase {
         }
         return (object) $data;
     }
-
 }

--- a/tests/ValidateRelationsTest.php
+++ b/tests/ValidateRelationsTest.php
@@ -9,14 +9,16 @@ namespace SwaggerTests;
 /**
  * Test if the nesting/parent relations are coherent.
  */
-class ValidateRelationsTest extends SwaggerTestCase {
+class ValidateRelationsTest extends SwaggerTestCase
+{
 
     /**
      *
      * @dataProvider getAnnotations
      * @param string $class
      */
-    public function testParents($class) {
+    public function testParents($class)
+    {
         foreach ($class::$_parents as $parent) {
             $found = false;
             foreach (array_keys($parent::$_nested) as $nested) {
@@ -36,7 +38,8 @@ class ValidateRelationsTest extends SwaggerTestCase {
      * @dataProvider getAnnotations
      * @param string $class
      */
-    public function testNested($class) {
+    public function testNested($class)
+    {
         foreach (array_keys($class::$_nested) as $nested) {
             $found = false;
             foreach ($nested::$_parents as $parent) {
@@ -55,7 +58,8 @@ class ValidateRelationsTest extends SwaggerTestCase {
      * dataProvider for testExample
      * @return array
      */
-    public function getAnnotations() {
+    public function getAnnotations()
+    {
         $classes = [];
         $dir = new \DirectoryIterator(__DIR__ . '/../src/Annotations');
         foreach ($dir as $entry) {
@@ -68,5 +72,4 @@ class ValidateRelationsTest extends SwaggerTestCase {
         }
         return $classes;
     }
-
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,3 +1,0 @@
-<?php
-require_once(__DIR__.'/../vendor/autoload.php');
-require_once(__DIR__.'/SwaggerTestCase.php');


### PR DESCRIPTION
PSR-2 compliance is discussed in #175. I thought I'd run [PHP CS Fixer](https://github.com/fabpot/PHP-CS-Fixer)  (`php-cs-fixer fix --level=psr2`) and this is the result. Of course this won't change everything to match PSR-2, but it could be a start.

In addition, tests now use PSR-4 autoloading directly as well.