### PR TITLE
Use env variables for specific Travis matrix builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: php
 
-before_script:
-  - composer install
-
 php:
   - 5.4
   - 5.5
@@ -10,9 +7,24 @@ php:
   - 7.0
   - hhvm
 
+sudo: false
+
+env:
+  global:
+    - PHPUNIT=1
+
 matrix:
+  fast_finish: true
+
   allow_failures:
     - php: hhvm
 
-script: phpunit
-sudo: false
+before_script:
+  - composer self-update
+  - composer install --prefer-dist --no-interaction
+
+script:
+  - sh -c "if [ 'PHPUNIT' = '1' ]; then phpunit; fi"
+
+notifications:
+  email: false


### PR DESCRIPTION
This PR:

- restructures the current `travis.yml` to use env variables to configure various matrix builds
- does not change the current Travis runs in any way (all PHP version will continue to run phpunit due to the default value for env `PHPUNIT` being set to 1)

The restructure allows for easily adding different specific builds when required. For example, to add a build for only [codecov.io](https://codecov.io) code coverage and thus no phpunit tests one could simply add:

```yml
matrix:
  include:
    - php: 7.0
      env: CODECOVERAGE=1 PHPUNIT=0

script:
  - sh -c "if [ '$CODECOVERAGE' = '1' ]; then phpunit --coverage-clover=clover.xml || true; fi"
  - sh -c "if [ '$CODECOVERAGE' = '1' ]; then wget -O codecov.sh https://codecov.io/bash; fi"
  - sh -c "if [ '$CODECOVERAGE' = '1' ]; then bash codecov.sh; fi"
```