### PR TITLE
Update finder options to force Swagger-PHP parse only *.php file

### DIFF
--- a/src/Util.php
+++ b/src/Util.php
@@ -75,7 +75,7 @@ class Util
             $finder = new Finder();
             $finder->sortByName();
         }
-        $finder->files();
+        $finder->files()->name('*.php');
         if (is_string($directory)) {
             if (is_file($directory)) { // Scan a single file?
                 $finder->append([$directory]);


### PR DESCRIPTION
We faced a issue where swagger-php trying to parse non-php files, that causes `Unexpected token error`. I added this patch to our version of swagger-php, to parse only files with .php extensions.

Is there any use case that swagger php needed to parse non-php files?