### PR TITLE
When schema type is array, items key must always exist.

### DIFF
--- a/src/Annotations/Items.php
+++ b/src/Annotations/Items.php
@@ -40,10 +40,6 @@ class Items extends Schema
         }
         $valid = parent::validate($parents, $skip);
         if (!$this->ref) {
-            if ($this->type === 'array' && $this->items === null) {
-                Logger::notice('@SWG\Items() is required when ' . $this->identity() . ' has type "array" in ' . $this->_context);
-                $valid = false;
-            }
             $parent = end($parents);
             if (is_object($parent) && ($parent instanceof Parameter && $parent->in !== 'body' || $parent instanceof Header)) {
                 // This is a "Items Object" https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#items-object

--- a/src/Annotations/Schema.php
+++ b/src/Annotations/Schema.php
@@ -6,6 +6,8 @@
 
 namespace Swagger\Annotations;
 
+use Swagger\Logger;
+
 /**
  * @Annotation
  * The definition of input and output data types.
@@ -234,4 +236,13 @@ class Schema extends AbstractAnnotation
         'Swagger\Annotations\Response',
         'Swagger\Annotations\Parameter',
     ];
+
+    public function validate($parents = [], $skip = [], $ref = '')
+    {
+        if ($this->type === 'array' && $this->items === null) {
+            Logger::notice('@SWG\Items() is required when ' . $this->identity() . ' has type "array" in ' . $this->_context);
+            return false;
+        }
+        return parent::validate($parents, $skip, $ref);
+    }
 }

--- a/tests/ItemsTest.php
+++ b/tests/ItemsTest.php
@@ -8,10 +8,17 @@ namespace SwaggerTests;
 
 class ItemsTest extends SwaggerTestCase
 {
-    public function testTypeArray()
+    public function testItemTypeArray()
     {
         $annotations = $this->parseComment('@SWG\Items(type="array")');
         $this->assertSwaggerLogEntryStartsWith('@SWG\Items() is required when @SWG\Items() has type "array" in ');
+        $annotations[0]->validate();
+    }
+
+    public function testSchemaTypeArray()
+    {
+        $annotations = $this->parseComment('@SWG\Schema(type="array")');
+        $this->assertSwaggerLogEntryStartsWith('@SWG\Items() is required when @SWG\Schema() has type "array" in ');
         $annotations[0]->validate();
     }
 


### PR DESCRIPTION
According to the spec, when a schema has type `array`, the `items` key must always exist.  This rule was being validated for `@SWG\Items()` but not for all `@SWG\Schema()`.

* Includes a new test to cover the generic `@SWG\Schema()` case.
* Keeps the old test case for `@SWG\Items()` to ensure the log message remained the same.