### PR TITLE
Fix errors when parsing php7 anonymous class

### DIFF
--- a/src/StaticAnalyser.php
+++ b/src/StaticAnalyser.php
@@ -90,6 +90,12 @@ class StaticAnalyser
                     continue;
                 }
                 $token = $this->nextToken($tokens, $parseContext);
+
+                if (is_string($token) && $token === '{') {
+                    // php7 anonymous classes (i.e. new class { public function foo() {} };)
+                    continue;
+                }
+
                 $definitionContext = new Context(['class' => $token[1], 'line' => $token[2]], $parseContext);
                 if ($classDefinition) {
                     $analysis->addClassDefinition($classDefinition);

--- a/tests/Fixtures/php7.php
+++ b/tests/Fixtures/php7.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace SwaggerFixures;
+
+$o = new class
+{
+    public function foo()
+    {
+    }
+};
+
+$o = new class extends stdClass
+{
+};
+
+$o = new class implements foo
+{
+};

--- a/tests/StaticAnalyserTest.php
+++ b/tests/StaticAnalyserTest.php
@@ -58,4 +58,14 @@ class StaticAnalyserTest extends SwaggerTestCase
         $this->assertSame('\SwaggerFixtures\ThirdPartyAnnotations', $context->fullyQualifiedName($context->class));
         $this->assertCount(2, $context->annotations);
     }
+
+    public function testAnonymousClassProducesNoError()
+    {
+        try {
+            $analyser = new StaticAnalyser(__DIR__ . '/Fixtures/php7.php');
+            $this->assertTrue(true);
+        } catch (\Exception $e) {
+            $this->fail("Analyser produced an error: {$e->getMessage()}");
+        }
+    }
 }


### PR DESCRIPTION
When parsing my project I got some error output like this
[NOTICE] Uninitialized string offset: 1 in vendor\zircote\swagger-php\src\StaticAnalyser.php on line 93

This resulted from parsing php7 anonymous classes.

I called the new fixture file 'php7.php' so that more php7 specific syntax can be added there in future.