### PR TITLE
Set example as null if property is nullable but no examples have been defined

### DIFF
--- a/src/Annotations/AbstractAnnotation.php
+++ b/src/Annotations/AbstractAnnotation.php
@@ -305,6 +305,11 @@ abstract class AbstractAnnotation implements JsonSerializable
             $data->$dollarRef = $data->ref;
             unset($data->ref);
         }
+
+        if (isset($data->nullable) && !isset($data->example)) {
+            $data->example = null;
+        }
+
         return $data;
     }
 

--- a/tests/AbstractAnnotationTest.php
+++ b/tests/AbstractAnnotationTest.php
@@ -100,4 +100,10 @@ END;
 //        $this->assertOpenApiLogEntryStartsWith('@OA\Parameter(name=123,in="dunno")->type must be "string", "number", "integer", "boolean", "array", "file" when @OA\Parameter()->in != "body" in ');
         $parameter->validate();
     }
+
+    public function testItReturnExpectedExamplesOnNullableParameters()
+    {
+        $openapi = \OpenApi\scan(__DIR__.'/Fixtures/NullableExamples.php');
+        $this->assertOpenApiEqualsFile(__DIR__.'/ExamplesOutput/nullable-variables.json', $openapi);
+    }
 }

--- a/tests/ExamplesOutput/nullable-variables.json
+++ b/tests/ExamplesOutput/nullable-variables.json
@@ -1,0 +1,25 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Example for nullable variables with example",
+    "version": "1.0"
+  },
+  "components": {
+    "schemas": {
+      "NullableExamples": {
+        "properties": {
+          "notNullable": {},
+          "nullableWithExample": {
+            "example": "hello",
+            "nullable": true
+          },
+          "variable": {
+            "example": null,
+            "nullable": true
+          }
+        }
+      }
+    }
+  },
+  "paths": {}
+}

--- a/tests/Fixtures/NullableExamples.php
+++ b/tests/Fixtures/NullableExamples.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace OpenApiTests\Fixtures;
+
+/**
+ * @OA\Info(
+ *     version="1.0",
+ *     title="Example for nullable variables with example"
+ * )
+ */
+
+/**
+ * @OA\Schema()
+ */
+class NullableExamples
+{
+    /**
+     * @OA\Property(
+     *   nullable=true,
+     * )
+     */
+    public $variable;
+
+    /**
+     * @OA\Property(example=null)
+     */
+    public $notNullable;
+
+    /**
+     * @OA\Property(
+     *   nullable=true,
+     *   example="hello"
+     * )
+     */
+    public $nullableWithExample;
+}

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -10,7 +10,7 @@ class UtilTest extends OpenApiTestCase
 {
     public function testExclude()
     {
-        $openapi = \OpenApi\scan(__DIR__.'/Fixtures', ['exclude' => ['Customer.php', 'UsingRefs.php', 'UsingPhpDoc.php', 'DynamicReference.php', 'GrandAncestor.php']]);
+        $openapi = \OpenApi\scan(__DIR__.'/Fixtures', ['exclude' => ['NullableExamples.php', 'Customer.php', 'UsingRefs.php', 'UsingPhpDoc.php', 'DynamicReference.php', 'GrandAncestor.php']]);
         $this->assertSame('Fixture for ParserTest', $openapi->info->title, 'No errors about duplicate @OA\Info() annotations');
     }
 }


### PR DESCRIPTION
Hello there

this might not be the best solution but it suits my needs. I'm very happy to change the way it does this with the lead of someone more experienced in this project.

My first idea was to create a null object to use or wrap null in strings and detect that but in the end this is working fine.

Let me know your thoughts