### PR TITLE
Fix PHP 7.4 notice for invalid array access

### DIFF
--- a/src/StaticAnalyser.php
+++ b/src/StaticAnalyser.php
@@ -326,6 +326,10 @@ class StaticAnalyser
     {
         while (true) {
             $token = next($tokens);
+            if ($token === false) {
+                return false;
+            }
+            
             if ($token[0] === T_WHITESPACE) {
                 continue;
             }


### PR DESCRIPTION
next() returns false if there are no more elements left and thus an invalid array access occurs (on the returned false value).
The exact notice is: "Trying to access array offset on value of type bool"

For more information see this RFC: https://wiki.php.net/rfc/notice-for-non-valid-array-container