### PR TITLE
PHP 7.4 Preloading: define 'scan()' function only if not already defined

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -16,7 +16,9 @@ if (defined('OpenApi\UNDEFINED') === false) {
     define('OpenApi\UNDEFINED', '@OA\UNDEFINED🙈');
     define('OpenApi\Annotations\UNDEFINED', UNDEFINED);
     define('OpenApi\Processors\UNDEFINED', UNDEFINED);
+}
 
+if (function_exists('OpenApi\scan') === false) {
     /**
      * Scan the filesystem for OpenAPI annotations and build openapi-documentation.
      *


### PR DESCRIPTION
Hi,

If the `functions.php` file is preloaded and then included at runtime, it triggers a `PHP Fatal error:  Cannot redeclare OpenApi\scan()`.

Constants are not preloaded, so this PR split constants and function definition to fix this issue.