### PR TITLE
Allow the use of the discriminator inside property and items object

### DIFF
--- a/src/Annotations/Discriminator.php
+++ b/src/Annotations/Discriminator.php
@@ -41,6 +41,8 @@ class Discriminator extends AbstractAnnotation
 
     /** @inheritdoc */
     public static $_parents = [
-        'OpenApi\Annotations\Schema'
+        'OpenApi\Annotations\Schema',
+        'OpenApi\Annotations\Property',
+        'OpenApi\Annotations\Items',
     ];
 }

--- a/src/Annotations/Items.php
+++ b/src/Annotations/Items.php
@@ -19,7 +19,8 @@ class Items extends Schema
         'OpenApi\Annotations\Items' => 'items',
         'OpenApi\Annotations\Property' => ['properties', 'property'],
         'OpenApi\Annotations\ExternalDocumentation' => 'externalDocs',
-        'OpenApi\Annotations\Xml' => 'xml'
+        'OpenApi\Annotations\Xml' => 'xml',
+        'OpenApi\Annotations\Discriminator' => 'discriminator'
     ];
 
     /** @inheritdoc */

--- a/src/Annotations/Property.php
+++ b/src/Annotations/Property.php
@@ -33,5 +33,6 @@ class Property extends Schema
         'OpenApi\Annotations\Property' => ['properties', 'property'],
         'OpenApi\Annotations\ExternalDocumentation' => 'externalDocs',
         'OpenApi\Annotations\Xml' => 'xml',
+        'OpenApi\Annotations\Discriminator' => 'discriminator'
     ];
 }


### PR DESCRIPTION
According to doc we can use `oneOf` inside properties and items. For more clearness, oneOf is also used with a discriminator.
```
type: array
items:
  oneOf:
    - $ref: '#/components/schemas/Cat'
    - $ref: '#/components/schemas/Dog'
```
This PR allows you to use the `Discriminator` class inside the `Property` and `Items` classes.