### PR TITLE
Make `context->comment` typesafe in case it is not set

### DIFF
--- a/src/Context.php
+++ b/src/Context.php
@@ -225,7 +225,7 @@ class Context
      */
     public function phpdocContent()
     {
-        $comment = preg_split('/(\n|\r\n)/', $this->comment);
+        $comment = preg_split('/(\n|\r\n)/', (string) $this->comment);
         $comment[0] = preg_replace('/[ \t]*\\/\*\*/', '', $comment[0]); // strip '/**'
         $i = count($comment) - 1;
         $comment[$i] = preg_replace('/\*\/[ \t]*$/', '', $comment[$i]); // strip '*/'

--- a/src/Processors/AugmentProperties.php
+++ b/src/Processors/AugmentProperties.php
@@ -62,7 +62,7 @@ class AugmentProperties
             if ($property->ref !== UNDEFINED) {
                 continue;
             }
-            $comment = str_replace("\r\n", "\n", $context->comment);
+            $comment = str_replace("\r\n", "\n", (string) $context->comment);
             if ($property->type === UNDEFINED && $context->type && $context->type !== UNDEFINED) {
                 if ($context->nullable === true) {
                     $property->nullable = true;


### PR DESCRIPTION
Typecase to `string` to avoid type errors using `preg_xxx` methods on
the value.

Fixes #790 790