### PR TITLE
Use badges from shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# swagger-php
+[![Build Status](https://img.shields.io/travis/zircote/swagger-php/master.svg?style=flat-square)](https://travis-ci.org/zircote/swagger-php)
+[![Total Downloads](https://img.shields.io/packagist/dt/zircote/swagger-php.svg?style=flat-square)](https://packagist.org/packages/zircote/swagger-php)
+[![License](https://img.shields.io/badge/license-Apache-blue.svg?style=flat-square)](LICENSE-2.0.txt)
 
-[![Build Status](https://api.travis-ci.org/zircote/swagger-php.png?branch=master)](http://travis-ci.org/zircote/swagger-php) `master`
+# swagger-php
 
 Generate interactive [Swagger](http://swagger.io) documentation for your RESTful API using [doctrine annotations](http://doctrine-common.readthedocs.org/en/latest/reference/annotations.html).
 


### PR DESCRIPTION
This PR:

- capitalizes README.md
- makes use of badges from [shields.io](http://shields.io/) so we get consistent badges
- changes badge type from round to (now more commonly/modern) square
- adds a badge for number of packagist downloads
- adds a badge to display the license type (linked to the license file)

Basically I intended this PR as a preparation for two additional badge PRs (code coverage + coding styles) but this could also support #266.