### PR TITLE
Added the option: "operationid".

### DIFF
--- a/bin/swagger
+++ b/bin/swagger
@@ -10,6 +10,7 @@ $options = array(
     'help' => false,
     'version' => false,
     'debug' => false,
+    'operationid' => false,
 );
 $aliases = array(
     'o' => 'output',
@@ -86,6 +87,8 @@ Usage: swagger [--option value] [/path/to/project ...]
 Options:
   --output (-o)     Path to store the generated documentation.
   --stdout          Write to the standard output.
+  --operationid     Overrides the "operationid" property based on 
+                    the PHP Annotation Context
   --exclude (-e)    Exclude path(s).
                     ex: --exclude vendor,library/Zend
   --bootstrap (-b)  Bootstrap a php file for defining constants, etc.
@@ -154,6 +157,7 @@ set_exception_handler(function ($exception) use ($options) {
 
 
 $exclude = $options['exclude'] ? explode(',', $options['exclude']) : null;
+define('OVERRIDE_OPERATIONID', $options["operationid"]);
 
 $swagger = Swagger\scan($paths, ['exclude' => $exclude]);
 $methods = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch'];

--- a/bin/swagger
+++ b/bin/swagger
@@ -157,7 +157,9 @@ set_exception_handler(function ($exception) use ($options) {
 
 
 $exclude = $options['exclude'] ? explode(',', $options['exclude']) : null;
-define('OVERRIDE_OPERATIONID', $options["operationid"]);
+if ($options["operationid"]) {
+    \Swagger\Analysis::registerProcessor(new \Swagger\Processors\DetectOperationId());
+}
 
 $swagger = Swagger\scan($paths, ['exclude' => $exclude]);
 $methods = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch'];

--- a/src/Analysis.php
+++ b/src/Analysis.php
@@ -76,10 +76,6 @@ class Analysis
             return;
         }
 
-        if ($annotation instanceof Operation && defined('OVERRIDE_OPERATIONID') && OVERRIDE_OPERATIONID) {
-            $annotation->operationId = $context->namespace . "\\" . $context->class . "::" . $context->method;
-        }
-
         if ($annotation instanceof AbstractAnnotation) {
             $context = $annotation->_context;
         } else {

--- a/src/Analysis.php
+++ b/src/Analysis.php
@@ -11,7 +11,6 @@ use Exception;
 use SplObjectStorage;
 use stdClass;
 use Swagger\Annotations\AbstractAnnotation;
-use Swagger\Annotations\Operation;
 use Swagger\Annotations\Swagger;
 use Swagger\Processors\AugmentDefinitions;
 use Swagger\Processors\AugmentOperations;
@@ -75,7 +74,6 @@ class Analysis
         if ($this->annotations->contains($annotation)) {
             return;
         }
-
         if ($annotation instanceof AbstractAnnotation) {
             $context = $annotation->_context;
         } else {

--- a/src/Analysis.php
+++ b/src/Analysis.php
@@ -11,6 +11,7 @@ use Exception;
 use SplObjectStorage;
 use stdClass;
 use Swagger\Annotations\AbstractAnnotation;
+use Swagger\Annotations\Operation;
 use Swagger\Annotations\Swagger;
 use Swagger\Processors\AugmentDefinitions;
 use Swagger\Processors\AugmentOperations;
@@ -74,6 +75,11 @@ class Analysis
         if ($this->annotations->contains($annotation)) {
             return;
         }
+
+        if ($annotation instanceof Operation && defined('OVERRIDE_OPERATIONID') && OVERRIDE_OPERATIONID) {
+            $annotation->operationId = $context->namespace . "\\" . $context->class . "::" . $context->method;
+        }
+
         if ($annotation instanceof AbstractAnnotation) {
             $context = $annotation->_context;
         } else {

--- a/src/Processors/DetectOperationId.php
+++ b/src/Processors/DetectOperationId.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace Swagger\Processors;
+
+use Swagger\Analysis;
+
+/**
+ * Replaces the OperationId based on the context of the Swagger comment.
+ */
+class DetectOperationId
+{
+    public function __invoke(Analysis $analysis)
+    {
+        $allOperations = $analysis->getAnnotationsOfType('\Swagger\Annotations\Operation');
+
+        /** @var \Swagger\Annotations\Operation $operation */
+        foreach ($allOperations as $operation) {
+            $context = $operation->_context;
+            if ($context && $context->namespace && $context->class && $context->method) {
+                $operation->operationId = $context->namespace . "\\" . $context->class . "::" . $context->method;
+            }
+        }
+    }
+}


### PR DESCRIPTION
I am developing a Route Generator for REST calls based on the swagger.json. 

As I am using your library to create my JSON file and you have the context where the Annotation was placed I made a small change to override the "operationid" with the Namespace, class and method of the annotation context. 

This change does not break compatibility because it is optional. 

