### PR TITLE
Improve XmlContent

### DIFF
--- a/src/Processors/MergeXmlContent.php
+++ b/src/Processors/MergeXmlContent.php
@@ -33,10 +33,12 @@ class MergeXmlContent
                 [
                     'mediaType' => 'application/xml',
                     'schema' => $xmlContent,
+                    'example' => $xmlContent->example,
                     'examples' => $xmlContent->examples,
                     '_context' => new Context(['generated' => true], $xmlContent->_context)
                 ]
             );
+            $xmlContent->example = UNDEFINED;
             $xmlContent->examples = UNDEFINED;
 
             $index = array_search($xmlContent, $response->_unmerged, true);

--- a/src/Processors/MergeXmlContent.php
+++ b/src/Processors/MergeXmlContent.php
@@ -7,14 +7,14 @@
 namespace OpenApi\Processors;
 
 use OpenApi\Annotations\MediaType;
-use OpenApi\Annotations\JsonContent;
+use OpenApi\Annotations\RequestBody;
 use OpenApi\Annotations\Response;
 use OpenApi\Analysis;
 use OpenApi\Annotations\XmlContent;
 use OpenApi\Context;
 
 /**
- * Split JsonContent into Schema and MediaType
+ * Split XmlContent into Schema and MediaType
  */
 class MergeXmlContent
 {
@@ -23,7 +23,7 @@ class MergeXmlContent
         $annotations = $analysis->getAnnotationsOfType(XmlContent::class);
         foreach ($annotations as $xmlContent) {
             $response = $xmlContent->_context->nested;
-            if (!($response instanceof Response)) {
+            if (!($response instanceof Response) && !($response instanceof RequestBody)) {
                 continue;
             }
             if ($response->content === UNDEFINED) {


### PR DESCRIPTION
The XmlContent annotation is ignored in RequestBody. Also, defining a single example is not supported.

These both work for JsonContent annotation. This pull request is to bring XmlContent up to par with JsonContent.