### PR TITLE
Implement nullable refs

### DIFF
--- a/tests/AugmentPropertiesTest.php
+++ b/tests/AugmentPropertiesTest.php
@@ -40,6 +40,7 @@ class AugmentPropertiesTest extends OpenApiTestCase
         $tags = $customer->properties[5];
         $submittedBy = $customer->properties[6];
         $friends = $customer->properties[7];
+        $bestFriend = $customer->properties[8];
 
         // Verify no values where defined in the annotation.
         $this->assertSame(UNDEFINED, $firstName->property);
@@ -59,6 +60,10 @@ class AugmentPropertiesTest extends OpenApiTestCase
 
         $this->assertSame(UNDEFINED, $friends->property);
         $this->assertSame(UNDEFINED, $friends->type);
+
+        $this->assertSame(UNDEFINED, $bestFriend->property);
+        $this->assertSame(UNDEFINED, $bestFriend->nullable);
+        $this->assertSame(UNDEFINED, $bestFriend->allOf);
 
         $analysis->process(new AugmentProperties());
 
@@ -112,6 +117,10 @@ class AugmentPropertiesTest extends OpenApiTestCase
         $this->assertSame('friends', $friends->property);
         $this->assertSame('array', $friends->type);
         $this->assertSame('#/components/schemas/Customer', $friends->items->ref);
+
+        $this->assertSame('bestFriend', $bestFriend->property);
+        $this->assertTrue($bestFriend->nullable);
+        $this->assertSame('#/components/schemas/Customer', $bestFriend->allOf[0]->ref);
     }
 
     /**

--- a/tests/AugmentSchemasTest.php
+++ b/tests/AugmentSchemasTest.php
@@ -26,6 +26,6 @@ class AugmentSchemasTest extends OpenApiTestCase
         $this->assertSame(UNDEFINED, $customer->properties, 'Sanity check. @OA\Property\'s not yet merged ');
         $analysis->process(new AugmentSchemas());
         $this->assertSame('Customer', $customer->schema, '@OA\Schema()->schema based on classname');
-        $this->assertCount(8, $customer->properties, '@OA\Property()s are merged into the @OA\Schema of the class');
+        $this->assertCount(9, $customer->properties, '@OA\Property()s are merged into the @OA\Schema of the class');
     }
 }

--- a/tests/Fixtures/Customer.php
+++ b/tests/Fixtures/Customer.php
@@ -73,6 +73,12 @@ class Customer
     public $friends;
 
     /**
+     * @OA\Property()
+     * @var Customer|null
+     */
+    public $bestFriend;
+
+    /**
      * for ContextTest
      */
     public function testResolvingFullyQualifiedNames()


### PR DESCRIPTION
This is a follow-up to #670.

The idea is to transform a nullable property:

```php
/**
 * @OA\Schema()
 */
class Reservation
{
    /**
     * @OA\Property()
     *
     * @var Deal|null
     */
    public $deal;
}
```

Into this:

```yaml
components:
  schemas:
    Reservation:
      properties:
        deal:
          nullable: true
          allOf:
            -
              $ref: '#/components/schemas/Deal'
```

The implementation is simple:

- if the property types contain 'null': set `nullable` and `allOf` with `ref`
- else: set `ref` as usual

✅ No BC breaks
✅ Covered by tests