### PR TITLE
Fix "Unexpected field "descriptions"" error in example

### DIFF
--- a/docs/Getting-started.md
+++ b/docs/Getting-started.md
@@ -179,7 +179,7 @@ As if you'd written:
      * @SWG\Property(
      *   property="name",
      *   type="string",
-     *   descriptions="The product name" 
+     *   description="The product name" 
      * )
      */
     public $name;


### PR DESCRIPTION
remove "s" to description