### PR TITLE
Refactor tests

### DIFF
--- a/tests/Annotations/AbstractAnnotationTest.php
+++ b/tests/Annotations/AbstractAnnotationTest.php
@@ -4,7 +4,9 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests;
+namespace OpenApiTests\Annotations;
+
+use OpenApiTests\OpenApiTestCase;
 
 class AbstractAnnotationTest extends OpenApiTestCase
 {

--- a/tests/Annotations/AnnotationPropertiesDefinedTest.php
+++ b/tests/Annotations/AnnotationPropertiesDefinedTest.php
@@ -4,18 +4,18 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests;
+namespace OpenApiTests\Annotations;
 
 use OpenApi\Annotations\AbstractAnnotation;
-use const OpenApi\UNDEFINED;
+use OpenApiTests\OpenApiTestCase;
 use function get_class_vars;
 
-class UndefinedTest extends OpenApiTestCase
+class AnnotationPropertiesDefinedTest extends OpenApiTestCase
 {
     /**
-     * @dataProvider allAnnotations
+     * @dataProvider allAnnotationClasses
      */
-    public function testDefaultPropertiesAreUndefined($annotation)
+    public function testPropertiesAreNotUndefined($annotation)
     {
         $properties = get_class_vars($annotation);
         $skip = AbstractAnnotation::$_blacklist;
@@ -24,7 +24,7 @@ class UndefinedTest extends OpenApiTestCase
                 continue;
             }
             if ($value === null) {
-                $this->fail("Property ".basename($annotation).'->'.$property.' should be UNDEFINED');
+                $this->fail("Property ".basename($annotation).'->'.$property.' should be DEFINED');
             }
         }
     }

--- a/tests/Annotations/ItemsTest.php
+++ b/tests/Annotations/ItemsTest.php
@@ -4,9 +4,10 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests;
+namespace OpenApiTests\Annotations;
 
 use OpenApi\StaticAnalyser;
+use OpenApiTests\OpenApiTestCase;
 
 class ItemsTest extends OpenApiTestCase
 {
@@ -35,8 +36,9 @@ class ItemsTest extends OpenApiTestCase
     public function testRefDefinitionInProperty()
     {
         $analyser = new StaticAnalyser();
-        $analysis = $analyser->fromFile(__DIR__.'/Fixtures/UsingVar.php');
+        $analysis = $analyser->fromFile($this->fixtures('UsingVar.php')[0]);
         $analysis->process();
+
         $this->assertCount(2, $analysis->openapi->components->schemas);
         $this->assertEquals('UsingVar', $analysis->openapi->components->schemas[0]->schema);
         $this->assertIsArray($analysis->openapi->components->schemas[0]->properties);

--- a/tests/Annotations/NestedPropertyTest.php
+++ b/tests/Annotations/NestedPropertyTest.php
@@ -4,21 +4,20 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests;
+namespace OpenApiTests\Annotations;
 
 use OpenApi\Processors\AugmentProperties;
 use OpenApi\Processors\AugmentSchemas;
 use OpenApi\Processors\MergeIntoComponents;
 use OpenApi\Processors\MergeIntoOpenApi;
-use OpenApi\StaticAnalyser;
+use OpenApiTests\OpenApiTestCase;
 use const OpenApi\UNDEFINED;
 
 class NestedPropertyTest extends OpenApiTestCase
 {
     public function testNestedProperties()
     {
-        $analyser = new StaticAnalyser();
-        $analysis = $analyser->fromFile(__DIR__.'/Fixtures/NestedProperty.php');
+        $analysis = $this->analysisFromFixtures('NestedProperty.php');
         $analysis->process(new MergeIntoOpenApi());
         $analysis->process(new MergeIntoComponents());
         $analysis->process(new AugmentSchemas());

--- a/tests/Annotations/ResponseTest.php
+++ b/tests/Annotations/ResponseTest.php
@@ -4,7 +4,9 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests;
+namespace OpenApiTests\Annotations;
+
+use OpenApiTests\OpenApiTestCase;
 
 class ResponseTest extends OpenApiTestCase
 {

--- a/tests/Annotations/SecuritySchemesTest.php
+++ b/tests/Annotations/SecuritySchemesTest.php
@@ -4,12 +4,13 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests;
+namespace OpenApiTests\Annotations;
 
 use OpenApi\Analyser;
 use OpenApi\Annotations\Info;
 use OpenApi\Annotations\SecurityScheme;
 use OpenApi\Annotations\Server;
+use OpenApiTests\OpenApiTestCase;
 
 /**
  * Class SecuritySchemesTest

--- a/tests/Annotations/ValidateRelationsTest.php
+++ b/tests/Annotations/ValidateRelationsTest.php
@@ -4,17 +4,19 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests;
+namespace OpenApiTests\Annotations;
+
+use OpenApiTests\OpenApiTestCase;
 
 /**
- * Test if the nesting/parent relations are coherent.
+ * Test if the annotation class nesting parent/child relations are coherent.
  */
 class ValidateRelationsTest extends OpenApiTestCase
 {
 
     /**
      *
-     * @dataProvider getAnnotationClasses
+     * @dataProvider allAnnotationClasses
      *
      * @param string $class
      */
@@ -36,7 +38,7 @@ class ValidateRelationsTest extends OpenApiTestCase
 
     /**
      *
-     * @dataProvider getAnnotationClasses
+     * @dataProvider allAnnotationClasses
      *
      * @param string $class
      */
@@ -54,25 +56,5 @@ class ValidateRelationsTest extends OpenApiTestCase
                 $this->fail($class.' not found in '.$nested."::\$parent. Found:\n  ".implode("\n  ", $nested::$_parents));
             }
         }
-    }
-
-    /**
-     * dataProvider for testExample
-     *
-     * @return array
-     */
-    public function getAnnotationClasses()
-    {
-        $classes = [];
-        $dir = new \DirectoryIterator(__DIR__.'/../src/Annotations');
-        foreach ($dir as $entry) {
-            if ($entry->getFilename() === 'AbstractAnnotation.php') {
-                continue;
-            }
-            if ($entry->getExtension() === 'php') {
-                $classes[] = ['OpenApi\Annotations\\'.substr($entry->getFilename(), 0, -4)];
-            }
-        }
-        return $classes;
     }
 }

--- a/tests/Processors/AugmentOperationTest.php
+++ b/tests/Processors/AugmentOperationTest.php
@@ -4,19 +4,18 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests;
+namespace OpenApiTests\Processors;
 
 use OpenApi\Annotations\Operation;
 use OpenApi\Processors\AugmentOperations;
-use OpenApi\StaticAnalyser;
+use OpenApiTests\OpenApiTestCase;
 use const OpenApi\UNDEFINED;
 
 class AugmentOperationTest extends OpenApiTestCase
 {
     public function testAugmentOperation()
     {
-        $analyser = new StaticAnalyser();
-        $analysis = $analyser->fromFile(__DIR__.'/Fixtures/UsingPhpDoc.php');
+        $analysis = $this->analysisFromFixtures('UsingPhpDoc.php');
         $analysis->process(
             [
             new AugmentOperations(),

--- a/tests/Processors/AugmentParameterTest.php
+++ b/tests/Processors/AugmentParameterTest.php
@@ -4,13 +4,15 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests;
+namespace OpenApiTests\Processors;
+
+use OpenApiTests\OpenApiTestCase;
 
 class AugmentParameterTest extends OpenApiTestCase
 {
     public function testAugmentParameter()
     {
-        $openapi = \OpenApi\scan(__DIR__.'/Fixtures/UsingRefs.php');
+        $openapi = \OpenApi\scan($this->fixtures('UsingRefs.php'));
         $this->assertCount(1, $openapi->components->parameters, 'OpenApi contains 1 reusable parameter specification');
         $this->assertEquals('ItemName', $openapi->components->parameters[0]->parameter, 'When no @OA\Parameter()->parameter is specified, use @OA\Parameter()->name');
     }

--- a/tests/Processors/AugmentPropertiesTest.php
+++ b/tests/Processors/AugmentPropertiesTest.php
@@ -4,14 +4,14 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests;
+namespace OpenApiTests\Processors;
 
 use OpenApi\Annotations\Property;
 use OpenApi\Processors\AugmentProperties;
 use OpenApi\Processors\AugmentSchemas;
 use OpenApi\Processors\MergeIntoComponents;
 use OpenApi\Processors\MergeIntoOpenApi;
-use OpenApi\StaticAnalyser;
+use OpenApiTests\OpenApiTestCase;
 use const OpenApi\UNDEFINED;
 
 /**
@@ -21,8 +21,7 @@ class AugmentPropertiesTest extends OpenApiTestCase
 {
     public function testAugmentProperties()
     {
-        $analyser = new StaticAnalyser();
-        $analysis = $analyser->fromFile(__DIR__ . '/Fixtures/Customer.php');
+        $analysis = $this->analysisFromFixtures('Customer.php');
         $analysis->process(new MergeIntoOpenApi());
         $analysis->process(new MergeIntoComponents());
         $analysis->process(new AugmentSchemas());
@@ -123,8 +122,7 @@ class AugmentPropertiesTest extends OpenApiTestCase
 
     public function testTypedProperties()
     {
-        $analyser = new StaticAnalyser();
-        $analysis = $analyser->fromFile(__DIR__ . '/Fixtures/TypedProperties.php');
+        $analysis = $this->analysisFromFixtures('TypedProperties.php');
         $analysis->process(new MergeIntoOpenApi());
         $analysis->process(new MergeIntoComponents());
         $analysis->process(new AugmentSchemas());

--- a/tests/Processors/AugmentSchemasTest.php
+++ b/tests/Processors/AugmentSchemasTest.php
@@ -4,22 +4,22 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests;
+namespace OpenApiTests\Processors;
 
 use OpenApi\Processors\AugmentSchemas;
 use OpenApi\Processors\MergeIntoComponents;
 use OpenApi\Processors\MergeIntoOpenApi;
-use OpenApi\StaticAnalyser;
+use OpenApiTests\OpenApiTestCase;
 use const OpenApi\UNDEFINED;
 
 class AugmentSchemasTest extends OpenApiTestCase
 {
     public function testAugmentSchemas()
     {
-        $analyser = new StaticAnalyser();
-        $analysis = $analyser->fromFile(__DIR__.'/Fixtures/Customer.php');
+        $analysis = $this->analysisFromFixtures('Customer.php');
         $analysis->process(new MergeIntoOpenApi()); // create openapi->components
         $analysis->process(new MergeIntoComponents()); // Merge standalone Scheme's into openapi->components
+
         $this->assertCount(1, $analysis->openapi->components->schemas);
         $customer = $analysis->openapi->components->schemas[0];
         $this->assertSame(UNDEFINED, $customer->schema, 'Sanity check. No scheme was defined');
@@ -31,10 +31,10 @@ class AugmentSchemasTest extends OpenApiTestCase
 
     public function testAugmentSchemasForInterface()
     {
-        $analyser = new StaticAnalyser();
-        $analysis = $analyser->fromFile(__DIR__.'/Fixtures/CustomerInterface.php');
+        $analysis = $this->analysisFromFixtures('CustomerInterface.php');
         $analysis->process(new MergeIntoOpenApi()); // create openapi->components
         $analysis->process(new MergeIntoComponents()); // Merge standalone Scheme's into openapi->components
+
         $this->assertCount(1, $analysis->openapi->components->schemas);
         $customer = $analysis->openapi->components->schemas[0];
         $this->assertSame(UNDEFINED, $customer->properties, 'Sanity check. @OA\Property\'s not yet merged ');

--- a/tests/Processors/BuildPathsTest.php
+++ b/tests/Processors/BuildPathsTest.php
@@ -4,7 +4,7 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests;
+namespace OpenApiTests\Processors;
 
 use OpenApi\Analysis;
 use OpenApi\Annotations\Get;
@@ -13,6 +13,7 @@ use OpenApi\Annotations\PathItem;
 use OpenApi\Annotations\Post;
 use OpenApi\Processors\BuildPaths;
 use OpenApi\Processors\MergeIntoOpenApi;
+use OpenApiTests\OpenApiTestCase;
 use const OpenApi\UNDEFINED;
 
 class BuildPathsTest extends OpenApiTestCase

--- a/tests/Processors/CleanUnmergedTest.php
+++ b/tests/Processors/CleanUnmergedTest.php
@@ -4,13 +4,14 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests;
+namespace OpenApiTests\Processors;
 
 use OpenApi\Analysis;
 use OpenApi\Annotations\Contact;
 use OpenApi\Annotations\License;
 use OpenApi\Processors\CleanUnmerged;
 use OpenApi\Processors\MergeIntoOpenApi;
+use OpenApiTests\OpenApiTestCase;
 
 class CleanUnmergedTest extends OpenApiTestCase
 {

--- a/tests/Processors/InheritPropertiesTest.php
+++ b/tests/Processors/InheritPropertiesTest.php
@@ -4,7 +4,7 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests;
+namespace OpenApiTests\Processors;
 
 use OpenApi\Annotations\Components;
 use OpenApi\Annotations\Info;
@@ -15,17 +15,20 @@ use OpenApi\Processors\AugmentSchemas;
 use OpenApi\Processors\InheritProperties;
 use OpenApi\Processors\MergeIntoComponents;
 use OpenApi\Processors\MergeIntoOpenApi;
-use OpenApi\StaticAnalyser;
+use OpenApiTests\OpenApiTestCase;
 use const OpenApi\UNDEFINED;
 
 class InheritPropertiesTest extends OpenApiTestCase
 {
     public function testInheritProperties()
     {
-        $analyser = new StaticAnalyser();
-        $analysis = $analyser->fromFile(__DIR__.'/Fixtures/InheritProperties/Child.php');
-        $analysis->addAnalysis($analyser->fromFile(__DIR__.'/Fixtures/InheritProperties/GrandAncestor.php'));
-        $analysis->addAnalysis($analyser->fromFile(__DIR__.'/Fixtures/InheritProperties/Ancestor.php'));
+        $analysis = $this->analysisFromFixtures(
+            [
+                'InheritProperties/Child.php',
+                'InheritProperties/GrandAncestor.php',
+                'InheritProperties/Ancestor.php'
+            ]
+        );
         $analysis->process(
             [
             new MergeIntoOpenApi(),
@@ -51,13 +54,14 @@ class InheritPropertiesTest extends OpenApiTestCase
      */
     public function testInheritPropertiesWithoutDocBlocks()
     {
-        $analyser = new StaticAnalyser();
-
-        // this class has docblocks
-        $analysis = $analyser->fromFile(__DIR__.'/Fixtures/InheritProperties/ChildWithDocBlocks.php');
-        // this one doesn't
-        $analysis->addAnalysis($analyser->fromFile(__DIR__.'/Fixtures/InheritProperties/AncestorWithoutDocBlocks.php'));
-
+        $analysis = $this->analysisFromFixtures(
+            [
+                // this class has docblocks
+                'InheritProperties/ChildWithDocBlocks.php',
+                // this one doesn't
+                'InheritProperties/AncestorWithoutDocBlocks.php'
+            ]
+        );
         $analysis->process(
             [
             new MergeIntoOpenApi(),
@@ -84,11 +88,13 @@ class InheritPropertiesTest extends OpenApiTestCase
      */
     public function testInheritPropertiesWithAllOf()
     {
-        $analyser = new StaticAnalyser();
-        // this class has all of
-        $analysis = $analyser->fromFile(__DIR__ . '/Fixtures/InheritProperties/Extended.php');
-        $analysis->addAnalysis($analyser->fromFile(__DIR__ . '/Fixtures/InheritProperties/Base.php'));
-
+        $analysis = $this->analysisFromFixtures(
+            [
+                // this class has all of
+                'InheritProperties/Extended.php',
+                'InheritProperties/Base.php',
+            ]
+        );
         $analysis->process(
             [
                 new MergeIntoOpenApi(),
@@ -124,11 +130,13 @@ class InheritPropertiesTest extends OpenApiTestCase
      */
     public function testInheritPropertiesWithOtAllOf()
     {
-        $analyser = new StaticAnalyser();
-        // this class has all of
-        $analysis = $analyser->fromFile(__DIR__ . '/Fixtures/InheritProperties/ExtendedWithoutAllOf.php');
-        $analysis->addAnalysis($analyser->fromFile(__DIR__ . '/Fixtures/InheritProperties/Base.php'));
-
+        $analysis = $this->analysisFromFixtures(
+            [
+                // this class has all of
+                'InheritProperties/ExtendedWithoutAllOf.php',
+                'InheritProperties/Base.php',
+            ]
+        );
         $analysis->process(
             [
                 new MergeIntoOpenApi(),
@@ -162,11 +170,13 @@ class InheritPropertiesTest extends OpenApiTestCase
      */
     public function testInheritPropertiesWitTwoChildSchemas()
     {
-        $analyser = new StaticAnalyser();
-        // this class has all of
-        $analysis = $analyser->fromFile(__DIR__ . '/Fixtures/InheritProperties/ExtendedWithTwoSchemas.php');
-        $analysis->addAnalysis($analyser->fromFile(__DIR__ . '/Fixtures/InheritProperties/Base.php'));
-
+        $analysis = $this->analysisFromFixtures(
+            [
+                // this class has all of
+                'InheritProperties/ExtendedWithTwoSchemas.php',
+                'InheritProperties/Base.php',
+            ]
+        );
         $analysis->process(
             [
                 new MergeIntoOpenApi(),

--- a/tests/Processors/MergeIntoComponentsTest.php
+++ b/tests/Processors/MergeIntoComponentsTest.php
@@ -4,12 +4,13 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests;
+namespace OpenApiTests\Processors;
 
 use OpenApi\Analysis;
 use OpenApi\Annotations\OpenApi;
 use OpenApi\Annotations\Response;
 use OpenApi\Processors\MergeIntoComponents;
+use OpenApiTests\OpenApiTestCase;
 use const OpenApi\UNDEFINED;
 
 class MergeIntoComponentsTest extends OpenApiTestCase

--- a/tests/Processors/MergeIntoOpenApiTest.php
+++ b/tests/Processors/MergeIntoOpenApiTest.php
@@ -4,12 +4,13 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests;
+namespace OpenApiTests\Processors;
 
 use OpenApi\Analysis;
 use OpenApi\Annotations\Info;
 use OpenApi\Annotations\OpenApi;
 use OpenApi\Processors\MergeIntoOpenApi;
+use OpenApiTests\OpenApiTestCase;
 use const OpenApi\UNDEFINED;
 
 class MergeIntoOpenApiTest extends OpenApiTestCase

--- a/tests/Processors/MergeJsonContentTest.php
+++ b/tests/Processors/MergeJsonContentTest.php
@@ -4,20 +4,21 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests;
+namespace OpenApiTests\Processors;
 
 use OpenApi\Analysis;
 use OpenApi\Annotations\Response;
-use OpenApi\Processors\MergeXmlContent;
+use OpenApi\Processors\MergeJsonContent;
+use OpenApiTests\OpenApiTestCase;
 use const OpenApi\UNDEFINED;
 
-class MergeXmlContentTest extends OpenApiTestCase
+class MergeJsonContentTest extends OpenApiTestCase
 {
-    public function testXmlContent()
+    public function testJsonContent()
     {
         $comment = <<<END
         @OA\Response(response=200,
-            @OA\XmlContent(type="array",
+            @OA\JsonContent(type="array",
                 @OA\Items(ref="#/components/schemas/repository")
             )
         )
@@ -27,11 +28,11 @@ END;
         $response = $analysis->getAnnotationsOfType(Response::class)[0];
         $this->assertSame(UNDEFINED, $response->content);
         $this->assertCount(1, $response->_unmerged);
-        $analysis->process(new MergeXmlContent());
+        $analysis->process(new MergeJsonContent());
         $this->assertCount(1, $response->content);
         $this->assertCount(0, $response->_unmerged);
         $json = json_decode(json_encode($response), true);
-        $this->assertSame('#/components/schemas/repository', $json['content']['application/xml']['schema']['items']['$ref']);
+        $this->assertSame('#/components/schemas/repository', $json['content']['application/json']['schema']['items']['$ref']);
     }
 
     public function testMultipleMediaTypes()
@@ -39,7 +40,7 @@ END;
         $comment = <<<END
         @OA\Response(response=200,
             @OA\MediaType(mediaType="image/png"),
-            @OA\XmlContent(type="array",
+            @OA\JsonContent(type="array",
                 @OA\Items(ref="#/components/schemas/repository")
             )
         )
@@ -47,7 +48,7 @@ END;
         $analysis = new Analysis($this->parseComment($comment));
         $response = $analysis->getAnnotationsOfType(Response::class)[0];
         $this->assertCount(1, $response->content);
-        $analysis->process(new MergeXmlContent());
+        $analysis->process(new MergeJsonContent());
         $this->assertCount(2, $response->content);
     }
 }

--- a/tests/Processors/MergeXmlContentTest.php
+++ b/tests/Processors/MergeXmlContentTest.php
@@ -4,20 +4,21 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests;
+namespace OpenApiTests\Processors;
 
 use OpenApi\Analysis;
 use OpenApi\Annotations\Response;
-use OpenApi\Processors\MergeJsonContent;
+use OpenApi\Processors\MergeXmlContent;
+use OpenApiTests\OpenApiTestCase;
 use const OpenApi\UNDEFINED;
 
-class MergeJsonContentTest extends OpenApiTestCase
+class MergeXmlContentTest extends OpenApiTestCase
 {
-    public function testJsonContent()
+    public function testXmlContent()
     {
         $comment = <<<END
         @OA\Response(response=200,
-            @OA\JsonContent(type="array",
+            @OA\XmlContent(type="array",
                 @OA\Items(ref="#/components/schemas/repository")
             )
         )
@@ -27,11 +28,11 @@ END;
         $response = $analysis->getAnnotationsOfType(Response::class)[0];
         $this->assertSame(UNDEFINED, $response->content);
         $this->assertCount(1, $response->_unmerged);
-        $analysis->process(new MergeJsonContent());
+        $analysis->process(new MergeXmlContent());
         $this->assertCount(1, $response->content);
         $this->assertCount(0, $response->_unmerged);
         $json = json_decode(json_encode($response), true);
-        $this->assertSame('#/components/schemas/repository', $json['content']['application/json']['schema']['items']['$ref']);
+        $this->assertSame('#/components/schemas/repository', $json['content']['application/xml']['schema']['items']['$ref']);
     }
 
     public function testMultipleMediaTypes()
@@ -39,7 +40,7 @@ END;
         $comment = <<<END
         @OA\Response(response=200,
             @OA\MediaType(mediaType="image/png"),
-            @OA\JsonContent(type="array",
+            @OA\XmlContent(type="array",
                 @OA\Items(ref="#/components/schemas/repository")
             )
         )
@@ -47,7 +48,7 @@ END;
         $analysis = new Analysis($this->parseComment($comment));
         $response = $analysis->getAnnotationsOfType(Response::class)[0];
         $this->assertCount(1, $response->content);
-        $analysis->process(new MergeJsonContent());
+        $analysis->process(new MergeXmlContent());
         $this->assertCount(2, $response->content);
     }
 }


### PR DESCRIPTION
**Changes**
* Mirror the namespaces from `src/` in the `tests/` folder.
* Add some helper methods around fixtures (resolve, load)
* Clarify a couple comments and test names to what I believe they actually do
* Remove redundant dataProvider in favour of shared `OpenApiTestCase::allAnnotationClasses()`

**Motivation**
I've started looking at the current traits support and got really annoyed by the long list of test cases in the `tests` folder itself.
Working my  way backwards through the code I found it hard to see which library classes have corresponding test cases and which not.
Also, before going any further I wanted to see first if my style / thinking is appropriate before committing to more work...

Looking forward I plan on adding more tests first, in particular around the way the code uses `Context::$class` as that seems to be the root of (at least some) evil.
Only after that I'll move forward with actual code changes itself.