### PR TITLE
Ensure operation security data conforms to spec

### DIFF
--- a/src/Annotations/Operation.php
+++ b/src/Annotations/Operation.php
@@ -1,10 +1,10 @@
 <?php declare(strict_types=1);
 
- /**
-  * @license Apache 2.0
-  */
+/**
+ * @license Apache 2.0
+ */
 
- namespace OpenApi\Annotations;
+namespace OpenApi\Annotations;
 
 use OpenApi\Logger;
 
@@ -170,8 +170,16 @@ abstract class Operation extends AbstractAnnotation
     public function jsonSerialize()
     {
         $data = parent::jsonSerialize();
+
         unset($data->method);
         unset($data->path);
+
+        // ensure security elements are object
+        if (isset($data->security) && is_array($data->security)) {
+            foreach ($data->security as $key => $scheme) {
+                $data->security[$key] = (object) $scheme;
+            }
+        }
 
         return $data;
     }

--- a/tests/Annotations/OperationTest.php
+++ b/tests/Annotations/OperationTest.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Annotations;
+
+use OpenApi\Annotations as OA;
+use OpenApi\Tests\OpenApiTestCase;
+
+class OperationTest extends OpenApiTestCase
+{
+    public function securityData()
+    {
+        return [
+            'empty' => [
+                [],
+                '/** @OA\Get(security={ }) */',
+                '{"security":[]}',
+            ],
+            'basic' => [
+                [['api_key' => []]],
+                '/** @OA\Get(security={ {"api_key":{}} }) */',
+                '{"security":[{"api_key":[]}]}',
+            ],
+            'optional' => [
+                [[]],
+                '/** @OA\Get(security={ {} }) */',
+                '{"security":[{}]}',
+            ],
+            'optional-oauth2' => [
+                [[], ['petstore_auth' => ['write:pets', 'read:pets']]],
+                '/** @OA\Get(security={ {}, {"petstore_auth":{"write:pets","read:pets"}} }) */',
+                '{"security":[{},{"petstore_auth":["write:pets","read:pets"]}]}',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider securityData
+     */
+    public function testSecuritySerialization($security, $dockBlock, $expected)
+    {
+        // test with Get implementation...
+        $operation = new OA\Get([
+            'security' => $security,
+        ]);
+        $flags = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
+        $json = $operation->toJson($flags);
+        $this->assertEquals($expected, $json);
+
+        $analysis = $this->analysisFromDockBlock($dockBlock);
+        $this->assertCount(1, $analysis);
+        $json = $analysis[0]->toJson($flags);
+        $this->assertEquals($expected, $json);
+    }
+}

--- a/tests/Annotations/SecuritySchemesTest.php
+++ b/tests/Annotations/SecuritySchemesTest.php
@@ -6,7 +6,6 @@
 
 namespace OpenApi\Tests\Annotations;
 
-use OpenApi\Analyser;
 use OpenApi\Annotations\Info;
 use OpenApi\Annotations\SecurityScheme;
 use OpenApi\Annotations\Server;
@@ -41,7 +40,7 @@ class SecuritySchemesTest extends OpenApiTestCase
  */
 
 INFO;
-        $analysis = $this->getAnalysis($comment);
+        $analysis = $this->analysisFromDockBlock($comment);
 
         $this->assertCount(3, $analysis);
         $this->assertInstanceOf(Info::class, $analysis[0]);
@@ -80,7 +79,7 @@ INFO;
  */
 SCHEME;
 
-        $analysis = $this->getAnalysis($comment);
+        $analysis = $this->analysisFromDockBlock($comment);
         $this->assertCount(1, $analysis);
         /** @var \OpenApi\Annotations\SecurityScheme $security */
         $security = $analysis[0];
@@ -120,7 +119,7 @@ SCHEME;
  */
 SCHEME;
 
-        $analysis = $this->getAnalysis($comment);
+        $analysis = $this->analysisFromDockBlock($comment);
         $this->assertCount(1, $analysis);
         /** @var \OpenApi\Annotations\SecurityScheme $security */
         $security = $analysis[0];
@@ -133,20 +132,5 @@ SCHEME;
         $this->assertEquals('http://authClient.test.com', $security->flows[1]->authorizationUrl);
         $this->assertEquals('http://authClient.test.com/token', $security->flows[1]->tokenUrl);
         $this->assertEquals('http://authClient.test.com/refresh-token', $security->flows[1]->refreshUrl);
-    }
-
-    /**
-     * Get scheme analysis.
-     *
-     * @param string $comment
-     *
-     * @return array
-     */
-    private function getAnalysis($comment)
-    {
-        $analyser = new Analyser();
-        $analysis = $analyser->fromComment($comment, null);
-
-        return $analysis;
     }
 }

--- a/tests/OpenApiTestCase.php
+++ b/tests/OpenApiTestCase.php
@@ -183,6 +183,11 @@ class OpenApiTestCase extends TestCase
         return (new StaticAnalyser())->fromCode("<?php\n".$code, $context ?: new Context());
     }
 
+    public function analysisFromDockBlock($comment)
+    {
+        return (new Analyser())->fromComment($comment, null);
+    }
+
     /**
      * Collect list of all non abstract annotation classes.
      *


### PR DESCRIPTION
Force each item in the security list to be of type object rather than array/list.

Fixes #811 