### PR TITLE
Fix for deserialization of allOf properties

### DIFF
--- a/src/Annotations/Schema.php
+++ b/src/Annotations/Schema.php
@@ -344,28 +344,31 @@ class Schema extends AbstractAnnotation
         'minItems' => 'integer',
         'uniqueItems' => 'boolean',
         'multipleOf' => 'integer',
+        'allOf' => '[' . Schema::class . ']',
+        'oneOf' => '[' . Schema::class . ']',
+        'anyOf' => '[' . Schema::class . ']'
     ];
 
     /**
      * @inheritdoc
      */
     public static $_nested = [
-        'OpenApi\Annotations\Discriminator' => 'discriminator',
-        'OpenApi\Annotations\Items' => 'items',
-        'OpenApi\Annotations\Property' => ['properties', 'property'],
-        'OpenApi\Annotations\ExternalDocumentation' => 'externalDocs',
-        'OpenApi\Annotations\Xml' => 'xml',
-        'OpenApi\Annotations\AdditionalProperties' => 'additionalProperties'
+        Discriminator::class         => 'discriminator',
+        Items::class                 => 'items',
+        Property::class              => ['properties', 'property'],
+        ExternalDocumentation::class => 'externalDocs',
+        Xml::class                   => 'xml',
+        AdditionalProperties::class  => 'additionalProperties'
     ];
 
     /**
      * @inheritdoc
      */
     public static $_parents = [
-        'OpenApi\Annotations\Components',
-        'OpenApi\Annotations\Parameter',
-        'OpenApi\Annotations\MediaType',
-        'OpenApi\Annotations\Header',
+        Components::class,
+        Parameter::class,
+        MediaType::class,
+        Header::class,
     ];
 
     public function validate($parents = [], $skip = [], $ref = '')


### PR DESCRIPTION
Deserializer work incorrect when we trying to deserialize schema with `allOf` property.
For example allOf properties will be deserialized like `stdClass` with the `$ref` property but according to swagger `allOf,oneOf,anyOf` is array of schemes [link](https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/).

Json  string example
```
{
	"openapi": "3.0.0",
	"info": {
		"title": "Pet store",
		"version": "1.0"
	},
	"components": {
		"schemas": {
			"Dog": {
				"allOf": [{
					"$ref": "#/components/schemas/SomeSchema"
				}]
			},
			"Cat": {
				"allOf": [{
					"$ref": "#/components/schemas/SomeSchema"
				}]
			}
		}
	}
}
```
The result of deserealization
```
object(OpenApi\Annotations\OpenApi)#2844 (5) {
  ["openapi"]=>
  string(5) "3.0.0"
  ["info"]=>
  object(OpenApi\Annotations\Info)#2848 (4) {
    ["title"]=>
    string(9) "Pet store"
    ["version"]=>
    string(3) "1.0"
    ["_context"]=>
    object(OpenApi\Context)#2846 (1) {
      ["-"]=>
      string(107) "\OpenApi\Serializer->doDeserialize() in .../dev/swagger-php/src/Serializer.php on line 120"
    }
    ["_unmerged"]=>
    array(0) {
    }
  }
  ["components"]=>
  object(OpenApi\Annotations\Components)#2847 (3) {
    ["schemas"]=>
    array(2) {
      ["Dog"]=>
      object(OpenApi\Annotations\Schema)#2798 (4) {
        ["schema"]=>
        string(3) "Dog"
        ["allOf"]=>
        array(1) {
          [0]=>
          object(stdClass)#2852 (1) {
            ["$ref"]=>
            string(31) "#/components/schemas/SomeSchema"
          }
        }
        .....
```
My proposal to mark the properties that hasn't simple key like discriminator or items as simple array of objects. This PR will fix this problem also this fix is covered by the unit test.