### PR TITLE
Examples: can be named, can be referenced

### DIFF
--- a/src/Annotations/Components.php
+++ b/src/Annotations/Components.php
@@ -100,7 +100,7 @@ class Components extends AbstractAnnotation
         Response::class => ['responses', 'response'],
         Parameter::class => ['parameters', 'parameter'],
         RequestBody::class => ['requestBodies', 'request'],
-        Examples::class => ['examples'],
+        Examples::class => ['examples', 'name'],
         Header::class => ['headers', 'header'],
         SecurityScheme::class => ['securitySchemes', 'securityScheme'],
         Link::class => ['links', 'link'],

--- a/src/Annotations/Examples.php
+++ b/src/Annotations/Examples.php
@@ -12,6 +12,18 @@ namespace OpenApi\Annotations;
 class Examples extends AbstractAnnotation
 {
     /**
+     * $ref See https://swagger.io/docs/specification/using-ref/
+     *
+     * @var string
+     */
+    public $ref = UNDEFINED;
+
+    /**
+     * @var string
+     */
+    public $name = UNDEFINED;
+
+    /**
      * Short description for the example.
      *
      * @var string
@@ -54,8 +66,6 @@ class Examples extends AbstractAnnotation
         'description' => 'string',
         'externalValue' => 'string',
     ];
-
-    public static $_required = ['summary'];
 
     public static $_parents = [
         Components::class,


### PR DESCRIPTION
Current state of the @Examples annotation is quite strange, as according to [OpenApi specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#components-object) it should be referencable from /components, but our current implementation is kinda half-hearted. @Examples doesn't have any name so numeric index is used (so it goes into components as #/components/examples/0, #/components/examples/1 etc.) and also can't be referenced, so you can't even use it as a reference anywhere (so no point in even adding it to /components/examples).

This PR tries to solve this issue, as it 

- adds name to Examples, so it can have meaningful name in /components
- allows Examples to have $ref, so having global examples in /components makes some sense

I didn't yet add any tests, examples nor documentation, as I would love to first have some feedback on the general idea and implementation.

How to try it: 

add example somewhere as general standalone annotation
```
	 * @OA\Examples(
	 *     name="FolderForbiddenErrorExample",
	 *     summary="30005: Unable to access folder.",
	 *     description="The requested folder could not be accessed. It might not exist, or provided user might not be able to access it.",
	 *     value="{
	""code"": 30005,
	""message"": ""Unable to access folder.""
}"
	 * )
```
reference it somewhere
```	 
	 *     @OA\Response(
	 *         response="403",
	 *         description="This is bad error, much the baddest. Don't you do this error, eww nasty.",
	 *         @OA\JsonContent(
	 *             ref="#/components/schemas/ErrorSchema",
	 *             examples={
	 *                 @OA\Examples(ref="#/components/examples/UserForbiddenErrorExample"),
	 *                 @OA\Examples(ref="#/components/examples/FolderForbiddenErrorExample"),
	 *             }
	 *         ),
	 *     )
```

