### PR TITLE
Fixed version doctrine/annotations in require dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
   "require": {
     "php": ">=7.2",
     "ext-json": "*",
-    "doctrine/annotations": "*",
+    "doctrine/annotations": ">=1.7",
     "symfony/finder": ">=2.2",
     "symfony/yaml": ">=3.3"
   },


### PR DESCRIPTION
 A bug has been fixed for version php 7.4 in version 1.7 of doctrine/annotations. If you install the zircote/swagger-php 3.0.4 now, then doctrine/annotations won't be updated and you will get an error: "Trying to access array offset on value of type null".

Link to package release:
https://github.com/doctrine/annotations/releases/tag/v1.7.0