### PR TITLE
Allow free parameter formats

### DIFF
--- a/src/Annotations/Parameter.php
+++ b/src/Annotations/Parameter.php
@@ -169,7 +169,7 @@ class Parameter extends AbstractAnnotation
         'in' => ['query', 'header', 'path', 'formData', 'body'],
         'description' => 'string',
         'required' => 'boolean',
-        'format' => ['int32', 'int64', 'float', 'double', 'byte', 'date', 'date-time'],
+        'format' => [],
         'collectionFormat' => ['csv', 'ssv', 'tsv', 'pipes', 'multi'],
         'maximum' => 'number',
         'exclusiveMaximum' => 'boolean',


### PR DESCRIPTION
This is a follow-up to #253 and #3236b99. Without it the same error is still thrown.