### PR TITLE
Allow custom nested annotations out-of-the-box

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
     }
   },
   "scripts": {
-    "test": "phpunit && phpcs -p --extensions=php --standard=PSR2 --error-severity=1 --warning-severity=0 ./src ./tests",
+    "test": "phpunit && phpcs -p --extensions=php --standard=PSR2 --error-severity=1 --warning-severity=0 ./src ./tests --ignore=./tests/Fixtures/Apis",
     "docs": "vuepress dev docs/",
     "deploy_docs": "vuepress build docs/ && cp -r .git docs/.vuepress/dist/.git && cd docs/.vuepress/dist/ && git symbolic-ref HEAD refs/heads/gh-pages && git add --all"
   }

--- a/src/Processors/MergeIntoComponents.php
+++ b/src/Processors/MergeIntoComponents.php
@@ -22,10 +22,10 @@ class MergeIntoComponents
             $components = new Components([]);
             $components->_context->generated = true;
         }
-        $classes = array_keys(Components::$_nested);
+
         foreach ($analysis->annotations as $annotation) {
-            $class = get_class($annotation);
-            if (in_array($class, $classes) && $annotation->_context->is('nested') === false) { // A top level annotation.
+            if (Components::nestedProperty(get_class($annotation)) && $annotation->_context->is('nested') === false) {
+                // A top level annotation.
                 $components->merge([$annotation], true);
                 $analysis->openapi->components = $components;
             }

--- a/src/Processors/MergeIntoOpenApi.php
+++ b/src/Processors/MergeIntoOpenApi.php
@@ -27,7 +27,6 @@ class MergeIntoOpenApi
 
         // Merge annotations into the target openapi
         $merge = [];
-        $classes = array_keys(OpenApi::$_nested);
         foreach ($analysis->annotations as $annotation) {
             if ($annotation === $openapi) {
                 continue;
@@ -44,8 +43,9 @@ class MergeIntoOpenApi
                         $openapi->paths[] = $path;
                     }
                 }
-            } elseif (in_array(get_class($annotation), $classes) && property_exists($annotation, '_context') && $annotation->_context->is('nested') === false) { // A top level annotation.
-                // Also merge @OA\Info, @OA\Server and other directly nested annotations.
+            } elseif (OpenApi::nestedProperty(get_class($annotation)) && property_exists($annotation, '_context') && $annotation->_context->is('nested') === false) {
+                // A top level annotation.;
+                // also merge @OA\Info, @OA\Server and other directly nested annotations.
                 $merge[] = $annotation;
             }
         }

--- a/tests/Annotations/CustomGet.php
+++ b/tests/Annotations/CustomGet.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApiTests\Annotations;
+
+use OpenApi\Annotations\Get;
+
+/**
+ * @Annotation
+ */
+class CustomGet extends Get
+{
+}

--- a/tests/Fixtures/Apis/basic_custom_get.php
+++ b/tests/Fixtures/Apis/basic_custom_get.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Single file API.
+ */
+
+namespace OpenApiTests\Fixtures\Apis;
+
+use OpenApi\Annotations as OA;
+use OpenApiTests\Annotations as OAT;
+
+/**
+ * @OA\Info(
+ *   version="1.0.0",
+ *   title="Basic single file API",
+ * )
+ */
+class Api
+{
+
+}
+
+interface ProductInterface {
+
+}
+
+/**
+ * @OA\Schema()
+ */
+trait NameTrait {
+    /**
+     * The name.
+     *
+     * @OA\Property()
+     */
+    public $name;
+
+}
+
+/**
+ * @OA\Schema(
+ *     description="Product",
+ *     title="Product"
+ * )
+ */
+class Product implements ProductInterface
+{
+    use NameTrait;
+
+    /**
+     * The id.
+     *
+     * @OA\Property(format="int64", example=1)
+     */
+    public $id;
+}
+
+class ProductController
+{
+
+    /**
+     * @OAT\CustomGet(
+     *   tags={"Products"},
+     *   path="/products/{product_id}",
+     *   @OA\Response(
+     *       response=200,
+     *       description="successful operation",
+     *       @OA\JsonContent(ref="#/components/schemas/Product")
+     *   )
+     * )
+     */
+    public function getProduct($id)
+    {
+    }
+}

--- a/tests/StaticAnalyserTest.php
+++ b/tests/StaticAnalyserTest.php
@@ -218,4 +218,17 @@ class StaticAnalyserTest extends OpenApiTestCase
             $this->assertSame($traits, $description['traits']);
         }
     }
+
+    public function testCustomGetAnnotation()
+    {
+        // ah, static!
+        $backup = Analyser::$whitelist;
+        Analyser::$whitelist[] = 'OpenApiTests\Annotations';
+
+        $analysis = $this->analysisFromFixtures('Apis/basic_custom_get.php');
+        $analysis->process();
+        $analysis->validate();
+
+        Analyser::$whitelist = $backup;
+    }
 }

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -12,6 +12,7 @@ class UtilTest extends OpenApiTestCase
     {
         $openapi = \OpenApi\scan(__DIR__.'/Fixtures', [
             'exclude' => [
+                'Apis',
                 'Customer.php',
                 'CustomerInterface.php',
                 'GrandAncestor.php',


### PR DESCRIPTION
Refactor of `$_nested` processing to allow custom nested annotations to work out-of-the-box.

Part of some more clean up in preparation for a more modular internal setup...

Also fixes an issue someone commented on a while back, however I cannot seem to find it any more :/