### PR TITLE
ugly fix #326 #474

### DIFF
--- a/src/Annotations/AbstractAnnotation.php
+++ b/src/Annotations/AbstractAnnotation.php
@@ -222,7 +222,7 @@ abstract class AbstractAnnotation implements JsonSerializable
 
     public function __toString()
     {
-        return json_encode($this, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        return preg_replace(["/\\\\\\\\[nr]/", "/(\\\\[nr])+\s+\*\s+/"], ['\n','\n\n'], json_encode($this, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
     }
 
     public function __debugInfo()


### PR DESCRIPTION
handle line breaks as expected (preg_replace)
support cyrillic as is (JSON_UNESCAPED_UNICODE)

example
```
 * @OA\Info(
 *     version="1.0",
 *     title="Sample API",
 *     description="Длинное\n\nпредлинное
 *     `1` first
 *     `2` second
 *     ```shell\nX-Request-ID: g9h3LkdJf8\n```
 *     Описание api
 *     для блока ```@OA\Info```",
 *     @OA\Contact(
 *         name="company name",
 *         url="https://domain.tld"
 *     ),
 * )
```
generates
```
    "info": {
        "title": "Sample API",
        "description": "Длинное\n\nпредлинное\n\n`1` first\n\n`2` second\n\n```shell\nX-Request-ID: g9h3LkdJf8\n```\n\nОписание api\n\nдля блока ```@OA\\Info```",
        "contact": {
            "name": "company name",
            "url": "https://domain.tld"
        },
        "version": "1.0"
    },
```
and in e.g. [ReDoc](https://github.com/Rebilly/ReDoc) it looks something like this
![ReDoc Sample Info](https://monosnap.com/image/CSoY2myIO0QrELvhC0gfBhd1k0GBNZ.png)