### PR TITLE
Add php7 compatibility (rename Parent test class), turn on php7 for autotests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
 
   include:
     - php: 7.0
-      env: PHPCS=1 PHPUNIT=0
+      env: PHPCS=1 PHPUNIT=1
 
   allow_failures:
     - php: hhvm

--- a/src/Processors/HandleReferences.php
+++ b/src/Processors/HandleReferences.php
@@ -1,9 +1,7 @@
 <?php
-
 /**
  * @license Apache 2.0
  */
-
 namespace Swagger\Processors;
 
 use Swagger\Annotations\Operation;

--- a/tests/AnalysisTest.php
+++ b/tests/AnalysisTest.php
@@ -33,29 +33,29 @@ class AnalysisTest extends SwaggerTestCase
     {
         $analyser = new StaticAnalyser();
         $analysis = $analyser->fromFile(__DIR__ . '/Fixtures/Child.php');
-        $analysis->addAnalysis($analyser->fromFile(__DIR__ . '/Fixtures/GrandParent.php'));
-        $analysis->addAnalysis($analyser->fromFile(__DIR__ . '/Fixtures/Parent.php'));
+        $analysis->addAnalysis($analyser->fromFile(__DIR__ . '/Fixtures/GrandAncestor.php'));
+        $analysis->addAnalysis($analyser->fromFile(__DIR__ . '/Fixtures/Ancestor.php'));
         
         $this->assertCount(3, $analysis->classes, '3 classes should\'ve been detected');
         
-        $subclasses = $analysis->getSubClasses('\SwaggerFixtures\GrandParent');
-        $this->assertCount(2, $subclasses, 'GrandParent has 2 subclasses');
-        $this->assertSame(['\SwaggerFixtures\Parent', '\AnotherNamespace\Child'], array_keys($subclasses));
-        $this->assertSame(['\AnotherNamespace\Child'], array_keys($analysis->getSubClasses('\SwaggerFixtures\Parent')));
+        $subclasses = $analysis->getSubClasses('\SwaggerFixtures\GrandAncestor');
+        $this->assertCount(2, $subclasses, 'GrandAncestor has 2 subclasses');
+        $this->assertSame(['\SwaggerFixtures\Ancestor', '\AnotherNamespace\Child'], array_keys($subclasses));
+        $this->assertSame(['\AnotherNamespace\Child'], array_keys($analysis->getSubClasses('\SwaggerFixtures\Ancestor')));
     }
     
-    public function testGetParentClasses()
+    public function testGetAncestorClasses()
     {
         $analyser = new StaticAnalyser();
         $analysis = $analyser->fromFile(__DIR__ . '/Fixtures/Child.php');
-        $analysis->addAnalysis($analyser->fromFile(__DIR__ . '/Fixtures/GrandParent.php'));
-        $analysis->addAnalysis($analyser->fromFile(__DIR__ . '/Fixtures/Parent.php'));
+        $analysis->addAnalysis($analyser->fromFile(__DIR__ . '/Fixtures/GrandAncestor.php'));
+        $analysis->addAnalysis($analyser->fromFile(__DIR__ . '/Fixtures/Ancestor.php'));
         
         $this->assertCount(3, $analysis->classes, '3 classes should\'ve been detected');
         
         $superclasses = $analysis->getSuperClasses('\AnotherNamespace\Child');
         $this->assertCount(2, $superclasses, 'Child has a chain of 2 super classes');
-        $this->assertSame(['\SwaggerFixtures\Parent', '\SwaggerFixtures\GrandParent'], array_keys($superclasses));
-        $this->assertSame(['\SwaggerFixtures\GrandParent'], array_keys($analysis->getSuperClasses('\SwaggerFixtures\Parent')));
+        $this->assertSame(['\SwaggerFixtures\Ancestor', '\SwaggerFixtures\GrandAncestor'], array_keys($superclasses));
+        $this->assertSame(['\SwaggerFixtures\GrandAncestor'], array_keys($analysis->getSuperClasses('\SwaggerFixtures\Ancestor')));
     }
 }

--- a/tests/Fixtures/Ancestor.php
+++ b/tests/Fixtures/Ancestor.php
@@ -4,7 +4,7 @@ namespace SwaggerFixtures;
 /**
  * An intermediate class
  */
-class Parent extends GrandParent
+class Ancestor extends GrandAncestor
 {
 
     /**

--- a/tests/Fixtures/AncestorWithoutDocBlocks.php
+++ b/tests/Fixtures/AncestorWithoutDocBlocks.php
@@ -1,7 +1,7 @@
 <?php
 namespace SwaggerFixtures;
 
-class ParentWithoutDocBlocks extends GrandParent
+class AncestorWithoutDocBlocks extends GrandAncestor
 {
     public $firstname;
 }

--- a/tests/Fixtures/Child.php
+++ b/tests/Fixtures/Child.php
@@ -5,7 +5,7 @@ namespace AnotherNamespace;
 /**
  * @SWG\Definition()
  */
-class Child extends \SwaggerFixtures\Parent
+class Child extends \SwaggerFixtures\Ancestor
 {
 
     /**

--- a/tests/Fixtures/ChildWithDocBlocks.php
+++ b/tests/Fixtures/ChildWithDocBlocks.php
@@ -5,7 +5,7 @@ namespace AnotherNamespace;
 /**
  * @SWG\Definition()
  */
-class ChildWithDocBlocks extends \SwaggerFixtures\ParentWithoutDocBlocks
+class ChildWithDocBlocks extends \SwaggerFixtures\AncestorWithoutDocBlocks
 {
 
     /**

--- a/tests/Fixtures/GrandAncestor.php
+++ b/tests/Fixtures/GrandAncestor.php
@@ -1,7 +1,7 @@
 <?php
 namespace SwaggerFixtures;
 
-class GrandParent
+class GrandAncestor
 {
 
     /**

--- a/tests/InheritPropertiesTest.php
+++ b/tests/InheritPropertiesTest.php
@@ -20,8 +20,8 @@ class InheritPropertiesTest extends SwaggerTestCase
     {
         $analyser = new StaticAnalyser();
         $analysis = $analyser->fromFile(__DIR__ . '/Fixtures/Child.php');
-        $analysis->addAnalysis($analyser->fromFile(__DIR__ . '/Fixtures/GrandParent.php'));
-        $analysis->addAnalysis($analyser->fromFile(__DIR__ . '/Fixtures/Parent.php'));
+        $analysis->addAnalysis($analyser->fromFile(__DIR__ . '/Fixtures/GrandAncestor.php'));
+        $analysis->addAnalysis($analyser->fromFile(__DIR__ . '/Fixtures/Ancestor.php'));
         $analysis->process([
             new MergeIntoSwagger(),
             new AugmentDefinitions(),

--- a/tests/InheritPropertiesTest.php
+++ b/tests/InheritPropertiesTest.php
@@ -49,7 +49,7 @@ class InheritPropertiesTest extends SwaggerTestCase
         // this class has docblocks
         $analysis = $analyser->fromFile(__DIR__ . '/Fixtures/ChildWithDocBlocks.php');
         // this one doesn't
-        $analysis->addAnalysis($analyser->fromFile(__DIR__ . '/Fixtures/ParentWithoutDocBlocks.php'));
+        $analysis->addAnalysis($analyser->fromFile(__DIR__ . '/Fixtures/AncestorWithoutDocBlocks.php'));
 
         $analysis->process([
             new MergeIntoSwagger(),

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -13,7 +13,7 @@ class UtilTest extends SwaggerTestCase
 
     public function testExclude()
     {
-        $swagger = \Swagger\scan(__DIR__ . '/Fixtures', ['exclude' => ['Customer.php', 'UsingRefs.php', 'UsingPhpDoc.php', 'GrandParent.php']]);
+        $swagger = \Swagger\scan(__DIR__ . '/Fixtures', ['exclude' => ['Customer.php', 'UsingRefs.php', 'UsingPhpDoc.php', 'GrandAncestor.php']]);
         $this->assertSame('Fixture for ParserTest', $swagger->info->title, 'No errors about duplicate @SWG\Info() annotations');
     }
 }

--- a/tests/ValidateRelationsTest.php
+++ b/tests/ValidateRelationsTest.php
@@ -17,7 +17,7 @@ class ValidateRelationsTest extends SwaggerTestCase
      * @dataProvider getAnnotations
      * @param string $class
      */
-    public function testParents($class)
+    public function testAncestors($class)
     {
         foreach ($class::$_parents as $parent) {
             $found = false;


### PR DESCRIPTION
I've just fixed 2 of 3 php7cc messages and launched tests under php7.