### PR TITLE
Fixed response annotation example in readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -34,7 +34,7 @@ Add annotations to your php files.
 /**
  * @SWG\Get(
  *     path="/api/resource.json",
- *     @SWG\Response(name="200", description="An example resource")
+ *     @SWG\Response(response="200", description="An example resource")
  * )
  */
 ```


### PR DESCRIPTION
I grabbed the new release, but the readme had an outdated example. I was getting this error before the change:

```php
( ! ) Notice: Unexpected field "name" for @SWG\Response(), expecting "ref", "response", "description", "schema", "headers", "examples", "x" in 
```

Do the docs need to be updated too? http://zircote.com/swagger-php

What do you think @bfanger?