### PR TITLE
Apply fix from #407 to this version to fix invalid YAML generated with empty scopes

### DIFF
--- a/src/Annotations/Flow.php
+++ b/src/Annotations/Flow.php
@@ -78,4 +78,13 @@ class Flow extends AbstractAnnotation
     public static $_parents = [
         SecurityScheme::class,
     ];
+
+    /** {@inheritdoc} */
+    public function jsonSerialize()
+    {
+        if (is_array($this->scopes) && empty($this->scopes)) {
+            $this->scopes = new \StdClass();
+        }
+        return parent::jsonSerialize();
+    }
 }


### PR DESCRIPTION
The issue reported in #407 and fixed in #408 regressed with the new @OA\Flow keyword.

This annotation:
```
     *  @OA\SecurityScheme(
     *      type="oauth2",
     *      securityScheme="ClientAuth",
     *      @OA\Flow(
     *          flow="clientCredentials",
     *          tokenUrl="/oauth2/token",
     *          scopes={},
     *      ),
     *  ),
```

produces this YAML:
```
securitySchemes:
    UserAuth:
      type: oauth2
      flows:
        password:
          tokenUrl: /oauth2/token
          refreshUrl: /oauth2/token
          scopes: []
```

As per the [spec](https://swagger.io/docs/specification/authentication/oauth2/#no-scopes), this should be an empty object, which there isn't a way to directly define with the annotations.

This applies the same fix as #408, but now in the Flow element versus the SecurityScheme element to match OAS3.

With this patch, we get:
```
  securitySchemes:
    UserAuth:
      type: oauth2
      flows:
        password:
          tokenUrl: /oauth2/token
          refreshUrl: /oauth2/token
          scopes: {  }
```