### PR TITLE
[WIP] Implement reader using reflection

### DIFF
--- a/Examples/petstore.swagger.io/ApiResponse.php
+++ b/Examples/petstore.swagger.io/ApiResponse.php
@@ -2,6 +2,8 @@
 
 namespace PetstoreIO;
 
+use Swagger\Annotations as SWG;
+
 /**
  * @SWG\Definition(
  *   @SWG\Xml(name="##default")

--- a/Examples/petstore.swagger.io/Controllers/PetController.php
+++ b/Examples/petstore.swagger.io/Controllers/PetController.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace PetstoreIO;
+namespace PetstoreIO\Controllers;
+
+use Swagger\Annotations as SWG;
 
 class PetController
 {

--- a/Examples/petstore.swagger.io/Controllers/StoreController.php
+++ b/Examples/petstore.swagger.io/Controllers/StoreController.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace PetstoreIO;
+namespace PetstoreIO\Controllers;
+
+use Swagger\Annotations as SWG;
 
 class StoreController
 {

--- a/Examples/petstore.swagger.io/Controllers/UserController.php
+++ b/Examples/petstore.swagger.io/Controllers/UserController.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace PetstoreIO;
+namespace PetstoreIO\Controllers;
+
+use Swagger\Annotations as SWG;
 
 class UserController
 {
@@ -70,6 +72,9 @@ class UserController
      *   @SWG\Response(response="default", description="successful operation")
      * )
      */
+    function createUsersWithListInput() {
+
+    }
 
     /**
      * @SWG\Get(path="/user/login",

--- a/Examples/petstore.swagger.io/Models/Category.php
+++ b/Examples/petstore.swagger.io/Models/Category.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace PetstoreIO;
+namespace PetstoreIO\Models;
+
+use Swagger\Annotations as SWG;
 
 /**
  * @SWG\Definition(

--- a/Examples/petstore.swagger.io/Models/Order.php
+++ b/Examples/petstore.swagger.io/Models/Order.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace PetstoreIO;
+namespace PetstoreIO\Models;
+
+use Swagger\Annotations as SWG;
 
 /**
  * @SWG\Definition(@SWG\Xml(name="Order"))

--- a/Examples/petstore.swagger.io/Models/Pet.php
+++ b/Examples/petstore.swagger.io/Models/Pet.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace PetstoreIO;
+namespace PetstoreIO\Models;
+
+use Swagger\Annotations as SWG;
 
 /**
  * @SWG\Definition(required={"name", "photoUrls"}, @SWG\Xml(name="Pet"))

--- a/Examples/petstore.swagger.io/Models/Tag.php
+++ b/Examples/petstore.swagger.io/Models/Tag.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace PetstoreIO;
+namespace PetstoreIO\Models;
+
+use Swagger\Annotations as SWG;
 
 /**
  * @SWG\Definition(

--- a/Examples/petstore.swagger.io/Models/User.php
+++ b/Examples/petstore.swagger.io/Models/User.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace PetstoreIO;
+namespace PetstoreIO\Models;
+
+use Swagger\Annotations as SWG;
 
 /**
  * @SWG\Definition(@SWG\Xml(name="User"))

--- a/Examples/petstore.swagger.io/Security.php
+++ b/Examples/petstore.swagger.io/Security.php
@@ -1,4 +1,9 @@
 <?php
+
+namespace PetstoreIO;
+
+use Swagger\Annotations as SWG;
+
 /**
  * @SWG\SecurityScheme(
  *   securityDefinition="api_key",
@@ -6,9 +11,6 @@
  *   in="header",
  *   name="api_key"
  * )
- */
-
-/**
  * @SWG\SecurityScheme(
  *   securityDefinition="petstore_auth",
  *   type="oauth2",
@@ -20,3 +22,6 @@
  *   }
  * )
  */
+class Security
+{
+}

--- a/Examples/petstore.swagger.io/SwaggerV2.php
+++ b/Examples/petstore.swagger.io/SwaggerV2.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace PetstoreIO;
+
+use Swagger\Annotations as SWG;
+
 /**
  * @SWG\Swagger(
  *     schemes={"http"},
@@ -24,3 +28,6 @@
  *     )
  * )
  */
+class SwaggerV2
+{
+}

--- a/Examples/petstore.swagger.io/Tags.php
+++ b/Examples/petstore.swagger.io/Tags.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace PetstoreIO;
+
+use Swagger\Annotations as SWG;
+
 /**
  * @SWG\Tag(
  *   name="pet",
@@ -22,3 +26,6 @@
  *   )
  * )
  */
+class Tags
+{
+}

--- a/Examples/swagger-spec/Petstore/Api.php
+++ b/Examples/swagger-spec/Petstore/Api.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace Petstore;
+
+use Swagger\Annotations as SWG;
+
 /**
  * @SWG\Swagger(
  *     basePath="/api",
@@ -26,3 +30,6 @@
  *     )
  * )
  */
+class Api
+{
+}

--- a/Examples/swagger-spec/Petstore/Pet.php
+++ b/Examples/swagger-spec/Petstore/Pet.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace petstore;
+namespace Petstore;
+
+use Swagger\Annotations as SWG;
 
 /**
  * @SWG\Definition(required={"id", "name"})

--- a/Examples/swagger-spec/Petstore/PetsController.php
+++ b/Examples/swagger-spec/Petstore/PetsController.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace petstore;
+namespace Petstore;
+
+use Swagger\Annotations as SWG;
 
 class PetsController
 {

--- a/Examples/swagger-spec/PetstoreSimple/Api.php
+++ b/Examples/swagger-spec/PetstoreSimple/Api.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace PetstoreSimple;
+
+use Swagger\Annotations as SWG;
+
 /**
  * @SWG\Swagger(
  *     basePath="/api",
@@ -30,3 +34,6 @@
  *     )
  * )
  */
+class Api
+{
+}

--- a/Examples/swagger-spec/PetstoreSimple/SimplePet.php
+++ b/Examples/swagger-spec/PetstoreSimple/SimplePet.php
@@ -1,6 +1,8 @@
 <?php
 
-namespace Petstore;
+namespace PetstoreSimple;
+
+use Swagger\Annotations as SWG;
 
 /**
  * @SWG\Definition(definition="pet", required={"id", "name"})

--- a/Examples/swagger-spec/PetstoreSimple/SimplePetsController.php
+++ b/Examples/swagger-spec/PetstoreSimple/SimplePetsController.php
@@ -1,81 +1,11 @@
 <?php
 
-/**
- *
- */
-class PetWithDocsController
+namespace PetstoreSimple;
+
+use Swagger\Annotations as SWG;
+
+class SimplePetsController
 {
-
-    /**
-     * @SWG\Definition(
-     *   definition="NewPet",
-     *   allOf={
-     *     @SWG\Schema(ref="#/definitions/Pet"),
-     *     @SWG\Schema(required={"name"}, @SWG\Property(property="id", format="int64", type="integer"))
-     *   },
-     * )
-     * * @SWG\Post(
-     *     path="/pets",
-     *     operationId="addPet",
-     *     description="Creates a new pet in the store.  Duplicates are allowed",
-     *     produces={"application/json"},
-     *     @SWG\Parameter(
-     *         name="pet",
-     *         in="body",
-     *         description="Pet to add to the store",
-     *         required=true,
-     *         @SWG\Schema(ref="#/definitions/NewPet"),
-     *     ),
-     *     @SWG\Response(
-     *         response=200,
-     *         description="pet response",
-     *         @SWG\Schema(ref="#/definitions/Pet")
-     *     ),
-     *     @SWG\Response(
-     *         response="default",
-     *         description="unexpected error",
-     *         @SWG\Schema(ref="#/definitions/ErrorModel")
-     *     )
-     * )
-     */
-    public function addPet()
-    {
-    }
-
-    /**
-     * @SWG\Get(
-     *     path="/pets/{id}",
-     *     description="Returns a user based on a single ID, if the user does not have access to the pet",
-     *     operationId="findPetById",
-     *     @SWG\Parameter(
-     *         description="ID of pet to fetch",
-     *         format="int64",
-     *         in="path",
-     *         name="id",
-     *         required=true,
-     *         type="integer"
-     *     ),
-     *     produces={
-     *         "application/json",
-     *         "application/xml",
-     *         "text/html",
-     *         "text/xml"
-     *     },
-     *     @SWG\Response(
-     *         response=200,
-     *         description="pet response",
-     *         @SWG\Schema(ref="#/definitions/Pet")
-     *     ),
-     *     @SWG\Response(
-     *         response="default",
-     *         description="unexpected error",
-     *         @SWG\Schema(ref="#/definitions/ErrorModel")
-     *     )
-     * )
-     */
-    public function findPetById()
-    {
-    }
 
     /**
      * @SWG\Get(
@@ -105,23 +35,97 @@ class PetWithDocsController
      *         description="pet response",
      *         @SWG\Schema(
      *             type="array",
-     *             @SWG\Items(ref="#/definitions/Pet")
+     *             @SWG\Items(ref="#/definitions/pet")
      *         ),
      *     ),
      *     @SWG\Response(
      *         response="default",
      *         description="unexpected error",
      *         @SWG\Schema(
-     *             ref="#/definitions/ErrorModel"
+     *             ref="#/definitions/errorModel"
      *         )
-     *     ),
-     *     @SWG\ExternalDocumentation(
-     *         description="find more info here",
-     *         url="https://swagger.io/about"
      *     )
      * )
      */
     public function findPets()
+    {
+    }
+
+    /**
+     * @SWG\Get(
+     *     path="/pets/{id}",
+     *     description="Returns a user based on a single ID, if the user does not have access to the pet",
+     *     operationId="findPetById",
+     *     @SWG\Parameter(
+     *         description="ID of pet to fetch",
+     *         format="int64",
+     *         in="path",
+     *         name="id",
+     *         required=true,
+     *         type="integer"
+     *     ),
+     *     produces={
+     *         "application/json",
+     *         "application/xml",
+     *         "text/html",
+     *         "text/xml"
+     *     },
+     *     @SWG\Response(
+     *         response=200,
+     *         description="pet response",
+     *         @SWG\Schema(ref="#/definitions/pet")
+     *     ),
+     *     @SWG\Response(
+     *         response="default",
+     *         description="unexpected error",
+     *         @SWG\Schema(ref="#/definitions/errorModel")
+     *     )
+     * )
+     */
+    public function findPetById()
+    {
+    }
+
+    /**
+     * @SWG\Post(
+     *     path="/pets",
+     *     operationId="addPet",
+     *     description="Creates a new pet in the store.  Duplicates are allowed",
+     *     produces={"application/json"},
+     *     @SWG\Parameter(
+     *         name="pet",
+     *         in="body",
+     *         description="Pet to add to the store",
+     *         required=true,
+     *         @SWG\Schema(ref="#/definitions/petInput"),
+     *     ),
+     *     @SWG\Response(
+     *         response=200,
+     *         description="pet response",
+     *         @SWG\Schema(ref="#/definitions/pet")
+     *     ),
+     *     @SWG\Response(
+     *         response="default",
+     *         description="unexpected error",
+     *         @SWG\Schema(ref="#/definitions/errorModel")
+     *     )
+     * )
+     * @SWG\Definition(
+     *     definition="petInput",
+     *     allOf={
+     *         @SWG\Schema(ref="pet"),
+     *         @SWG\Schema(
+     *             required={"name"},
+     *             @SWG\Property(
+     *                 property="id",
+     *                 type="integer",
+     *                 format="int64"
+     *             )
+     *         )
+     *     }
+     * )
+     */
+    public function addPet()
     {
     }
 
@@ -145,7 +149,7 @@ class PetWithDocsController
      *     @SWG\Response(
      *         response="default",
      *         description="unexpected error",
-     *         @SWG\Schema(ref="#/definitions/ErrorModel")
+     *         @SWG\Schema(ref="#/definitions/errorModel")
      *     )
      * )
      */

--- a/Examples/swagger-spec/PetstoreWithExternalDocs/Controllers/PetWithDocsController.php
+++ b/Examples/swagger-spec/PetstoreWithExternalDocs/Controllers/PetWithDocsController.php
@@ -1,9 +1,85 @@
 <?php
 
-namespace Petstore;
+namespace PetstoreWithExternalDocs\Controllers;
 
-class SimplePetsController
+use Swagger\Annotations as SWG;
+
+/**
+ *
+ */
+class PetWithDocsController
 {
+
+    /**
+     * @SWG\Definition(
+     *   definition="NewPet",
+     *   allOf={
+     *     @SWG\Schema(ref="#/definitions/Pet"),
+     *     @SWG\Schema(required={"name"}, @SWG\Property(property="id", format="int64", type="integer"))
+     *   },
+     * )
+     * @SWG\Post(
+     *     path="/pets",
+     *     operationId="addPet",
+     *     description="Creates a new pet in the store.  Duplicates are allowed",
+     *     produces={"application/json"},
+     *     @SWG\Parameter(
+     *         name="pet",
+     *         in="body",
+     *         description="Pet to add to the store",
+     *         required=true,
+     *         @SWG\Schema(ref="#/definitions/NewPet"),
+     *     ),
+     *     @SWG\Response(
+     *         response=200,
+     *         description="pet response",
+     *         @SWG\Schema(ref="#/definitions/Pet")
+     *     ),
+     *     @SWG\Response(
+     *         response="default",
+     *         description="unexpected error",
+     *         @SWG\Schema(ref="#/definitions/ErrorModel")
+     *     )
+     * )
+     */
+    public function addPet()
+    {
+    }
+
+    /**
+     * @SWG\Get(
+     *     path="/pets/{id}",
+     *     description="Returns a user based on a single ID, if the user does not have access to the pet",
+     *     operationId="findPetById",
+     *     @SWG\Parameter(
+     *         description="ID of pet to fetch",
+     *         format="int64",
+     *         in="path",
+     *         name="id",
+     *         required=true,
+     *         type="integer"
+     *     ),
+     *     produces={
+     *         "application/json",
+     *         "application/xml",
+     *         "text/html",
+     *         "text/xml"
+     *     },
+     *     @SWG\Response(
+     *         response=200,
+     *         description="pet response",
+     *         @SWG\Schema(ref="#/definitions/Pet")
+     *     ),
+     *     @SWG\Response(
+     *         response="default",
+     *         description="unexpected error",
+     *         @SWG\Schema(ref="#/definitions/ErrorModel")
+     *     )
+     * )
+     */
+    public function findPetById()
+    {
+    }
 
     /**
      * @SWG\Get(
@@ -33,97 +109,23 @@ class SimplePetsController
      *         description="pet response",
      *         @SWG\Schema(
      *             type="array",
-     *             @SWG\Items(ref="#/definitions/pet")
+     *             @SWG\Items(ref="#/definitions/Pet")
      *         ),
      *     ),
      *     @SWG\Response(
      *         response="default",
      *         description="unexpected error",
      *         @SWG\Schema(
-     *             ref="#/definitions/errorModel"
+     *             ref="#/definitions/ErrorModel"
      *         )
+     *     ),
+     *     @SWG\ExternalDocumentation(
+     *         description="find more info here",
+     *         url="https://swagger.io/about"
      *     )
      * )
      */
     public function findPets()
-    {
-    }
-
-    /**
-     * @SWG\Get(
-     *     path="/pets/{id}",
-     *     description="Returns a user based on a single ID, if the user does not have access to the pet",
-     *     operationId="findPetById",
-     *     @SWG\Parameter(
-     *         description="ID of pet to fetch",
-     *         format="int64",
-     *         in="path",
-     *         name="id",
-     *         required=true,
-     *         type="integer"
-     *     ),
-     *     produces={
-     *         "application/json",
-     *         "application/xml",
-     *         "text/html",
-     *         "text/xml"
-     *     },
-     *     @SWG\Response(
-     *         response=200,
-     *         description="pet response",
-     *         @SWG\Schema(ref="#/definitions/pet")
-     *     ),
-     *     @SWG\Response(
-     *         response="default",
-     *         description="unexpected error",
-     *         @SWG\Schema(ref="#/definitions/errorModel")
-     *     )
-     * )
-     */
-    public function findPetById()
-    {
-    }
-
-    /**
-     * @SWG\Post(
-     *     path="/pets",
-     *     operationId="addPet",
-     *     description="Creates a new pet in the store.  Duplicates are allowed",
-     *     produces={"application/json"},
-     *     @SWG\Parameter(
-     *         name="pet",
-     *         in="body",
-     *         description="Pet to add to the store",
-     *         required=true,
-     *         @SWG\Schema(ref="#/definitions/petInput"),
-     *     ),
-     *     @SWG\Response(
-     *         response=200,
-     *         description="pet response",
-     *         @SWG\Schema(ref="#/definitions/pet")
-     *     ),
-     *     @SWG\Response(
-     *         response="default",
-     *         description="unexpected error",
-     *         @SWG\Schema(ref="#/definitions/errorModel")
-     *     )
-     * )
-     * @SWG\Definition(
-     *     definition="petInput",
-     *     allOf={
-     *         @SWG\Schema(ref="pet"),
-     *         @SWG\Schema(
-     *             required={"name"},
-     *             @SWG\Property(
-     *                 property="id",
-     *                 type="integer",
-     *                 format="int64"
-     *             )
-     *         )
-     *     }
-     * )
-     */
-    public function addPet()
     {
     }
 
@@ -147,7 +149,7 @@ class SimplePetsController
      *     @SWG\Response(
      *         response="default",
      *         description="unexpected error",
-     *         @SWG\Schema(ref="#/definitions/errorModel")
+     *         @SWG\Schema(ref="#/definitions/ErrorModel")
      *     )
      * )
      */

--- a/Examples/swagger-spec/PetstoreWithExternalDocs/Docs.php
+++ b/Examples/swagger-spec/PetstoreWithExternalDocs/Docs.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace PetstoreWithExternalDocs;
+
+use Swagger\Annotations as SWG;
+
 /**
  * @SWG\Info(
  *   title="Swagger Petstore",
@@ -28,3 +32,6 @@
  *   )
  * )
  */
+class Docs
+{
+}

--- a/Examples/swagger-spec/PetstoreWithExternalDocs/Models/ErrorModel.php
+++ b/Examples/swagger-spec/PetstoreWithExternalDocs/Models/ErrorModel.php
@@ -1,4 +1,10 @@
 <?php
+
+namespace PetstoreWithExternalDocs\Models;
+
+use Exception;
+use Swagger\Annotations as SWG;
+
 /**
  * @SWG\Definition(required={"code", "message"});
  */

--- a/Examples/swagger-spec/PetstoreWithExternalDocs/Models/Pet.php
+++ b/Examples/swagger-spec/PetstoreWithExternalDocs/Models/Pet.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace PetstoreWithExternalDocs\Models;
+
+use Swagger\Annotations as SWG;
+
 /**
  * @SWG\Definition(
  *   required={"id","name"},

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,9 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "SwaggerTests\\": "tests/"
+            "SwaggerTests\\": "tests/",
+            "": "Examples/swagger-spec",
+            "PetstoreIO\\": "Examples/petstore.swagger.io"
         }
     }
 }

--- a/src/AnalyserInterface.php
+++ b/src/AnalyserInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace Swagger;
+
+use Swagger\Annotations\AbstractAnnotation;
+
+interface AnalyserInterface
+{
+    /**
+     * Extract and process all annotations from a file.
+     *
+     * @param string $filename Path to a php file.
+     *
+     * @return AbstractAnnotation[]
+     */
+    public function fromFile($filename);
+}

--- a/src/ClassAnnotations.php
+++ b/src/ClassAnnotations.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace Swagger;
+
+/**
+ * Data container for all annotations found from a single class.
+ */
+class ClassAnnotations
+{
+    /** @var ReflectedAnnotations */
+    public $classAnnotations;
+    /** @var ReflectedAnnotations[] */
+    public $methodAnnotations;
+    /** @var ReflectedAnnotations[] */
+    public $propertyAnnotations;
+
+    public function __construct($classAnnotations, $methodAnnotations, $propertyAnnotations)
+    {
+        $this->classAnnotations    = $classAnnotations;
+        $this->methodAnnotations   = $methodAnnotations;
+        $this->propertyAnnotations = $propertyAnnotations;
+    }
+
+    public function getAnnotations()
+    {
+        $classAnnotations = $this->classAnnotations->getSwaggerAnnotations();
+        $subAnnotations   = $this->getSubAnnotations();
+
+        if (count($classAnnotations) > 0) {
+            // Method and property annotations get merged with the first class annotation.
+            $rootAnnotation = reset($classAnnotations);
+            $rootAnnotation->merge($subAnnotations);
+
+            return $classAnnotations;
+        } else {
+            return $subAnnotations;
+        }
+    }
+
+    private function getSubAnnotations()
+    {
+        $getAnnotations = function (ReflectedAnnotations $container) { return $container->getSwaggerAnnotations(); };
+
+        return array_reduce(
+            array_merge(
+                array_map($getAnnotations, $this->methodAnnotations),
+                array_map($getAnnotations, $this->propertyAnnotations)
+            ),
+            'array_merge',
+            []
+        );
+    }
+}

--- a/src/Processors/DefinitionName.php
+++ b/src/Processors/DefinitionName.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace Swagger\Processors;
+
+use Swagger\Annotations\AbstractAnnotation;
+use Swagger\Annotations\Definition;
+use Swagger\ClassAnnotations;
+
+/**
+ * Sets the definition name from the annotated class name.
+ */
+class DefinitionName
+{
+    public function __invoke(ClassAnnotations $annotations)
+    {
+        if (! $annotations->classAnnotations) {
+            return;
+        }
+
+        foreach ($annotations->classAnnotations->getSwaggerAnnotations() as $annotation) {
+            $this->processAnnotation($annotations->classAnnotations->target, $annotation);
+        }
+    }
+
+    private function processAnnotation(\ReflectionClass $class, AbstractAnnotation $annotation)
+    {
+        if ($annotation instanceof Definition && ! $annotation->definition) {
+            $annotation->definition = $class->getShortName();
+        }
+    }
+}

--- a/src/Processors/MergeSwagger.php
+++ b/src/Processors/MergeSwagger.php
@@ -23,6 +23,7 @@ class MergeSwagger
                 $definitions = $annotation->definitions;
                 unset($annotation->paths);
                 unset($annotation->definitions);
+                $unmerged = array_merge($unmerged, $annotation->_unmerged);
                 $swagger->mergeProperties($annotation);
                 unset($unmerged[$i]);
                 foreach ($paths as $path) {

--- a/src/Processors/PropertyDescriptionComment.php
+++ b/src/Processors/PropertyDescriptionComment.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace Swagger\Processors;
+
+use Swagger\Annotations\Property;
+use Swagger\ClassAnnotations;
+use Swagger\Utils\DocComment;
+
+/**
+ * Sets the property description from the comment summary.
+ */
+class PropertyDescriptionComment
+{
+    public function __invoke(ClassAnnotations $annotations)
+    {
+        foreach ($annotations->propertyAnnotations as $property) {
+            foreach ($property->getSwaggerAnnotations() as $annotation) {
+                $this->processAnnotation($property->target, $annotation);
+            }
+        }
+    }
+
+    private function processAnnotation(\ReflectionProperty $property, Property $annotation)
+    {
+        if (! $annotation->description) {
+            $annotation->description = (new DocComment($property->getDocComment()))->getSummary();
+        }
+    }
+}

--- a/src/Processors/PropertyName.php
+++ b/src/Processors/PropertyName.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace Swagger\Processors;
+
+use Swagger\Annotations\Property;
+use Swagger\ClassAnnotations;
+
+/**
+ * Sets the property name from the name of the annotated property.
+ */
+class PropertyName
+{
+    public function __invoke(ClassAnnotations $annotations)
+    {
+        foreach ($annotations->propertyAnnotations as $property) {
+            foreach ($property->getSwaggerAnnotations() as $annotation) {
+                $this->processAnnotation($property->target, $annotation);
+            }
+        }
+    }
+
+    private function processAnnotation(\ReflectionProperty $property, Property $annotation)
+    {
+        if (! $annotation->property) {
+            $annotation->property = $property->name;
+        }
+    }
+}

--- a/src/Processors/PropertyTypeComment.php
+++ b/src/Processors/PropertyTypeComment.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace Swagger\Processors;
+
+use Swagger\Annotations\Items;
+use Swagger\Annotations\Property;
+use Swagger\ClassAnnotations;
+use Swagger\Utils\DocComment;
+
+/**
+ * Sets the property type from the comment var tag.
+ *
+ * Supports scalar types and basic non-scalar use cases.
+ */
+class PropertyTypeComment
+{
+    public function __invoke(ClassAnnotations $annotations)
+    {
+        foreach ($annotations->propertyAnnotations as $property) {
+            foreach ($property->getSwaggerAnnotations() as $annotation) {
+                $this->processAnnotation($property->target, $annotation);
+            }
+        }
+    }
+
+    private function processAnnotation(\ReflectionProperty $property, Property $annotation)
+    {
+        if ($annotation->type) {
+            return;
+        }
+        $varType = (new DocComment($property->getDocComment()))->getTag('var');
+        if ($varType === null) {
+            return;
+        }
+
+        $isArray   = substr($varType, -2) === '[]';
+        $innerType = $isArray ? substr($varType, 0, -2) : $varType;
+
+        $swaggerType = isset(ClassProperties::$types[strtolower($innerType)])
+            ? ClassProperties::$types[strtolower($innerType)]
+            : null;
+
+        if ($isArray) {
+            $annotation->type  = 'array';
+            $annotation->items = $annotation->items ?: new Items([]);
+        }
+
+        $this->setScalarType($innerType, $swaggerType, $isArray ? $annotation->items : $annotation);
+    }
+
+    private function setScalarType($innerType, $swaggerType, $target)
+    {
+        if ($swaggerType && is_array($swaggerType)) {
+            list($target->type, $target->format) = $swaggerType;
+        } elseif ($swaggerType) {
+            $target->type = $swaggerType;
+        } else {
+            $target->ref = '#/definitions/' . $innerType;
+        }
+    }
+}

--- a/src/ReflectedAnnotations.php
+++ b/src/ReflectedAnnotations.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace Swagger;
+
+use Swagger\Annotations\AbstractAnnotation;
+
+/**
+ * Data container for a single reflection target and related annotations.
+ */
+class ReflectedAnnotations
+{
+    /** @var \ReflectionClass|\ReflectionMethod|\ReflectionProperty */
+    public $target;
+    /** @var AbstractAnnotation[]|object[] */
+    public $annotations = [];
+
+    public function __construct($target, array $annotations)
+    {
+        $this->target      = $target;
+        $this->annotations = $annotations;
+    }
+
+    /**
+     * @return AbstractAnnotation[]
+     */
+    public function getSwaggerAnnotations()
+    {
+        $isSwaggerAnnotation = function ($annotation) { return $annotation instanceof AbstractAnnotation; };
+
+        return array_filter($this->annotations, $isSwaggerAnnotation);
+    }
+}

--- a/src/ReflectingAnalyser.php
+++ b/src/ReflectingAnalyser.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace Swagger;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\Common\Annotations\TokenParser;
+use Swagger\Annotations\AbstractAnnotation;
+
+/**
+ * ReflectingAnalyser extracts swagger-php annotations using reflection.
+ */
+class ReflectingAnalyser implements AnalyserInterface
+{
+    /** @var AnnotationReader */
+    private $annotationReader;
+
+    public function __construct(AnnotationReader $annotationReader)
+    {
+        $this->annotationReader = new AnnotationReader();
+    }
+
+    /**
+     * Create a new reader using the default annotation reader.
+     *
+     * @return static
+     */
+    public static function createDefault()
+    {
+        return new static(new AnnotationReader());
+    }
+
+    /**
+     * Extract and process all annotations from a file.
+     *
+     * @param string $filename Path to a php file.
+     *
+     * @return AbstractAnnotation[]
+     */
+    public function fromFile($filename)
+    {
+        $class = $this->getClassName($filename);
+        if ($class === null) {
+            return [];
+        }
+
+        $annotations = $this->parseClass(new \ReflectionClass($class));
+
+        return $annotations;
+    }
+
+    private function parseClass(\ReflectionClass $class)
+    {
+        $createMethod   = function (\ReflectionMethod $method) {
+            return new ReflectedAnnotations($method, $this->annotationReader->getMethodAnnotations($method));
+        };
+        $createProperty = function (\ReflectionProperty $property) {
+            return new ReflectedAnnotations($property, $this->annotationReader->getPropertyAnnotations($property));
+        };
+
+        $annotations = new ClassAnnotations(
+            new ReflectedAnnotations($class, $this->annotationReader->getClassAnnotations($class)),
+            array_map($createMethod, $class->getMethods()),
+            array_map($createProperty, $class->getProperties())
+        );
+
+        return $annotations->getAnnotations();
+    }
+
+    private function getClassName($filename)
+    {
+        $parser = new TokenParser(file_get_contents($filename));
+
+        while ($token = $parser->next()) {
+            if ($token[0] === T_NAMESPACE) {
+                $namespace = $parser->parseNamespace();
+            } elseif ($token[0] === T_CLASS) {
+                $class = $parser->parseClass();
+                break;
+            }
+        }
+
+        return isset($class) ? (isset($namespace) ? $namespace . '\\' . $class : $class) : null;
+    }
+}

--- a/src/Scanner.php
+++ b/src/Scanner.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace Swagger;
+
+use Exception;
+use Swagger\Annotations\Swagger;
+use Swagger\Processors\BuildPaths;
+use Swagger\Processors\MergeSwagger;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * Scanner extracts extracts swagger-php annotations from given locations.
+ */
+class Scanner
+{
+    /** @var AnalyserInterface */
+    private $analyser;
+    /** @var callable[] */
+    private $processors;
+    /** @var bool */
+    private $validate;
+
+    public function __construct(AnalyserInterface $analyser, array $processors, $validate = true)
+    {
+        $this->analyser   = $analyser;
+        $this->processors = $processors;
+        $this->validate   = $validate;
+    }
+
+    /**
+     * Create a new scanner using the reflecting analyser and default processor configuration.
+     *
+     * @return static
+     */
+    public static function createReflecting()
+    {
+        return new static(ReflectingAnalyser::createDefault(), [
+            new MergeSwagger(),
+            new BuildPaths(),
+        ]);
+    }
+
+    /**
+     * Read annotations from given locations and build a Swagger object.
+     *
+     * @param string|array|Finder $directory
+     * @param array|string        $exclude
+     *
+     * @return Swagger
+     * @throws Exception
+     */
+    public function scan($directory, $exclude = [])
+    {
+        $finder  = buildFinder($directory, $exclude);
+        $swagger = new Swagger([]);
+
+        foreach ($this->getAnnotations($finder) as $fileAnnotations) {
+            $swagger->merge($fileAnnotations);
+        }
+
+        foreach ($this->processors as $processor) {
+            $processor($swagger);
+        }
+
+        if ($this->validate) {
+            $swagger->validate();
+        }
+
+        return $swagger;
+    }
+
+    private function getAnnotations(Finder $finder)
+    {
+        $annotations = [];
+        /** @var \SplFileInfo $file */
+        foreach ($finder as $file) {
+            $annotations[] = $this->analyser->fromFile($file->getPathname());
+        }
+
+        return $annotations;
+    }
+}

--- a/src/StaticAnalyser.php
+++ b/src/StaticAnalyser.php
@@ -11,7 +11,7 @@ use Swagger\Annotations\AbstractAnnotation;
 /**
  * Swagger\StaticAnalyser extracts swagger-php annotations from php code using static analysis.
  */
-class StaticAnalyser
+class StaticAnalyser implements AnalyserInterface
 {
 
     /**

--- a/src/Utils/DocComment.php
+++ b/src/Utils/DocComment.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace Swagger\Utils;
+
+/**
+ * Data object for parsing the contents of a single DocBlock.
+ */
+class DocComment
+{
+    /** @var string[] */
+    private $rows;
+
+    /**
+     * @param string $comment
+     */
+    public function __construct($comment)
+    {
+        $this->rows = $this->parseCommentRows($comment);
+    }
+
+    public function getSummary()
+    {
+        $firstRow = reset($this->rows);
+
+        return strpos($firstRow, '@') !== 0 ? $firstRow : null;
+    }
+
+    public function getTag($name)
+    {
+        $pattern = sprintf('@%s ', $name);
+
+        foreach ($this->rows as $row) {
+            if (strpos($row, $pattern) === 0) {
+                return substr($row, strlen($pattern));
+            }
+        }
+
+        return null;
+    }
+
+    private function parseCommentRows($comment)
+    {
+        $rawRows = array_map('trim', explode("\n", $comment));
+
+        return count($rawRows) > 1
+            ? array_map(function ($row) { return trim(substr($row, 1)); }, array_slice($rawRows, 1, -1))
+            : implode(' ', array_slice(explode(' ', $rawRows), 1, -1));
+    }
+}

--- a/tests/CommandlineInterfaceTest.php
+++ b/tests/CommandlineInterfaceTest.php
@@ -19,7 +19,7 @@ class CommandlineInterfaceTest extends SwaggerTestCase
 
     public function testStdout()
     {
-        exec(__DIR__ . '/../bin/swagger --stdout ' . escapeshellarg(__DIR__ . '/../Examples/swagger-spec/petstore-simple') . ' 2> /dev/null', $output, $retval);
+        exec(__DIR__ . '/../bin/swagger --stdout ' . escapeshellarg(__DIR__ . '/../Examples/swagger-spec/PetstoreSimple') . ' 2> /dev/null', $output, $retval);
         $this->assertSame(0, $retval);
         $json = json_decode(implode("\n", $output));
         $this->assertSame(JSON_ERROR_NONE, json_last_error());
@@ -29,7 +29,7 @@ class CommandlineInterfaceTest extends SwaggerTestCase
     public function testOutputTofile()
     {
         $filename = sys_get_temp_dir() . '/swagger-php-clitest.json';
-        exec(__DIR__ . '/../bin/swagger -o ' . escapeshellarg($filename) . ' ' . escapeshellarg(__DIR__ . '/../Examples/swagger-spec/petstore-simple') . ' 2> /dev/null', $output, $retval);
+        exec(__DIR__ . '/../bin/swagger -o ' . escapeshellarg($filename) . ' ' . escapeshellarg(__DIR__ . '/../Examples/swagger-spec/PetstoreSimple') . ' 2> /dev/null', $output, $retval);
         $this->assertSame(0, $retval);
         $this->assertCount(0, $output, 'No output to stdout');
         $contents = file_get_contents($filename);

--- a/tests/ExamplesTest.php
+++ b/tests/ExamplesTest.php
@@ -31,9 +31,9 @@ class ExamplesTest extends SwaggerTestCase
     {
         return [
             ['petstore.swagger.io', 'petstore.swagger.io.json'],
-            ['swagger-spec/petstore', 'petstore.json'],
-            ['swagger-spec/petstore-simple', 'petstore-simple.json'],
-            ['swagger-spec/petstore-with-external-docs', 'petstore-with-external-docs.json'],
+            ['swagger-spec/Petstore', 'petstore.json'],
+            ['swagger-spec/PetstoreSimple', 'petstore-simple.json'],
+            ['swagger-spec/PetstoreWithExternalDocs', 'petstore-with-external-docs.json'],
         ];
     }
 }

--- a/tests/Fixtures/Output/Shop.json
+++ b/tests/Fixtures/Output/Shop.json
@@ -1,0 +1,67 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "title": "Shop",
+        "version": "3.7"
+    },
+    "host": "example.com",
+    "basePath": "/api",
+    "schemes": [
+        "http"
+    ],
+    "paths": {
+        "/products/{product}": {
+            "get": {
+                "parameters": [
+                    {
+                        "name": "product",
+                        "in": "path",
+                        "description": "Product number",
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Product information",
+                        "schema": {
+                            "$ref": "#/definitions/Product"
+                        }
+                    }
+                }
+            }
+        },
+        "/products": {
+            "post": {
+                "parameters": [
+                    {
+                        "name": "product",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/Product"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Product information",
+                        "schema": {
+                            "$ref": "#/definitions/Product"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "Product": {
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "category": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/tests/Fixtures/Shop/Controller/ShopController.php
+++ b/tests/Fixtures/Shop/Controller/ShopController.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace SwaggerTests\Fixtures\Shop\Controller;
+
+use Swagger\Annotations as SWG;
+
+/**
+ * @SWG\Swagger(
+ *      schemes={"http"},
+ *      host="example.com",
+ *      basePath="/api",
+ *      @SWG\Info(
+ *          title="Shop",
+ *          version="3.7"
+ *      )
+ * )
+ */
+class ShopController
+{
+    /**
+     * @SWG\Get(
+     *      path="/products/{product}",
+     *      @SWG\Parameter(
+     *          name="product",
+     *          in="path",
+     *          type="string",
+     *          description="Product number"
+     *      ),
+     *      @SWG\Response(
+     *          response="200",
+     *          description="Product information",
+     *          @SWG\Schema(ref="#/definitions/Product")
+     *      )
+     * )
+     */
+    public function getProduct($product)
+    {
+    }
+
+    /**
+     * @SWG\Post(
+     *      path="/products",
+     *      @SWG\Parameter(
+     *          name="product",
+     *          in="body",
+     *          @SWG\Schema(ref="#/definitions/Product")
+     *      ),
+     *      @SWG\Response(
+     *          response="200",
+     *          description="Product information",
+     *          @SWG\Schema(ref="#/definitions/Product")
+     *      )
+     * )
+     */
+    public function addProduct()
+    {
+    }
+}

--- a/tests/Fixtures/Shop/Model/CategoryTrait.php
+++ b/tests/Fixtures/Shop/Model/CategoryTrait.php
@@ -8,7 +8,7 @@ trait CategoryTrait
 {
     /**
      * @var string
-     * @SWG\Property(property="category", type="string")
+     * @SWG\Property
      */
     public $category;
 }

--- a/tests/Fixtures/Shop/Model/CategoryTrait.php
+++ b/tests/Fixtures/Shop/Model/CategoryTrait.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace SwaggerTests\Fixtures\Shop\Model;
+
+use Swagger\Annotations as SWG;
+
+trait CategoryTrait
+{
+    /**
+     * @var string
+     * @SWG\Property(property="category", type="string")
+     */
+    public $category;
+}

--- a/tests/Fixtures/Shop/Model/Product.php
+++ b/tests/Fixtures/Shop/Model/Product.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace SwaggerTests\Fixtures\Shop\Model;
+
+use Swagger\Annotations as SWG;
+
+/**
+ * @SWG\Definition(definition="Product")
+ */
+class Product
+{
+    use CategoryTrait;
+
+    /**
+     * @var string
+     * @SWG\Property(property="name", type="string")
+     */
+    public $name;
+}

--- a/tests/Fixtures/Shop/Model/Product.php
+++ b/tests/Fixtures/Shop/Model/Product.php
@@ -5,7 +5,7 @@ namespace SwaggerTests\Fixtures\Shop\Model;
 use Swagger\Annotations as SWG;
 
 /**
- * @SWG\Definition(definition="Product")
+ * @SWG\Definition
  */
 class Product
 {
@@ -13,7 +13,7 @@ class Product
 
     /**
      * @var string
-     * @SWG\Property(property="name", type="string")
+     * @SWG\Property
      */
     public $name;
 }

--- a/tests/ReflectingAnalyserTest.php
+++ b/tests/ReflectingAnalyserTest.php
@@ -22,4 +22,23 @@ class ReflectingAnalyserTest extends SwaggerTestCase
         $swagger = Scanner::createReflecting()->scan(__DIR__ . '/Fixtures/Shop');
         $this->assertSwaggerEqualsFile(__DIR__ . '/Fixtures/Output/Shop.json', $swagger);
     }
+
+    /**
+     * @dataProvider getExamples
+     */
+    public function testExample($exampleDir, $outputFile)
+    {
+        $swagger = Scanner::createReflecting()->scan(dirname(__DIR__) . '/Examples/' . $exampleDir);
+        $this->assertSwaggerEqualsFile(__DIR__ . '/ExamplesOutput/' . $outputFile, $swagger);
+    }
+
+    public function getExamples()
+    {
+        return [
+            ['petstore.swagger.io', 'petstore.swagger.io.json'],
+            ['swagger-spec/Petstore', 'petstore.json'],
+            ['swagger-spec/PetstoreSimple', 'petstore-simple.json'],
+            ['swagger-spec/PetstoreWithExternalDocs', 'petstore-with-external-docs.json'],
+        ];
+    }
 }

--- a/tests/ReflectingAnalyserTest.php
+++ b/tests/ReflectingAnalyserTest.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace SwaggerTests;
+
+use Doctrine\Common\Annotations\AnnotationRegistry;
+use Swagger\Scanner;
+
+class ReflectingAnalyserTest extends SwaggerTestCase
+{
+    public static function setUpBeforeClass()
+    {
+        $loader = require dirname(__DIR__) . '/vendor/autoload.php';
+        AnnotationRegistry::registerLoader([$loader, 'loadClass']);
+    }
+
+    public function testTrait()
+    {
+        $swagger = Scanner::createReflecting()->scan(__DIR__ . '/Fixtures/Shop');
+        $this->assertSwaggerEqualsFile(__DIR__ . '/Fixtures/Output/Shop.json', $swagger);
+    }
+}


### PR DESCRIPTION
#### Intro

I have a use case where I'd like to use Swagger annotations in traits and I noticed that the parsing mechanism didn't support this. I thought using reflection to read the annotations would be easier anyway and this is what I came up with.

This PR contains an alternative, work in progress implementation of using reflection and Doctrine `AnnotationReader` to read the annotations instead of a token parser. It's not meant to be merged as is, but I wanted to get some feedback to decide how to proceed from here.

#### How it works

To the user reading the annotations works pretty much the same as currently. With default options, it'd look something like this:
```php
use Swagger\Builder;
$builder = Builder::createDefault();
$swagger = $builder->parse('/my/project/dir');
```
The new `Builder` and `Reader` classes can be customized with dependency injection as needed.

Internally the build process works as follows:

1. Find files using `Finder`.
2. Find the PHP class in the file using `TokenParser`.
3. Use reflection and `AnnotationReader` to read class, method and property annotations from these files.
4. Process these annotations: Read property and class names from the related reflection objects etc.
5. Merge annotations from a single class into one `AbstractAnnotation` object.
6. Merge annotations from different classes into a single `Swagger` object.
7. Process the `Swagger` object.
8. Validate the `Swagger` object.

Steps 2 - 5 are mostly new, the rest are basically the same as using the current version.

#### Notes

- The `FinderFactory` class was extracted from `Swagger` and is used by both build processes.
- The reflection based reader does not use the `Parser` class.
- Instead of using the `Context` class, the annotations are wrapped in `AnnotationContainer` objects that also contain the matching reflection object. The class reflection could also be accessed when processing method and property annotations if needed.
- New processors are used to process the `AnnotationContainer` objects since token parsing is not needed in this case.

The new reader has basic functionality, and produces correct results for the included examples (with some additions, included). There are currently incompatibilities between the reader implementations, but at least some of them can be solved with some additional development:
- The reflecting reader does not consider stand-alone DocBlocks, only those attached to classes, methods or properties. While by definition annotations should annotate *something*, this is not a requirement currently in Swagger-PHP.
- Similarly, all annotation classes must available when reading annotations, or explicit blacklisting must be used.
- Since the `Context` class is effectively not used, the output from validation is not very useful.

#### How to proceed

There's probably more to consider, but overall I think that there are three options:

1. If this is too drastic a change / addition, I can split the reader into a new library. This library would then use Swagger-PHP as a dependency for the annotation classes.
2. Since some of the incompatibilities are quite fundamental, reflecting reader could be added to Swagger-PHP as an optional feature. With further refactoring, it would be possible to increase code reuse between the readers.
3. If the incompatibilities are not an obstacle, using reflection and `AnnotationReader` could replace the current reader implementation entirely with some additional development. The immediate benefit would be trait support, but not having the own `Parser` implementation would also mean a lot less code to maintain in the long run.

In any case, I'm just looking for some overall thoughts at this point.