### PR TITLE
+ added multiple definitions of project input paths

### DIFF
--- a/bin/swagger
+++ b/bin/swagger
@@ -39,7 +39,7 @@ try {
                 throw new Exception('Unknown option: "' . $arg . '"');
             }
         } else {
-            $paths[] = $arg;
+            $paths = explode(',', $arg);
             continue;
         }
         if (array_key_exists($option, $options) === false) {
@@ -81,7 +81,7 @@ if ($error) {
 if ($options['help']) {
     $help = <<<EOF
 
-Usage: swagger [--option value] [/path/to/project ...]
+Usage: swagger [--option value] [/path/to/project,/path/to/another/project ...]
 
 Options:
   --output (-o)     Path to store the generated documentation.


### PR DESCRIPTION
I created entity library where is located definitions of my entities, because i want to use these entities on server api side and on client site as well. So on api server side, definitions of entities are located in vendor folder and definitions of apis are located in different folder (./src/), where my controllers is located. To have full definition of swagger.json i have to run swagger binary script on top folder of my aplication which is "./". Then all vendor libraries are included and processing takes really long time in this case. Anyway, to set up exlude folder for all libraries in vendor is not so good way. So i added possibility to make a multiple definitions of input paths to generate swagger.json fast. All functionalitites are backward compatible. 