### PR TITLE
Misc annotation improvements

### DIFF
--- a/src/Annotations/AdditionalProperties.php
+++ b/src/Annotations/AdditionalProperties.php
@@ -19,7 +19,8 @@ class AdditionalProperties extends Schema
 {
     /** @inheritdoc */
     public static $_parents = [
-        'Swagger\Annotations\Schema'
+        'Swagger\Annotations\Schema',
+        'Swagger\Annotations\Property'
     ];
 
     /** @inheritdoc */

--- a/src/Annotations/JsonContent.php
+++ b/src/Annotations/JsonContent.php
@@ -14,6 +14,12 @@ namespace Swagger\Annotations;
  */
 class JsonContent extends Schema
 {
+
+    /**
+     * @var object
+     */
+    public $example;
+
     /**
      * @var object
      */

--- a/src/Annotations/Property.php
+++ b/src/Annotations/Property.php
@@ -31,6 +31,7 @@ class Property extends Schema
     public static $_nested = [
         'Swagger\Annotations\Items' => 'items',
         'Swagger\Annotations\Property' => ['properties', 'property'],
+        'Swagger\Annotations\AdditionalProperties' => 'additionalProperties',
         'Swagger\Annotations\ExternalDocumentation' => 'externalDocs',
         'Swagger\Annotations\Xml' => 'xml',
     ];

--- a/src/Processors/MergeJsonContent.php
+++ b/src/Processors/MergeJsonContent.php
@@ -8,6 +8,7 @@ namespace Swagger\Processors;
 
 use Swagger\Annotations\MediaType;
 use Swagger\Annotations\JsonContent;
+use Swagger\Annotations\RequestBody;
 use Swagger\Annotations\Response;
 use Swagger\Analysis;
 use Swagger\Context;
@@ -22,7 +23,7 @@ class MergeJsonContent
         $annotations = $analysis->getAnnotationsOfType(JsonContent::class);
         foreach ($annotations as $jsonContent) {
             $response = $jsonContent->_context->nested;
-            if (!($response instanceof Response)) {
+            if (!($response instanceof Response) && !($response instanceof RequestBody)) {
                 continue;
             }
             if ($response->content === null) {

--- a/src/Processors/MergeJsonContent.php
+++ b/src/Processors/MergeJsonContent.php
@@ -32,9 +32,11 @@ class MergeJsonContent
             $response->content['application/json'] = new MediaType([
                 'mediaType' => 'application/json',
                 'schema' => $jsonContent,
+                'example' => $jsonContent->example,
                 'examples' => $jsonContent->examples,
                 '_context' => new Context(['generated' => true], $jsonContent->_context)
             ]);
+            $jsonContent->example = null;
             $jsonContent->examples = null;
 
             $index = array_search($jsonContent, $response->_unmerged, true);


### PR DESCRIPTION
- Allow JsonContent in RequestBody annotations
- Allow AdditionalProperties to be nested in Property annotations to allow free-form objects
- JsonContent: allow single example (see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#fixed-fields-10)