### PR TITLE
Upgrade from abandoned zendframewok to laminas

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,9 +45,9 @@
     ]
   },
   "require-dev": {
+    "laminas/laminas-form": "^2.14",
     "phpunit/phpunit": ">=8",
-    "squizlabs/php_codesniffer": ">=3.3",
-    "zendframework/zend-form": "<2.8"
+    "squizlabs/php_codesniffer": ">=3.3"
   },
   "autoload-dev": {
     "psr-4": {

--- a/tests/ConstantsTest.php
+++ b/tests/ConstantsTest.php
@@ -45,10 +45,10 @@ class ConstantsTest extends OpenApiTestCase
 
     public function testAutoloadConstant()
     {
-        if (class_exists('Zend\Validator\Timezone', false)) {
+        if (class_exists('Laminas\Validator\Timezone', false)) {
             $this->markTestSkipped();
         }
-        $annotations = $this->parseComment('@OA\Contact(name=Zend\Validator\Timezone::INVALID_TIMEZONE_LOCATION)');
+        $annotations = $this->parseComment('@OA\Contact(name=Laminas\Validator\Timezone::INVALID_TIMEZONE_LOCATION)');
         $this->assertSame('invalidTimezoneLocation', $annotations[0]->name);
     }
 

--- a/tests/Fixtures/ThirdPartyAnnotations.php
+++ b/tests/Fixtures/ThirdPartyAnnotations.php
@@ -1,16 +1,16 @@
 <?php declare(strict_types=1);
 
-namespace OpenApiFixtures;
+namespace OpenApiTests\Fixtures;
 
 /**
  * @OA\Info(title="Fixture for ParserTest", version="test")
  * Based on the examplefrom http://framework.zend.com/manual/current/en/modules/zend.form.quick-start.html
  */
-use Zend\Form\Annotation;
+use Laminas\Form\Annotation;
 
 /**
  * @Annotation\Name("user")
- * @Annotation\Hydrator("Zend\Stdlib\Hydrator\ObjectProperty")
+ * @Annotation\Hydrator("Laminas\Stdlib\Hydrator\ObjectProperty")
  */
 class ThirdPartyAnnotations
 {
@@ -29,7 +29,7 @@ class ThirdPartyAnnotations
     public $username;
 
     /**
-     * @Annotation\Type("Zend\Form\Element\Email")
+     * @Annotation\Type("Laminas\Form\Element\Email")
      * @Annotation\Options({"label":"Your email address:"})
      */
     public $email;

--- a/tests/StaticAnalyserTest.php
+++ b/tests/StaticAnalyserTest.php
@@ -45,18 +45,18 @@ class StaticAnalyserTest extends OpenApiTestCase
         $this->assertCount(3, $defaultAnalysis->annotations, 'Only read the @OA annotations, skip the others.');
         // Allow the analyser to parse 3rd party annotations, which might
         // contain useful info that could be extracted with a custom processor
-        Analyser::$whitelist[] = 'Zend\Form\Annotation';
+        Analyser::$whitelist[] = 'Laminas\Form\Annotation';
         $openapi = \OpenApi\scan(__DIR__.'/Fixtures/ThirdPartyAnnotations.php');
         $this->assertSame('api/3rd-party', $openapi->paths[0]->path);
         $this->assertCount(10, $openapi->_unmerged);
         Analyser::$whitelist = $backup;
         $analysis = $openapi->_analysis;
-        $annotations = $analysis->getAnnotationsOfType('Zend\Form\Annotation\Name');
+        $annotations = $analysis->getAnnotationsOfType('Laminas\Form\Annotation\Name');
         $this->assertCount(1, $annotations);
         $context = $analysis->getContext($annotations[0]);
         $this->assertInstanceOf('OpenApi\Context', $context);
         $this->assertSame('ThirdPartyAnnotations', $context->class);
-        $this->assertSame('\OpenApiFixtures\ThirdPartyAnnotations', $context->fullyQualifiedName($context->class));
+        $this->assertSame('\OpenApiTests\Fixtures\ThirdPartyAnnotations', $context->fullyQualifiedName($context->class));
         $this->assertCount(2, $context->annotations);
     }
 


### PR DESCRIPTION
Upgrade the test for 3rd party annotation support from the abandoned
zendframework to the successor laminas project.