### PR TITLE
Configurable File Patterns added

### DIFF
--- a/bin/openapi
+++ b/bin/openapi
@@ -14,6 +14,7 @@ $options = [
     'output' => false,
     'format' => 'auto',
     'exclude' => [],
+    'pattern' => '*.php',
     'bootstrap' => false,
     'help' => false,
     'debug' => false,
@@ -22,6 +23,7 @@ $options = [
 $aliases = [
     'o' => 'output',
     'e' => 'exclude',
+    'n' => 'pattern',
     'b' => 'bootstrap',
     'h' => 'help',
     'd' => 'debug',
@@ -32,6 +34,7 @@ $needsArgument = [
     'output',
     'format',
     'exclude',
+    'pattern',
     'bootstrap',
     'processor',
 ];
@@ -103,6 +106,8 @@ Options:
                     ex: --output openapi.yaml
   --exclude (-e)    Exclude path(s).
                     ex: --exclude vendor,library/Zend
+  --pattern (-n)    Pattern of files to scan.
+                    ex: --pattern "*.php" or --pattern "/\.(phps|php)$/"
   --bootstrap (-b)  Bootstrap a php file for defining constants, etc.
                     ex: --bootstrap config/constants.php
   --processor       Register an additional processor.
@@ -210,6 +215,11 @@ if ($options['exclude']) {
     }
 }
 
+$pattern = "*.php";
+if ($options['pattern']) {
+    $pattern = $options['pattern'];
+}
+
 foreach ($options["processor"] as $processor) {
     $class = '\OpenApi\Processors\\'.$processor;
     if (class_exists($class)) {
@@ -220,7 +230,7 @@ foreach ($options["processor"] as $processor) {
     Analysis::registerProcessor($processor);
 }
 
-$openapi = OpenApi\scan($paths, ['exclude' => $exclude]);
+$openapi = OpenApi\scan($paths, ['exclude' => $exclude, 'pattern' => $pattern]);
 
 if ($exit !== 0) {
     error_log('');

--- a/src/Util.php
+++ b/src/Util.php
@@ -65,9 +65,10 @@ class Util
      *
      * @param  string|array|Finder $directory The directory(s) or filename(s)
      * @param  null|string|array   $exclude   The directory(s) or filename(s) to exclude (as absolute or relative paths)
+     * @param  null|string         $pattern   The pattern of the files to scan
      * @throws InvalidArgumentException
      */
-    public static function finder($directory, $exclude = null)
+    public static function finder($directory, $exclude = null, $pattern = null)
     {
         if ($directory instanceof Finder) {
             return $directory;
@@ -75,7 +76,11 @@ class Util
             $finder = new Finder();
             $finder->sortByName();
         }
-        $finder->files()->followLinks()->name('*.php');
+        if ($pattern === null) {
+            $pattern = '*.php';
+        }
+
+        $finder->files()->followLinks()->name($pattern);
         if (is_string($directory)) {
             if (is_file($directory)) { // Scan a single file?
                 $finder->append([$directory]);

--- a/src/functions.php
+++ b/src/functions.php
@@ -23,6 +23,7 @@ if (defined('OpenApi\UNDEFINED') === false) {
      * @param  string|array|Finder $directory The directory(s) or filename(s)
      * @param  array               $options
      *   exclude: string|array $exclude The directory(s) or filename(s) to exclude (as absolute or relative paths)
+     *   pattern: string       $pattern File pattern(s) to scan (default: *.php)
      *   analyser: defaults to StaticAnalyser
      *   analysis: defaults to a new Analysis
      *   processors: defaults to the registered processors in Analysis
@@ -34,9 +35,10 @@ if (defined('OpenApi\UNDEFINED') === false) {
         $analysis = array_key_exists('analysis', $options) ? $options['analysis'] : new Analysis();
         $processors = array_key_exists('processors', $options) ? $options['processors'] : Analysis::processors();
         $exclude = array_key_exists('exclude', $options) ? $options['exclude'] : null;
+        $pattern = array_key_exists('pattern', $options) ? $options['pattern'] : null;
 
         // Crawl directory and parse all files
-        $finder = Util::finder($directory, $exclude);
+        $finder = Util::finder($directory, $exclude, $pattern);
         foreach ($finder as $file) {
             $analysis->addAnalysis($analyser->fromFile($file->getPathname()));
         }


### PR DESCRIPTION
Configurable File Patterns added for OpenAPI (CLI included).
This enables to properly scan projects which are using alternate extensions for PHP files.
The pattern parameter is using standard Symfony/Finder patterns.