### PR TITLE
Limit inheriting interface/trait to existing schemas

### DIFF
--- a/src/Analysis.php
+++ b/src/Analysis.php
@@ -8,6 +8,7 @@ namespace OpenApi;
 
 use Closure;
 use Exception;
+use OpenApi\Annotations\Schema;
 use OpenApi\Processors\InheritInterfaces;
 use SplObjectStorage;
 use stdClass;
@@ -344,6 +345,36 @@ class Analysis
         }
 
         return $annotations;
+    }
+
+    /**
+     *
+     * @param string $fqdn The source class/interface/trait.
+     *
+     * @return null|Schema
+     */
+    public function getSchemaForSource($fqdn)
+    {
+        $sourceDefinitions = [
+            $this->classes,
+            $this->interfaces,
+            $this->traits,
+        ];
+
+        foreach ($sourceDefinitions as $definitions) {
+            if (array_key_exists($fqdn, $definitions)) {
+                $definition = $definitions[$fqdn];
+                if (is_iterable($definition['context']->annotations)) {
+                    foreach ($definition['context']->annotations as $annotation) {
+                        if (get_class($annotation) === Schema::class) {
+                            return $annotation;
+                        }
+                    }
+                }
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/src/Processors/InheritInterfaces.php
+++ b/src/Processors/InheritInterfaces.php
@@ -13,16 +13,17 @@ class InheritInterfaces
         $schemas = $analysis->getAnnotationsOfType(Schema::class);
         foreach ($schemas as $schema) {
             if ($schema->_context->is('class')) {
-                if ($interfaces = $analysis->getInterfacesOfClass($schema->_context->fullyQualifiedName($schema->_context->class), true)) {
-                    if ($schema->allOf === UNDEFINED) {
-                        $schema->allOf = [];
-                    }
-                }
+                $interfaces = $analysis->getInterfacesOfClass($schema->_context->fullyQualifiedName($schema->_context->class), true);
                 foreach ($interfaces as $interface) {
-                    $schema->allOf[] = new Schema([
-                        '_context' => $interface['context']->_context,
-                        'ref' => Components::SCHEMA_REF . $interface['interface']
-                    ]);
+                    if ($analysis->getSchemaForSource($interface['context']->fullyQualifiedName($interface['interface']))) {
+                        if ($schema->allOf === UNDEFINED) {
+                            $schema->allOf = [];
+                        }
+                        $schema->allOf[] = new Schema([
+                            '_context' => $interface['context']->_context,
+                            'ref' => Components::SCHEMA_REF . $interface['interface']
+                        ]);
+                    }
                 }
             }
         }

--- a/src/Processors/InheritTraits.php
+++ b/src/Processors/InheritTraits.php
@@ -14,16 +14,17 @@ class InheritTraits
         foreach ($schemas as $schema) {
             if ($schema->_context->is('class') || $schema->_context->is('trait')) {
                 $source = $schema->_context->class ?: $schema->_context->trait;
-                if ($traits = $analysis->getTraitsOfClass($schema->_context->fullyQualifiedName($source), true)) {
-                    if ($schema->allOf === UNDEFINED) {
-                        $schema->allOf = [];
-                    }
-                }
+                $traits = $analysis->getTraitsOfClass($schema->_context->fullyQualifiedName($source), true);
                 foreach ($traits as $trait) {
-                    $schema->allOf[] = new Schema([
-                        '_context' => $trait['context']->_context,
-                        'ref' => Components::SCHEMA_REF . $trait['trait']
-                    ]);
+                    if ($analysis->getSchemaForSource($trait['context']->fullyQualifiedName($trait['trait']))) {
+                        if ($schema->allOf === UNDEFINED) {
+                            $schema->allOf = [];
+                        }
+                        $schema->allOf[] = new Schema([
+                            '_context' => $trait['context']->_context,
+                            'ref' => Components::SCHEMA_REF . $trait['trait']
+                        ]);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Only inherit an interface/trait if it actually has a schema associated with it.