### PR TITLE
Does not work with symfony/finder lower than 2.2 version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": ">=5.6",
         "doctrine/annotations": "*",
-        "symfony/finder": "*"
+        "symfony/finder": "^2.2 | ^3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
```
1) SwaggerMiddlewareTest\GeneratorTest::testCanGenerate
LogicException: You must call the in() method before iterating over a Finder.

/home/svycka/Documents/projects/github/swagger-middleware/vendor/symfony/finder/Symfony/Component/Finder/Finder.php:518
/home/svycka/Documents/projects/github/swagger-middleware/vendor/zircote/swagger-php/src/functions.php:39
```