### PR TITLE
Preserve existing `allOf` when merging properties

### DIFF
--- a/Examples/misc/misc.yaml
+++ b/Examples/misc/misc.yaml
@@ -4,7 +4,7 @@ info:
   version: 1.0.0
 servers:
   -
-    url: "{schema}://host.dev"
+    url: '{schema}://host.dev'
     description: 'OpenApi parameters'
     variables:
       schema:

--- a/Examples/using-traits/using-traits-inherit.yaml
+++ b/Examples/using-traits/using-traits-inherit.yaml
@@ -66,10 +66,6 @@ components:
         -
           $ref: '#/components/schemas/BellsAndWhistles'
         -
-          $ref: '#/components/schemas/Bells'
-        -
-          $ref: '#/components/schemas/Whistles'
-        -
           properties:
             id:
               description: 'The unique identifier of a product in our catalog.'
@@ -92,13 +88,13 @@ components:
               format: int64
               example: 1
     TrickyProduct:
-      title: 'TrickyProduct model'
       allOf:
-        -
-          $ref: '#/components/schemas/Bells'
         -
           $ref: '#/components/schemas/Blink'
         -
+          $ref: '#/components/schemas/SimpleProduct'
+        -
+          title: 'TrickyProduct model'
           properties:
             trick:
               description: 'The trick.'

--- a/src/Analysis.php
+++ b/src/Analysis.php
@@ -232,12 +232,13 @@ class Analysis
     /**
      * Get the list of interfaces used by the given class or by classes which it extends.
      *
-     * @param string $class The class name.
+     * @param string $class   The class name.
+     * @param bool   $direct  Flag to find only the actual class interfaces.
      * @return array Map of class => definition pairs of interfaces.
      */
-    public function getInterfacesOfClass($class)
+    public function getInterfacesOfClass($class, $direct = false)
     {
-        $classes = array_keys($this->getSuperClasses($class));
+        $classes = $direct ? [] : array_keys($this->getSuperClasses($class));
         // add self
         $classes[] = $class;
 
@@ -255,18 +256,20 @@ class Analysis
             }
         }
 
-        // expand recursively for interfaces extending other interfaces
-        $collect = function ($interfaces, $cb) use (&$definitions) {
-            foreach ($interfaces as $interface) {
-                if (isset($this->interfaces[$interface]['extends'])) {
-                    $cb($this->interfaces[$interface]['extends'], $cb);
-                    foreach ($this->interfaces[$interface]['extends'] as $fqdn) {
-                        $definitions[$fqdn] = $this->interfaces[$fqdn];
+        if (!$direct) {
+            // expand recursively for interfaces extending other interfaces
+            $collect = function ($interfaces, $cb) use (&$definitions) {
+                foreach ($interfaces as $interface) {
+                    if (isset($this->interfaces[$interface]['extends'])) {
+                        $cb($this->interfaces[$interface]['extends'], $cb);
+                        foreach ($this->interfaces[$interface]['extends'] as $fqdn) {
+                            $definitions[$fqdn] = $this->interfaces[$fqdn];
+                        }
                     }
                 }
-            }
-        };
-        $collect(array_keys($definitions), $collect);
+            };
+            $collect(array_keys($definitions), $collect);
+        }
 
         return $definitions;
     }
@@ -275,11 +278,12 @@ class Analysis
      * Get the list of traits used by the given class or by classes which it extends.
      *
      * @param string $class The class name.
+     * @param bool   $direct  Flag to find only the actual class traits.
      * @return array Map of class => definition pairs of traits.
      */
-    public function getTraitsOfClass($class)
+    public function getTraitsOfClass($class, $direct = false)
     {
-        $classes = array_keys($this->getSuperClasses($class));
+        $classes = $direct ? [] : array_keys($this->getSuperClasses($class));
         // add self
         $classes[] = $class;
 
@@ -297,18 +301,20 @@ class Analysis
             }
         }
 
-        // expand recursively for traits using other tratis
-        $collect = function ($traits, $cb) use (&$definitions) {
-            foreach ($traits as $trait) {
-                if (isset($this->traits[$trait]['traits'])) {
-                    $cb($this->traits[$trait]['traits'], $cb);
-                    foreach ($this->traits[$trait]['traits'] as $fqdn) {
-                        $definitions[$fqdn] = $this->traits[$fqdn];
+        if (!$direct) {
+            // expand recursively for traits using other tratis
+            $collect = function ($traits, $cb) use (&$definitions) {
+                foreach ($traits as $trait) {
+                    if (isset($this->traits[$trait]['traits'])) {
+                        $cb($this->traits[$trait]['traits'], $cb);
+                        foreach ($this->traits[$trait]['traits'] as $fqdn) {
+                            $definitions[$fqdn] = $this->traits[$fqdn];
+                        }
                     }
                 }
-            }
-        };
-        $collect(array_keys($definitions), $collect);
+            };
+            $collect(array_keys($definitions), $collect);
+        }
 
         return $definitions;
     }

--- a/src/Processors/AugmentSchemas.php
+++ b/src/Processors/AugmentSchemas.php
@@ -12,7 +12,8 @@ use OpenApi\Annotations\Property;
 
 /**
  * Use the Schema context to extract useful information and inject that into the annotation.
- * Merges properties
+ *
+ * Merges properties.
  */
 class AugmentSchemas
 {

--- a/src/Processors/CleanUnmerged.php
+++ b/src/Processors/CleanUnmerged.php
@@ -7,7 +7,6 @@
 namespace OpenApi\Processors;
 
 use OpenApi\Analysis;
-use SplObjectStorage;
 
 /**
  *

--- a/src/Processors/InheritInterfaces.php
+++ b/src/Processors/InheritInterfaces.php
@@ -13,7 +13,7 @@ class InheritInterfaces
         $schemas = $analysis->getAnnotationsOfType(Schema::class);
         foreach ($schemas as $schema) {
             if ($schema->_context->is('class')) {
-                if ($interfaces = $analysis->getInterfacesOfClass($schema->_context->fullyQualifiedName($schema->_context->class))) {
+                if ($interfaces = $analysis->getInterfacesOfClass($schema->_context->fullyQualifiedName($schema->_context->class), true)) {
                     if ($schema->allOf === UNDEFINED) {
                         $schema->allOf = [];
                     }

--- a/src/Processors/InheritProperties.php
+++ b/src/Processors/InheritProperties.php
@@ -10,6 +10,7 @@ use OpenApi\Annotations\Components;
 use OpenApi\Annotations\Property;
 use OpenApi\Annotations\Schema;
 use OpenApi\Analysis;
+use OpenApi\UNDEFINED;
 use Traversable;
 
 /**
@@ -27,19 +28,13 @@ class InheritProperties
         foreach ($schemas as $schema) {
             if ($schema->_context->is('class')) {
                 if (in_array($schema->_context, $processedSchemas, true)) {
-                    //We should process only first schema in the same context
+                    // we should process only first schema in the same context
                     continue;
                 }
 
                 $processedSchemas[] = $schema->_context;
 
-                if ($schema->allOf !== UNDEFINED) {
-                    //if the allOf in the child is set, do noting
-                    continue;
-                }
-
                 $existing = [];
-
                 if (is_array($schema->properties) || $schema->properties instanceof Traversable) {
                     foreach ($schema->properties as $property) {
                         if ($property->property) {
@@ -76,34 +71,48 @@ class InheritProperties
     }
 
     /**
-     * Add to child schema allOf property
+     * Add schema to child schema allOf property
      *
      * @param \OpenApi\Annotations\Schema $childSchema
      * @param \OpenApi\Annotations\Schema $parentSchema
      */
     private function addAllOfProperty(Schema $childSchema, Schema $parentSchema)
     {
+        // clone (child) properties (except when they are already in allOf)
         $currentSchema = new Schema(['_context' => $childSchema->_context]);
-
         $currentSchema->mergeProperties($childSchema);
 
         $defaultValues = get_class_vars(Schema::class);
-
-        foreach (get_object_vars($currentSchema) as $property => $val) {
+        foreach (array_keys(get_object_vars($currentSchema)) as $property) {
             $childSchema->{$property} = $defaultValues[$property];
         }
 
         $childSchema->schema = $currentSchema->schema;
-        unset($currentSchema->schema);
+        $currentSchema->schema = UNDEFINED;
+
         if ($childSchema->allOf === UNDEFINED) {
             $childSchema->allOf = [];
         }
-        $childSchema->allOf[] = new Schema(
-            [
+
+        if ($currentSchema->allOf !== UNDEFINED) {
+            foreach ($currentSchema->allOf as $ii => $schema) {
+                if ($schema->schema === UNDEFINED && $schema->properties !== UNDEFINED) {
+                    // move properties from allOf back up into schema
+                    $currentSchema->properties = $schema->properties;
+                } elseif ($schema->ref !== UNDEFINED && $schema->ref != Components::SCHEMA_REF . $parentSchema->schema) {
+                    // keep other schemas
+                    $childSchema->allOf[] = $schema;
+                }
+            }
+            $currentSchema->allOf = UNDEFINED;
+        }
+
+        $childSchema->allOf[] = new Schema([
             '_context' => $parentSchema->_context,
             'ref' => Components::SCHEMA_REF . $parentSchema->schema
-            ]
-        );
-        $childSchema->allOf[] = $currentSchema;
+        ]);
+        if ($currentSchema->properties !== UNDEFINED) {
+            $childSchema->allOf[] = $currentSchema;
+        }
     }
 }

--- a/src/Processors/InheritTraits.php
+++ b/src/Processors/InheritTraits.php
@@ -13,7 +13,7 @@ class InheritTraits
         $schemas = $analysis->getAnnotationsOfType(Schema::class);
         foreach ($schemas as $schema) {
             if ($schema->_context->is('class')) {
-                if ($traits = $analysis->getTraitsOfClass($schema->_context->fullyQualifiedName($schema->_context->class))) {
+                if ($traits = $analysis->getTraitsOfClass($schema->_context->fullyQualifiedName($schema->_context->class), true)) {
                     if ($schema->allOf === UNDEFINED) {
                         $schema->allOf = [];
                     }

--- a/src/Processors/MergeIntoComponents.php
+++ b/src/Processors/MergeIntoComponents.php
@@ -8,7 +8,6 @@ namespace OpenApi\Processors;
 
 use OpenApi\Annotations\Components;
 use OpenApi\Analysis;
-use OpenApi\Context;
 use OpenApi\UNDEFINED;
 
 /**

--- a/tests/Fixtures/InheritProperties/BaseInterface.php
+++ b/tests/Fixtures/InheritProperties/BaseInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace OpenApiTests\Fixtures\InheritProperties;
+
+/**
+ * @OA\Schema()
+ */
+interface BaseInterface
+{
+
+    /**
+     * @OA\Property(property="interfaceProperty");
+     * @var string
+     */
+    public function getInterfaceProperty();
+}

--- a/tests/Fixtures/InheritProperties/BaseThatImplements.php
+++ b/tests/Fixtures/InheritProperties/BaseThatImplements.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace OpenApiTests\Fixtures\InheritProperties;
+
+/**
+ * @OA\Schema()
+ */
+class BaseThatImplements implements BaseInterface
+{
+
+    /**
+     * @OA\Property();
+     * @var string
+     */
+    public $baseProperty;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getInterfaceProperty()
+    {
+        return "foo";
+    }
+}

--- a/tests/Fixtures/InheritProperties/ExtendsBaseThatImplements.php
+++ b/tests/Fixtures/InheritProperties/ExtendsBaseThatImplements.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace OpenApiTests\Fixtures\InheritProperties;
+
+/**
+ * @OA\Schema()
+ */
+class ExtendsBaseThatImplements extends BaseThatImplements
+{
+    use TraitUsedByExtendsBaseThatImplements;
+
+    /**
+     * @OA\Property();
+     * @var string
+     */
+    public $extendsProperty;
+}

--- a/tests/Fixtures/InheritProperties/TraitUsedByExtendsBaseThatImplements.php
+++ b/tests/Fixtures/InheritProperties/TraitUsedByExtendsBaseThatImplements.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace OpenApiTests\Fixtures\InheritProperties;
+
+/**
+ * @OA\Schema()
+ */
+trait TraitUsedByExtendsBaseThatImplements
+{
+
+    /**
+     * @OA\Property(property="traitProperty");
+     * @var string
+     */
+    public function getTraitProperty()
+    {
+        return "bar";
+    }
+}

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -15,6 +15,7 @@ class UtilTest extends OpenApiTestCase
                 'Customer.php',
                 'CustomerInterface.php',
                 'GrandAncestor.php',
+                'InheritProperties',
                 'Parser',
                 'UsingRefs.php',
                 'UsingPhpDoc.php',


### PR DESCRIPTION
Make the `InheritProperties` processor deal with existing `allOf` refs
and properties.

Also fixes an issue with redundant `#ref`s in case of multiple inheritance in interfaces and traits.