### PR TITLE
Serializer - doDeserialize - fix support for $ref

### DIFF
--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -96,6 +96,10 @@ class Serializer
     {
         $annotation = new $class([]);
         foreach ($c as $property => $value) {
+            if ($property === '$ref') {
+                $property = 'ref';
+            }
+            
             if (substr($property, 0, 2) === 'x-') {
                 $custom = substr($property, 2);
                 $annotation->x[$custom] = $value;


### PR DESCRIPTION
Hey!

Looks like deserialize was broken with `$ref` field :atom: , example swagger spec

![image](https://cloud.githubusercontent.com/assets/572096/25395256/6ede7d98-2a1b-11e7-801b-609b06f8b1f1.png)

It's `$ref` in JSON scheme, but it's `ref` property inside this library

![image](https://cloud.githubusercontent.com/assets/572096/25395313/a902fbca-2a1b-11e7-9764-cdb3a1e22800.png)

I am getting a notice "$ref property does not exists", and I am interested to drop hack inside my project:

![image](https://cloud.githubusercontent.com/assets/572096/25395275/83271288-2a1b-11e7-9cf5-4071de76e3c2.png)

See: https://github.com/SocialConnect/swagger-codegen/commit/ec274ed6e547ca761f8d47714a8acde4cf0cb7ee

Thank, Have a nice day  