### PR TITLE
Fix invalid `_context` reference

### DIFF
--- a/src/Processors/MergeJsonContent.php
+++ b/src/Processors/MergeJsonContent.php
@@ -27,7 +27,7 @@ class MergeJsonContent
             $parent = $jsonContent->_context->nested;
             if (!($parent instanceof Response) && !($parent instanceof RequestBody) && !($parent instanceof Parameter)) {
                 if ($parent) {
-                    Logger::notice('Unexpected '.$jsonContent->identity() .' in ' . $parent->identity() . ' in ' . $this->_context);
+                    Logger::notice('Unexpected '.$jsonContent->identity() .' in ' . $parent->identity() . ' in ' . $parent->_context);
                 } else {
                     Logger::notice('Unexpected '.$jsonContent->identity() .' must be nested');
                 }

--- a/src/Processors/MergeXmlContent.php
+++ b/src/Processors/MergeXmlContent.php
@@ -27,7 +27,7 @@ class MergeXmlContent
             $parent = $xmlContent->_context->nested;
             if (!($parent instanceof Response) && !($parent instanceof RequestBody) && !($parent instanceof Parameter)) {
                 if ($parent) {
-                    Logger::notice('Unexpected '.$xmlContent->identity() .' in ' . $parent->identity() . ' in ' . $this->_context);
+                    Logger::notice('Unexpected '.$xmlContent->identity() .' in ' . $parent->identity() . ' in ' . $parent->_context);
                 } else {
                     Logger::notice('Unexpected '.$xmlContent->identity() .' must be nested');
                 }


### PR DESCRIPTION
Supersedes https://github.com/zircote/swagger-php/pull/786 and https://github.com/zircote/swagger-php/pull/777.

Fixes both the XML and Json processor plus adds tests.

Seeing that there is no progress on the other PRs and I've had this sitting around from when I looked at the issue I figured I might as well make it a proper PR...

I think using the parent context is the right choice as the message tries to display parent details of where the invalid child was found.