### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "require-dev": {
         "zendframework/zend-form": "<2.8",
         "squizlabs/php_codesniffer": ">=2.7",
-        "phpunit/phpunit": ">=4.8 <=5.6"
+        "phpunit/phpunit": ">=4.8.35 <=5.6"
     },
     "autoload-dev": {
         "psr-4": {

--- a/tests/SwaggerTestCase.php
+++ b/tests/SwaggerTestCase.php
@@ -7,7 +7,7 @@
 namespace SwaggerTests;
 
 use Closure;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 use Exception;
 use Swagger\Annotations\AbstractAnnotation;
@@ -16,7 +16,7 @@ use Swagger\Context;
 use Swagger\Logger;
 use Swagger\Analyser;
 
-class SwaggerTestCase extends PHPUnit_Framework_TestCase
+class SwaggerTestCase extends TestCase
 {
 
     /**


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`>=4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.