### PR TITLE
Annotations\Parameters - declare consts for IN_

### DIFF
--- a/src/Annotations/Parameter.php
+++ b/src/Annotations/Parameter.php
@@ -16,6 +16,12 @@ use \Swagger\Logger;
  */
 class Parameter extends AbstractAnnotation
 {
+    const IN_QUERY = 'query';
+    const IN_HEADER = 'header';
+    const IN_PATH= 'path';
+    const IN_FORMDATA = 'formData';
+    const IN_BODY = 'body';
+
     /**
      * $ref See http://json-schema.org/latest/json-schema-core.html#rfc.section.7
      * @var string


### PR DESCRIPTION
Hey!

I started to working on https://github.com/ovr/swagger-assert-helper
I prefer to use constants instead of string

Can we declare it?

Thanks