### PR TITLE
Amend command line runner help message

### DIFF
--- a/bin/swagger
+++ b/bin/swagger
@@ -79,7 +79,7 @@ if ($error) {
 if ($options['help']) {
     $help = <<<EOF
 
-usage: swagger [/path/to/project] [--output ./swagger.json] ...
+usage: swagger [/path/to/project] [/path/additional/1] [/path/additional/n] [--output ./swagger.json] ...
 
   --output (-o)     Path to store the generated documentation.
   --stdout          Write to the standard output.


### PR DESCRIPTION
Reflect the fact that you can add more than one path as arguments to the command line runner.

Fixes #379