### PR TITLE
Added field name allowEmptyValue

### DIFF
--- a/src/Annotations/Parameter.php
+++ b/src/Annotations/Parameter.php
@@ -71,6 +71,12 @@ class Parameter extends AbstractAnnotation
     public $format;
 
     /**
+     * Sets the ability to pass empty-valued parameters. This is valid only for either query or formData parameters and allows you to send a parameter with a name only or an empty value. Default value is false.
+     * @var boolean
+     */
+    public $allowEmptyValue;
+    
+    /**
      * Required if type is "array". Describes the type of items in the array.
      * @var \Swagger\Annotations\Items
      */


### PR DESCRIPTION
Hello,

This change ads the Parameter annotation field name allowEmptyValue as this seems to be part of the swagger-php api spec.

https://bfanger.nl/swagger-explained/#parameterObject

Thanks,
Jamie