### PR TITLE
fix for deserialization of allOf property (2.x)

### DIFF
--- a/src/Annotations/AbstractAnnotation.php
+++ b/src/Annotations/AbstractAnnotation.php
@@ -49,7 +49,8 @@ abstract class AbstractAnnotation implements JsonSerializable
      *   'name' => 'string' // a string
      *   'required' => 'boolean', // true or false
      *   'tags' => '[string]', // array containing strings
-     *   'in' => ["query", "header", "path", "formData", "body"] // must be one on these
+     *   'in' => ["query", "header", "path", "formData", "body"], // must be one on these
+     *   'allOf' => ['Annotation\Schema'] //array of schema objects
      * @var array
      */
     public static $_types = [];
@@ -479,6 +480,15 @@ abstract class AbstractAnnotation implements JsonSerializable
         return '@' . str_replace('Swagger\\Annotations\\', 'SWG\\', get_class($this)) . '(' . implode(',', $fields) . ')';
     }
 
+    /**
+     * Validates the matching of the property value to a annotation type
+     *
+     * @param string $type  The annotations property type
+     * @param mixed  $value The property value
+     *
+     * @return bool
+     * @throws \Exception
+     */
     private function validateType($type, $value)
     {
         if (substr($type, 0, 1) === '[' && substr($type, -1) === ']') { // Array of a specified type?
@@ -493,6 +503,11 @@ abstract class AbstractAnnotation implements JsonSerializable
             }
             return true;
         }
+
+        if (is_subclass_of($type, AbstractAnnotation::class)) {
+            $type = 'object';
+        }
+
         switch ($type) {
             case 'string':
                 return is_string($value);
@@ -505,6 +520,9 @@ abstract class AbstractAnnotation implements JsonSerializable
 
             case 'number':
                 return is_numeric($value);
+
+            case 'object':
+                return is_object($value);
 
             case 'array':
                 if (is_array($value) === false) {

--- a/src/Annotations/Schema.php
+++ b/src/Annotations/Schema.php
@@ -221,6 +221,7 @@ class Schema extends AbstractAnnotation
         'minItems' => 'integer',
         'uniqueItems' => 'boolean',
         'multipleOf' => 'integer',
+        'allOf' => '[' . Schema::class . ']',
     ];
 
     /** @inheritdoc */

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -119,4 +119,49 @@ JSON;
         $this->assertInstanceOf('Swagger\Annotations\Swagger', $swagger);
         $this->assertSwaggerEqualsFile(__DIR__ . '/ExamplesOutput/petstore.swagger.io.json', $swagger);
     }
+
+    /**
+     * Test for correct deserialize schemas 'allOf' property.
+     * @throws \Exception
+     */
+    public function testDeserializeAllOfProperty()
+    {
+        $serializer = new Serializer();
+        $json = <<<JSON
+{
+  "swagger": "2.0",
+  "definitions": {
+   "Pet": {
+     "type": "object",
+      "required": [
+        "name",
+        "photoUrls"
+      ]
+    },
+    "Dog": {
+      "type": "object",
+      "allOf": [{
+        "\$ref": "#/definitions/Pet"
+                
+      }, {
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      }]
+    }
+  }
+}
+JSON;
+
+        /** @var Annotations\Swagger $swagger */
+        $swagger = $serializer->deserialize($json, 'Swagger\Annotations\Swagger');
+
+        $this->assertNotEmpty($swagger->definitions['Dog']->allOf);
+
+        foreach ($swagger->definitions['Dog']->allOf as $schemaObject) {
+            $this->assertInstanceOf(Annotations\Schema::class, $schemaObject);
+        }
+    }
 }


### PR DESCRIPTION
partly backport of #605 

Partly because we just have `allOf` available as property right now, no `oneOf` or anyOf.
Also I did not do other refactoring which was done in #605 to not change to much in 2.x

Simple test for definitions is added