### PR TITLE
Bare minimum fix for #216

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor
 /composer.lock
+/.idea

--- a/src/functions.php
+++ b/src/functions.php
@@ -6,6 +6,7 @@
 
 namespace Swagger;
 
+use InvalidArgumentException;
 use Swagger\Annotations\Swagger;
 use Symfony\Component\Finder\Finder;
 
@@ -19,8 +20,8 @@ define('Swagger\Processors\UNDEFINED', UNDEFINED);
 /**
  * Scan the filesystem for swagger annotations and build swagger-documentation.
  *
- * @param string|array|Finder $directory
- * @param string|array $exclude
+ * @param string|array|Finder $directory The directory(s) or filename(s)
+ * @param null|string|array $exclude
  * @return Swagger
  */
 function scan($directory, $exclude = null)
@@ -42,17 +43,18 @@ function scan($directory, $exclude = null)
 }
 
 /**
- * Build a Symfony Finder object that scan the given $directory.
+ * Build a Symfony Finder object that scans the given $directory.
+ *
  * @param string|array|Finder $directory The directory(s) or filename(s)
- * @param string|array $exclude
- * @throws Exception
+ * @param null|string|array $exclude
+ * @throws InvalidArgumentException
  */
-function buildFinder($directory, $exclude)
+function buildFinder($directory, $exclude = null)
 {
-    if (is_object($directory)) {
+    if ($directory instanceof Finder) {
         return $directory;
     } else {
-        $finder = new Finder($directory, $exclude);
+        $finder = new Finder();
     }
     $finder->files();
     if (is_string($directory)) {
@@ -70,7 +72,7 @@ function buildFinder($directory, $exclude)
             }
         }
     } else {
-        throw new Exception('Unexpected $directory value:' . gettype($directory));
+        throw new InvalidArgumentException('Unexpected $directory value:' . gettype($directory));
     }
     if ($exclude !== null) {
         $finder->exclude($exclude);

--- a/src/functions.php
+++ b/src/functions.php
@@ -21,7 +21,7 @@ define('Swagger\Processors\UNDEFINED', UNDEFINED);
  * Scan the filesystem for swagger annotations and build swagger-documentation.
  *
  * @param string|array|Finder $directory The directory(s) or filename(s)
- * @param null|string|array $exclude
+ * @param null|string|array $exclude The directory(s) or filename(s) to exclude (as relative paths)
  * @return Swagger
  */
 function scan($directory, $exclude = null)
@@ -46,7 +46,7 @@ function scan($directory, $exclude = null)
  * Build a Symfony Finder object that scans the given $directory.
  *
  * @param string|array|Finder $directory The directory(s) or filename(s)
- * @param null|string|array $exclude
+ * @param null|string|array $exclude The directory(s) or filename(s) to exclude (as relative paths)
  * @throws InvalidArgumentException
  */
 function buildFinder($directory, $exclude = null)
@@ -74,8 +74,16 @@ function buildFinder($directory, $exclude = null)
     } else {
         throw new InvalidArgumentException('Unexpected $directory value:' . gettype($directory));
     }
-    if ($exclude !== null) {
-        $finder->exclude($exclude);
+    if (!is_null($exclude)) {
+        if (is_string($exclude)) {
+            $finder->notPath($exclude);
+        } elseif (is_array($exclude)) {
+            foreach ($exclude as $path) {
+                $finder->notPath($path);
+            }
+        } else {
+            throw new InvalidArgumentException('Unexpected $exclude value:' . gettype($exclude));
+        }
     }
     return $finder;
 }


### PR DESCRIPTION
This is the bare minimum needed to get the 'exclude' param at least somewhat working as it should; however, it puts the burden on the user to format the input to `exclude` exactly right (using only relative paths, no trailing slashes, etc).

The main change is to use `notPath` instead of `exclude` because it turns out `notPath` can handle either files or directories (which means you also don't need to do an `is_file` check in order to figure out how to handle the exclude/s); however `notPath` can't take an array, only a string, so a little extra code was needed.

See my next PR for a more user-friendly fix.