### PR TITLE
Used Trait's properties are accounted for

### DIFF
--- a/src/Analysis.php
+++ b/src/Analysis.php
@@ -168,6 +168,20 @@ class Analysis
         return $definitions;
     }
 
+    public function getUsedTraits($class)
+    {
+        $usedTraits = class_uses($class);
+        $definitions = [];
+        foreach($usedTraits as $usedTrait){
+            $usedTrait = '\\'.$usedTrait;
+            $usedDefinition = isset($this->classes[$usedTrait]) ? $this->classes[$usedTrait] : null;
+            if ($usedDefinition) {
+                $definitions[$usedTrait] = $usedDefinition;
+            }
+        }
+        return $definitions;
+    }
+
     /**
      *
      * @param string $class

--- a/src/Analysis.php
+++ b/src/Analysis.php
@@ -170,6 +170,8 @@ class Analysis
 
     public function getUsedTraits($class)
     {
+        if(!class_exists($class))
+            return [];
         $usedTraits = class_uses($class);
         $definitions = [];
         foreach($usedTraits as $usedTrait){

--- a/src/Processors/InheritProperties.php
+++ b/src/Processors/InheritProperties.php
@@ -30,9 +30,17 @@ class InheritProperties
                         }
                     }
                 }
-                $classes = $analysis->getSuperClasses($schema->_context->fullyQualifiedName($schema->_context->class));
-                foreach ($classes as $class) {
-                    foreach ($class['properties'] as $property) {
+                
+                $className = $schema->_context->fullyQualifiedName($schema->_context->class);
+                //Get inherited/exteneded classes to combine properties
+                $inheritedClasses = $analysis->getSuperClasses($className);
+                //Get Traits to combine properties
+                $usedTraits = $analysis->getUsedTraits($className);
+
+                $defintions = array_merge($inheritedClasses, $usedTraits);
+
+                foreach ($defintions as $defintion) {
+                    foreach ($defintion['properties'] as $property) {
                         if (is_array($property->annotations) === false && !($property->annotations instanceof Traversable)) {
                             continue;
                         }

--- a/src/StaticAnalyser.php
+++ b/src/StaticAnalyser.php
@@ -94,7 +94,7 @@ class StaticAnalyser
             if (in_array($token[0], [T_ABSTRACT, T_FINAL])) {
                 $token = $this->nextToken($tokens, $parseContext); // Skip "abstract" and "final" keywords
             }
-            if ($token[0] === T_CLASS) { // Doc-comment before a class?
+            if ($token[0] === T_CLASS || $token[0] === T_TRAIT) { // Doc-comment before a class?
                 if (is_array($previousToken) && $previousToken[0] === T_DOUBLE_COLON) {
                     //php 5.5 class name resolution (i.e. ClassName::class)
                     continue;
@@ -123,17 +123,6 @@ class StaticAnalyser
                     $definitionContext->extends = $this->parseNamespace($tokens, $token, $parseContext);
                     $classDefinition['extends'] = $definitionContext->fullyQualifiedName($definitionContext->extends);
                 }
-                if ($comment) {
-                    $definitionContext->line = $line;
-                    $this->analyseComment($analysis, $analyser, $comment, $definitionContext);
-                    $comment = false;
-                    continue;
-                }
-            }
-            if ($token[0] === T_TRAIT) {
-                $classDefinition = false;
-                $token = $this->nextToken($tokens, $parseContext);
-                $definitionContext = new Context(['trait' => $token[1], 'line' => $token[2]], $parseContext);
                 if ($comment) {
                     $definitionContext->line = $line;
                     $this->analyseComment($analysis, $analyser, $comment, $definitionContext);

--- a/tests/StaticAnalyserTest.php
+++ b/tests/StaticAnalyserTest.php
@@ -32,7 +32,7 @@ class StaticAnalyserTest extends SwaggerTestCase
         $analysis = $analyser->fromFile(__DIR__ . '/Fixtures/HelloTrait.php');
         $this->assertCount(2, $analysis->annotations);
         $property = $analysis->getAnnotationsOfType('Swagger\Annotations\Property')[0];
-        $this->assertSame('Hello', $property->_context->trait);
+        $this->assertSame('Hello', $property->_context->class);
     }
     
     public function testThirdPartyAnnotations()


### PR DESCRIPTION
Thanks for the library, great work, in our situation we have been using traits in our classes and wanted the properties to be accounted for in an object's swagger definition. Now if the definition annotation for an object is in a class, and that class uses a trait that has property annotations, they will be included in the Object's definition.