### PR TITLE
Reinstate oneOf and anyOf

### DIFF
--- a/src/Annotations/Swagger.php
+++ b/src/Annotations/Swagger.php
@@ -21,7 +21,7 @@ class Swagger extends AbstractAnnotation
      * Specifies the Swagger Specification version being used. It can be used by the Swagger UI and other clients to interpret the API listing.
      * @var string
      */
-    public $openapi = '3.0.0-RC1';
+    public $swagger = '2.0';
 
     /**
      * Provides metadata about the API. The metadata can be used by the clients if needed.

--- a/src/Annotations/Swagger.php
+++ b/src/Annotations/Swagger.php
@@ -21,7 +21,7 @@ class Swagger extends AbstractAnnotation
      * Specifies the Swagger Specification version being used. It can be used by the Swagger UI and other clients to interpret the API listing.
      * @var string
      */
-    public $swagger = '2.0';
+    public $openapi = '3.0.0-RC1';
 
     /**
      * Provides metadata about the API. The metadata can be used by the clients if needed.

--- a/src/Annotations/Swagger.php
+++ b/src/Annotations/Swagger.php
@@ -116,7 +116,7 @@ class Swagger extends AbstractAnnotation
     public static $_blacklist = ['_context', '_unmerged', '_analysis'];
     
     /** @inheritdoc */
-    public static $_required = ['openapi', 'info', 'paths'];
+    public static $_required = ['swagger', 'info', 'paths'];
 
     /** @inheritdoc */
     public static $_nested = [

--- a/src/Annotations/Swagger.php
+++ b/src/Annotations/Swagger.php
@@ -116,7 +116,7 @@ class Swagger extends AbstractAnnotation
     public static $_blacklist = ['_context', '_unmerged', '_analysis'];
     
     /** @inheritdoc */
-    public static $_required = ['swagger', 'info', 'paths'];
+    public static $_required = ['openapi', 'info', 'paths'];
 
     /** @inheritdoc */
     public static $_nested = [

--- a/src/Util.php
+++ b/src/Util.php
@@ -75,7 +75,7 @@ class Util
             $finder = new Finder();
             $finder->sortByName();
         }
-        $finder->files()->name('*.php');
+        $finder->files()->followLinks()->name('*.php');
         if (is_string($directory)) {
             if (is_file($directory)) { // Scan a single file?
                 $finder->append([$directory]);


### PR DESCRIPTION
Hello,

Since [OAI version 3](https://www.openapis.org/blog/2017/03/01/openapi-spec-3-implementers-draft-released) is in RC for the tooling to adapt would you accept this little change to add the previously deleted keywords oneOf and anyOf in #273 ?

I sadly didn't have more time to help porting the OAI 3 but for this small improvement I needed on my project, this should contribute a little bit to #384 