### PR TITLE
Add phpunit to the project for development purposes

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ The documentation website resides within the `gh-pages` branch.
 Make sure pull requests pass [PHPUnit](https://phpunit.de/)
 and [PHP_CodeSniffer](https://github.com/cakephp/cakephp-codesniffer) (PSR-2) tests.
 
+Running tests can be done with this command in the root of the project:
+
+```bash
+bin/phpunit
+```
+
 To run the phpcs tests on your local machine execute:
 
 ```bash

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
     },
     "require-dev": {
         "zendframework/zend-form": "*",
-        "squizlabs/php_codesniffer": "2.*"
+        "squizlabs/php_codesniffer": "2.*",
+        "phpunit/phpunit": "^4.8"
     },
     "autoload-dev": {
         "psr-4": {


### PR DESCRIPTION
Seems weird that it's not been there already. Makes running tests much easier and more consistent.
