### PR TITLE
More user-friendly fix for #216

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor
 /composer.lock
+/.idea

--- a/src/Util.php
+++ b/src/Util.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace Swagger;
+
+/**
+ * Class Util
+ * Convenient utility functions that don't neatly fit anywhere else
+ *
+ * @package Swagger
+ */
+class Util
+{
+    /**
+     * Turns the given $fullPath into a relative path based on $basePaths, which can either
+     * be a single string path, or a list of possible paths. If a list is given, the first
+     * matching basePath in the list will be used to compute the relative path. If no
+     * relative path could be computed, the original string will be returned because there
+     * is always a chance it was a valid relative path to begin with.
+     *
+     * It should be noted that these are "relative paths" primarily in Finder's sense of them,
+     * and conform specifically to what is expected by functions like `exclude()` and `notPath()`.
+     * In particular, leading and trailing slashes are removed.
+     *
+     * @param string $fullPath
+     * @param string|array $basePaths
+     * @return string
+     */
+    public function getRelativePath($fullPath, $basePaths)
+    {
+        $relativePath = null;
+        if (is_string($basePaths)) { // just a single path, not an array of possible paths
+            $relativePath = $this->removePrefix($fullPath, $basePaths);
+        } else { // an array of paths
+            foreach ($basePaths as $basePath) {
+                $relativePath = $this->removePrefix($fullPath, $basePath);
+                if (!empty($relativePath)) {
+                    break;
+                }
+            }
+        }
+        return !empty($relativePath) ? trim($relativePath, '/') : $fullPath;
+    }
+
+    /**
+     * Removes a prefix from the start of a string if it exists, or null otherwise.
+     *
+     * @param string $str
+     * @param string $prefix
+     * @return null|string
+     */
+    private function removePrefix($str, $prefix)
+    {
+        if (substr($str, 0, strlen($prefix)) == $prefix) {
+            return substr($str, strlen($prefix));
+        }
+        return null;
+    }
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -6,6 +6,7 @@
 
 namespace Swagger;
 
+use InvalidArgumentException;
 use Swagger\Annotations\Swagger;
 use Symfony\Component\Finder\Finder;
 
@@ -19,8 +20,8 @@ define('Swagger\Processors\UNDEFINED', UNDEFINED);
 /**
  * Scan the filesystem for swagger annotations and build swagger-documentation.
  *
- * @param string|array|Finder $directory
- * @param string|array $exclude
+ * @param string|array|Finder $directory The directory(s) or filename(s)
+ * @param null|string|array $exclude
  * @return Swagger
  */
 function scan($directory, $exclude = null)
@@ -42,17 +43,18 @@ function scan($directory, $exclude = null)
 }
 
 /**
- * Build a Symfony Finder object that scan the given $directory.
+ * Build a Symfony Finder object that scans the given $directory.
+ *
  * @param string|array|Finder $directory The directory(s) or filename(s)
- * @param string|array $exclude
- * @throws Exception
+ * @param null|string|array $exclude
+ * @throws InvalidArgumentException
  */
-function buildFinder($directory, $exclude)
+function buildFinder($directory, $exclude = null)
 {
-    if (is_object($directory)) {
+    if ($directory instanceof Finder) {
         return $directory;
     } else {
-        $finder = new Finder($directory, $exclude);
+        $finder = new Finder();
     }
     $finder->files();
     if (is_string($directory)) {
@@ -70,7 +72,7 @@ function buildFinder($directory, $exclude)
             }
         }
     } else {
-        throw new Exception('Unexpected $directory value:' . gettype($directory));
+        throw new InvalidArgumentException('Unexpected $directory value:' . gettype($directory));
     }
     if ($exclude !== null) {
         $finder->exclude($exclude);

--- a/src/functions.php
+++ b/src/functions.php
@@ -21,7 +21,7 @@ define('Swagger\Processors\UNDEFINED', UNDEFINED);
  * Scan the filesystem for swagger annotations and build swagger-documentation.
  *
  * @param string|array|Finder $directory The directory(s) or filename(s)
- * @param null|string|array $exclude
+ * @param null|string|array $exclude The directory(s) or filename(s) to exclude (as relative paths)
  * @return Swagger
  */
 function scan($directory, $exclude = null)
@@ -46,7 +46,7 @@ function scan($directory, $exclude = null)
  * Build a Symfony Finder object that scans the given $directory.
  *
  * @param string|array|Finder $directory The directory(s) or filename(s)
- * @param null|string|array $exclude
+ * @param null|string|array $exclude The directory(s) or filename(s) to exclude (as relative paths)
  * @throws InvalidArgumentException
  */
 function buildFinder($directory, $exclude = null)
@@ -74,8 +74,16 @@ function buildFinder($directory, $exclude = null)
     } else {
         throw new InvalidArgumentException('Unexpected $directory value:' . gettype($directory));
     }
-    if ($exclude !== null) {
-        $finder->exclude($exclude);
+    if (!is_null($exclude)) {
+        if (is_string($exclude)) {
+            $finder->notPath($exclude);
+        } elseif (is_array($exclude)) {
+            foreach ($exclude as $path) {
+                $finder->notPath($path);
+            }
+        } else {
+            throw new InvalidArgumentException('Unexpected $exclude value:' . gettype($exclude));
+        }
     }
     return $finder;
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -21,7 +21,7 @@ define('Swagger\Processors\UNDEFINED', UNDEFINED);
  * Scan the filesystem for swagger annotations and build swagger-documentation.
  *
  * @param string|array|Finder $directory The directory(s) or filename(s)
- * @param null|string|array $exclude The directory(s) or filename(s) to exclude (as relative paths)
+ * @param null|string|array $exclude The directory(s) or filename(s) to exclude (as absolute or relative paths)
  * @return Swagger
  */
 function scan($directory, $exclude = null)
@@ -46,7 +46,7 @@ function scan($directory, $exclude = null)
  * Build a Symfony Finder object that scans the given $directory.
  *
  * @param string|array|Finder $directory The directory(s) or filename(s)
- * @param null|string|array $exclude The directory(s) or filename(s) to exclude (as relative paths)
+ * @param null|string|array $exclude The directory(s) or filename(s) to exclude (as absolute or relative paths)
  * @throws InvalidArgumentException
  */
 function buildFinder($directory, $exclude = null)
@@ -76,10 +76,11 @@ function buildFinder($directory, $exclude = null)
     }
     if (!is_null($exclude)) {
         if (is_string($exclude)) {
-            $finder->notPath($exclude);
+            $finder->notPath((new Util())->getRelativePath($exclude, $directory));
         } elseif (is_array($exclude)) {
+            $util = new Util();
             foreach ($exclude as $path) {
-                $finder->notPath($path);
+                $finder->notPath($util->getRelativePath($path, $directory));
             }
         } else {
             throw new InvalidArgumentException('Unexpected $exclude value:' . gettype($exclude));


### PR DESCRIPTION
This allows either absolute or relative paths to be passed in to `exclude`; if an absolute path is passed in, it'll turn it into a relative path based on what was passed in to `directory` (which can also be an array). It'll also ensure leading and trailing slashes are trimmed when doing this input processing. This means more work on Swagger's side, but the user's experience is better because they don't need to worry about formatting the input to `exclude` exactly right to conform with Finder's undocumented expectations.