### PR TITLE
fixed case of UNDEFINED constants namespaces

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -13,9 +13,9 @@ if (defined('Swagger\UNDEFINED') === false) {
     /**
      * Special value to differentiate between null and undefined.
      */
-    define('SWAGGER\UNDEFINED', '{SWAGGER-PHP-UNDEFINED-46EC-07AB32D2-D50C}');
-    define('SWAGGER\ANNOTATIONS\UNDEFINED', UNDEFINED);
-    define('SWAGGER\PROCESSORS\UNDEFINED', UNDEFINED);
+    define('Swagger\UNDEFINED', '{SWAGGER-PHP-UNDEFINED-46EC-07AB32D2-D50C}');
+    define('Swagger\Annotations\UNDEFINED', UNDEFINED);
+    define('Swagger\Processors\UNDEFINED', UNDEFINED);
 
     /**
      * Scan the filesystem for swagger annotations and build swagger-documentation.


### PR DESCRIPTION
Hi! I changed namespace from uppercase to title case, because it causes strange errors like 'Use of undefined constant UNDEFINED - assumed 'UNDEFINED'' in my environment (hhvm 3.13)