### PR TITLE
Fix property value in Examples is only string

### DIFF
--- a/src/Annotations/Examples.php
+++ b/src/Annotations/Examples.php
@@ -51,7 +51,6 @@ class Examples extends AbstractAnnotation
 
     public static $_types = [
         'summary' => 'string',
-        'value' => 'string',
         'description' => 'string',
         'externalValue' => 'string',
     ];


### PR DESCRIPTION
Property value is limited to a string, although an example can also be represented by a boolean, integer, array or object.