### PR TITLE
Fixed a bug with inherited properties being null

### DIFF
--- a/src/Processors/InheritProperties.php
+++ b/src/Processors/InheritProperties.php
@@ -30,6 +30,11 @@ class InheritProperties
                 $classes = $analysis->getSuperClasses($schema->_context->fullyQualifiedName($schema->_context->class));
                 foreach ($classes as $class) {
                     foreach ($class['properties'] as $property) {
+                        if ((! is_array($property->annotations)) ||
+                            ($property->annotations instanceof \Traversable)) {
+                            continue;
+                        }
+
                         foreach ($property->annotations as $annotation) {
                             if ($annotation instanceof Property && in_array($annotation->property, $existing) === false) {
                                 $existing[] = $annotation->property;

--- a/tests/Fixtures/ChildWithDocBlocks.php
+++ b/tests/Fixtures/ChildWithDocBlocks.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace AnotherNamespace;
+
+/**
+ * @SWG\Definition()
+ */
+class ChildWithDocBlocks extends \SwaggerFixtures\ParentWithoutDocBlocks
+{
+
+    /**
+     * @var bool
+     * @SWG\Property()
+     */
+    public $isBaby;
+}

--- a/tests/Fixtures/ParentWithoutDocBlocks.php
+++ b/tests/Fixtures/ParentWithoutDocBlocks.php
@@ -1,0 +1,6 @@
+<?php
+namespace SwaggerFixtures;
+
+class ParentWithoutDocBlocks extends GrandParent {
+	public $firstname;
+}

--- a/tests/InheritPropertiesTest.php
+++ b/tests/InheritPropertiesTest.php
@@ -37,4 +37,35 @@ class InheritPropertiesTest extends SwaggerTestCase
         $analysis->swagger->info = new Info(['title' => 'test', 'version' => 1]);
         $analysis->validate();
     }
+
+    /**
+     * Tests, if InheritProperties works even without any
+     * docBlocks at all in the parent class.
+     */
+    public function testInheritPropertiesWithoutDocBlocks()
+    {
+        $analyser = new StaticAnalyser();
+
+        // this class has docblocks
+        $analysis = $analyser->fromFile(__DIR__ . '/Fixtures/ChildWithDocBlocks.php');
+        // this one doesn't
+        $analysis->addAnalysis($analyser->fromFile(__DIR__ . '/Fixtures/ParentWithoutDocBlocks.php'));
+
+        $analysis->process([
+            new MergeIntoSwagger(),
+            new AugmentDefinitions(),
+            new AugmentProperties()
+        ]);
+        $definitions = $analysis->getAnnotationsOfType('\Swagger\Annotations\Definition');
+        $childDefinition = $definitions[0];
+        $this->assertSame('ChildWithDocBlocks', $childDefinition->definition);
+        $this->assertCount(1, $childDefinition->properties);
+
+        // no error occurs
+        $analysis->process(new InheritProperties());
+        $this->assertCount(1, $childDefinition->properties);
+
+        $analysis->swagger->info = new Info(['title' => 'test', 'version' => 1]);
+        $analysis->validate();
+    }
 }


### PR DESCRIPTION
If a class inherits from another class without docblocks, swagger-php throws an error, because it is trying to loop through null.

I encountered this problem today. My models inherited from a class without a docblock.
When i tried to run `Swagger\scan('/path/to/app')`, it greeted me with `Invalid argument supplied for foreach()`. Not having DocBlocks in a class is certainly not the best thing to do, but it should not stop me from seeing the swagger generated docs.

I included a unit test with fixtures. If you comment out the `if` statement in `InheritProperties`, you will see, that the unit test fails with said error.