### PR TITLE
Add missing use statements to MergeXmlContent

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,10 +26,12 @@
     }
   ],
   "config": {
-    "bin-dir": "bin"
+    "bin-dir": "bin",
+    "sort-packages": true
   },
   "require": {
     "php": ">=7.2",
+    "ext-json": "*",
     "doctrine/annotations": "*",
     "symfony/finder": ">=2.2",
     "symfony/yaml": ">=3.3"
@@ -43,9 +45,9 @@
     ]
   },
   "require-dev": {
-    "zendframework/zend-form": "<2.8",
+    "phpunit/phpunit": ">=8",
     "squizlabs/php_codesniffer": ">=3.3",
-    "phpunit/phpunit": ">=8"
+    "zendframework/zend-form": "<2.8"
   },
   "autoload-dev": {
     "psr-4": {

--- a/src/Processors/MergeXmlContent.php
+++ b/src/Processors/MergeXmlContent.php
@@ -7,11 +7,13 @@
 namespace OpenApi\Processors;
 
 use OpenApi\Annotations\MediaType;
+use OpenApi\Annotations\Parameter;
 use OpenApi\Annotations\RequestBody;
 use OpenApi\Annotations\Response;
 use OpenApi\Analysis;
 use OpenApi\Annotations\XmlContent;
 use OpenApi\Context;
+use OpenApi\Logger;
 
 /**
  * Split XmlContent into Schema and MediaType

--- a/tests/MergeJsonContentTest.php
+++ b/tests/MergeJsonContentTest.php
@@ -7,6 +7,7 @@
 namespace OpenApiTests;
 
 use OpenApi\Analysis;
+use OpenApi\Annotations\Parameter;
 use OpenApi\Annotations\Response;
 use OpenApi\Processors\MergeJsonContent;
 use const OpenApi\UNDEFINED;
@@ -49,5 +50,27 @@ END;
         $this->assertCount(1, $response->content);
         $analysis->process(new MergeJsonContent());
         $this->assertCount(2, $response->content);
+    }
+
+    public function testParameter()
+    {
+        $comment = <<<END
+        @OA\Parameter(name="filter",in="query", @OA\JsonContent(
+            @OA\Property(property="type", type="string"),
+            @OA\Property(property="color", type="string"),
+        ))
+END;
+        $analysis = new Analysis($this->parseComment($comment));
+        $this->assertCount(4, $analysis->annotations);
+        $parameter = $analysis->getAnnotationsOfType(Parameter::class)[0];
+        $this->assertSame(UNDEFINED, $parameter->content);
+        $this->assertCount(1, $parameter->_unmerged);
+        $analysis->process(new MergeJsonContent());
+        $this->assertCount(1, $parameter->content);
+        $this->assertCount(0, $parameter->_unmerged);
+        $json = json_decode(json_encode($parameter), true);
+        $this->assertSame('query', $json['in']);
+        $this->assertSame('application/json', array_keys($json['content'])[0]);
+        $this->assertSame('application/json', $json['content']['application/json']['mediaType']);
     }
 }


### PR DESCRIPTION
Adds missing use statements and corresponding test(s).
Also adds `ext-json` as requirement to `composer.json`.

@bfanger sorry for adding nw PRs now that you've cleaned up so nicely.
Feels to me that changes to the repo have been a bit disjointed so there are all sorts of little mismatches. [Also, code coverage is a bit low, IMHO :)]