### PR TITLE
Added the option: "operationid" (Branch 3.x)

### DIFF
--- a/bin/swagger
+++ b/bin/swagger
@@ -10,6 +10,7 @@ $options = array(
     'help' => false,
     'version' => false,
     'debug' => false,
+    'donotchangeopid' => false,
 );
 $aliases = array(
     'o' => 'output',
@@ -86,6 +87,8 @@ Usage: swagger [--option value] [/path/to/project ...]
 Options:
   --output (-o)     Path to store the generated documentation.
   --stdout          Write to the standard output.
+  --donotchangeopid Do not overrides the "operationid" property based on 
+                    the PHP Annotation Context (default is override)
   --exclude (-e)    Exclude path(s).
                     ex: --exclude vendor,library/Zend
   --bootstrap (-b)  Bootstrap a php file for defining constants, etc.
@@ -154,6 +157,9 @@ set_exception_handler(function ($exception) use ($options) {
 
 
 $exclude = $options['exclude'] ? explode(',', $options['exclude']) : null;
+if (!$options["donotchangeopid"]) {
+    \Swagger\Analysis::registerProcessor(new \Swagger\Processors\DetectOperationId());
+}
 
 $openapi = Swagger\scan($paths, ['exclude' => $exclude]);
 $methods = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch'];

--- a/src/Processors/DetectOperationId.php
+++ b/src/Processors/DetectOperationId.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace Swagger\Processors;
+
+use Swagger\Analysis;
+
+/**
+ * Replaces the OperationId based on the context of the Swagger comment.
+ */
+class DetectOperationId
+{
+    public function __invoke(Analysis $analysis)
+    {
+        $allOperations = $analysis->getAnnotationsOfType('\Swagger\Annotations\Operation');
+
+        /** @var \Swagger\Annotations\Operation $operation */
+        foreach ($allOperations as $operation) {
+            $context = $operation->_context;
+            if ($context && $context->namespace && $context->class && $context->method) {
+                $operation->operationId = $context->namespace . "\\" . $context->class . "::" . $context->method;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This option replaces the "operationid" Swagger Property by the
namespace and method in the context.

This is the implementation on branch 3.x of the PR #483 

The default behavior is to replace the "OperationID"