### PR TITLE
fix for allOf in InheritProperties

### DIFF
--- a/src/Processors/InheritProperties.php
+++ b/src/Processors/InheritProperties.php
@@ -51,7 +51,7 @@ class InheritProperties
                 foreach ($classes as $class) {
                     if ($class['context']->annotations) {
                         foreach ($class['context']->annotations as $annotation) {
-                            if ($annotation instanceof Schema && $annotation->schema) {
+                            if ($annotation instanceof Schema && $annotation->schema !== UNDEFINED) {
                                 $this->addAllOfProperty($schema, $annotation);
 
                                 continue 2;


### PR DESCRIPTION
We should add allOf for child schema only if parent schema has defined schema name. This behavior has been broken when we added undefined as default value into all annotation properties.