### PR TITLE
Change reference to _context variable to $parent

### DIFF
--- a/src/Processors/MergeJsonContent.php
+++ b/src/Processors/MergeJsonContent.php
@@ -27,7 +27,7 @@ class MergeJsonContent
             $parent = $jsonContent->_context->nested;
             if (!($parent instanceof Response) && !($parent instanceof RequestBody) && !($parent instanceof Parameter)) {
                 if ($parent) {
-                    Logger::notice('Unexpected '.$jsonContent->identity() .' in ' . $parent->identity() . ' in ' . $this->_context);
+                    Logger::notice('Unexpected '.$jsonContent->identity() .' in ' . $parent->identity() . ' in ' . $parent->_context);
                 } else {
                     Logger::notice('Unexpected '.$jsonContent->identity() .' must be nested');
                 }


### PR DESCRIPTION
I was getting an error about error reporting from this mis referenced variable.