### PR TITLE
Accept Windows/DOS line breaks in phpdoc summary

### DIFF
--- a/src/Context.php
+++ b/src/Context.php
@@ -171,7 +171,7 @@ class Context
         if (!$content) {
             return null;
         }
-        $lines = explode("\n", $content);
+        $lines = preg_split('/(\n|\r\n)/', $content);
         $summary = '';
         foreach ($lines as $line) {
             $summary .= $line."\n";
@@ -209,7 +209,7 @@ class Context
      */
     public function phpdocContent()
     {
-        $comment = explode("\n", $this->comment);
+        $comment = preg_split('/(\n|\r\n)/', $this->comment);
         $comment[0] = preg_replace('/[ \t]*\\/\*\*/', '', $comment[0]); // strip '/**'
         $i = count($comment) -1;
         $comment[$i] = preg_replace('/\*\/[ \t]*$/', '', $comment[$i]); // strip '*/'


### PR DESCRIPTION
The phpdoc content is statically parsed (in Context.php). During parsing, the comments are split into an array of lines. Previously, the code used explode("\n", ...) in order to split at Unix (lf) line breaks. In order to also be able to accept Windows/DOS line breaks (cr + lf), explode is replaced by splitting with preg_split on either \n or \r\n.