### PR TITLE
Code style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /openapi.yaml
 /docs/.vuepress/dist
 .phpunit.result.cache
+/.php_cs.cache

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -14,7 +14,7 @@ return PhpCsFixer\Config::create()
         'no_unused_imports' => true,
         'blank_line_before_statement' => ['statements' => ['return']],
         'cast_spaces' => ['space' => 'single'],
-        'concat_space' => ['spacing' => 'one'],
+        'concat_space' => true,
         'declare_strict_types' => true,
         'function_typehint_space' => true,
         'lowercase_cast' => true,

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,69 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->path('src')->name('*.php')
+    ->path('tests')->name('*.php')
+    ->notPath('tests/Fixtures')
+    ->in(__DIR__)
+;
+
+return PhpCsFixer\Config::create()
+    ->setRules([
+        '@PSR2' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'no_unused_imports' => true,
+        'blank_line_before_statement' => ['statements' => ['return']],
+        'cast_spaces' => ['space' => 'single'],
+        'concat_space' => ['spacing' => 'one'],
+        'declare_strict_types' => true,
+        'function_typehint_space' => true,
+        'lowercase_cast' => true,
+        'magic_constant_casing' => true,
+        'method_separation' => true,
+        'single_blank_line_before_namespace' => true,
+        'no_singleline_whitespace_before_semicolons' => true,
+        'no_spaces_around_offset' => true,
+        'no_unused_imports' => true,
+        'no_whitespace_before_comma_in_array' => true,
+        'no_whitespace_in_blank_line' => true,
+        'object_operator_without_whitespace' => true,
+        'single_quote' => true,
+        'method_separation' => true,
+        'no_blank_lines_after_phpdoc' => true,
+        'no_extra_consecutive_blank_lines' => true,
+        'return_type_declaration' => ['space_before' => 'none'],
+        'no_trailing_comma_in_list_call' => true,
+        'no_trailing_comma_in_singleline_array' => true,
+        'no_unneeded_control_parentheses' => true,
+        'no_unneeded_curly_braces' => true,
+        'ordered_imports' => true,
+        'short_scalar_cast' => true,
+        'space_after_semicolon' => true,
+        'ternary_operator_spaces' => true,
+        'trailing_comma_in_multiline_array' => true,
+        'trim_array_spaces' => true,
+
+        'no_empty_phpdoc' => true,
+        'no_superfluous_phpdoc_tags' => true,
+        'phpdoc_align' => true,
+        'phpdoc_inline_tag' => true,
+        'phpdoc_annotation_without_dot' => true,
+        'phpdoc_indent' => true,
+        'phpdoc_var_without_name' => true,
+        'phpdoc_types' => true,
+        'phpdoc_types_order' => true,
+        'phpdoc_trim' => true,
+        'phpdoc_to_comment' => true,
+        'phpdoc_summary' => true,
+        'phpdoc_single_line_var_spacing' => true,
+        'phpdoc_separation' => true,
+        'phpdoc_scalar' => true,
+        'phpdoc_no_useless_inheritdoc' => true,
+        'phpdoc_no_empty_return' => true,
+        'phpdoc_no_alias_tag' => true,
+        'phpdoc_order' => true,
+        'phpdoc_var_annotation_correct_order' => true,
+        'phpdoc_var_without_name' => true,
+    ])
+    ->setFinder($finder)
+;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,24 @@
+sudo: false
 language: php
+
+cache:
+  directories:
+    - $HOME/.composer/cache
 
 php:
   - 7.2
   - 7.3
   - 7.4
 
-sudo: false
-
-env:
-  global:
-    - PHPUNIT=1
-
 matrix:
   include:
     - php: 7.4
-      env: PHPCS=1 PHPUNIT=0
+      env: CS=yes
 
 before_script:
   - composer self-update
   - composer install --prefer-dist --no-interaction
 
 script:
-  - sh -c "if [ '$PHPUNIT' = '1' ]; then ./bin/phpunit; fi"
-
-  - sh -c "if [ '$PHPCS' = '1' ]; then ./bin/phpcs -p --extensions=php --standard=PSR2 --error-severity=1 --warning-severity=0 ./src ./tests; fi"
+  - ./bin/phpunit
+  - if [ '$CS' = 'yes' ]; then composer run-script fix-cs; fi

--- a/README.md
+++ b/README.md
@@ -103,22 +103,24 @@ or pull requests.
 The documentation website is build from the [docs](docs/) folder with [vuepress](https://vuepress.vuejs.org).
 
 Make sure pull requests pass [PHPUnit](https://phpunit.de/)
-and [PHP_CodeSniffer](https://github.com/cakephp/cakephp-codesniffer) (PSR-2) tests.
+and [PHP-CS-Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) (PSR-2) tests.
 
-To run both unittests and linting execute:
-
+### To run both unit tests and linting execute:
 ```bash
 composer test
 ```
 
-Running only unittests:
-
+### Running unit tests only:
 ```bash
 ./bin/phpunit
 ```
 
-Running only linting:
-
+### Running linting only:
 ```bash
-./bin/phpcs -p --extensions=php --standard=PSR2 --error-severity=1 --warning-severity=0 ./src ./tests
+composer lint
+```
+
+### To make `php-cs-fixer` fix linting errors:
+```bash
+composer cs
 ```

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
     "bin-dir": "bin",
     "sort-packages": true
   },
+  "minimum-stability": "stable",
   "require": {
     "php": ">=7.2",
     "ext-json": "*",
@@ -45,17 +46,19 @@
     ]
   },
   "require-dev": {
-    "laminas/laminas-form": "^2.14",
-    "phpunit/phpunit": ">=8",
-    "squizlabs/php_codesniffer": ">=3.3"
+    "friendsofphp/php-cs-fixer": "^2.16",
+    "phpunit/phpunit": ">=8"
   },
   "autoload-dev": {
     "psr-4": {
-      "OpenApiTests\\": "tests/"
+      "OpenApi\\Tests\\": "tests/",
+      "AnotherNamespace\\": "tests/Fixtures/AnotherNamespace"
     }
   },
   "scripts": {
-    "test": "phpunit && phpcs -p --extensions=php --standard=PSR2 --error-severity=1 --warning-severity=0 ./src ./tests",
+    "cs": "php-cs-fixer fix --allow-risky=yes",
+    "lint": "@cs --dry-run",
+    "test": ["phpunit", "@lint"],
     "docs": "vuepress dev docs/",
     "deploy_docs": "vuepress build docs/ && cp -r .git docs/.vuepress/dist/.git && cd docs/.vuepress/dist/ && git symbolic-ref HEAD refs/heads/gh-pages && git add --all"
   }

--- a/src/Analyser.php
+++ b/src/Analyser.php
@@ -26,9 +26,11 @@ if (class_exists('Doctrine\Common\Annotations\AnnotationRegistry', true)) {
                             throw new Exception('The annotation @SWG\\' . substr($class, 20) . '() is deprecated. Found in ' . Analyser::$context . "\nFor more information read the migration guide: https://github.com/zircote/swagger-php/blob/master/docs/Migrating-to-v3.md");
                         }
                     }
+
                     return $loaded;
                 }
             }
+
             return false;
         }
     );
@@ -82,8 +84,9 @@ class Analyser
     /**
      * Use doctrine to parse the comment block and return the detected annotations.
      *
-     * @param  string  $comment a T_DOC_COMMENT.
-     * @param  Context $context
+     * @param string  $comment a T_DOC_COMMENT
+     * @param Context $context
+     *
      * @return array Annotations
      */
     public function fromComment($comment, $context = null)
@@ -109,12 +112,13 @@ class Analyser
             );
             $annotations = $this->docParser->parse($comment, $context);
             self::$context = null;
+
             return $annotations;
         } catch (Exception $e) {
             self::$context = null;
-            if (preg_match('/^(.+) at position ([0-9]+) in ' . preg_quote((string)$context, '/') . '\.$/', $e->getMessage(), $matches)) {
+            if (preg_match('/^(.+) at position ([0-9]+) in ' . preg_quote((string) $context, '/') . '\.$/', $e->getMessage(), $matches)) {
                 $errorMessage = $matches[1];
-                $errorPos = (int)$matches[2];
+                $errorPos = (int) $matches[2];
                 $atPos = strpos($comment, '@');
                 $context->line += substr_count($comment, "\n", 0, $atPos + $errorPos);
                 $lines = explode("\n", substr($comment, $atPos, $errorPos));
@@ -123,6 +127,7 @@ class Analyser
             } else {
                 Logger::warning($e);
             }
+
             return [];
         }
     }

--- a/src/Analyser.php
+++ b/src/Analyser.php
@@ -23,7 +23,7 @@ if (class_exists('Doctrine\Common\Annotations\AnnotationRegistry', true)) {
                     $loaded = class_exists($class);
                     if (!$loaded && $namespace === 'OpenApi\Annotations\\') {
                         if (in_array(strtolower(substr($class, 20)), ['definition', 'path'])) { // Detected an 2.x annotation?
-                            throw new Exception('The annotation @SWG\\' . substr($class, 20) . '() is deprecated. Found in ' . Analyser::$context . "\nFor more information read the migration guide: https://github.com/zircote/swagger-php/blob/master/docs/Migrating-to-v3.md");
+                            throw new Exception('The annotation @SWG\\'.substr($class, 20).'() is deprecated. Found in '.Analyser::$context."\nFor more information read the migration guide: https://github.com/zircote/swagger-php/blob/master/docs/Migrating-to-v3.md");
                         }
                     }
 
@@ -116,14 +116,14 @@ class Analyser
             return $annotations;
         } catch (Exception $e) {
             self::$context = null;
-            if (preg_match('/^(.+) at position ([0-9]+) in ' . preg_quote((string) $context, '/') . '\.$/', $e->getMessage(), $matches)) {
+            if (preg_match('/^(.+) at position ([0-9]+) in '.preg_quote((string) $context, '/').'\.$/', $e->getMessage(), $matches)) {
                 $errorMessage = $matches[1];
                 $errorPos = (int) $matches[2];
                 $atPos = strpos($comment, '@');
                 $context->line += substr_count($comment, "\n", 0, $atPos + $errorPos);
                 $lines = explode("\n", substr($comment, $atPos, $errorPos));
                 $context->character = strlen(array_pop($lines)) + 1; // position starts at 0 character starts at 1
-                Logger::warning(new Exception($errorMessage . ' in ' . $context, $e->getCode(), $e));
+                Logger::warning(new Exception($errorMessage.' in '.$context, $e->getCode(), $e));
             } else {
                 Logger::warning($e);
             }

--- a/src/Analysis.php
+++ b/src/Analysis.php
@@ -8,25 +8,25 @@ namespace OpenApi;
 
 use Closure;
 use Exception;
-use OpenApi\Annotations\Schema;
-use OpenApi\Processors\InheritInterfaces;
-use SplObjectStorage;
-use stdClass;
 use OpenApi\Annotations\AbstractAnnotation;
 use OpenApi\Annotations\OpenApi;
+use OpenApi\Annotations\Schema;
 use OpenApi\Processors\AugmentOperations;
 use OpenApi\Processors\AugmentParameters;
 use OpenApi\Processors\AugmentProperties;
 use OpenApi\Processors\AugmentSchemas;
 use OpenApi\Processors\BuildPaths;
 use OpenApi\Processors\CleanUnmerged;
+use OpenApi\Processors\InheritInterfaces;
 use OpenApi\Processors\InheritProperties;
+use OpenApi\Processors\InheritTraits;
 use OpenApi\Processors\MergeIntoComponents;
 use OpenApi\Processors\MergeIntoOpenApi;
 use OpenApi\Processors\MergeJsonContent;
 use OpenApi\Processors\MergeXmlContent;
 use OpenApi\Processors\OperationId;
-use OpenApi\Processors\InheritTraits;
+use SplObjectStorage;
+use stdClass;
 
 /**
  * Result of the analyser which pretends to be an array of annotations, but also contains detected classes and helper
@@ -40,21 +40,21 @@ class Analysis
     public $annotations;
 
     /**
-     * Class definitions
+     * Class definitions.
      *
      * @var array
      */
     public $classes = [];
 
     /**
-     * Trait definitions
+     * Trait definitions.
      *
      * @var array
      */
     public $traits = [];
 
     /**
-     * Interface definitions
+     * Interface definitions.
      *
      * @var array
      */
@@ -191,8 +191,9 @@ class Analysis
     /**
      * Get all sub classes of the given parent class.
      *
-     * @param string $parent The parent class.
-     * @return array Map of class => definition pairs of sub-classes.
+     * @param string $parent the parent class
+     *
+     * @return array map of class => definition pairs of sub-classes
      */
     public function getSubClasses($parent)
     {
@@ -210,8 +211,9 @@ class Analysis
     /**
      * Get a list of all super classes for the given class.
      *
-     * @param string $class The class name.
-     * @return array Map of class => definition pairs of parent classes.
+     * @param string $class the class name
+     *
+     * @return array map of class => definition pairs of parent classes
      */
     public function getSuperClasses($class)
     {
@@ -233,9 +235,10 @@ class Analysis
     /**
      * Get the list of interfaces used by the given class or by classes which it extends.
      *
-     * @param string $class   The class name.
-     * @param bool   $direct  Flag to find only the actual class interfaces.
-     * @return array Map of class => definition pairs of interfaces.
+     * @param string $class  the class name
+     * @param bool   $direct flag to find only the actual class interfaces
+     *
+     * @return array map of class => definition pairs of interfaces
      */
     public function getInterfacesOfClass($class, $direct = false)
     {
@@ -278,9 +281,10 @@ class Analysis
     /**
      * Get the list of traits used by the given class/trait or by classes which it extends.
      *
-     * @param string $source The source name.
-     * @param bool   $direct  Flag to find only the actual class traits.
-     * @return array Map of class => definition pairs of traits.
+     * @param string $source the source name
+     * @param bool   $direct flag to find only the actual class traits
+     *
+     * @return array map of class => definition pairs of traits
      */
     public function getTraitsOfClass($source, $direct = false)
     {
@@ -321,9 +325,8 @@ class Analysis
     }
 
     /**
-     *
-     * @param string  $class
-     * @param boolean $strict Innon-strict mode childclasses are also detected.
+     * @param string $class
+     * @param bool   $strict innon-strict mode childclasses are also detected
      *
      * @return array
      */
@@ -348,8 +351,7 @@ class Analysis
     }
 
     /**
-     *
-     * @param string $fqdn The source class/interface/trait.
+     * @param string $fqdn the source class/interface/trait
      *
      * @return null|Schema
      */
@@ -378,7 +380,6 @@ class Analysis
     }
 
     /**
-     *
      * @param object $annotation
      *
      * @return \OpenApi\Context
@@ -448,7 +449,7 @@ class Analysis
     }
 
     /**
-     * Apply the processor(s)
+     * Apply the processor(s).
      *
      * @param Closure|Closure[] $processors One or more processors
      */
@@ -497,7 +498,7 @@ class Analysis
     }
 
     /**
-     * Register a processor
+     * Register a processor.
      *
      * @param Closure $processor
      */
@@ -507,7 +508,7 @@ class Analysis
     }
 
     /**
-     * Unregister a processor
+     * Unregister a processor.
      *
      * @param Closure $processor
      */

--- a/src/Annotations/AbstractAnnotation.php
+++ b/src/Annotations/AbstractAnnotation.php
@@ -1,4 +1,4 @@
-<?php declare (strict_types = 1);
+<?php declare(strict_types = 1);
 
 /**
  * @license Apache 2.0
@@ -8,10 +8,10 @@ namespace OpenApi\Annotations;
 
 use Exception;
 use JsonSerializable;
-use stdClass;
 use OpenApi\Analyser;
 use OpenApi\Context;
 use OpenApi\Logger;
+use stdClass;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -41,7 +41,7 @@ abstract class AbstractAnnotation implements JsonSerializable
     public $_unmerged = [];
 
     /**
-     * The properties which are required by [the spec](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md)
+     * The properties which are required by [the spec](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md).
      *
      * @var array
      */
@@ -54,7 +54,7 @@ abstract class AbstractAnnotation implements JsonSerializable
      *   'required' => 'boolean', // true or false
      *   'tags' => '[string]', // array containing strings
      *   'in' => ["query", "header", "path", "formData", "body"] // must be one on these
-     *   'oneOf' => [Schema::class] // array of schema objects
+     *   'oneOf' => [Schema::class] // array of schema objects.
      *
      * @var array
      */
@@ -153,8 +153,9 @@ abstract class AbstractAnnotation implements JsonSerializable
      * Merge given annotations to their mapped properties configured in static::$_nested.
      * Annotations that couldn't be merged are added to the _unmerged array.
      *
-     * @param  AbstractAnnotation[] $annotations
-     * @param  bool                 $ignore      Ignore unmerged annotations
+     * @param AbstractAnnotation[] $annotations
+     * @param bool                 $ignore      Ignore unmerged annotations
+     *
      * @return AbstractAnnotation[] The unmerged annotations
      */
     public function merge($annotations, $ignore = false)
@@ -188,6 +189,7 @@ abstract class AbstractAnnotation implements JsonSerializable
                 $this->_unmerged[] = $this->nested($annotation, $nestedContext);
             }
         }
+
         return $unmerged;
     }
 
@@ -238,6 +240,7 @@ abstract class AbstractAnnotation implements JsonSerializable
         if ($flags === null) {
             $flags = Yaml::DUMP_OBJECT_AS_MAP ^ Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE;
         }
+
         return Yaml::dump(json_decode($this->toJson(0)), 10, 2, $flags);
     }
 
@@ -251,6 +254,7 @@ abstract class AbstractAnnotation implements JsonSerializable
         if ($flags === null) {
             $flags = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
         }
+
         return json_encode($this, $flags);
     }
 
@@ -262,6 +266,7 @@ abstract class AbstractAnnotation implements JsonSerializable
                 $properties[$property] = $value;
             }
         }
+
         return $properties;
     }
 
@@ -329,16 +334,19 @@ abstract class AbstractAnnotation implements JsonSerializable
             $data->$dollarRef = $data->ref;
             unset($data->ref);
         }
+
         return $data;
     }
 
     /**
      * Validate annotation tree, and log notices & warnings.
      *
-     * @param  array $parents The path of annotations above this annotation in the tree.
-     * @param  array $skip    (prevent stack overflow, when traversing an infinite dependency graph)
-     * @return boolean
+     * @param array $parents the path of annotations above this annotation in the tree
+     * @param array $skip    (prevent stack overflow, when traversing an infinite dependency graph)
+     *
      * @throws Exception
+     *
+     * @return bool
      */
     public function validate($parents = [], $skip = [], $ref = '')
     {
@@ -356,7 +364,7 @@ abstract class AbstractAnnotation implements JsonSerializable
             if (isset(static::$_nested[$class])) {
                 $property = static::$_nested[$class];
                 if (is_array($property)) {
-                    Logger::notice('Only one @' . str_replace('OpenApi\Annotations\\', 'OA\\', get_class($annotation)) . '() allowed for ' . $this->identity() . " multiple found, skipped: " . $annotation->_context);
+                    Logger::notice('Only one @' . str_replace('OpenApi\Annotations\\', 'OA\\', get_class($annotation)) . '() allowed for ' . $this->identity() . ' multiple found, skipped: ' . $annotation->_context);
                 } else {
                     Logger::notice('Only one @' . str_replace('OpenApi\Annotations\\', 'OA\\', get_class($annotation)) . '() allowed for ' . $this->identity() . " multiple found in:\n    Using: " . $this->$property->_context . "\n  Skipped: " . $annotation->_context);
                 }
@@ -448,16 +456,18 @@ abstract class AbstractAnnotation implements JsonSerializable
             }
         }
         $parents[] = $this;
+
         return self::_validate($this, $parents, $skip, $ref) ? $valid : false;
     }
 
     /**
      * Recursively validate all annotation properties.
      *
-     * @param  array|object $fields
-     * @param  array        $parents The path of annotations above this annotation in the tree.
-     * @param  array [      $skip]   Array with objects which are already validated
-     * @return boolean
+     * @param array|object $fields
+     * @param array        $parents the path of annotations above this annotation in the tree
+     * @param array [      $skip]   Array with objects which are already validated
+     *
+     * @return bool
      */
     private static function _validate($fields, $parents, $skip, $baseRef)
     {
@@ -475,7 +485,7 @@ abstract class AbstractAnnotation implements JsonSerializable
             if ($value === null || is_scalar($value) || in_array($field, $blacklist)) {
                 continue;
             }
-            $ref = $baseRef !== '' ? $baseRef . '/' . urlencode((string)$field) : urlencode((string)$field);
+            $ref = $baseRef !== '' ? $baseRef . '/' . urlencode((string) $field) : urlencode((string) $field);
             if (is_object($value)) {
                 if (method_exists($value, 'validate')) {
                     if (!$value->validate($parents, $skip, $ref)) {
@@ -488,12 +498,13 @@ abstract class AbstractAnnotation implements JsonSerializable
                 $valid = false;
             }
         }
+
         return $valid;
     }
 
     /**
      * Return a identity for easy debugging.
-     * Example: "@OA\Get(path="/pets")"
+     * Example: "@OA\Get(path="/pets")".
      *
      * @return string
      */
@@ -503,9 +514,10 @@ abstract class AbstractAnnotation implements JsonSerializable
     }
 
     /**
-     * Helper for generating the identity()
+     * Helper for generating the identity().
      *
-     * @param  array $properties
+     * @param array $properties
+     *
      * @return string
      */
     protected function _identity($properties)
@@ -517,16 +529,16 @@ abstract class AbstractAnnotation implements JsonSerializable
                 $fields[] = $property . '=' . (is_string($value) ? '"' . $value . '"' : $value);
             }
         }
+
         return '@' . str_replace('OpenApi\\Annotations\\', 'OA\\', get_class($this)) . '(' . implode(',', $fields) . ')';
     }
 
     /**
-     * Validates the matching of the property value to a annotation type
+     * Validates the matching of the property value to a annotation type.
      *
      * @param string $type  The annotations property type
      * @param mixed  $value The property value
      *
-     * @return bool
      * @throws \Exception
      */
     private function validateType($type, $value): bool
@@ -541,6 +553,7 @@ abstract class AbstractAnnotation implements JsonSerializable
                     return false;
                 }
             }
+
             return true;
         }
 
@@ -552,12 +565,11 @@ abstract class AbstractAnnotation implements JsonSerializable
     }
 
     /**
-     * Validates default Open Api types
+     * Validates default Open Api types.
      *
-     * @param string $type The property type
-     * @param mixed $value The value to validate
+     * @param string $type  The property type
+     * @param mixed  $value The value to validate
      *
-     * @return bool
      * @throws \Exception
      */
     private function validateDefaultTypes($type, $value): bool
@@ -583,11 +595,7 @@ abstract class AbstractAnnotation implements JsonSerializable
     }
 
     /**
-     * Validate array type
-     *
-     * @param mixed $value
-     *
-     * @return bool
+     * Validate array type.
      */
     private function validateArrayType($value): bool
     {
@@ -602,14 +610,16 @@ abstract class AbstractAnnotation implements JsonSerializable
             }
             $count++;
         }
+
         return true;
     }
 
     /**
      * Wrap the context with a reference to the annotation it is nested in.
      *
-     * @param  AbstractAnnotation $annotation
-     * @param  Context            $nestedContext
+     * @param AbstractAnnotation $annotation
+     * @param Context            $nestedContext
+     *
      * @return AbstractAnnotation
      */
     private function nested($annotation, $nestedContext)
@@ -617,6 +627,7 @@ abstract class AbstractAnnotation implements JsonSerializable
         if (property_exists($annotation, '_context') && $annotation->_context === $this->_context) {
             $annotation->_context = $nestedContext;
         }
+
         return $annotation;
     }
 }

--- a/src/Annotations/AbstractAnnotation.php
+++ b/src/Annotations/AbstractAnnotation.php
@@ -121,14 +121,14 @@ abstract class AbstractAnnotation implements JsonSerializable
                     if (is_object($annotation) && $annotation instanceof AbstractAnnotation) {
                         $annotations[] = $annotation;
                     } else {
-                        Logger::notice('Unexpected field in ' . $this->identity() . ' in ' . $this->_context);
+                        Logger::notice('Unexpected field in '.$this->identity().' in '.$this->_context);
                     }
                 }
                 $this->merge($annotations);
             } elseif (is_object($value)) {
                 $this->merge([$value]);
             } else {
-                Logger::notice('Unexpected parameter in ' . $this->identity());
+                Logger::notice('Unexpected parameter in '.$this->identity());
             }
         }
     }
@@ -136,7 +136,7 @@ abstract class AbstractAnnotation implements JsonSerializable
     public function __get($property)
     {
         $properties = get_object_vars($this);
-        Logger::notice('Property "' . $property . '" doesn\'t exist in a ' . $this->identity() . ', existing properties: "' . implode('", "', array_keys($properties)) . '" in ' . $this->_context);
+        Logger::notice('Property "'.$property.'" doesn\'t exist in a '.$this->identity().', existing properties: "'.implode('", "', array_keys($properties)).'" in '.$this->_context);
     }
 
     public function __set($property, $value)
@@ -145,7 +145,7 @@ abstract class AbstractAnnotation implements JsonSerializable
         foreach (static::$_blacklist as $_property) {
             unset($fields[$_property]);
         }
-        Logger::notice('Unexpected field "' . $property . '" for ' . $this->identity() . ', expecting "' . implode('", "', array_keys($fields)) . '" in ' . $this->_context);
+        Logger::notice('Unexpected field "'.$property.'" for '.$this->identity().', expecting "'.implode('", "', array_keys($fields)).'" in '.$this->_context);
         $this->$property = $value;
     }
 
@@ -225,7 +225,7 @@ abstract class AbstractAnnotation implements JsonSerializable
                 if (is_object($this->$property) && $this->$property instanceof AbstractAnnotation) {
                     $context1 = $this->$property->_context;
                 }
-                Logger::warning('Multiple definitions for ' . $identity . '->' . $property . "\n     Using: " . $context1 . "\n  Skipping: " . $context2);
+                Logger::warning('Multiple definitions for '.$identity.'->'.$property."\n     Using: ".$context1."\n  Skipping: ".$context2);
             }
         }
     }
@@ -296,7 +296,7 @@ abstract class AbstractAnnotation implements JsonSerializable
         unset($data->x);
         if (is_array($this->x)) {
             foreach ($this->x as $property => $value) {
-                $prefixed = 'x-' . $property;
+                $prefixed = 'x-'.$property;
                 $data->$prefixed = $value;
             }
         }
@@ -357,27 +357,27 @@ abstract class AbstractAnnotation implements JsonSerializable
         // Report orphaned annotations
         foreach ($this->_unmerged as $annotation) {
             if (!is_object($annotation)) {
-                Logger::notice('Unexpected type: "' . gettype($annotation) . '" in ' . $this->identity() . '->_unmerged, expecting a Annotation object');
+                Logger::notice('Unexpected type: "'.gettype($annotation).'" in '.$this->identity().'->_unmerged, expecting a Annotation object');
                 break;
             }
             $class = get_class($annotation);
             if (isset(static::$_nested[$class])) {
                 $property = static::$_nested[$class];
                 if (is_array($property)) {
-                    Logger::notice('Only one @' . str_replace('OpenApi\Annotations\\', 'OA\\', get_class($annotation)) . '() allowed for ' . $this->identity() . ' multiple found, skipped: ' . $annotation->_context);
+                    Logger::notice('Only one @'.str_replace('OpenApi\Annotations\\', 'OA\\', get_class($annotation)).'() allowed for '.$this->identity().' multiple found, skipped: '.$annotation->_context);
                 } else {
-                    Logger::notice('Only one @' . str_replace('OpenApi\Annotations\\', 'OA\\', get_class($annotation)) . '() allowed for ' . $this->identity() . " multiple found in:\n    Using: " . $this->$property->_context . "\n  Skipped: " . $annotation->_context);
+                    Logger::notice('Only one @'.str_replace('OpenApi\Annotations\\', 'OA\\', get_class($annotation)).'() allowed for '.$this->identity()." multiple found in:\n    Using: ".$this->$property->_context."\n  Skipped: ".$annotation->_context);
                 }
             } elseif ($annotation instanceof AbstractAnnotation) {
-                $message = 'Unexpected ' . $annotation->identity();
+                $message = 'Unexpected '.$annotation->identity();
                 if (count($class::$_parents)) {
                     $shortNotations = [];
                     foreach ($class::$_parents as $_class) {
-                        $shortNotations[] = '@' . str_replace('OpenApi\Annotations\\', 'OA\\', $_class);
+                        $shortNotations[] = '@'.str_replace('OpenApi\Annotations\\', 'OA\\', $_class);
                     }
-                    $message .= ', expected to be inside ' . implode(', ', $shortNotations);
+                    $message .= ', expected to be inside '.implode(', ', $shortNotations);
                 }
-                Logger::notice($message . ' in ' . $annotation->_context);
+                Logger::notice($message.' in '.$annotation->_context);
             }
             $valid = false;
         }
@@ -395,12 +395,12 @@ abstract class AbstractAnnotation implements JsonSerializable
             $keyField = $nested[1];
             foreach ($this->$property as $key => $item) {
                 if (is_array($item) && is_numeric($key) === false) {
-                    Logger::notice($this->identity() . '->' . $property . ' is an object literal, use nested @' . str_replace('OpenApi\\Annotations\\', 'OA\\', $annotationClass) . '() annotation(s) in ' . $this->_context);
+                    Logger::notice($this->identity().'->'.$property.' is an object literal, use nested @'.str_replace('OpenApi\\Annotations\\', 'OA\\', $annotationClass).'() annotation(s) in '.$this->_context);
                     $keys[$key] = $item;
                 } elseif ($item->$keyField === UNDEFINED) {
-                    Logger::warning($item->identity() . ' is missing key-field: "' . $keyField . '" in ' . $item->_context);
+                    Logger::warning($item->identity().' is missing key-field: "'.$keyField.'" in '.$item->_context);
                 } elseif (isset($keys[$item->$keyField])) {
-                    Logger::warning('Multiple ' . $item->_identity([]) . ' with the same ' . $keyField . '="' . $item->$keyField . "\":\n  " . $item->_context . "\n  " . $keys[$item->$keyField]->_context);
+                    Logger::warning('Multiple '.$item->_identity([]).' with the same '.$keyField.'="'.$item->$keyField."\":\n  ".$item->_context."\n  ".$keys[$item->$keyField]->_context);
                 } else {
                     $keys[$item->$keyField] = $item;
                 }
@@ -411,23 +411,23 @@ abstract class AbstractAnnotation implements JsonSerializable
                 try {
                     $parents[0]->ref($this->ref);
                 } catch (Exception $exception) {
-                    Logger::notice($exception->getMessage() . ' for ' . $this->identity() . ' in ' . $this->_context);
+                    Logger::notice($exception->getMessage().' for '.$this->identity().' in '.$this->_context);
                 }
             }
         } else {
             // Report missing required fields (when not a $ref)
             foreach (static::$_required as $property) {
                 if ($this->$property === UNDEFINED) {
-                    $message = 'Missing required field "' . $property . '" for ' . $this->identity() . ' in ' . $this->_context;
+                    $message = 'Missing required field "'.$property.'" for '.$this->identity().' in '.$this->_context;
                     foreach (static::$_nested as $class => $nested) {
                         $nestedProperty = is_array($nested) ? $nested[0] : $nested;
                         if ($property === $nestedProperty) {
                             if ($this instanceof OpenApi) {
-                                $message = 'Required @' . str_replace('OpenApi\\Annotations\\', 'OA\\', $class) . '() not found';
+                                $message = 'Required @'.str_replace('OpenApi\\Annotations\\', 'OA\\', $class).'() not found';
                             } elseif (is_array($nested)) {
-                                $message = $this->identity() . ' requires at least one @' . str_replace('OpenApi\\Annotations\\', 'OA\\', $class) . '() in ' . $this->_context;
+                                $message = $this->identity().' requires at least one @'.str_replace('OpenApi\\Annotations\\', 'OA\\', $class).'() in '.$this->_context;
                             } else {
-                                $message = $this->identity() . ' requires a @' . str_replace('OpenApi\\Annotations\\', 'OA\\', $class) . '() in ' . $this->_context;
+                                $message = $this->identity().' requires a @'.str_replace('OpenApi\\Annotations\\', 'OA\\', $class).'() in '.$this->_context;
                             }
                             break;
                         }
@@ -445,14 +445,14 @@ abstract class AbstractAnnotation implements JsonSerializable
             if (is_string($type)) {
                 if ($this->validateType($type, $value) === false) {
                     $valid = false;
-                    Logger::notice($this->identity() . '->' . $property . ' is a "' . gettype($value) . '", expecting a "' . $type . '" in ' . $this->_context);
+                    Logger::notice($this->identity().'->'.$property.' is a "'.gettype($value).'", expecting a "'.$type.'" in '.$this->_context);
                 }
             } elseif (is_array($type)) { // enum?
                 if (in_array($value, $type) === false) {
-                    Logger::notice($this->identity() . '->' . $property . ' "' . $value . '" is invalid, expecting "' . implode('", "', $type) . '" in ' . $this->_context);
+                    Logger::notice($this->identity().'->'.$property.' "'.$value.'" is invalid, expecting "'.implode('", "', $type).'" in '.$this->_context);
                 }
             } else {
-                throw new Exception('Invalid ' . get_class($this) . '::$_types[' . $property . ']');
+                throw new Exception('Invalid '.get_class($this).'::$_types['.$property.']');
             }
         }
         $parents[] = $this;
@@ -485,7 +485,7 @@ abstract class AbstractAnnotation implements JsonSerializable
             if ($value === null || is_scalar($value) || in_array($field, $blacklist)) {
                 continue;
             }
-            $ref = $baseRef !== '' ? $baseRef . '/' . urlencode((string) $field) : urlencode((string) $field);
+            $ref = $baseRef !== '' ? $baseRef.'/'.urlencode((string) $field) : urlencode((string) $field);
             if (is_object($value)) {
                 if (method_exists($value, 'validate')) {
                     if (!$value->validate($parents, $skip, $ref)) {
@@ -526,11 +526,11 @@ abstract class AbstractAnnotation implements JsonSerializable
         foreach ($properties as $property) {
             $value = $this->$property;
             if ($value !== null && $value !== UNDEFINED) {
-                $fields[] = $property . '=' . (is_string($value) ? '"' . $value . '"' : $value);
+                $fields[] = $property.'='.(is_string($value) ? '"'.$value.'"' : $value);
             }
         }
 
-        return '@' . str_replace('OpenApi\\Annotations\\', 'OA\\', get_class($this)) . '(' . implode(',', $fields) . ')';
+        return '@'.str_replace('OpenApi\\Annotations\\', 'OA\\', get_class($this)).'('.implode(',', $fields).')';
     }
 
     /**
@@ -590,7 +590,7 @@ abstract class AbstractAnnotation implements JsonSerializable
             case 'scheme':
                 return in_array($value, ['http', 'https', 'ws', 'wss'], true);
             default:
-                throw new Exception('Invalid type "' . $type . '"');
+                throw new Exception('Invalid type "'.$type.'"');
         }
     }
 

--- a/src/Annotations/AdditionalProperties.php
+++ b/src/Annotations/AdditionalProperties.php
@@ -12,7 +12,7 @@ namespace OpenApi\Annotations;
 class AdditionalProperties extends Schema
 {
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_parents = [
         Schema::class,
@@ -24,7 +24,7 @@ class AdditionalProperties extends Schema
     ];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_nested = [
         Discriminator::class => 'discriminator',

--- a/src/Annotations/Components.php
+++ b/src/Annotations/Components.php
@@ -16,7 +16,7 @@ namespace OpenApi\Annotations;
 class Components extends AbstractAnnotation
 {
     /**
-     * Schema reference
+     * Schema reference.
      *
      * @var string
      */
@@ -81,19 +81,19 @@ class Components extends AbstractAnnotation
     /**
      * Reusable Callbacks.
      *
-     * @var Callback[]
+     * @var callback[]
      */
     public $callbacks = UNDEFINED;
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_parents = [
-        OpenApi::class
+        OpenApi::class,
     ];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_nested = [
         Schema::class => ['schemas', 'schema'],

--- a/src/Annotations/Contact.php
+++ b/src/Annotations/Contact.php
@@ -36,18 +36,18 @@ class Contact extends AbstractAnnotation
     public $email = UNDEFINED;
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_types = [
         'name' => 'string',
         'url' => 'string',
-        'email' => 'string'
+        'email' => 'string',
     ];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_parents = [
-        Info::class
+        Info::class,
     ];
 }

--- a/src/Annotations/Delete.php
+++ b/src/Annotations/Delete.php
@@ -12,14 +12,14 @@ namespace OpenApi\Annotations;
 class Delete extends Operation
 {
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public $method = 'delete';
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_parents = [
-        PathItem::class
+        PathItem::class,
     ];
 }

--- a/src/Annotations/Discriminator.php
+++ b/src/Annotations/Discriminator.php
@@ -19,33 +19,33 @@ namespace OpenApi\Annotations;
 class Discriminator extends AbstractAnnotation
 {
     /**
-     * The name of the property in the payload that will hold the discriminator value
+     * The name of the property in the payload that will hold the discriminator value.
      *
      * @var string
      */
     public $propertyName = UNDEFINED;
 
     /**
-     * An object to hold mappings between payload values and schema names or references
+     * An object to hold mappings between payload values and schema names or references.
      *
      * @var string[]
      */
     public $mapping = UNDEFINED;
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_required = ['propertyName'];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_types = [
         'propertyName' => 'string',
     ];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_parents = [
         Schema::class,

--- a/src/Annotations/Examples.php
+++ b/src/Annotations/Examples.php
@@ -12,7 +12,7 @@ namespace OpenApi\Annotations;
 class Examples extends AbstractAnnotation
 {
     /**
-     * $ref See https://swagger.io/docs/specification/using-ref/
+     * $ref See https://swagger.io/docs/specification/using-ref/.
      *
      * @var string
      */

--- a/src/Annotations/ExternalDocumentation.php
+++ b/src/Annotations/ExternalDocumentation.php
@@ -29,7 +29,7 @@ class ExternalDocumentation extends AbstractAnnotation
     public $url = UNDEFINED;
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_types = [
         'description' => 'string',
@@ -37,12 +37,12 @@ class ExternalDocumentation extends AbstractAnnotation
     ];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_required = ['url'];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_parents = [
         OpenApi::class,

--- a/src/Annotations/Flow.php
+++ b/src/Annotations/Flow.php
@@ -8,7 +8,7 @@ namespace OpenApi\Annotations;
 
 /**
  * Configuration details for a supported OAuth Flow
- * [OAuth Flow Object](https://swagger.io/specification/#oauthFlowObject)
+ * [OAuth Flow Object](https://swagger.io/specification/#oauthFlowObject).
  *
  * @Annotation
  */
@@ -39,7 +39,7 @@ class Flow extends AbstractAnnotation
     public $refreshUrl = UNDEFINED;
 
     /**
-     * Flow name. One of ['implicit', 'password', 'authorizationCode', 'clientCredentials']
+     * Flow name. One of ['implicit', 'password', 'authorizationCode', 'clientCredentials'].
      *
      * @var string
      */
@@ -53,7 +53,7 @@ class Flow extends AbstractAnnotation
     public $scopes = UNDEFINED;
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_required = ['scopes', 'flow'];
 
@@ -63,7 +63,7 @@ class Flow extends AbstractAnnotation
     public static $_blacklist = ['_context', '_unmerged'];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_types = [
         'flow' => ['implicit', 'password', 'authorizationCode', 'clientCredentials'],
@@ -73,7 +73,7 @@ class Flow extends AbstractAnnotation
     ];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_parents = [
         SecurityScheme::class,
@@ -85,6 +85,7 @@ class Flow extends AbstractAnnotation
         if (is_array($this->scopes) && empty($this->scopes)) {
             $this->scopes = new \StdClass();
         }
+
         return parent::jsonSerialize();
     }
 }

--- a/src/Annotations/Get.php
+++ b/src/Annotations/Get.php
@@ -12,14 +12,14 @@ namespace OpenApi\Annotations;
 class Get extends Operation
 {
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public $method = 'get';
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_parents = [
-        PathItem::class
+        PathItem::class,
     ];
 }

--- a/src/Annotations/Head.php
+++ b/src/Annotations/Head.php
@@ -12,14 +12,14 @@ namespace OpenApi\Annotations;
 class Head extends Operation
 {
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public $method = 'head';
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_parents = [
-        PathItem::class
+        PathItem::class,
     ];
 }

--- a/src/Annotations/Header.php
+++ b/src/Annotations/Header.php
@@ -13,7 +13,7 @@ namespace OpenApi\Annotations;
 class Header extends AbstractAnnotation
 {
     /**
-     * $ref See https://swagger.io/docs/specification/using-ref/
+     * $ref See https://swagger.io/docs/specification/using-ref/.
      *
      * @var string
      */
@@ -37,7 +37,7 @@ class Header extends AbstractAnnotation
     public $required = UNDEFINED;
 
     /**
-     * Schema object
+     * Schema object.
      *
      * @var \OpenApi\Annotations\Schema
      */
@@ -61,12 +61,12 @@ class Header extends AbstractAnnotation
     public $allowEmptyValue = UNDEFINED;
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_required = ['header', 'schema'];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_types = [
         'header' => 'string',
@@ -74,17 +74,17 @@ class Header extends AbstractAnnotation
     ];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_nested = [
-        Schema::class => 'schema'
+        Schema::class => 'schema',
     ];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_parents = [
         Components::class,
-        Response::class
+        Response::class,
     ];
 }

--- a/src/Annotations/Info.php
+++ b/src/Annotations/Info.php
@@ -58,32 +58,32 @@ class Info extends AbstractAnnotation
     public $version = UNDEFINED;
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_required = ['title', 'version'];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_types = [
         'title' => 'string',
         'version' => 'string',
         'description' => 'string',
-        'termsOfService' => 'string'
+        'termsOfService' => 'string',
     ];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_nested = [
         Contact::class => 'contact',
-        License::class => 'license'
+        License::class => 'license',
     ];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_parents = [
-        OpenApi::class
+        OpenApi::class,
     ];
 }

--- a/src/Annotations/Items.php
+++ b/src/Annotations/Items.php
@@ -15,7 +15,7 @@ use OpenApi\Logger;
 class Items extends Schema
 {
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_nested = [
         Discriminator::class => 'discriminator',
@@ -23,11 +23,11 @@ class Items extends Schema
         Property::class => ['properties', 'property'],
         ExternalDocumentation::class => 'externalDocs',
         Xml::class => 'xml',
-        AdditionalProperties::class => 'additionalProperties'
+        AdditionalProperties::class => 'additionalProperties',
     ];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_parents = [
         Property::class,
@@ -35,11 +35,11 @@ class Items extends Schema
         Schema::class,
         JsonContent::class,
         XmlContent::class,
-        Items::class
+        Items::class,
     ];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function validate($parents = [], $skip = [], $ref = '')
     {
@@ -54,11 +54,12 @@ class Items extends Schema
                 // A limited subset of JSON-Schema's items object.
                 $allowedTypes = ['string', 'number', 'integer', 'boolean', 'array'];
                 if (in_array($this->type, $allowedTypes) === false) {
-                    Logger::notice('@OA\Items()->type="'.$this->type.'" not allowed inside a '.$parent->_identity([]).' must be "'.implode('", "', $allowedTypes).'" in ' . $this->_context);
+                    Logger::notice('@OA\Items()->type="' . $this->type . '" not allowed inside a ' . $parent->_identity([]) . ' must be "' . implode('", "', $allowedTypes) . '" in ' . $this->_context);
                     $valid = false;
                 }
             }
         }
+
         return $valid;
         // @todo Additional validation when used inside a Header or Parameter context.
     }

--- a/src/Annotations/Items.php
+++ b/src/Annotations/Items.php
@@ -54,7 +54,7 @@ class Items extends Schema
                 // A limited subset of JSON-Schema's items object.
                 $allowedTypes = ['string', 'number', 'integer', 'boolean', 'array'];
                 if (in_array($this->type, $allowedTypes) === false) {
-                    Logger::notice('@OA\Items()->type="' . $this->type . '" not allowed inside a ' . $parent->_identity([]) . ' must be "' . implode('", "', $allowedTypes) . '" in ' . $this->_context);
+                    Logger::notice('@OA\Items()->type="'.$this->type.'" not allowed inside a '.$parent->_identity([]).' must be "'.implode('", "', $allowedTypes).'" in '.$this->_context);
                     $valid = false;
                 }
             }

--- a/src/Annotations/JsonContent.php
+++ b/src/Annotations/JsonContent.php
@@ -26,12 +26,12 @@ class JsonContent extends Schema
     public $examples = UNDEFINED;
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_parents = [];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_nested = [
         Discriminator::class => 'discriminator',
@@ -39,6 +39,6 @@ class JsonContent extends Schema
         Property::class => ['properties', 'property'],
         ExternalDocumentation::class => 'externalDocs',
         Xml::class => 'xml',
-        AdditionalProperties::class => 'additionalProperties'
+        AdditionalProperties::class => 'additionalProperties',
     ];
 }

--- a/src/Annotations/License.php
+++ b/src/Annotations/License.php
@@ -29,7 +29,7 @@ class License extends AbstractAnnotation
     public $url = UNDEFINED;
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_types = [
         'name' => 'string',
@@ -37,14 +37,14 @@ class License extends AbstractAnnotation
     ];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_required = ['name'];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_parents = [
-        Info::class
+        Info::class,
     ];
 }

--- a/src/Annotations/Link.php
+++ b/src/Annotations/Link.php
@@ -19,7 +19,7 @@ class Link extends AbstractAnnotation
 {
 
     /**
-     * $ref See https://swagger.io/docs/specification/using-ref/
+     * $ref See https://swagger.io/docs/specification/using-ref/.
      *
      * @var string
      */
@@ -77,17 +77,17 @@ class Link extends AbstractAnnotation
     public $server = UNDEFINED;
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_nested = [
         Server::class => 'server',
     ];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_parents = [
         Components::class,
-        Response::class
+        Response::class,
     ];
 }

--- a/src/Annotations/MediaType.php
+++ b/src/Annotations/MediaType.php
@@ -55,14 +55,14 @@ class MediaType extends AbstractAnnotation
     public $encoding = UNDEFINED;
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_nested = [
         Schema::class => 'schema',
         Examples::class => ['examples'],
     ];
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_parents = [
         Response::class,

--- a/src/Annotations/OpenApi.php
+++ b/src/Annotations/OpenApi.php
@@ -56,7 +56,6 @@ class OpenApi extends AbstractAnnotation
      */
     public $components = UNDEFINED;
 
-
     /**
      * Lists the required security schemes to execute this operation.
      * The name used for each property must correspond to a security scheme declared
@@ -97,17 +96,17 @@ class OpenApi extends AbstractAnnotation
     public $_analysis = UNDEFINED;
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_blacklist = ['_context', '_unmerged', '_analysis'];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_required = ['openapi', 'info', 'paths'];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_nested = [
         Info::class => 'info',
@@ -119,30 +118,33 @@ class OpenApi extends AbstractAnnotation
     ];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_types = [];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function validate($parents = null, $skip = null, $ref = null)
     {
         if ($parents !== null || $skip !== null || $ref !== null) {
-            Logger::notice('Nested validation for '.$this->identity().' not allowed');
+            Logger::notice('Nested validation for ' . $this->identity() . ' not allowed');
+
             return false;
         }
+
         return parent::validate([], [], '#');
     }
+
     /**
      * Save the OpenAPI documentation to a file.
      *
-     * @param  string $filename
+     * @param string $filename
+     *
      * @throws Exception
      */
     public function saveAs($filename, $format = 'auto')
     {
-
         if ($format === 'auto') {
             $format =   strtolower(substr($filename, -5)) === '.json' ? 'json' : 'yaml';
         }
@@ -152,14 +154,15 @@ class OpenApi extends AbstractAnnotation
             $content = $this->toYaml();
         }
         if (file_put_contents($filename, $content) === false) {
-            throw new Exception('Failed to saveAs("' . $filename . '", "'.$format.'")');
+            throw new Exception('Failed to saveAs("' . $filename . '", "' . $format . '")');
         }
     }
 
     /**
      * Look up an annotation with a $ref url.
      *
-     * @param  string $ref The $ref value, for example: "#/components/schemas/Product"
+     * @param string $ref The $ref value, for example: "#/components/schemas/Product"
+     *
      * @throws Exception
      */
     public function ref($ref)
@@ -168,16 +171,15 @@ class OpenApi extends AbstractAnnotation
             // @todo Add support for external (http) refs?
             throw new Exception('Unsupported $ref "' . $ref . '", it should start with "#/"');
         }
+
         return $this->resolveRef($ref, '#/', $this, []);
     }
 
     /**
-     * Recursive helper for ref()
+     * Recursive helper for ref().
      *
-     * @param string $prefix    The resolved path of the ref.
-     * @param string $path      A partial ref
-     * @param *      $container the container to resolve the ref in.
-     * @param Array  $mapping
+     * @param *     $container the container to resolve the ref in
+     * @param array $mapping
      */
     private static function resolveRef($ref, $resolved, $container, $mapping)
     {
@@ -206,6 +208,7 @@ class OpenApi extends AbstractAnnotation
                     }
                 }
             }
+
             return self::resolveRef($ref, $unresolved, $container->$property, $mapping);
         } elseif (is_array($container)) {
             if (array_key_exists($property, $container)) {
@@ -250,6 +253,7 @@ class OpenApi extends AbstractAnnotation
                 $decoded .= $char;
             }
         }
+
         return $decoded;
     }
 }

--- a/src/Annotations/OpenApi.php
+++ b/src/Annotations/OpenApi.php
@@ -128,7 +128,7 @@ class OpenApi extends AbstractAnnotation
     public function validate($parents = null, $skip = null, $ref = null)
     {
         if ($parents !== null || $skip !== null || $ref !== null) {
-            Logger::notice('Nested validation for ' . $this->identity() . ' not allowed');
+            Logger::notice('Nested validation for '.$this->identity().' not allowed');
 
             return false;
         }
@@ -154,7 +154,7 @@ class OpenApi extends AbstractAnnotation
             $content = $this->toYaml();
         }
         if (file_put_contents($filename, $content) === false) {
-            throw new Exception('Failed to saveAs("' . $filename . '", "' . $format . '")');
+            throw new Exception('Failed to saveAs("'.$filename.'", "'.$format.'")');
         }
     }
 
@@ -169,7 +169,7 @@ class OpenApi extends AbstractAnnotation
     {
         if (substr($ref, 0, 2) !== '#/') {
             // @todo Add support for external (http) refs?
-            throw new Exception('Unsupported $ref "' . $ref . '", it should start with "#/"');
+            throw new Exception('Unsupported $ref "'.$ref.'", it should start with "#/"');
         }
 
         return $this->resolveRef($ref, '#/', $this, []);
@@ -191,11 +191,11 @@ class OpenApi extends AbstractAnnotation
 
         $subpath = $slash === false ? $path : substr($path, 0, $slash);
         $property = self::unescapeRef($subpath);
-        $unresolved = $slash === false ? $resolved . $subpath : $resolved . $subpath . '/';
+        $unresolved = $slash === false ? $resolved.$subpath : $resolved.$subpath.'/';
 
         if (is_object($container)) {
             if (property_exists($container, $property) === false) {
-                throw new Exception('$ref "' . $ref . '" not found');
+                throw new Exception('$ref "'.$ref.'" not found');
             }
             if ($slash === false) {
                 return $container->$property;
@@ -222,7 +222,7 @@ class OpenApi extends AbstractAnnotation
                 }
             }
         }
-        throw new Exception('$ref "' . $unresolved . '" not found');
+        throw new Exception('$ref "'.$unresolved.'" not found');
     }
 
     /**

--- a/src/Annotations/Operation.php
+++ b/src/Annotations/Operation.php
@@ -1,8 +1,8 @@
 <?php declare(strict_types=1);
 
-/**
- * @license Apache 2.0
- */
+ /**
+  * @license Apache 2.0
+  */
 
  namespace OpenApi\Annotations;
 
@@ -18,7 +18,7 @@ use OpenApi\Logger;
 abstract class Operation extends AbstractAnnotation
 {
     /**
-     * key in the OpenApi "Paths Object" for this operation
+     * key in the OpenApi "Paths Object" for this operation.
      *
      * @var string
      */
@@ -34,7 +34,7 @@ abstract class Operation extends AbstractAnnotation
 
     /**
      * Key in the OpenApi "Path Item Object" for this operation.
-     * Allowed values: 'get', 'post', put', 'patch', 'delete', 'options', 'head' and 'trace'
+     * Allowed values: 'get', 'post', put', 'patch', 'delete', 'options', 'head' and 'trace'.
      *
      * @var string
      */
@@ -104,7 +104,7 @@ abstract class Operation extends AbstractAnnotation
      * Each value in the map is a Callback Object that describes a request that may be initiated by the API provider and the expected responses.
      * The key value used to identify the callback object is an expression, evaluated at runtime, that identifies a URL to use for the callback operation.
      *
-     * @var Callback[]
+     * @var callback[]
      */
     public $callbacks = UNDEFINED;
 
@@ -113,7 +113,7 @@ abstract class Operation extends AbstractAnnotation
      * Consumers should refrain from usage of the declared operation.
      * Default value is false.
      *
-     * @var boolean
+     * @var bool
      */
     public $deprecated = UNDEFINED;
 
@@ -137,12 +137,12 @@ abstract class Operation extends AbstractAnnotation
     public $servers = UNDEFINED;
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_required = ['responses'];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_types = [
         'path' => 'string',
@@ -150,11 +150,11 @@ abstract class Operation extends AbstractAnnotation
         'tags' => '[string]',
         'summary' => 'string',
         'description' => 'string',
-        'deprecated' => 'boolean'
+        'deprecated' => 'boolean',
     ];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_nested = [
         Parameter::class => ['parameters'],
@@ -165,13 +165,14 @@ abstract class Operation extends AbstractAnnotation
     ];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function jsonSerialize()
     {
         $data = parent::jsonSerialize();
         unset($data->method);
         unset($data->path);
+
         return $data;
     }
 
@@ -188,6 +189,7 @@ abstract class Operation extends AbstractAnnotation
                 }
             }
         }
+
         return $valid;
     }
 }

--- a/src/Annotations/Operation.php
+++ b/src/Annotations/Operation.php
@@ -185,7 +185,7 @@ abstract class Operation extends AbstractAnnotation
         if ($this->responses !== UNDEFINED) {
             foreach ($this->responses as $response) {
                 if ($response->response !== UNDEFINED && $response->response !== 'default' && preg_match('/^([12345]{1}[0-9]{2})|([12345]{1}XX)$/', (string) $response->response) === 0) {
-                    Logger::notice('Invalid value "' . $response->response . '" for ' . $response->_identity([]) . '->response, expecting "default", a HTTP Status Code or HTTP Status Code range definition in ' . $response->_context);
+                    Logger::notice('Invalid value "'.$response->response.'" for '.$response->_identity([]).'->response, expecting "default", a HTTP Status Code or HTTP Status Code range definition in '.$response->_context);
                 }
             }
         }

--- a/src/Annotations/Options.php
+++ b/src/Annotations/Options.php
@@ -12,14 +12,14 @@ namespace OpenApi\Annotations;
 class Options extends Operation
 {
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public $method = 'options';
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_parents = [
-        PathItem::class
+        PathItem::class,
     ];
 }

--- a/src/Annotations/Parameter.php
+++ b/src/Annotations/Parameter.php
@@ -243,7 +243,7 @@ class Parameter extends AbstractAnnotation
         if ($this->ref === UNDEFINED) {
             if ($this->in === 'body') {
                 if ($this->schema === UNDEFINED) {
-                    Logger::notice('Field "schema" is required when ' . $this->identity() . ' is in "' . $this->in . '" in ' . $this->_context);
+                    Logger::notice('Field "schema" is required when '.$this->identity().' is in "'.$this->in.'" in '.$this->_context);
                     $valid = false;
                 }
             } else {

--- a/src/Annotations/Parameter.php
+++ b/src/Annotations/Parameter.php
@@ -17,7 +17,7 @@ use OpenApi\Logger;
 class Parameter extends AbstractAnnotation
 {
     /**
-     * $ref See https://swagger.io/docs/specification/using-ref/
+     * $ref See https://swagger.io/docs/specification/using-ref/.
      *
      * @var string
      */
@@ -61,16 +61,16 @@ class Parameter extends AbstractAnnotation
     /**
      * Determines whether this parameter is mandatory.
      * If the parameter location is "path", this property is required and its value must be true.
-     * Otherwise, the property may be included and its default value is false
+     * Otherwise, the property may be included and its default value is false.
      *
-     * @var boolean
+     * @var bool
      */
     public $required = UNDEFINED;
 
     /**
      * Specifies that a parameter is deprecated and should be transitioned out of usage.
      *
-     * @var boolean
+     * @var bool
      */
     public $deprecated = UNDEFINED;
 
@@ -79,11 +79,10 @@ class Parameter extends AbstractAnnotation
      * This is valid only for query parameters and allows sending a parameter with an empty value.
      * Default value is false. If style is used, and if behavior is n/a (cannot be serialized), the value of allowEmptyValue shall be ignored.
      *
-     * @var boolean
+     * @var bool
      */
     public $allowEmptyValue = UNDEFINED;
 
-    
     /**
      * Describes how the parameter value will be serialized depending on the type of the parameter value.
      * Default values (based on value of in): for query - form; for path - simple; for header - simple; for cookie - form.
@@ -98,7 +97,7 @@ class Parameter extends AbstractAnnotation
      * When style is form, the default value is true.
      * For all other styles, the default value is false.
      *
-     * @var boolean
+     * @var bool
      */
     public $explode = UNDEFINED;
 
@@ -107,7 +106,7 @@ class Parameter extends AbstractAnnotation
      * This property only applies to parameters with an in value of query.
      * The default value is false.
      *
-     * @var boolean
+     * @var bool
      */
     public $allowReserved = UNDEFINED;
 
@@ -147,12 +146,12 @@ class Parameter extends AbstractAnnotation
     public $content = UNDEFINED;
 
     /**
-     * Path-style parameters defined by https://tools.ietf.org/html/rfc6570#section-3.2.7
+     * Path-style parameters defined by https://tools.ietf.org/html/rfc6570#section-3.2.7.
      */
     public $matrix = UNDEFINED;
 
     /**
-     * Label style parameters defined by https://tools.ietf.org/html/rfc6570#section-3.2.5
+     * Label style parameters defined by https://tools.ietf.org/html/rfc6570#section-3.2.5.
      */
     public $label = UNDEFINED;
 
@@ -192,12 +191,12 @@ class Parameter extends AbstractAnnotation
     public $deepObject = UNDEFINED;
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_required = ['name', 'in'];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_types = [
         'name' => 'string',
@@ -208,7 +207,7 @@ class Parameter extends AbstractAnnotation
     ];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_nested = [
         Schema::class => 'schema',
@@ -216,7 +215,7 @@ class Parameter extends AbstractAnnotation
     ];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_parents = [
         Components::class,
@@ -233,7 +232,7 @@ class Parameter extends AbstractAnnotation
     ];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function validate($parents = [], $skip = [], $ref = '')
     {
@@ -264,11 +263,12 @@ class Parameter extends AbstractAnnotation
                 //                }
             }
         }
+
         return $valid;
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function identity()
     {

--- a/src/Annotations/Patch.php
+++ b/src/Annotations/Patch.php
@@ -12,14 +12,14 @@ namespace OpenApi\Annotations;
 class Patch extends Operation
 {
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public $method = 'patch';
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_parents = [
-        PathItem::class
+        PathItem::class,
     ];
 }

--- a/src/Annotations/PathItem.php
+++ b/src/Annotations/PathItem.php
@@ -16,7 +16,7 @@ namespace OpenApi\Annotations;
 class PathItem extends AbstractAnnotation
 {
     /**
-     * $ref See https://swagger.io/docs/specification/using-ref/
+     * $ref See https://swagger.io/docs/specification/using-ref/.
      *
      * @var string
      */
@@ -111,14 +111,14 @@ class PathItem extends AbstractAnnotation
     public $parameters = UNDEFINED;
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_types = [
-        'path' => 'string'
+        'path' => 'string',
     ];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_nested = [
         Get::class => 'get',
@@ -134,9 +134,9 @@ class PathItem extends AbstractAnnotation
     ];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_parents = [
-        OpenApi::class
+        OpenApi::class,
     ];
 }

--- a/src/Annotations/Post.php
+++ b/src/Annotations/Post.php
@@ -12,14 +12,14 @@ namespace OpenApi\Annotations;
 class Post extends Operation
 {
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public $method = 'post';
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_parents = [
-        PathItem::class
+        PathItem::class,
     ];
 }

--- a/src/Annotations/Property.php
+++ b/src/Annotations/Property.php
@@ -19,7 +19,7 @@ class Property extends Schema
     public $property = UNDEFINED;
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_parents = [
         AdditionalProperties::class,
@@ -31,7 +31,7 @@ class Property extends Schema
     ];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_nested = [
         Discriminator::class => 'discriminator',
@@ -39,6 +39,6 @@ class Property extends Schema
         Property::class => ['properties', 'property'],
         ExternalDocumentation::class => 'externalDocs',
         Xml::class => 'xml',
-        AdditionalProperties::class => 'additionalProperties'
+        AdditionalProperties::class => 'additionalProperties',
     ];
 }

--- a/src/Annotations/Put.php
+++ b/src/Annotations/Put.php
@@ -12,14 +12,14 @@ namespace OpenApi\Annotations;
 class Put extends Operation
 {
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public $method = 'put';
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_parents = [
-        PathItem::class
+        PathItem::class,
     ];
 }

--- a/src/Annotations/RequestBody.php
+++ b/src/Annotations/RequestBody.php
@@ -36,23 +36,23 @@ class RequestBody extends AbstractAnnotation
     /**
      * Determines whether this parameter is mandatory.
      * If the parameter location is "path", this property is required and its value must be true.
-     * Otherwise, the property may be included and its default value is false
+     * Otherwise, the property may be included and its default value is false.
      *
-     * @var boolean
+     * @var bool
      */
     public $required = UNDEFINED;
 
     /**
      * The content of the request body.
      * The key is a media type or media type range and the value describes it. For requests that match multiple keys,
-     * only the most specific key is applicable. e.g. text/plain overrides text/*
+     * only the most specific key is applicable. e.g. text/plain overrides text/*.
      *
      * @var MediaType[]
      */
     public $content = UNDEFINED;
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_types = [
         'description' => 'string',
@@ -74,7 +74,7 @@ class RequestBody extends AbstractAnnotation
     ];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_nested = [
         MediaType::class => ['content', 'mediaType'],

--- a/src/Annotations/Response.php
+++ b/src/Annotations/Response.php
@@ -15,7 +15,7 @@ namespace OpenApi\Annotations;
 class Response extends AbstractAnnotation
 {
     /**
-     * $ref See https://swagger.io/docs/specification/using-ref/
+     * $ref See https://swagger.io/docs/specification/using-ref/.
      *
      * @var string
      */
@@ -48,7 +48,7 @@ class Response extends AbstractAnnotation
     /**
      * A map containing descriptions of potential response payloads.
      * The key is a media type or media type range and the value describes it.
-     * For responses that match multiple keys, only the most specific key is applicable. e.g. text/plain overrides text/*
+     * For responses that match multiple keys, only the most specific key is applicable. e.g. text/plain overrides text/*.
      *
      * @var MediaType[]
      */
@@ -63,19 +63,19 @@ class Response extends AbstractAnnotation
     public $links = UNDEFINED;
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_required = ['description'];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_types = [
         'description' => 'string',
     ];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_nested = [
         MediaType::class => ['content', 'mediaType'],
@@ -84,7 +84,7 @@ class Response extends AbstractAnnotation
     ];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_parents = [
         Components::class,

--- a/src/Annotations/Schema.php
+++ b/src/Annotations/Schema.php
@@ -342,9 +342,9 @@ class Schema extends AbstractAnnotation
         'minItems' => 'integer',
         'uniqueItems' => 'boolean',
         'multipleOf' => 'integer',
-        'allOf' => '[' . Schema::class . ']',
-        'oneOf' => '[' . Schema::class . ']',
-        'anyOf' => '[' . Schema::class . ']',
+        'allOf' => '['.Schema::class.']',
+        'oneOf' => '['.Schema::class.']',
+        'anyOf' => '['.Schema::class.']',
     ];
 
     /**
@@ -372,7 +372,7 @@ class Schema extends AbstractAnnotation
     public function validate($parents = [], $skip = [], $ref = '')
     {
         if ($this->type === 'array' && $this->items === UNDEFINED) {
-            Logger::notice('@OA\Items() is required when ' . $this->identity() . ' has type "array" in ' . $this->_context);
+            Logger::notice('@OA\Items() is required when '.$this->identity().' has type "array" in '.$this->_context);
 
             return false;
         }

--- a/src/Annotations/Schema.php
+++ b/src/Annotations/Schema.php
@@ -21,7 +21,7 @@ use OpenApi\Logger;
 class Schema extends AbstractAnnotation
 {
     /**
-     * $ref See https://swagger.io/docs/specification/using-ref/
+     * $ref See https://swagger.io/docs/specification/using-ref/.
      *
      * @var string
      */
@@ -51,14 +51,14 @@ class Schema extends AbstractAnnotation
     /**
      * An object instance is valid against "maxProperties" if its number of properties is less than, or equal to, the value of this property.
      *
-     * @var integer
+     * @var int
      */
     public $maxProperties = UNDEFINED;
 
     /**
      * An object instance is valid against "minProperties" if its number of properties is greater than, or equal to, the value of this property.
      *
-     * @var integer
+     * @var int
      */
     public $minProperties = UNDEFINED;
 
@@ -102,8 +102,6 @@ class Schema extends AbstractAnnotation
 
     /**
      * Sets a default value to the parameter. The type of the value depends on the defined type. See http://json-schema.org/latest/json-schema-validation.html#anchor101.
-     *
-     * @var mixed
      */
     public $default = UNDEFINED;
 
@@ -117,7 +115,7 @@ class Schema extends AbstractAnnotation
     /**
      * See http://json-schema.org/latest/json-schema-validation.html#anchor17.
      *
-     * @var boolean
+     * @var bool
      */
     public $exclusiveMaximum = UNDEFINED;
 
@@ -131,21 +129,21 @@ class Schema extends AbstractAnnotation
     /**
      * See http://json-schema.org/latest/json-schema-validation.html#anchor21.
      *
-     * @var boolean
+     * @var bool
      */
     public $exclusiveMinimum = UNDEFINED;
 
     /**
      * See http://json-schema.org/latest/json-schema-validation.html#anchor26.
      *
-     * @var integer
+     * @var int
      */
     public $maxLength = UNDEFINED;
 
     /**
      * See http://json-schema.org/latest/json-schema-validation.html#anchor29.
      *
-     * @var integer
+     * @var int
      */
     public $minLength = UNDEFINED;
 
@@ -159,21 +157,21 @@ class Schema extends AbstractAnnotation
     /**
      * See http://json-schema.org/latest/json-schema-validation.html#anchor42.
      *
-     * @var integer
+     * @var int
      */
     public $maxItems = UNDEFINED;
 
     /**
      * See http://json-schema.org/latest/json-schema-validation.html#anchor45.
      *
-     * @var integer
+     * @var int
      */
     public $minItems = UNDEFINED;
 
     /**
      * See http://json-schema.org/latest/json-schema-validation.html#anchor49.
      *
-     * @var boolean
+     * @var bool
      */
     public $uniqueItems = UNDEFINED;
 
@@ -208,7 +206,7 @@ class Schema extends AbstractAnnotation
      * A property must not be marked as both readOnly and writeOnly being true.
      * Default value is false.
      *
-     * @var boolean
+     * @var bool
      */
     public $readOnly = UNDEFINED;
 
@@ -220,7 +218,7 @@ class Schema extends AbstractAnnotation
      * A property must not be marked as both readOnly and writeOnly being true.
      * Default value is false.
      *
-     * @var boolean
+     * @var bool
      */
     public $writeOnly = UNDEFINED;
 
@@ -250,7 +248,7 @@ class Schema extends AbstractAnnotation
      * Allows sending a null value for the defined schema.
      * Default value is false.
      *
-     * @var boolean
+     * @var bool
      */
     public $nullable = UNDEFINED;
 
@@ -258,7 +256,7 @@ class Schema extends AbstractAnnotation
      * Specifies that a schema is deprecated and should be transitioned out of usage.
      * Default value is false.
      *
-     * @var boolean
+     * @var bool
      */
     public $deprecated = UNDEFINED;
 
@@ -284,49 +282,49 @@ class Schema extends AbstractAnnotation
     public $oneOf = UNDEFINED;
 
     /**
-     * http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.29
+     * http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.29.
      */
     public $not = UNDEFINED;
 
     /**
-     * http://json-schema.org/latest/json-schema-validation.html#anchor64
+     * http://json-schema.org/latest/json-schema-validation.html#anchor64.
      *
      * @var bool|object
      */
     public $additionalProperties = UNDEFINED;
 
     /**
-     * http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.10
+     * http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.10.
      */
     public $additionalItems = UNDEFINED;
 
     /**
-     * http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.14
+     * http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.14.
      */
     public $contains = UNDEFINED;
 
     /**
-     * http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.19
+     * http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.19.
      */
     public $patternProperties = UNDEFINED;
 
     /**
-     * http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.21
+     * http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.21.
      */
     public $dependencies = UNDEFINED;
 
     /**
-     * http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.22
+     * http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.22.
      */
     public $propertyNames = UNDEFINED;
 
     /**
-     * http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.24
+     * http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.24.
      */
     public $const = UNDEFINED;
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_types = [
         'description' => 'string',
@@ -346,11 +344,11 @@ class Schema extends AbstractAnnotation
         'multipleOf' => 'integer',
         'allOf' => '[' . Schema::class . ']',
         'oneOf' => '[' . Schema::class . ']',
-        'anyOf' => '[' . Schema::class . ']'
+        'anyOf' => '[' . Schema::class . ']',
     ];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_nested = [
         Discriminator::class => 'discriminator',
@@ -358,11 +356,11 @@ class Schema extends AbstractAnnotation
         Property::class => ['properties', 'property'],
         ExternalDocumentation::class => 'externalDocs',
         Xml::class => 'xml',
-        AdditionalProperties::class => 'additionalProperties'
+        AdditionalProperties::class => 'additionalProperties',
     ];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_parents = [
         Components::class,
@@ -375,8 +373,10 @@ class Schema extends AbstractAnnotation
     {
         if ($this->type === 'array' && $this->items === UNDEFINED) {
             Logger::notice('@OA\Items() is required when ' . $this->identity() . ' has type "array" in ' . $this->_context);
+
             return false;
         }
+
         return parent::validate($parents, $skip, $ref);
     }
 }

--- a/src/Annotations/SecurityScheme.php
+++ b/src/Annotations/SecurityScheme.php
@@ -14,7 +14,7 @@ namespace OpenApi\Annotations;
 class SecurityScheme extends AbstractAnnotation
 {
     /**
-     * $ref See http://json-schema.org/latest/json-schema-core.html#rfc.section.7
+     * $ref See http://json-schema.org/latest/json-schema-core.html#rfc.section.7.
      *
      * @var string
      */
@@ -74,6 +74,7 @@ class SecurityScheme extends AbstractAnnotation
      * The name of the HTTP Authorization scheme.
      *
      * @see https://tools.ietf.org/html/rfc7235#section-5.1
+     *
      * @var string
      */
     public $scheme = UNDEFINED;
@@ -86,12 +87,12 @@ class SecurityScheme extends AbstractAnnotation
     public $openIdConnectUrl = UNDEFINED;
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_required = ['securityScheme', 'type'];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_types = [
         'type' => ['http', 'apiKey', 'oauth2', 'openIdConnect'],
@@ -102,21 +103,21 @@ class SecurityScheme extends AbstractAnnotation
     ];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_nested = [
         Flow::class => ['flows', 'flow'],
     ];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_parents = [
         Components::class,
     ];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function merge($annotations, $ignore = false)
     {

--- a/src/Annotations/Server.php
+++ b/src/Annotations/Server.php
@@ -39,7 +39,7 @@ class Server extends AbstractAnnotation
     public $variables = UNDEFINED;
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_parents = [
         OpenApi::class,
@@ -57,19 +57,19 @@ class Server extends AbstractAnnotation
     ];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_nested = [
         ServerVariable::class => ['variables', 'serverVariable'],
     ];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_required = ['url'];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_types = [
         'url' => 'string',

--- a/src/Annotations/ServerVariable.php
+++ b/src/Annotations/ServerVariable.php
@@ -52,19 +52,19 @@ class ServerVariable extends AbstractAnnotation
     public $description = UNDEFINED;
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_parents = [
-        Server::class
+        Server::class,
     ];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_required = ['default'];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_types = [
         'default' => 'string',

--- a/src/Annotations/Tag.php
+++ b/src/Annotations/Tag.php
@@ -35,12 +35,12 @@ class Tag extends AbstractAnnotation
     public $externalDocs = UNDEFINED;
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_required = ['name'];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_types = [
         'name' => 'string',
@@ -48,16 +48,16 @@ class Tag extends AbstractAnnotation
     ];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_parents = [
-        OpenApi::class
+        OpenApi::class,
     ];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_nested = [
-        ExternalDocumentation::class => 'externalDocs'
+        ExternalDocumentation::class => 'externalDocs',
     ];
 }

--- a/src/Annotations/Trace.php
+++ b/src/Annotations/Trace.php
@@ -12,14 +12,14 @@ namespace OpenApi\Annotations;
 class Trace extends Operation
 {
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public $method = 'trace';
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_parents = [
-        PathItem::class
+        PathItem::class,
     ];
 }

--- a/src/Annotations/Xml.php
+++ b/src/Annotations/Xml.php
@@ -37,30 +37,30 @@ class Xml extends AbstractAnnotation
     /**
      * Declares whether the property definition translates to an attribute instead of an element. Default value is false.
      *
-     * @var boolean
+     * @var bool
      */
     public $attribute = UNDEFINED;
 
     /**
      * MAY be used only for an array definition. Signifies whether the array is wrapped (for example, <books><book/><book/></books>) or unwrapped (<book/><book/>). Default value is false. The definition takes effect only when defined alongside type being array (outside the items).
      *
-     * @var boolean
+     * @var bool
      */
     public $wrapped = UNDEFINED;
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_types = [
         'name' => 'string',
         'namespace' => 'string',
         'prefix' => 'string',
         'attribute' => 'boolean',
-        'wrapped' => 'boolean'
+        'wrapped' => 'boolean',
     ];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_parents = [
         AdditionalProperties::class,

--- a/src/Annotations/XmlContent.php
+++ b/src/Annotations/XmlContent.php
@@ -20,12 +20,12 @@ class XmlContent extends Schema
     public $examples = UNDEFINED;
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_parents = [];
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public static $_nested = [
         Discriminator::class => 'discriminator',
@@ -33,6 +33,6 @@ class XmlContent extends Schema
         Property::class => ['properties', 'property'],
         ExternalDocumentation::class => 'externalDocs',
         Xml::class => 'xml',
-        AdditionalProperties::class => 'additionalProperties'
+        AdditionalProperties::class => 'additionalProperties',
     ];
 }

--- a/src/Context.php
+++ b/src/Context.php
@@ -7,7 +7,7 @@
 namespace OpenApi;
 
 /**
- * Context
+ * Context.
  *
  * The context in which the annotation is parsed.
  * It includes useful metadata which the Processors can use to augment the annotations.
@@ -24,11 +24,10 @@ namespace OpenApi;
  * @property string                           $filename
  * @property int                              $line
  * @property int                              $character
- *
  * @property string                           $namespace
  * @property array                            $uses
  * @property string                           $class
- * @property string|array                     $extends  Interfaces may extend a list of interfaces
+ * @property array|string                     $extends  Interfaces may extend a list of interfaces
  * @property array                            $implements
  * @property string                           $method
  * @property string                           $property
@@ -47,7 +46,7 @@ class Context
     private $_parent;
 
     /**
-     * @param array   $properties new properties for this context.
+     * @param array   $properties new properties for this context
      * @param Context $parent     The parent context
      */
     public function __construct($properties = [], $parent = null)
@@ -85,8 +84,9 @@ class Context
     /**
      * Return the context containing the specified property.
      *
-     * @param  string $property
-     * @return boolean|Context
+     * @param string $property
+     *
+     * @return bool|Context
      */
     public function with($property)
     {
@@ -151,8 +151,6 @@ class Context
      * Traverse the context tree to get the property value.
      *
      * @param string $property
-     *
-     * @return mixed
      */
     public function __get($property)
     {
@@ -220,7 +218,7 @@ class Context
     }
 
     /**
-     * The text contents of the phpdoc comment (excl. tags)
+     * The text contents of the phpdoc comment (excl. tags).
      *
      * @return string
      */
@@ -254,9 +252,10 @@ class Context
     }
 
     /**
-     * Create a Context based on the debug_backtrace
+     * Create a Context based on the debug_backtrace.
      *
-     * @param  int $index
+     * @param int $index
+     *
      * @return Context
      */
     public static function detect($index = 0)

--- a/src/Context.php
+++ b/src/Context.php
@@ -123,9 +123,9 @@ class Context
         if ($this->class && ($this->method || $this->property)) {
             $location .= $this->fullyQualifiedName($this->class);
             if ($this->method) {
-                $location .= ($this->static ? '::' : '->') . $this->method . '()';
+                $location .= ($this->static ? '::' : '->').$this->method.'()';
             } elseif ($this->property) {
-                $location .= ($this->static ? '::$' : '->') . $this->property;
+                $location .= ($this->static ? '::$' : '->').$this->property;
             }
         }
         if ($this->filename) {
@@ -138,9 +138,9 @@ class Context
             if ($location !== '') {
                 $location .= ' on';
             }
-            $location .= ' line ' . $this->line;
+            $location .= ' line '.$this->line;
             if ($this->character) {
-                $location .= ':' . $this->character;
+                $location .= ':'.$this->character;
             }
         }
 
@@ -185,7 +185,7 @@ class Context
         $lines = preg_split('/(\n|\r\n)/', $content);
         $summary = '';
         foreach ($lines as $line) {
-            $summary .= $line . "\n";
+            $summary .= $line."\n";
             if ($line === '' || substr($line, -1) === '.') {
                 return trim($summary);
             }
@@ -237,7 +237,7 @@ class Context
             }
             if ($append) {
                 $i = count($lines) - 1;
-                $lines[$i] = substr($lines[$i], 0, -1) . $line;
+                $lines[$i] = substr($lines[$i], 0, -1).$line;
             } else {
                 $lines[] = $line;
             }
@@ -302,7 +302,7 @@ class Context
         }
 
         if ($this->namespace) {
-            $namespace = str_replace('\\\\', '\\', '\\' . $this->namespace . '\\');
+            $namespace = str_replace('\\\\', '\\', '\\'.$this->namespace.'\\');
         } else {
             // global namespace
             $namespace = '\\';
@@ -310,7 +310,7 @@ class Context
 
         $thisSource = $this->class ?? $this->interface ?? $this->trait;
         if ($thisSource && strcasecmp($source, $thisSource) === 0) {
-            return $namespace . $thisSource;
+            return $namespace.$thisSource;
         }
         $pos = strpos($source, '\\');
         if ($pos !== false) {
@@ -324,7 +324,7 @@ class Context
                     $alias .= '\\';
                     if (strcasecmp(substr($source, 0, strlen($alias)), $alias) === 0) {
                         // Aliased namespace (use \Long\Namespace as Foo)
-                        return '\\' . $aliasedNamespace . substr($source, strlen($alias) - 1);
+                        return '\\'.$aliasedNamespace.substr($source, strlen($alias) - 1);
                     }
                 }
             }
@@ -332,11 +332,11 @@ class Context
             // Unqualified name (Foo)
             foreach ($this->uses as $alias => $aliasedNamespace) {
                 if (strcasecmp($alias, $source) === 0) {
-                    return '\\' . $aliasedNamespace;
+                    return '\\'.$aliasedNamespace;
                 }
             }
         }
 
-        return $namespace . $source;
+        return $namespace.$source;
     }
 }

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -15,7 +15,7 @@ use Exception;
 class Logger
 {
     /**
-     * Singleton
+     * Singleton.
      *
      * @var Logger
      */
@@ -28,7 +28,7 @@ class Logger
 
     protected function __construct()
     {
-        /**
+        /*
          * @param \Exception|string $entry
          * @param int $type Error type
          */
@@ -48,6 +48,7 @@ class Logger
         if (self::$instance === null) {
             self::$instance = new Logger();
         }
+
         return self::$instance;
     }
 

--- a/src/Processors/AugmentParameters.php
+++ b/src/Processors/AugmentParameters.php
@@ -9,7 +9,7 @@ namespace OpenApi\Processors;
 use OpenApi\Analysis;
 
 /**
- * Use the parameter->name as keyfield (parameter->parameter) when used as reusable component (openapi->components->parameters)
+ * Use the parameter->name as keyfield (parameter->parameter) when used as reusable component (openapi->components->parameters).
  */
 class AugmentParameters
 {

--- a/src/Processors/AugmentProperties.php
+++ b/src/Processors/AugmentProperties.php
@@ -47,7 +47,7 @@ class AugmentProperties
             foreach ($analysis->openapi->components->schemas as $schema) {
                 if ($schema->schema !== UNDEFINED) {
                     $refs[strtolower($schema->_context->fullyQualifiedName($schema->_context->class))]
-                        = Components::SCHEMA_REF . $schema->schema;
+                        = Components::SCHEMA_REF.$schema->schema;
                 }
             }
         }

--- a/src/Processors/AugmentProperties.php
+++ b/src/Processors/AugmentProperties.php
@@ -6,11 +6,11 @@
 
 namespace OpenApi\Processors;
 
-use OpenApi\Annotations\Components;
-use OpenApi\Annotations\Schema;
 use OpenApi\Analysis;
+use OpenApi\Annotations\Components;
 use OpenApi\Annotations\Items;
 use OpenApi\Annotations\Property;
+use OpenApi\Annotations\Schema;
 use OpenApi\Context;
 
 /**
@@ -77,7 +77,7 @@ class AugmentProperties
                         continue;
                     }
                 }
-            } else if (preg_match('/@var\s+(?<type>[^\s]+)([ \t])?(?<description>.+)?$/im', $comment, $varMatches)) {
+            } elseif (preg_match('/@var\s+(?<type>[^\s]+)([ \t])?(?<description>.+)?$/im', $comment, $varMatches)) {
                 if ($property->type === UNDEFINED) {
                     preg_match('/^([^\[]+)(.*$)/', trim($varMatches['type']), $typeMatches);
                     $isNullable = $this->isNullable($typeMatches[1]);
@@ -89,8 +89,8 @@ class AugmentProperties
                                 $property->oneOf = [
                                     new Schema([
                                         '_context' => $property->_context,
-                                        'ref' => $refs[$key]
-                                    ])
+                                        'ref' => $refs[$key],
+                                    ]),
                                 ];
                                 $property->nullable = true;
                             } else {

--- a/src/Processors/AugmentSchemas.php
+++ b/src/Processors/AugmentSchemas.php
@@ -7,8 +7,8 @@
 namespace OpenApi\Processors;
 
 use OpenApi\Analysis;
-use OpenApi\Annotations\Schema;
 use OpenApi\Annotations\Property;
+use OpenApi\Annotations\Schema;
 
 /**
  * Use the Schema context to extract useful information and inject that into the annotation.

--- a/src/Processors/BuildPaths.php
+++ b/src/Processors/BuildPaths.php
@@ -24,7 +24,7 @@ class BuildPaths
         if ($analysis->openapi->paths !== UNDEFINED) {
             foreach ($analysis->openapi->paths as $annotation) {
                 if (empty($annotation->path)) {
-                    Logger::notice($annotation->identity() . ' is missing required property "path" in ' . $annotation->_context);
+                    Logger::notice($annotation->identity().' is missing required property "path" in '.$annotation->_context);
                 } elseif (isset($paths[$annotation->path])) {
                     $paths[$annotation->path]->mergeProperties($annotation);
                     $analysis->annotations->detach($annotation);
@@ -48,7 +48,7 @@ class BuildPaths
                     $analysis->annotations->attach($paths[$operation->path]);
                 }
                 if ($paths[$operation->path]->merge([$operation])) {
-                    Logger::notice('Unable to merge ' . $operation->identity() . ' in ' . $operation->_context);
+                    Logger::notice('Unable to merge '.$operation->identity().' in '.$operation->_context);
                 }
             }
         }

--- a/src/Processors/BuildPaths.php
+++ b/src/Processors/BuildPaths.php
@@ -6,14 +6,14 @@
 
 namespace OpenApi\Processors;
 
-use OpenApi\Annotations\PathItem;
-use OpenApi\Annotations\Operation;
-use OpenApi\Logger;
-use OpenApi\Context;
 use OpenApi\Analysis;
+use OpenApi\Annotations\Operation;
+use OpenApi\Annotations\PathItem;
+use OpenApi\Context;
+use OpenApi\Logger;
 
 /**
- * Build the openapi->paths using the detected @OA\PathItem and @OA\Operations (like @OA\Get, @OA\Post, etc)
+ * Build the openapi->paths using the detected @OA\PathItem and @OA\Operations (like @OA\Get, @OA\Post, etc).
  */
 class BuildPaths
 {
@@ -42,13 +42,13 @@ class BuildPaths
                     $paths[$operation->path] = new PathItem(
                         [
                             'path' => $operation->path,
-                            '_context' => new Context(['generated' => true], $operation->_context)
+                            '_context' => new Context(['generated' => true], $operation->_context),
                         ]
                     );
                     $analysis->annotations->attach($paths[$operation->path]);
                 }
                 if ($paths[$operation->path]->merge([$operation])) {
-                    Logger::notice('Unable to merge '.$operation->identity() .' in '.$operation->_context);
+                    Logger::notice('Unable to merge ' . $operation->identity() . ' in ' . $operation->_context);
                 }
             }
         }

--- a/src/Processors/CleanUnmerged.php
+++ b/src/Processors/CleanUnmerged.php
@@ -8,9 +8,6 @@ namespace OpenApi\Processors;
 
 use OpenApi\Analysis;
 
-/**
- *
- */
 class CleanUnmerged
 {
     public function __invoke(Analysis $analysis)

--- a/src/Processors/InheritInterfaces.php
+++ b/src/Processors/InheritInterfaces.php
@@ -1,10 +1,14 @@
-<?php
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
 
 namespace OpenApi\Processors;
 
+use OpenApi\Analysis;
 use OpenApi\Annotations\Components;
 use OpenApi\Annotations\Schema;
-use OpenApi\Analysis;
 
 class InheritInterfaces
 {
@@ -21,7 +25,7 @@ class InheritInterfaces
                         }
                         $schema->allOf[] = new Schema([
                             '_context' => $interface['context']->_context,
-                            'ref' => Components::SCHEMA_REF . $interface['interface']
+                            'ref' => Components::SCHEMA_REF . $interface['interface'],
                         ]);
                     }
                 }

--- a/src/Processors/InheritInterfaces.php
+++ b/src/Processors/InheritInterfaces.php
@@ -25,7 +25,7 @@ class InheritInterfaces
                         }
                         $schema->allOf[] = new Schema([
                             '_context' => $interface['context']->_context,
-                            'ref' => Components::SCHEMA_REF . $interface['interface'],
+                            'ref' => Components::SCHEMA_REF.$interface['interface'],
                         ]);
                     }
                 }

--- a/src/Processors/InheritProperties.php
+++ b/src/Processors/InheritProperties.php
@@ -96,7 +96,7 @@ class InheritProperties
                 if ($schema->schema === UNDEFINED && $schema->properties !== UNDEFINED) {
                     // move properties from allOf back up into schema
                     $currentSchema->properties = $schema->properties;
-                } elseif ($schema->ref !== UNDEFINED && $schema->ref != Components::SCHEMA_REF . $parentSchema->schema) {
+                } elseif ($schema->ref !== UNDEFINED && $schema->ref != Components::SCHEMA_REF.$parentSchema->schema) {
                     // keep other schemas
                     $childSchema->allOf[] = $schema;
                 }
@@ -106,7 +106,7 @@ class InheritProperties
 
         $childSchema->allOf[] = new Schema([
             '_context' => $parentSchema->_context,
-            'ref' => Components::SCHEMA_REF . $parentSchema->schema,
+            'ref' => Components::SCHEMA_REF.$parentSchema->schema,
         ]);
         if ($currentSchema->properties !== UNDEFINED) {
             $childSchema->allOf[] = $currentSchema;

--- a/src/Processors/InheritProperties.php
+++ b/src/Processors/InheritProperties.php
@@ -6,15 +6,15 @@
 
 namespace OpenApi\Processors;
 
+use OpenApi\Analysis;
 use OpenApi\Annotations\Components;
 use OpenApi\Annotations\Property;
 use OpenApi\Annotations\Schema;
-use OpenApi\Analysis;
 use OpenApi\UNDEFINED;
 use Traversable;
 
 /**
- * Copy the annotated properties from parent classes;
+ * Copy the annotated properties from parent classes;.
  */
 class InheritProperties
 {
@@ -71,10 +71,7 @@ class InheritProperties
     }
 
     /**
-     * Add schema to child schema allOf property
-     *
-     * @param \OpenApi\Annotations\Schema $childSchema
-     * @param \OpenApi\Annotations\Schema $parentSchema
+     * Add schema to child schema allOf property.
      */
     private function addAllOfProperty(Schema $childSchema, Schema $parentSchema)
     {
@@ -109,7 +106,7 @@ class InheritProperties
 
         $childSchema->allOf[] = new Schema([
             '_context' => $parentSchema->_context,
-            'ref' => Components::SCHEMA_REF . $parentSchema->schema
+            'ref' => Components::SCHEMA_REF . $parentSchema->schema,
         ]);
         if ($currentSchema->properties !== UNDEFINED) {
             $childSchema->allOf[] = $currentSchema;

--- a/src/Processors/InheritTraits.php
+++ b/src/Processors/InheritTraits.php
@@ -1,10 +1,14 @@
-<?php
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
 
 namespace OpenApi\Processors;
 
+use OpenApi\Analysis;
 use OpenApi\Annotations\Components;
 use OpenApi\Annotations\Schema;
-use OpenApi\Analysis;
 
 class InheritTraits
 {
@@ -22,7 +26,7 @@ class InheritTraits
                         }
                         $schema->allOf[] = new Schema([
                             '_context' => $trait['context']->_context,
-                            'ref' => Components::SCHEMA_REF . $trait['trait']
+                            'ref' => Components::SCHEMA_REF . $trait['trait'],
                         ]);
                     }
                 }

--- a/src/Processors/InheritTraits.php
+++ b/src/Processors/InheritTraits.php
@@ -26,7 +26,7 @@ class InheritTraits
                         }
                         $schema->allOf[] = new Schema([
                             '_context' => $trait['context']->_context,
-                            'ref' => Components::SCHEMA_REF . $trait['trait'],
+                            'ref' => Components::SCHEMA_REF.$trait['trait'],
                         ]);
                     }
                 }

--- a/src/Processors/MergeInterfaces.php
+++ b/src/Processors/MergeInterfaces.php
@@ -1,10 +1,14 @@
-<?php
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
 
 namespace OpenApi\Processors;
 
+use OpenApi\Analysis;
 use OpenApi\Annotations\Property;
 use OpenApi\Annotations\Schema;
-use OpenApi\Analysis;
 use Traversable;
 
 class MergeInterfaces

--- a/src/Processors/MergeIntoComponents.php
+++ b/src/Processors/MergeIntoComponents.php
@@ -6,12 +6,12 @@
 
 namespace OpenApi\Processors;
 
-use OpenApi\Annotations\Components;
 use OpenApi\Analysis;
+use OpenApi\Annotations\Components;
 use OpenApi\UNDEFINED;
 
 /**
- * Merge reusable annotation into @OA\Schemas
+ * Merge reusable annotation into @OA\Schemas.
  */
 class MergeIntoComponents
 {

--- a/src/Processors/MergeIntoOpenApi.php
+++ b/src/Processors/MergeIntoOpenApi.php
@@ -6,8 +6,8 @@
 
 namespace OpenApi\Processors;
 
-use OpenApi\Annotations\OpenApi;
 use OpenApi\Analysis;
+use OpenApi\Annotations\OpenApi;
 use OpenApi\Context;
 
 /**

--- a/src/Processors/MergeJsonContent.php
+++ b/src/Processors/MergeJsonContent.php
@@ -27,9 +27,9 @@ class MergeJsonContent
             $parent = $jsonContent->_context->nested;
             if (!($parent instanceof Response) && !($parent instanceof RequestBody) && !($parent instanceof Parameter)) {
                 if ($parent) {
-                    Logger::notice('Unexpected ' . $jsonContent->identity() . ' in ' . $parent->identity() . ' in ' . $parent->_context);
+                    Logger::notice('Unexpected '.$jsonContent->identity().' in '.$parent->identity().' in '.$parent->_context);
                 } else {
-                    Logger::notice('Unexpected ' . $jsonContent->identity() . ' must be nested');
+                    Logger::notice('Unexpected '.$jsonContent->identity().' must be nested');
                 }
                 continue;
             }

--- a/src/Processors/MergeJsonContent.php
+++ b/src/Processors/MergeJsonContent.php
@@ -6,17 +6,17 @@
 
 namespace OpenApi\Processors;
 
-use OpenApi\Annotations\MediaType;
-use OpenApi\Annotations\JsonContent;
-use OpenApi\Annotations\Response;
-use OpenApi\Annotations\RequestBody;
-use OpenApi\Annotations\Parameter;
 use OpenApi\Analysis;
+use OpenApi\Annotations\JsonContent;
+use OpenApi\Annotations\MediaType;
+use OpenApi\Annotations\Parameter;
+use OpenApi\Annotations\RequestBody;
+use OpenApi\Annotations\Response;
 use OpenApi\Context;
 use OpenApi\Logger;
 
 /**
- * Split JsonContent into Schema and MediaType
+ * Split JsonContent into Schema and MediaType.
  */
 class MergeJsonContent
 {
@@ -27,9 +27,9 @@ class MergeJsonContent
             $parent = $jsonContent->_context->nested;
             if (!($parent instanceof Response) && !($parent instanceof RequestBody) && !($parent instanceof Parameter)) {
                 if ($parent) {
-                    Logger::notice('Unexpected '.$jsonContent->identity() .' in ' . $parent->identity() . ' in ' . $parent->_context);
+                    Logger::notice('Unexpected ' . $jsonContent->identity() . ' in ' . $parent->identity() . ' in ' . $parent->_context);
                 } else {
-                    Logger::notice('Unexpected '.$jsonContent->identity() .' must be nested');
+                    Logger::notice('Unexpected ' . $jsonContent->identity() . ' must be nested');
                 }
                 continue;
             }
@@ -42,7 +42,7 @@ class MergeJsonContent
                 'schema' => $jsonContent,
                 'example' => $jsonContent->example,
                 'examples' => $jsonContent->examples,
-                '_context' => new Context(['generated' => true], $jsonContent->_context)
+                '_context' => new Context(['generated' => true], $jsonContent->_context),
                 ]
             );
             $jsonContent->example = UNDEFINED;

--- a/src/Processors/MergeTraits.php
+++ b/src/Processors/MergeTraits.php
@@ -1,10 +1,14 @@
-<?php
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
 
 namespace OpenApi\Processors;
 
+use OpenApi\Analysis;
 use OpenApi\Annotations\Property;
 use OpenApi\Annotations\Schema;
-use OpenApi\Analysis;
 use Traversable;
 
 class MergeTraits

--- a/src/Processors/MergeXmlContent.php
+++ b/src/Processors/MergeXmlContent.php
@@ -6,17 +6,17 @@
 
 namespace OpenApi\Processors;
 
+use OpenApi\Analysis;
 use OpenApi\Annotations\MediaType;
 use OpenApi\Annotations\Parameter;
 use OpenApi\Annotations\RequestBody;
 use OpenApi\Annotations\Response;
-use OpenApi\Analysis;
 use OpenApi\Annotations\XmlContent;
 use OpenApi\Context;
 use OpenApi\Logger;
 
 /**
- * Split XmlContent into Schema and MediaType
+ * Split XmlContent into Schema and MediaType.
  */
 class MergeXmlContent
 {
@@ -27,9 +27,9 @@ class MergeXmlContent
             $parent = $xmlContent->_context->nested;
             if (!($parent instanceof Response) && !($parent instanceof RequestBody) && !($parent instanceof Parameter)) {
                 if ($parent) {
-                    Logger::notice('Unexpected '.$xmlContent->identity() .' in ' . $parent->identity() . ' in ' . $parent->_context);
+                    Logger::notice('Unexpected ' . $xmlContent->identity() . ' in ' . $parent->identity() . ' in ' . $parent->_context);
                 } else {
-                    Logger::notice('Unexpected '.$xmlContent->identity() .' must be nested');
+                    Logger::notice('Unexpected ' . $xmlContent->identity() . ' must be nested');
                 }
                 continue;
             }
@@ -42,7 +42,7 @@ class MergeXmlContent
                     'schema' => $xmlContent,
                     'example' => $xmlContent->example,
                     'examples' => $xmlContent->examples,
-                    '_context' => new Context(['generated' => true], $xmlContent->_context)
+                    '_context' => new Context(['generated' => true], $xmlContent->_context),
                 ]
             );
             $xmlContent->example = UNDEFINED;

--- a/src/Processors/MergeXmlContent.php
+++ b/src/Processors/MergeXmlContent.php
@@ -27,9 +27,9 @@ class MergeXmlContent
             $parent = $xmlContent->_context->nested;
             if (!($parent instanceof Response) && !($parent instanceof RequestBody) && !($parent instanceof Parameter)) {
                 if ($parent) {
-                    Logger::notice('Unexpected ' . $xmlContent->identity() . ' in ' . $parent->identity() . ' in ' . $parent->_context);
+                    Logger::notice('Unexpected '.$xmlContent->identity().' in '.$parent->identity().' in '.$parent->_context);
                 } else {
-                    Logger::notice('Unexpected ' . $xmlContent->identity() . ' must be nested');
+                    Logger::notice('Unexpected '.$xmlContent->identity().' must be nested');
                 }
                 continue;
             }

--- a/src/Processors/OperationId.php
+++ b/src/Processors/OperationId.php
@@ -27,9 +27,9 @@ class OperationId
                 $source = $context->class ?? $context->interface ?? $context->trait;
                 if ($source) {
                     if ($context->namespace) {
-                        $operation->operationId = $context->namespace . "\\" . $source . "::" . $context->method;
+                        $operation->operationId = $context->namespace . '\\' . $source . '::' . $context->method;
                     } else {
-                        $operation->operationId = $source . "::" . $context->method;
+                        $operation->operationId = $source . '::' . $context->method;
                     }
                 } else {
                     $operation->operationId = $context->method;

--- a/src/Processors/OperationId.php
+++ b/src/Processors/OperationId.php
@@ -27,9 +27,9 @@ class OperationId
                 $source = $context->class ?? $context->interface ?? $context->trait;
                 if ($source) {
                     if ($context->namespace) {
-                        $operation->operationId = $context->namespace . '\\' . $source . '::' . $context->method;
+                        $operation->operationId = $context->namespace.'\\'.$source.'::'.$context->method;
                     } else {
-                        $operation->operationId = $source . '::' . $context->method;
+                        $operation->operationId = $source.'::'.$context->method;
                     }
                 } else {
                     $operation->operationId = $context->method;

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -83,7 +83,7 @@ class Serializer
     public function deserialize($jsonString, $className)
     {
         if (!$this->isValidAnnotationClass($className)) {
-            throw new \Exception($className . ' is not defined in OpenApi PHP Annotations');
+            throw new \Exception($className.' is not defined in OpenApi PHP Annotations');
         }
 
         return $this->doDeserialize(json_decode($jsonString), $className);
@@ -102,7 +102,7 @@ class Serializer
     public function deserializeFile($filename, $className = 'OpenApi\Annotations\OpenApi')
     {
         if (!$this->isValidAnnotationClass($className)) {
-            throw new \Exception($className . ' is not defined in OpenApi PHP Annotations');
+            throw new \Exception($className.' is not defined in OpenApi PHP Annotations');
         }
 
         return $this->doDeserialize(json_decode(file_get_contents($filename)), $className);

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -11,7 +11,7 @@ use OpenApi\Annotations as OA;
 /**
  * Allows to serialize/de-serialize annotations from/to JSON.
  *
- * @link https://github.com/zircote/swagger-php
+ * @see https://github.com/zircote/swagger-php
  */
 class Serializer
 {
@@ -62,7 +62,7 @@ class Serializer
     /**
      * Serialize.
      *
-     * @param OA\AbstractAnnotation $annotation
+     *
      * @return string
      */
     public function serialize(OA\AbstractAnnotation $annotation)
@@ -71,14 +71,14 @@ class Serializer
     }
 
     /**
-     * Deserialize a string
+     * Deserialize a string.
      *
      * @param $jsonString
      * @param $className
      *
-     * @return OA\AbstractAnnotation
-     *
      * @throws \Exception
+     *
+     * @return OA\AbstractAnnotation
      */
     public function deserialize($jsonString, $className)
     {
@@ -90,14 +90,14 @@ class Serializer
     }
 
     /**
-     * Deserialize a file
+     * Deserialize a file.
      *
      * @param $filename
      * @param $className
      *
-     * @return OA\AbstractAnnotation
-     *
      * @throws \Exception
+     *
+     * @return OA\AbstractAnnotation
      */
     public function deserializeFile($filename, $className = 'OpenApi\Annotations\OpenApi')
     {
@@ -111,8 +111,7 @@ class Serializer
     /**
      * Do deserialization.
      *
-     * @param \stdClass $c
-     * @param string $class The class name of annotation.
+     * @param string $class the class name of annotation
      *
      * @return OA\AbstractAnnotation
      */
@@ -141,11 +140,7 @@ class Serializer
     /**
      * Deserialize the annotation's property.
      *
-     * @param OA\AbstractAnnotation $annotation
      * @param string $property
-     * @param mixed $value
-     *
-     * @return mixed
      */
     protected function doDeserializeProperty(OA\AbstractAnnotation $annotation, $property, $value)
     {
@@ -171,6 +166,7 @@ class Serializer
                 foreach ($value as $v) {
                     $annotationArr[] = $this->doDeserialize($v, $class);
                 }
+
                 return $annotationArr;
             }
 
@@ -183,6 +179,7 @@ class Serializer
                     $annotation->$key = $k;
                     $annotationHash[$k] = $annotation;
                 }
+
                 return $annotationHash;
             }
         }
@@ -191,10 +188,10 @@ class Serializer
     }
 
     /**
-     * Deserialize base annotation property
+     * Deserialize base annotation property.
      *
-     * @param string $type The property type
-     * @param mixed $value The value to deserialization
+     * @param string $type  The property type
+     * @param mixed  $value The value to deserialization
      *
      * @return array|OA\AbstractAnnotation
      */
@@ -212,6 +209,7 @@ class Serializer
                 foreach ($value as $v) {
                     $annotationArr[] = $this->doDeserialize($v, $class);
                 }
+
                 return $annotationArr;
             }
 

--- a/src/StaticAnalyser.php
+++ b/src/StaticAnalyser.php
@@ -24,7 +24,7 @@ class StaticAnalyser
     /**
      * Extract and process all doc-comments from a file.
      *
-     * @param string $filename Path to a php file.
+     * @param string $filename path to a php file
      *
      * @return Analysis
      */
@@ -49,7 +49,7 @@ class StaticAnalyser
      * Extract and process all doc-comments from the contents.
      *
      * @param string  $code    PHP code. (including <?php tags)
-     * @param Context $context The original location of the contents.
+     * @param Context $context the original location of the contents
      *
      * @return Analysis
      */
@@ -127,7 +127,7 @@ class StaticAnalyser
                     // php7 anonymous classes (i.e. new class() { public function foo() {} };)
                     continue;
                 }
-                
+
                 if (is_array($token) && ($token[1] === 'extends' || $token[1] === 'implements')) {
                     // php7 anonymous classes with extends (i.e. new class() extends { public function foo() {} };)
                     continue;
@@ -417,7 +417,7 @@ class StaticAnalyser
      * @param array   $tokens
      * @param Context $context
      *
-     * @return string|array The next token (or false)
+     * @return array|string The next token (or false)
      */
     private function nextToken(&$tokens, $context)
     {

--- a/src/StaticAnalyser.php
+++ b/src/StaticAnalyser.php
@@ -432,7 +432,7 @@ class StaticAnalyser
                     if ($pos) {
                         $line = $context->line ? $context->line + $token[2] : $token[2];
                         $commentContext = new Context(['line' => $line], $context);
-                        Logger::notice('Annotations are only parsed inside `/**` DocBlocks, skipping ' . $commentContext);
+                        Logger::notice('Annotations are only parsed inside `/**` DocBlocks, skipping '.$commentContext);
                     }
                     continue;
                 }

--- a/src/Util.php
+++ b/src/Util.php
@@ -101,7 +101,7 @@ class Util
                 }
             }
         } else {
-            throw new InvalidArgumentException('Unexpected $directory value:' . gettype($directory));
+            throw new InvalidArgumentException('Unexpected $directory value:'.gettype($directory));
         }
         if ($exclude !== null) {
             if (is_string($exclude)) {
@@ -111,7 +111,7 @@ class Util
                     $finder->notPath(Util::getRelativePath($path, $directory));
                 }
             } else {
-                throw new InvalidArgumentException('Unexpected $exclude value:' . gettype($exclude));
+                throw new InvalidArgumentException('Unexpected $exclude value:'.gettype($exclude));
             }
         }
 

--- a/src/Util.php
+++ b/src/Util.php
@@ -10,7 +10,7 @@ use InvalidArgumentException;
 use Symfony\Component\Finder\Finder;
 
 /**
- * Convenient utility functions that don't neatly fit anywhere else
+ * Convenient utility functions that don't neatly fit anywhere else.
  */
 class Util
 {
@@ -25,8 +25,9 @@ class Util
      * and conform specifically to what is expected by functions like `exclude()` and `notPath()`.
      * In particular, leading and trailing slashes are removed.
      *
-     * @param  string       $fullPath
-     * @param  string|array $basePaths
+     * @param string       $fullPath
+     * @param array|string $basePaths
+     *
      * @return string
      */
     public static function getRelativePath($fullPath, $basePaths)
@@ -42,14 +43,16 @@ class Util
                 }
             }
         }
+
         return !empty($relativePath) ? trim($relativePath, '/') : $fullPath;
     }
 
     /**
      * Removes a prefix from the start of a string if it exists, or null otherwise.
      *
-     * @param  string $str
-     * @param  string $prefix
+     * @param string $str
+     * @param string $prefix
+     *
      * @return null|string
      */
     private static function removePrefix($str, $prefix)
@@ -57,15 +60,17 @@ class Util
         if (substr($str, 0, strlen($prefix)) == $prefix) {
             return substr($str, strlen($prefix));
         }
+
         return null;
     }
 
     /**
      * Build a Symfony Finder object that scans the given $directory.
      *
-     * @param  string|array|Finder $directory The directory(s) or filename(s)
-     * @param  null|string|array   $exclude   The directory(s) or filename(s) to exclude (as absolute or relative paths)
-     * @param  null|string         $pattern   The pattern of the files to scan
+     * @param array|Finder|string $directory The directory(s) or filename(s)
+     * @param null|array|string   $exclude   The directory(s) or filename(s) to exclude (as absolute or relative paths)
+     * @param null|string         $pattern   The pattern of the files to scan
+     *
      * @throws InvalidArgumentException
      */
     public static function finder($directory, $exclude = null, $pattern = null)
@@ -109,6 +114,7 @@ class Util
                 throw new InvalidArgumentException('Unexpected $exclude value:' . gettype($exclude));
             }
         }
+
         return $finder;
     }
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -10,7 +10,7 @@ use OpenApi\Annotations\OpenApi;
 use Symfony\Component\Finder\Finder;
 
 if (defined('OpenApi\UNDEFINED') === false) {
-    /**
+    /*
      * Special value to differentiate between null and undefined.
      */
     define('OpenApi\UNDEFINED', '@OA\UNDEFINED🙈');
@@ -22,13 +22,14 @@ if (function_exists('OpenApi\scan') === false) {
     /**
      * Scan the filesystem for OpenAPI annotations and build openapi-documentation.
      *
-     * @param  string|array|Finder $directory The directory(s) or filename(s)
-     * @param  array               $options
-     *   exclude: string|array $exclude The directory(s) or filename(s) to exclude (as absolute or relative paths)
-     *   pattern: string       $pattern File pattern(s) to scan (default: *.php)
-     *   analyser: defaults to StaticAnalyser
-     *   analysis: defaults to a new Analysis
-     *   processors: defaults to the registered processors in Analysis
+     * @param array|Finder|string $directory The directory(s) or filename(s)
+     * @param array               $options
+     *                                       exclude: string|array $exclude The directory(s) or filename(s) to exclude (as absolute or relative paths)
+     *                                       pattern: string       $pattern File pattern(s) to scan (default: *.php)
+     *                                       analyser: defaults to StaticAnalyser
+     *                                       analysis: defaults to a new Analysis
+     *                                       processors: defaults to the registered processors in Analysis
+     *
      * @return OpenApi
      */
     function scan($directory, $options = [])
@@ -48,6 +49,7 @@ if (function_exists('OpenApi\scan') === false) {
         $analysis->process($processors);
         // Validation (Generate notices & warnings)
         $analysis->validate();
+
         return $analysis->openapi;
     }
 }

--- a/tests/AnalyserTest.php
+++ b/tests/AnalyserTest.php
@@ -4,7 +4,7 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests;
+namespace OpenApi\Tests;
 
 class AnalyserTest extends OpenApiTestCase
 {

--- a/tests/AnalysisTest.php
+++ b/tests/AnalysisTest.php
@@ -4,10 +4,9 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests;
+namespace OpenApi\Tests;
 
 use OpenApi\Analysis;
-use OpenApi\StaticAnalyser;
 
 class AnalysisTest extends OpenApiTestCase
 {
@@ -31,23 +30,23 @@ class AnalysisTest extends OpenApiTestCase
     public function testGetSubclasses()
     {
         $analysis = $this->analysisFromFixtures([
-            'InheritProperties/Child.php',
+            'AnotherNamespace/Child.php',
             'InheritProperties/GrandAncestor.php',
             'InheritProperties/Ancestor.php',
         ]);
 
         $this->assertCount(3, $analysis->classes, '3 classes should\'ve been detected');
 
-        $subclasses = $analysis->getSubClasses('\OpenApiFixtures\GrandAncestor');
+        $subclasses = $analysis->getSubClasses('\OpenApi\Tests\Fixtures\GrandAncestor');
         $this->assertCount(2, $subclasses, 'GrandAncestor has 2 subclasses');
-        $this->assertSame(['\OpenApiFixtures\Ancestor', '\AnotherNamespace\Child'], array_keys($subclasses));
-        $this->assertSame(['\AnotherNamespace\Child'], array_keys($analysis->getSubClasses('\OpenApiFixtures\Ancestor')));
+        $this->assertSame(['\OpenApi\Tests\Fixtures\Ancestor', '\AnotherNamespace\Child'], array_keys($subclasses));
+        $this->assertSame(['\AnotherNamespace\Child'], array_keys($analysis->getSubClasses('\OpenApi\Tests\Fixtures\Ancestor')));
     }
 
     public function testGetAncestorClasses()
     {
         $analysis = $this->analysisFromFixtures([
-            'InheritProperties/Child.php',
+            'AnotherNamespace/Child.php',
             'InheritProperties/GrandAncestor.php',
             'InheritProperties/Ancestor.php',
         ]);
@@ -56,8 +55,8 @@ class AnalysisTest extends OpenApiTestCase
 
         $superclasses = $analysis->getSuperClasses('\AnotherNamespace\Child');
         $this->assertCount(2, $superclasses, 'Child has a chain of 2 super classes');
-        $this->assertSame(['\OpenApiFixtures\Ancestor', '\OpenApiFixtures\GrandAncestor'], array_keys($superclasses));
-        $this->assertSame(['\OpenApiFixtures\GrandAncestor'], array_keys($analysis->getSuperClasses('\OpenApiFixtures\Ancestor')));
+        $this->assertSame(['\OpenApi\Tests\Fixtures\Ancestor', '\OpenApi\Tests\Fixtures\GrandAncestor'], array_keys($superclasses));
+        $this->assertSame(['\OpenApi\Tests\Fixtures\GrandAncestor'], array_keys($analysis->getSuperClasses('\OpenApi\Tests\Fixtures\Ancestor')));
     }
 
     public function testGetInterfacesOfClass()
@@ -71,11 +70,11 @@ class AnalysisTest extends OpenApiTestCase
         $this->assertCount(1, $analysis->classes);
         $this->assertCount(2, $analysis->interfaces);
 
-        $interfaces = $analysis->getInterfacesOfClass('\OpenApiTests\Fixtures\Parser\User');
+        $interfaces = $analysis->getInterfacesOfClass('\OpenApi\Tests\Fixtures\Parser\User');
         $this->assertCount(2, $interfaces);
         $this->assertSame([
-            '\OpenApiTests\Fixtures\Parser\UserInterface',
-            '\OpenApiTests\Fixtures\Parser\OtherInterface',
+            '\OpenApi\Tests\Fixtures\Parser\UserInterface',
+            '\OpenApi\Tests\Fixtures\Parser\OtherInterface',
         ], array_keys($interfaces));
     }
 
@@ -92,11 +91,11 @@ class AnalysisTest extends OpenApiTestCase
         $this->assertCount(1, $analysis->classes);
         $this->assertCount(4, $analysis->traits);
 
-        $traits = $analysis->getTraitsOfClass('\OpenApiTests\Fixtures\Parser\User');
+        $traits = $analysis->getTraitsOfClass('\OpenApi\Tests\Fixtures\Parser\User');
         $this->assertSame([
-            '\OpenApiTests\Fixtures\Parser\HelloTrait',
-            '\OpenApiTests\Fixtures\Parser\OtherTrait',
-            '\OpenApiTests\Fixtures\Parser\AsTrait',
+            '\OpenApi\Tests\Fixtures\Parser\HelloTrait',
+            '\OpenApi\Tests\Fixtures\Parser\OtherTrait',
+            '\OpenApi\Tests\Fixtures\Parser\AsTrait',
         ], array_keys($traits));
     }
 }

--- a/tests/Annotations/AbstractAnnotationTest.php
+++ b/tests/Annotations/AbstractAnnotationTest.php
@@ -4,9 +4,9 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests\Annotations;
+namespace OpenApi\Tests\Annotations;
 
-use OpenApiTests\OpenApiTestCase;
+use OpenApi\Tests\OpenApiTestCase;
 
 class AbstractAnnotationTest extends OpenApiTestCase
 {

--- a/tests/Annotations/AnnotationPropertiesDefinedTest.php
+++ b/tests/Annotations/AnnotationPropertiesDefinedTest.php
@@ -4,11 +4,11 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests\Annotations;
+namespace OpenApi\Tests\Annotations;
 
-use OpenApi\Annotations\AbstractAnnotation;
-use OpenApiTests\OpenApiTestCase;
 use function get_class_vars;
+use OpenApi\Annotations\AbstractAnnotation;
+use OpenApi\Tests\OpenApiTestCase;
 
 class AnnotationPropertiesDefinedTest extends OpenApiTestCase
 {
@@ -24,7 +24,7 @@ class AnnotationPropertiesDefinedTest extends OpenApiTestCase
                 continue;
             }
             if ($value === null) {
-                $this->fail("Property ".basename($annotation).'->'.$property.' should be DEFINED');
+                $this->fail('Property ' . basename($annotation) . '->' . $property . ' should be DEFINED');
             }
         }
     }

--- a/tests/Annotations/AnnotationPropertiesDefinedTest.php
+++ b/tests/Annotations/AnnotationPropertiesDefinedTest.php
@@ -24,7 +24,7 @@ class AnnotationPropertiesDefinedTest extends OpenApiTestCase
                 continue;
             }
             if ($value === null) {
-                $this->fail('Property ' . basename($annotation) . '->' . $property . ' should be DEFINED');
+                $this->fail('Property '.basename($annotation).'->'.$property.' should be DEFINED');
             }
         }
     }

--- a/tests/Annotations/ItemsTest.php
+++ b/tests/Annotations/ItemsTest.php
@@ -4,10 +4,10 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests\Annotations;
+namespace OpenApi\Tests\Annotations;
 
 use OpenApi\StaticAnalyser;
-use OpenApiTests\OpenApiTestCase;
+use OpenApi\Tests\OpenApiTestCase;
 
 class ItemsTest extends OpenApiTestCase
 {

--- a/tests/Annotations/NestedPropertyTest.php
+++ b/tests/Annotations/NestedPropertyTest.php
@@ -4,13 +4,13 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests\Annotations;
+namespace OpenApi\Tests\Annotations;
 
 use OpenApi\Processors\AugmentProperties;
 use OpenApi\Processors\AugmentSchemas;
 use OpenApi\Processors\MergeIntoComponents;
 use OpenApi\Processors\MergeIntoOpenApi;
-use OpenApiTests\OpenApiTestCase;
+use OpenApi\Tests\OpenApiTestCase;
 use const OpenApi\UNDEFINED;
 
 class NestedPropertyTest extends OpenApiTestCase

--- a/tests/Annotations/ResponseTest.php
+++ b/tests/Annotations/ResponseTest.php
@@ -4,37 +4,37 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests\Annotations;
+namespace OpenApi\Tests\Annotations;
 
-use OpenApiTests\OpenApiTestCase;
+use OpenApi\Tests\OpenApiTestCase;
 
 class ResponseTest extends OpenApiTestCase
 {
     public function testMisspelledDefault()
     {
-        $this->validateMisspelledAnnotation("Default");
+        $this->validateMisspelledAnnotation('Default');
     }
-    
+
     public function testMisspelledRangeDefinition()
     {
-        $this->validateMisspelledAnnotation("5xX");
+        $this->validateMisspelledAnnotation('5xX');
     }
-    
+
     public function testWrongRangeDefinition()
     {
-        $this->validateMisspelledAnnotation("6XX");
+        $this->validateMisspelledAnnotation('6XX');
     }
-    
-    protected function validateMisspelledAnnotation(string $response = "")
+
+    protected function validateMisspelledAnnotation(string $response = '')
     {
         $annotations = $this->parseComment(
             '@OA\Get(@OA\Response(response="' . $response . '", description="description"))'
         );
-        /**
+        /*
          * @see Annotations/Operation.php:187
          */
         $this->assertOpenApiLogEntryContains(
-            'Invalid value "'.$response.'" for @OA\Response()->response, expecting "default"'
+            'Invalid value "' . $response . '" for @OA\Response()->response, expecting "default"'
             . ', a HTTP Status Code or HTTP '
         );
         $annotations[0]->validate();

--- a/tests/Annotations/ResponseTest.php
+++ b/tests/Annotations/ResponseTest.php
@@ -28,14 +28,14 @@ class ResponseTest extends OpenApiTestCase
     protected function validateMisspelledAnnotation(string $response = '')
     {
         $annotations = $this->parseComment(
-            '@OA\Get(@OA\Response(response="' . $response . '", description="description"))'
+            '@OA\Get(@OA\Response(response="'.$response.'", description="description"))'
         );
         /*
          * @see Annotations/Operation.php:187
          */
         $this->assertOpenApiLogEntryContains(
-            'Invalid value "' . $response . '" for @OA\Response()->response, expecting "default"'
-            . ', a HTTP Status Code or HTTP '
+            'Invalid value "'.$response.'" for @OA\Response()->response, expecting "default"'
+            .', a HTTP Status Code or HTTP '
         );
         $annotations[0]->validate();
     }

--- a/tests/Annotations/SecuritySchemesTest.php
+++ b/tests/Annotations/SecuritySchemesTest.php
@@ -4,23 +4,23 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests\Annotations;
+namespace OpenApi\Tests\Annotations;
 
 use OpenApi\Analyser;
 use OpenApi\Annotations\Info;
 use OpenApi\Annotations\SecurityScheme;
 use OpenApi\Annotations\Server;
-use OpenApiTests\OpenApiTestCase;
+use OpenApi\Tests\OpenApiTestCase;
 
 /**
- * Class SecuritySchemesTest
+ * Class SecuritySchemesTest.
  *
  * Security openapi test
  */
 class SecuritySchemesTest extends OpenApiTestCase
 {
     /**
-     * Test parse servers
+     * Test parse servers.
      */
     public function testParseServers()
     {
@@ -56,7 +56,7 @@ INFO;
     }
 
     /**
-     * Test parse security scheme
+     * Test parse security scheme.
      */
     public function testImplicitFlowAnnotation()
     {
@@ -136,7 +136,7 @@ SCHEME;
     }
 
     /**
-     * Get scheme analysis
+     * Get scheme analysis.
      *
      * @param string $comment
      *

--- a/tests/Annotations/ValidateRelationsTest.php
+++ b/tests/Annotations/ValidateRelationsTest.php
@@ -29,7 +29,7 @@ class ValidateRelationsTest extends OpenApiTestCase
                 }
             }
             if ($found === false) {
-                $this->fail($class . ' not found in ' . $parent . "::\$_nested. Found:\n  " . implode("\n  ", array_keys($parent::$_nested)));
+                $this->fail($class.' not found in '.$parent."::\$_nested. Found:\n  ".implode("\n  ", array_keys($parent::$_nested)));
             }
         }
     }
@@ -50,7 +50,7 @@ class ValidateRelationsTest extends OpenApiTestCase
                 }
             }
             if ($found === false) {
-                $this->fail($class . ' not found in ' . $nested . "::\$parent. Found:\n  " . implode("\n  ", $nested::$_parents));
+                $this->fail($class.' not found in '.$nested."::\$parent. Found:\n  ".implode("\n  ", $nested::$_parents));
             }
         }
     }

--- a/tests/Annotations/ValidateRelationsTest.php
+++ b/tests/Annotations/ValidateRelationsTest.php
@@ -4,18 +4,16 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests\Annotations;
+namespace OpenApi\Tests\Annotations;
 
-use OpenApiTests\OpenApiTestCase;
+use OpenApi\Tests\OpenApiTestCase;
 
 /**
  * Test if the annotation class nesting parent/child relations are coherent.
  */
 class ValidateRelationsTest extends OpenApiTestCase
 {
-
     /**
-     *
      * @dataProvider allAnnotationClasses
      *
      * @param string $class
@@ -31,13 +29,12 @@ class ValidateRelationsTest extends OpenApiTestCase
                 }
             }
             if ($found === false) {
-                $this->fail($class.' not found in '.$parent."::\$_nested. Found:\n  ".implode("\n  ", array_keys($parent::$_nested)));
+                $this->fail($class . ' not found in ' . $parent . "::\$_nested. Found:\n  " . implode("\n  ", array_keys($parent::$_nested)));
             }
         }
     }
 
     /**
-     *
      * @dataProvider allAnnotationClasses
      *
      * @param string $class
@@ -53,7 +50,7 @@ class ValidateRelationsTest extends OpenApiTestCase
                 }
             }
             if ($found === false) {
-                $this->fail($class.' not found in '.$nested."::\$parent. Found:\n  ".implode("\n  ", $nested::$_parents));
+                $this->fail($class . ' not found in ' . $nested . "::\$parent. Found:\n  " . implode("\n  ", $nested::$_parents));
             }
         }
     }

--- a/tests/CommandlineInterfaceTest.php
+++ b/tests/CommandlineInterfaceTest.php
@@ -4,7 +4,7 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests;
+namespace OpenApi\Tests;
 
 class CommandlineInterfaceTest extends OpenApiTestCase
 {
@@ -15,22 +15,22 @@ class CommandlineInterfaceTest extends OpenApiTestCase
 
     public function testStdout()
     {
-        $path = __DIR__.'/../Examples/swagger-spec/petstore-simple';
-        exec(__DIR__.'/../bin/openapi --format yaml '.escapeshellarg($path).' 2> /dev/null', $output, $retval);
+        $path = __DIR__ . '/../Examples/swagger-spec/petstore-simple';
+        exec(__DIR__ . '/../bin/openapi --format yaml ' . escapeshellarg($path) . ' 2> /dev/null', $output, $retval);
         $this->assertSame(0, $retval);
         $yaml = implode("\n", $output);
-        $this->assertSpecEquals(file_get_contents($path.'/petstore-simple.yaml'), $yaml);
+        $this->assertSpecEquals(file_get_contents($path . '/petstore-simple.yaml'), $yaml);
     }
 
     public function testOutputTofile()
     {
-        $path = __DIR__.'/../Examples/swagger-spec/petstore-simple';
-        $filename = sys_get_temp_dir().'/swagger-php-clitest.yaml';
-        exec(__DIR__.'/../bin/openapi --format yaml -o '.escapeshellarg($filename).' '.escapeshellarg($path).' 2> /dev/null', $output, $retval);
+        $path = __DIR__ . '/../Examples/swagger-spec/petstore-simple';
+        $filename = sys_get_temp_dir() . '/swagger-php-clitest.yaml';
+        exec(__DIR__ . '/../bin/openapi --format yaml -o ' . escapeshellarg($filename) . ' ' . escapeshellarg($path) . ' 2> /dev/null', $output, $retval);
         $this->assertSame(0, $retval);
         $this->assertCount(0, $output, 'No output to stdout');
         $yaml = file_get_contents($filename);
         unlink($filename);
-        $this->assertSpecEquals(file_get_contents($path.'/petstore-simple.yaml'), $yaml);
+        $this->assertSpecEquals(file_get_contents($path . '/petstore-simple.yaml'), $yaml);
     }
 }

--- a/tests/CommandlineInterfaceTest.php
+++ b/tests/CommandlineInterfaceTest.php
@@ -15,22 +15,22 @@ class CommandlineInterfaceTest extends OpenApiTestCase
 
     public function testStdout()
     {
-        $path = __DIR__ . '/../Examples/swagger-spec/petstore-simple';
-        exec(__DIR__ . '/../bin/openapi --format yaml ' . escapeshellarg($path) . ' 2> /dev/null', $output, $retval);
+        $path = __DIR__.'/../Examples/swagger-spec/petstore-simple';
+        exec(__DIR__.'/../bin/openapi --format yaml '.escapeshellarg($path).' 2> /dev/null', $output, $retval);
         $this->assertSame(0, $retval);
         $yaml = implode("\n", $output);
-        $this->assertSpecEquals(file_get_contents($path . '/petstore-simple.yaml'), $yaml);
+        $this->assertSpecEquals(file_get_contents($path.'/petstore-simple.yaml'), $yaml);
     }
 
     public function testOutputTofile()
     {
-        $path = __DIR__ . '/../Examples/swagger-spec/petstore-simple';
-        $filename = sys_get_temp_dir() . '/swagger-php-clitest.yaml';
-        exec(__DIR__ . '/../bin/openapi --format yaml -o ' . escapeshellarg($filename) . ' ' . escapeshellarg($path) . ' 2> /dev/null', $output, $retval);
+        $path = __DIR__.'/../Examples/swagger-spec/petstore-simple';
+        $filename = sys_get_temp_dir().'/swagger-php-clitest.yaml';
+        exec(__DIR__.'/../bin/openapi --format yaml -o '.escapeshellarg($filename).' '.escapeshellarg($path).' 2> /dev/null', $output, $retval);
         $this->assertSame(0, $retval);
         $this->assertCount(0, $output, 'No output to stdout');
         $yaml = file_get_contents($filename);
         unlink($filename);
-        $this->assertSpecEquals(file_get_contents($path . '/petstore-simple.yaml'), $yaml);
+        $this->assertSpecEquals(file_get_contents($path.'/petstore-simple.yaml'), $yaml);
     }
 }

--- a/tests/ConstantsTest.php
+++ b/tests/ConstantsTest.php
@@ -18,13 +18,13 @@ class ConstantsTest extends OpenApiTestCase
     public function testConstant()
     {
         self::$counter++;
-        $const = 'OPENAPI_TEST_' . self::$counter;
+        $const = 'OPENAPI_TEST_'.self::$counter;
         $this->assertFalse(defined($const));
-        $this->assertOpenApiLogEntryContains("[Semantical Error] Couldn't find constant " . $const);
-        $this->parseComment('@OA\Contact(email=' . $const . ')');
+        $this->assertOpenApiLogEntryContains("[Semantical Error] Couldn't find constant ".$const);
+        $this->parseComment('@OA\Contact(email='.$const.')');
 
         define($const, 'me@domain.org');
-        $annotations = $this->parseComment('@OA\Contact(email=' . $const . ')');
+        $annotations = $this->parseComment('@OA\Contact(email='.$const.')');
         $this->assertSame('me@domain.org', $annotations[0]->email);
     }
 
@@ -57,7 +57,7 @@ class ConstantsTest extends OpenApiTestCase
         $backup = Analyser::$whitelist;
         Analyser::$whitelist = false;
         $analyser = new StaticAnalyser();
-        $analysis = $analyser->fromFile(__DIR__ . '/Fixtures/Customer.php');
+        $analysis = $analyser->fromFile(__DIR__.'/Fixtures/Customer.php');
         // @todo Only tests that $whitelist=false doesn't trigger errors,
         // No constants are used, because by default only class constants in the whitelisted namespace are allowed and no class in OpenApi\Annotation namespace has a constant.
 

--- a/tests/ConstantsTest.php
+++ b/tests/ConstantsTest.php
@@ -4,7 +4,7 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests;
+namespace OpenApi\Tests;
 
 use OpenApi\Analyser;
 use OpenApi\StaticAnalyser;
@@ -18,22 +18,22 @@ class ConstantsTest extends OpenApiTestCase
     public function testConstant()
     {
         self::$counter++;
-        $const = 'OPENAPI_TEST_'.self::$counter;
+        $const = 'OPENAPI_TEST_' . self::$counter;
         $this->assertFalse(defined($const));
-        $this->assertOpenApiLogEntryContains("[Semantical Error] Couldn't find constant ".$const);
-        $this->parseComment('@OA\Contact(email='.$const.')');
+        $this->assertOpenApiLogEntryContains("[Semantical Error] Couldn't find constant " . $const);
+        $this->parseComment('@OA\Contact(email=' . $const . ')');
 
         define($const, 'me@domain.org');
-        $annotations = $this->parseComment('@OA\Contact(email='.$const.')');
+        $annotations = $this->parseComment('@OA\Contact(email=' . $const . ')');
         $this->assertSame('me@domain.org', $annotations[0]->email);
     }
 
     public function testFQCNConstant()
     {
-        $annotations = $this->parseComment('@OA\Contact(url=OpenApiTests\ConstantsTest::URL)');
+        $annotations = $this->parseComment('@OA\Contact(url=OpenApi\Tests\ConstantsTest::URL)');
         $this->assertSame('http://example.com', $annotations[0]->url);
 
-        $annotations = $this->parseComment('@OA\Contact(url=\OpenApiTests\ConstantsTest::URL)');
+        $annotations = $this->parseComment('@OA\Contact(url=\OpenApi\Tests\ConstantsTest::URL)');
         $this->assertSame('http://example.com', $annotations[0]->url);
     }
 
@@ -45,10 +45,10 @@ class ConstantsTest extends OpenApiTestCase
 
     public function testAutoloadConstant()
     {
-        if (class_exists('Laminas\Validator\Timezone', false)) {
+        if (class_exists('AnotherNamespace\Annotations\Constants', false)) {
             $this->markTestSkipped();
         }
-        $annotations = $this->parseComment('@OA\Contact(name=Laminas\Validator\Timezone::INVALID_TIMEZONE_LOCATION)');
+        $annotations = $this->parseComment('@OA\Contact(name=AnotherNamespace\Annotations\Constants::INVALID_TIMEZONE_LOCATION)');
         $this->assertSame('invalidTimezoneLocation', $annotations[0]->name);
     }
 
@@ -57,7 +57,7 @@ class ConstantsTest extends OpenApiTestCase
         $backup = Analyser::$whitelist;
         Analyser::$whitelist = false;
         $analyser = new StaticAnalyser();
-        $analysis = $analyser->fromFile(__DIR__.'/Fixtures/Customer.php');
+        $analysis = $analyser->fromFile(__DIR__ . '/Fixtures/Customer.php');
         // @todo Only tests that $whitelist=false doesn't trigger errors,
         // No constants are used, because by default only class constants in the whitelisted namespace are allowed and no class in OpenApi\Annotation namespace has a constant.
 
@@ -71,7 +71,7 @@ class ConstantsTest extends OpenApiTestCase
         $backup = Analyser::$defaultImports;
         Analyser::$defaultImports = [
             'contact' => 'OpenApi\Annotations\Contact', // use OpenApi\Annotations\Contact;
-            'ctest' => 'OpenApiTests\ConstantsTesT' // use OpenApiTests\ConstantsTesT as CTest;
+            'ctest' => 'OpenApi\Tests\ConstantsTesT', // use OpenApi\Tests\ConstantsTesT as CTest;
         ];
         $annotations = $this->parseComment('@Contact(url=CTest::URL)');
         $this->assertSame('http://example.com', $annotations[0]->url);

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -4,7 +4,7 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests;
+namespace OpenApi\Tests;
 
 use OpenApi\Context;
 
@@ -15,26 +15,26 @@ class ContextTest extends OpenApiTestCase
         $context = Context::detect();
         $line = __LINE__ - 1;
         $this->assertSame('ContextTest', $context->class);
-        $this->assertSame('\OpenApiTests\ContextTest', $context->fullyQualifiedName($context->class));
+        $this->assertSame('\OpenApi\Tests\ContextTest', $context->fullyQualifiedName($context->class));
         $this->assertSame('testDetect', $context->method);
         $this->assertSame(__FILE__, $context->filename);
         $this->assertSame($line, $context->line);
-        $this->assertSame('OpenApiTests', $context->namespace);
+        $this->assertSame('OpenApi\Tests', $context->namespace);
         //        $this->assertCount(1, $context->uses); // Context::detect() doesn't pick up USE statements (yet)
     }
 
     public function testFullyQualifiedName()
     {
         $this->assertOpenApiLogEntryContains('Required @OA\PathItem() not found');
-        $openapi = \OpenApi\scan(__DIR__.'/Fixtures/Customer.php');
+        $openapi = \OpenApi\scan(__DIR__ . '/Fixtures/Customer.php');
         $context = $openapi->components->schemas[0]->_context;
         // resolve with namespace
         $this->assertSame('\FullyQualified', $context->fullyQualifiedName('\FullyQualified'));
-        $this->assertSame('\OpenApiFixures\Unqualified', $context->fullyQualifiedName('Unqualified'));
-        $this->assertSame('\OpenApiFixures\Namespace\Qualified', $context->fullyQualifiedName('Namespace\Qualified'));
+        $this->assertSame('\OpenApi\Tests\Fixtures\Unqualified', $context->fullyQualifiedName('Unqualified'));
+        $this->assertSame('\OpenApi\Tests\Fixtures\Namespace\Qualified', $context->fullyQualifiedName('Namespace\Qualified'));
         // respect use statements
         $this->assertSame('\Exception', $context->fullyQualifiedName('Exception'));
-        $this->assertSame('\OpenApiFixures\Customer', $context->fullyQualifiedName('Customer'));
+        $this->assertSame('\OpenApi\Tests\Fixtures\Customer', $context->fullyQualifiedName('Customer'));
         $this->assertSame('\OpenApi\Logger', $context->fullyQualifiedName('Logger'));
         $this->assertSame('\OpenApi\Logger', $context->fullyQualifiedName('lOgGeR')); // php has case-insensitive class names :-(
         $this->assertSame('\OpenApi\Logger', $context->fullyQualifiedName('OpenApiLogger'));
@@ -75,11 +75,11 @@ END
  */
 END
         ]);
-        $this->assertEquals("A single line spread across multiple lines.", $escapedLinebreak->phpdocContent());
+        $this->assertEquals('A single line spread across multiple lines.', $escapedLinebreak->phpdocContent());
     }
 
     /**
-     * https://phpdoc.org/docs/latest/guides/docblocks.html
+     * https://phpdoc.org/docs/latest/guides/docblocks.html.
      */
     public function testPhpdocSummaryAndDescription()
     {

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -26,7 +26,7 @@ class ContextTest extends OpenApiTestCase
     public function testFullyQualifiedName()
     {
         $this->assertOpenApiLogEntryContains('Required @OA\PathItem() not found');
-        $openapi = \OpenApi\scan(__DIR__ . '/Fixtures/Customer.php');
+        $openapi = \OpenApi\scan(__DIR__.'/Fixtures/Customer.php');
         $context = $openapi->components->schemas[0]->_context;
         // resolve with namespace
         $this->assertSame('\FullyQualified', $context->fullyQualifiedName('\FullyQualified'));

--- a/tests/ExamplesTest.php
+++ b/tests/ExamplesTest.php
@@ -66,8 +66,8 @@ class ExamplesTest extends OpenApiTestCase
             $options['processors'] = $processors;
         }
 
-        $path = __DIR__ . '/../Examples/' . $example;
+        $path = __DIR__.'/../Examples/'.$example;
         $openapi = \OpenApi\scan($path, $options);
-        $this->assertSpecEquals(file_get_contents($path . '/' . $spec), $openapi);
+        $this->assertSpecEquals(file_get_contents($path.'/'.$spec), $openapi);
     }
 }

--- a/tests/ExamplesTest.php
+++ b/tests/ExamplesTest.php
@@ -4,7 +4,7 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests;
+namespace OpenApi\Tests;
 
 use OpenApi\Analysis;
 use OpenApi\Logger;
@@ -12,11 +12,9 @@ use OpenApi\Processors\InheritInterfaces;
 use OpenApi\Processors\InheritTraits;
 use OpenApi\Processors\MergeInterfaces;
 use OpenApi\Processors\MergeTraits;
-use Symfony\Component\Yaml\Yaml;
 
 class ExamplesTest extends OpenApiTestCase
 {
-
     public function exampleMappings()
     {
         return [

--- a/tests/Fixtures/AnotherNamespace/Annotations/Constants.php
+++ b/tests/Fixtures/AnotherNamespace/Annotations/Constants.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace AnotherNamespace\Annotations;
+
+/**
+ * @Annotation
+ */
+class Constants
+{
+    const INVALID_TIMEZONE_LOCATION = "invalidTimezoneLocation";
+}

--- a/tests/Fixtures/AnotherNamespace/Annotations/Unrelated.php
+++ b/tests/Fixtures/AnotherNamespace/Annotations/Unrelated.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace AnotherNamespace\Annotations;
+
+/**
+ * Unrelated annotation.
+ *
+ * @Annotation
+ */
+class Unrelated
+{
+    protected $s;
+
+    public function __construct($s = null)
+    {
+        $this->s = $s;
+    }
+}

--- a/tests/Fixtures/AnotherNamespace/Child.php
+++ b/tests/Fixtures/AnotherNamespace/Child.php
@@ -5,7 +5,7 @@ namespace AnotherNamespace;
 /**
  * @OA\Schema()
  */
-class ChildWithDocBlocks extends \OpenApiFixtures\AncestorWithoutDocBlocks
+class Child extends \OpenApi\Tests\Fixtures\Ancestor
 {
 
     /**

--- a/tests/Fixtures/AnotherNamespace/ChildWithDocBlocks.php
+++ b/tests/Fixtures/AnotherNamespace/ChildWithDocBlocks.php
@@ -5,7 +5,7 @@ namespace AnotherNamespace;
 /**
  * @OA\Schema()
  */
-class Child extends \OpenApiFixtures\Ancestor
+class ChildWithDocBlocks extends \OpenApi\Tests\Fixtures\AncestorWithoutDocBlocks
 {
 
     /**

--- a/tests/Fixtures/Customer.php
+++ b/tests/Fixtures/Customer.php
@@ -1,11 +1,13 @@
 <?php declare(strict_types=1);
-// phpcs:ignoreFile (this file uses "\r\n" linebreaks on purpose)
-namespace OpenApiFixures;
+
+// NOTE: this file uses "\r\n" linebreaks on purpose
+
+namespace OpenApi\Tests\Fixtures;
 
 use Exception;
-use OpenApi\Annotations as OA;
 use OpenApi\Logger;
 use OpenApi\Logger as OpenApiLogger;
+use OpenApi\Annotations as OA;
 
 /**
  * @OA\Info(title="Fixture for ClassPropertiesTest", version="test")
@@ -83,9 +85,9 @@ class Customer
      */
     public function testResolvingFullyQualifiedNames()
     {
-        $test = new OpenApiLogger();
-        $test2 = new Logger();
-        $test3 = new OA\Contact();
+        OpenApiLogger::getInstance();
+        Logger::getInstance();
+        new OA\Contact([]);
         throw new Exception();
     }
 }

--- a/tests/Fixtures/CustomerInterface.php
+++ b/tests/Fixtures/CustomerInterface.php
@@ -1,8 +1,6 @@
-<?php
+<?php declare(strict_types=1);
 
-declare(strict_types=1);
-
-namespace OpenApiFixures;
+namespace OpenApi\Tests\Fixtures;
 
 use OpenApi\Annotations as OA;
 

--- a/tests/Fixtures/InheritProperties/Ancestor.php
+++ b/tests/Fixtures/InheritProperties/Ancestor.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace OpenApiFixtures;
+namespace OpenApi\Tests\Fixtures;
 
 /**
  * An intermediate class

--- a/tests/Fixtures/InheritProperties/AncestorWithoutDocBlocks.php
+++ b/tests/Fixtures/InheritProperties/AncestorWithoutDocBlocks.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace OpenApiFixtures;
+namespace OpenApi\Tests\Fixtures;
 
 class AncestorWithoutDocBlocks extends GrandAncestor
 {

--- a/tests/Fixtures/InheritProperties/Base.php
+++ b/tests/Fixtures/InheritProperties/Base.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OpenApiFixtures;
+namespace OpenApi\Tests\Fixtures;
 
 /**
  * @OA\Schema()

--- a/tests/Fixtures/InheritProperties/BaseInterface.php
+++ b/tests/Fixtures/InheritProperties/BaseInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OpenApiTests\Fixtures\InheritProperties;
+namespace OpenApi\Tests\Fixtures\InheritProperties;
 
 /**
  * @OA\Schema()

--- a/tests/Fixtures/InheritProperties/BaseThatImplements.php
+++ b/tests/Fixtures/InheritProperties/BaseThatImplements.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OpenApiTests\Fixtures\InheritProperties;
+namespace OpenApi\Tests\Fixtures\InheritProperties;
 
 /**
  * @OA\Schema()

--- a/tests/Fixtures/InheritProperties/Extended.php
+++ b/tests/Fixtures/InheritProperties/Extended.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OpenApiFixtures;
+namespace OpenApi\Tests\Fixtures;
 
 /**
  *  @OA\Schema(

--- a/tests/Fixtures/InheritProperties/ExtendedWithTwoSchemas.php
+++ b/tests/Fixtures/InheritProperties/ExtendedWithTwoSchemas.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OpenApiFixtures;
+namespace OpenApi\Tests\Fixtures;
 
 use OpenApi\Annotations\Property;
 use OpenApi\Annotations\Schema;

--- a/tests/Fixtures/InheritProperties/ExtendedWithoutAllOf.php
+++ b/tests/Fixtures/InheritProperties/ExtendedWithoutAllOf.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OpenApiFixtures;
+namespace OpenApi\Tests\Fixtures;
 
 /**
  * @OA\Schema()

--- a/tests/Fixtures/InheritProperties/ExtendsBaseThatImplements.php
+++ b/tests/Fixtures/InheritProperties/ExtendsBaseThatImplements.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OpenApiTests\Fixtures\InheritProperties;
+namespace OpenApi\Tests\Fixtures\InheritProperties;
 
 /**
  * @OA\Schema()

--- a/tests/Fixtures/InheritProperties/GrandAncestor.php
+++ b/tests/Fixtures/InheritProperties/GrandAncestor.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace OpenApiFixtures;
+namespace OpenApi\Tests\Fixtures;
 
 class GrandAncestor
 {

--- a/tests/Fixtures/InheritProperties/TraitUsedByExtendsBaseThatImplements.php
+++ b/tests/Fixtures/InheritProperties/TraitUsedByExtendsBaseThatImplements.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OpenApiTests\Fixtures\InheritProperties;
+namespace OpenApi\Tests\Fixtures\InheritProperties;
 
 /**
  * @OA\Schema()

--- a/tests/Fixtures/NestedProperty.php
+++ b/tests/Fixtures/NestedProperty.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace AnotherNamespace;
+namespace OpenApi\Tests\Fixtures;
 
 /**
  * @OA\Schema()

--- a/tests/Fixtures/Parser/AsTrait.php
+++ b/tests/Fixtures/Parser/AsTrait.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace OpenApiTests\Fixtures\Parser;
+namespace OpenApi\Tests\Fixtures\Parser;
 
 /**
  * @OA\Schema(schema="as")

--- a/tests/Fixtures/Parser/HelloTrait.php
+++ b/tests/Fixtures/Parser/HelloTrait.php
@@ -1,8 +1,8 @@
 <?php declare(strict_types=1);
 
-namespace OpenApiTests\Fixtures\Parser;
+namespace OpenApi\Tests\Fixtures\Parser;
 
-use OpenApiTests\Fixtures\Parser\AsTrait as Aliased;
+use OpenApi\Tests\Fixtures\Parser\AsTrait as Aliased;
 
 /**
  * @OA\Schema(schema="hello")

--- a/tests/Fixtures/Parser/OtherInterface.php
+++ b/tests/Fixtures/Parser/OtherInterface.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace OpenApiTests\Fixtures\Parser;
+namespace OpenApi\Tests\Fixtures\Parser;
 
 interface OtherInterface
 {

--- a/tests/Fixtures/Parser/OtherTrait.php
+++ b/tests/Fixtures/Parser/OtherTrait.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace OpenApiTests\Fixtures\Parser;
+namespace OpenApi\Tests\Fixtures\Parser;
 
 /**
  * @OA\Schema(schema="other")

--- a/tests/Fixtures/Parser/StaleTrait.php
+++ b/tests/Fixtures/Parser/StaleTrait.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace OpenApiTests\Fixtures\Parser;
+namespace OpenApi\Tests\Fixtures\Parser;
 
 /**
  * @OA\Schema(schema="stale")

--- a/tests/Fixtures/Parser/Sub/SubClass.php
+++ b/tests/Fixtures/Parser/Sub/SubClass.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace OpenApiTests\Fixtures\Parser\Sub;
+namespace OpenApi\Tests\Fixtures\Parser\Sub;
 
 class SubClass
 {

--- a/tests/Fixtures/Parser/User.php
+++ b/tests/Fixtures/Parser/User.php
@@ -1,14 +1,14 @@
 <?php declare(strict_types=1);
 
-namespace OpenApiTests\Fixtures\Parser;
+namespace OpenApi\Tests\Fixtures\Parser;
 
-use OpenApiTests\Fixtures\Parser\HelloTrait as Hello;
-use OpenApiTests\Fixtures\Parser\Sub\SubClass as ParentClass;
+use OpenApi\Tests\Fixtures\Parser\HelloTrait as Hello;
+use OpenApi\Tests\Fixtures\Parser\Sub\SubClass as ParentClass;
 
 /**
  * @OA\Schema()
  */
-class User extends ParentClass implements \OpenApiTests\Fixtures\Parser\UserInterface
+class User extends ParentClass implements \OpenApi\Tests\Fixtures\Parser\UserInterface
 {
     use Hello;
 

--- a/tests/Fixtures/Parser/UserInterface.php
+++ b/tests/Fixtures/Parser/UserInterface.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace OpenApiTests\Fixtures\Parser;
+namespace OpenApi\Tests\Fixtures\Parser;
 
 use OpenApi\Annotations as OA;
 

--- a/tests/Fixtures/Processors/EntityControllerClass.php
+++ b/tests/Fixtures/Processors/EntityControllerClass.php
@@ -1,6 +1,6 @@
-<?php
+<?php declare(strict_types=1);
 
-namespace OpenApiTests\Fixtures\Processors;
+namespace OpenApi\Tests\Fixtures\Processors;
 
 /**
  * An entity controller class.

--- a/tests/Fixtures/Processors/EntityControllerInterface.php
+++ b/tests/Fixtures/Processors/EntityControllerInterface.php
@@ -1,6 +1,6 @@
-<?php
+<?php declare(strict_types=1);
 
-namespace OpenApiTests\Fixtures\Processors;
+namespace OpenApi\Tests\Fixtures\Processors;
 
 /**
  * Entity controller interface.

--- a/tests/Fixtures/Processors/EntityControllerTrait.php
+++ b/tests/Fixtures/Processors/EntityControllerTrait.php
@@ -1,6 +1,6 @@
-<?php
+<?php declare(strict_types=1);
 
-namespace OpenApiTests\Fixtures\Processors;
+namespace OpenApi\Tests\Fixtures\Processors;
 
 /**
  * Entity controller trait.

--- a/tests/Fixtures/StaticAnalyser/php7.php
+++ b/tests/Fixtures/StaticAnalyser/php7.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace OpenApiFixures;
+namespace OpenApi\Tests\Fixtures;
 
 $o = new class
 {

--- a/tests/Fixtures/StaticAnalyser/routes.php
+++ b/tests/Fixtures/StaticAnalyser/routes.php
@@ -1,4 +1,5 @@
-<?php
+<?php declare(strict_types=1);
+
 //
 // Allow indentation with tab(s).
 //

--- a/tests/Fixtures/ThirdPartyAnnotations.php
+++ b/tests/Fixtures/ThirdPartyAnnotations.php
@@ -1,36 +1,30 @@
 <?php declare(strict_types=1);
 
-namespace OpenApiTests\Fixtures;
+namespace OpenApi\Tests\Fixtures;
 
 /**
  * @OA\Info(title="Fixture for ParserTest", version="test")
  * Based on the examplefrom http://framework.zend.com/manual/current/en/modules/zend.form.quick-start.html
  */
-use Laminas\Form\Annotation;
+use AnotherNamespace\Annotations as Annotation;
 
 /**
- * @Annotation\Name("user")
- * @Annotation\Hydrator("Laminas\Stdlib\Hydrator\ObjectProperty")
+ * @Annotation\Unrelated("user")
  */
 class ThirdPartyAnnotations
 {
     /**
-     * @Annotation\Exclude()
+     * @Annotation\Unrelated()
      */
     public $id;
 
     /**
-     * @Annotation\Filter({"name":"StringTrim"})
-     * @Annotation\Validator({"name":"StringLength", "options":{"min":1, "max":25}})
-     * @Annotation\Validator({"name":"Regex", "options":{"pattern":"/^[a-zA-Z][a-zA-Z0-9_-]{0,24}$/"}})
-     * @Annotation\Attributes({"type":"text"})
-     * @Annotation\Options({"label":"Username:"})
+     * @Annotation\Unrelated("user")
      */
     public $username;
 
     /**
-     * @Annotation\Type("Laminas\Form\Element\Email")
-     * @Annotation\Options({"label":"Your email address:"})
+     * @Annotation\Unrelated("email")
      */
     public $email;
 

--- a/tests/Fixtures/TypedProperties.php
+++ b/tests/Fixtures/TypedProperties.php
@@ -1,10 +1,8 @@
-<?php
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
-namespace OpenApiFixtures;
+namespace OpenApi\Tests\Fixtures;
 
 use DateTime;
-use App;
 
 /**
  * @OA\Schema()
@@ -27,7 +25,7 @@ class TypedProperties
     public ?string $nullableString;
 
     /**
-     * @var \OpenApiFixtures\TypedProperties[]
+     * @var \OpenApi\Tests\Fixtures\TypedProperties[]
      * @OA\Property()
      */
     public array $arrayType;
@@ -45,7 +43,7 @@ class TypedProperties
     /**
      * @OA\Property()
      */
-    public \OpenApiFixtures\TypedProperties $namespace;
+    public \OpenApi\Tests\Fixtures\TypedProperties $namespaced;
 
     /**
      * @OA\Property()

--- a/tests/Fixtures/UsingPhpDoc.php
+++ b/tests/Fixtures/UsingPhpDoc.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace OpenApiFixtures;
+namespace OpenApi\Tests\Fixtures;
 
 /**
  * @OA\Info(title="Fixture for AugmentOperationTest", version="test")

--- a/tests/Fixtures/UsingRefs.php
+++ b/tests/Fixtures/UsingRefs.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace OpenApiFixtures;
+namespace OpenApi\Tests\Fixtures;
 
 /**
  * @OA\Info(title="Using a parameter definition", version="unittest")

--- a/tests/Fixtures/UsingVar.php
+++ b/tests/Fixtures/UsingVar.php
@@ -1,6 +1,6 @@
-<?php
+<?php declare(strict_types=1);
 
-namespace OpenApiTests\Fixtures;
+namespace OpenApi\Tests\Fixtures;
 
 /**
  * @OA\Schema(

--- a/tests/OpenApiTestCase.php
+++ b/tests/OpenApiTestCase.php
@@ -4,22 +4,21 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests;
+namespace OpenApi\Tests;
 
 use Closure;
 use DirectoryIterator;
 use Exception;
-use OpenApi\Analysis;
-use OpenApi\StaticAnalyser;
-use PHPUnit\Framework\TestCase;
-use stdClass;
 use OpenApi\Analyser;
+use OpenApi\Analysis;
 use OpenApi\Annotations\AbstractAnnotation;
-use OpenApi\Annotations\OpenApi;
 use OpenApi\Annotations\Info;
+use OpenApi\Annotations\OpenApi;
 use OpenApi\Annotations\PathItem;
 use OpenApi\Context;
 use OpenApi\Logger;
+use OpenApi\StaticAnalyser;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
 
@@ -51,9 +50,9 @@ class OpenApiTestCase extends TestCase
                     E_USER_WARNING => 'warning',
                 ];
                 if (isset($map[$type])) {
-                    $this->fail('Unexpected \OpenApi\Logger::'.$map[$type].'("'.$entry.'")');
+                    $this->fail('Unexpected \OpenApi\Logger::' . $map[$type] . '("' . $entry . '")');
                 } else {
-                    $this->fail('Unexpected \OpenApi\Logger->getInstance()->log("'.$entry.'",'.$type.')');
+                    $this->fail('Unexpected \OpenApi\Logger->getInstance()->log("' . $entry . '",' . $type . ')');
                 }
             }
         };
@@ -62,7 +61,7 @@ class OpenApiTestCase extends TestCase
 
     protected function tearDown(): void
     {
-        $this->assertCount($this->countExceptions, $this->expectedLogMessages, count($this->expectedLogMessages).' OpenApi\Logger messages were not triggered');
+        $this->assertCount($this->countExceptions, $this->expectedLogMessages, count($this->expectedLogMessages) . ' OpenApi\Logger messages were not triggered');
         Logger::getInstance()->log = $this->originalLogger;
         parent::tearDown();
     }
@@ -80,10 +79,10 @@ class OpenApiTestCase extends TestCase
     /**
      * Compare OpenApi specs assuming strings to contain YAML.
      *
-     * @param string|array|\stdClass|OpenApi $expected
-     * @param string|array|\stdClass|OpenApi $spec
-     * @param string $message
-     * @param bool $normalized Flag indicating whether the inputs are already normalized or not.
+     * @param array|OpenApi|\stdClass|string $expected
+     * @param array|OpenApi|\stdClass|string $spec
+     * @param string                         $message
+     * @param bool                           $normalized flag indicating whether the inputs are already normalized or not
      */
     protected function assertSpecEquals($expected, $spec, $message = '', $normalized = false)
     {
@@ -132,7 +131,7 @@ class OpenApiTestCase extends TestCase
         $analyser = new Analyser();
         $context = Context::detect(1);
 
-        return $analyser->fromComment("<?php\n/**\n * ".implode("\n * ", explode("\n", $comment))."\n*/", $context);
+        return $analyser->fromComment("<?php\n/**\n * " . implode("\n * ", explode("\n", $comment)) . "\n*/", $context);
     }
 
     /**
@@ -156,8 +155,9 @@ class OpenApiTestCase extends TestCase
     /**
      * Resolve fixture filenames.
      *
-     * @param string|array $files One ore more files.
-     * @return array Resolved filenames for loading scanning etc.
+     * @param array|string $files one ore more files
+     *
+     * @return array resolved filenames for loading scanning etc
      */
     public function fixtures($files): array
     {
@@ -191,7 +191,7 @@ class OpenApiTestCase extends TestCase
     public function allAnnotationClasses()
     {
         $classes = [];
-        $dir = new DirectoryIterator(__DIR__.'/../src/Annotations');
+        $dir = new DirectoryIterator(__DIR__ . '/../src/Annotations');
         foreach ($dir as $entry) {
             if (!$entry->isFile() || $entry->getExtension() != 'php') {
                 continue;
@@ -200,7 +200,7 @@ class OpenApiTestCase extends TestCase
             if (in_array($class, ['AbstractAnnotation','Operation'])) {
                 continue;
             }
-            $classes[] = ['OpenApi\\Annotations\\'.$class];
+            $classes[] = ['OpenApi\\Annotations\\' . $class];
         }
 
         return $classes;

--- a/tests/OpenApiTestCase.php
+++ b/tests/OpenApiTestCase.php
@@ -50,9 +50,9 @@ class OpenApiTestCase extends TestCase
                     E_USER_WARNING => 'warning',
                 ];
                 if (isset($map[$type])) {
-                    $this->fail('Unexpected \OpenApi\Logger::' . $map[$type] . '("' . $entry . '")');
+                    $this->fail('Unexpected \OpenApi\Logger::'.$map[$type].'("'.$entry.'")');
                 } else {
-                    $this->fail('Unexpected \OpenApi\Logger->getInstance()->log("' . $entry . '",' . $type . ')');
+                    $this->fail('Unexpected \OpenApi\Logger->getInstance()->log("'.$entry.'",'.$type.')');
                 }
             }
         };
@@ -61,7 +61,7 @@ class OpenApiTestCase extends TestCase
 
     protected function tearDown(): void
     {
-        $this->assertCount($this->countExceptions, $this->expectedLogMessages, count($this->expectedLogMessages) . ' OpenApi\Logger messages were not triggered');
+        $this->assertCount($this->countExceptions, $this->expectedLogMessages, count($this->expectedLogMessages).' OpenApi\Logger messages were not triggered');
         Logger::getInstance()->log = $this->originalLogger;
         parent::tearDown();
     }
@@ -95,7 +95,7 @@ class OpenApiTestCase extends TestCase
                 try {
                     $in = Yaml::parse($in);
                 } catch (ParseException $e) {
-                    $this->fail('Invalid YAML: ' . $e->getMessage() . PHP_EOL . $in);
+                    $this->fail('Invalid YAML: '.$e->getMessage().PHP_EOL.$in);
                 }
             }
 
@@ -131,7 +131,7 @@ class OpenApiTestCase extends TestCase
         $analyser = new Analyser();
         $context = Context::detect(1);
 
-        return $analyser->fromComment("<?php\n/**\n * " . implode("\n * ", explode("\n", $comment)) . "\n*/", $context);
+        return $analyser->fromComment("<?php\n/**\n * ".implode("\n * ", explode("\n", $comment))."\n*/", $context);
     }
 
     /**
@@ -162,7 +162,7 @@ class OpenApiTestCase extends TestCase
     public function fixtures($files): array
     {
         return array_map(function ($file) {
-            return __DIR__ . '/Fixtures/' . $file;
+            return __DIR__.'/Fixtures/'.$file;
         }, (array) $files);
     }
 
@@ -180,7 +180,7 @@ class OpenApiTestCase extends TestCase
 
     public function analysisFromCode(string $code, ?Context $context = null)
     {
-        return (new StaticAnalyser())->fromCode("<?php\n" . $code, $context ?: new Context());
+        return (new StaticAnalyser())->fromCode("<?php\n".$code, $context ?: new Context());
     }
 
     /**
@@ -191,7 +191,7 @@ class OpenApiTestCase extends TestCase
     public function allAnnotationClasses()
     {
         $classes = [];
-        $dir = new DirectoryIterator(__DIR__ . '/../src/Annotations');
+        $dir = new DirectoryIterator(__DIR__.'/../src/Annotations');
         foreach ($dir as $entry) {
             if (!$entry->isFile() || $entry->getExtension() != 'php') {
                 continue;
@@ -200,7 +200,7 @@ class OpenApiTestCase extends TestCase
             if (in_array($class, ['AbstractAnnotation','Operation'])) {
                 continue;
             }
-            $classes[] = ['OpenApi\\Annotations\\' . $class];
+            $classes[] = ['OpenApi\\Annotations\\'.$class];
         }
 
         return $classes;

--- a/tests/Processors/AugmentOperationTest.php
+++ b/tests/Processors/AugmentOperationTest.php
@@ -4,11 +4,11 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests\Processors;
+namespace OpenApi\Tests\Processors;
 
 use OpenApi\Annotations\Operation;
 use OpenApi\Processors\AugmentOperations;
-use OpenApiTests\OpenApiTestCase;
+use OpenApi\Tests\OpenApiTestCase;
 use const OpenApi\UNDEFINED;
 
 class AugmentOperationTest extends OpenApiTestCase

--- a/tests/Processors/AugmentParameterTest.php
+++ b/tests/Processors/AugmentParameterTest.php
@@ -4,9 +4,9 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests\Processors;
+namespace OpenApi\Tests\Processors;
 
-use OpenApiTests\OpenApiTestCase;
+use OpenApi\Tests\OpenApiTestCase;
 
 class AugmentParameterTest extends OpenApiTestCase
 {

--- a/tests/Processors/AugmentPropertiesTest.php
+++ b/tests/Processors/AugmentPropertiesTest.php
@@ -4,14 +4,14 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests\Processors;
+namespace OpenApi\Tests\Processors;
 
 use OpenApi\Annotations\Property;
 use OpenApi\Processors\AugmentProperties;
 use OpenApi\Processors\AugmentSchemas;
 use OpenApi\Processors\MergeIntoComponents;
 use OpenApi\Processors\MergeIntoOpenApi;
-use OpenApiTests\OpenApiTestCase;
+use OpenApi\Tests\OpenApiTestCase;
 use const OpenApi\UNDEFINED;
 
 /**
@@ -133,7 +133,7 @@ class AugmentPropertiesTest extends OpenApiTestCase
             $arrayType,
             $dateTime,
             $qualified,
-            $namespace,
+            $namespaced,
             $importedNamespace,
             $nativeTrumpsVar,
             $annotationTrumpsNative,
@@ -170,7 +170,7 @@ class AugmentPropertiesTest extends OpenApiTestCase
             'property' => UNDEFINED,
             'type' => UNDEFINED,
         ]);
-        $this->assertName($namespace, [
+        $this->assertName($namespaced, [
             'property' => UNDEFINED,
             'type' => UNDEFINED,
         ]);
@@ -251,8 +251,8 @@ class AugmentPropertiesTest extends OpenApiTestCase
             'type' => 'string',
             'format' => 'date-time',
         ]);
-        $this->assertName($namespace, [
-            'property' => 'namespace',
+        $this->assertName($namespaced, [
+            'property' => 'namespaced',
             'ref' => '#/components/schemas/TypedProperties',
         ]);
         $this->assertName($importedNamespace, [
@@ -297,12 +297,6 @@ class AugmentPropertiesTest extends OpenApiTestCase
         ]);
     }
 
-    /**
-     * @param Property $property
-     * @param array $expectedValues
-     *
-     * @return void
-     */
     protected function assertName(Property $property, array $expectedValues)
     {
         foreach ($expectedValues as $key => $val) {

--- a/tests/Processors/AugmentSchemasTest.php
+++ b/tests/Processors/AugmentSchemasTest.php
@@ -4,12 +4,12 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests\Processors;
+namespace OpenApi\Tests\Processors;
 
 use OpenApi\Processors\AugmentSchemas;
 use OpenApi\Processors\MergeIntoComponents;
 use OpenApi\Processors\MergeIntoOpenApi;
-use OpenApiTests\OpenApiTestCase;
+use OpenApi\Tests\OpenApiTestCase;
 use const OpenApi\UNDEFINED;
 
 class AugmentSchemasTest extends OpenApiTestCase

--- a/tests/Processors/BuildPathsTest.php
+++ b/tests/Processors/BuildPathsTest.php
@@ -4,7 +4,7 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests\Processors;
+namespace OpenApi\Tests\Processors;
 
 use OpenApi\Analysis;
 use OpenApi\Annotations\Get;
@@ -13,7 +13,7 @@ use OpenApi\Annotations\PathItem;
 use OpenApi\Annotations\Post;
 use OpenApi\Processors\BuildPaths;
 use OpenApi\Processors\MergeIntoOpenApi;
-use OpenApiTests\OpenApiTestCase;
+use OpenApi\Tests\OpenApiTestCase;
 use const OpenApi\UNDEFINED;
 
 class BuildPathsTest extends OpenApiTestCase

--- a/tests/Processors/CleanUnmergedTest.php
+++ b/tests/Processors/CleanUnmergedTest.php
@@ -4,14 +4,14 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests\Processors;
+namespace OpenApi\Tests\Processors;
 
 use OpenApi\Analysis;
 use OpenApi\Annotations\Contact;
 use OpenApi\Annotations\License;
 use OpenApi\Processors\CleanUnmerged;
 use OpenApi\Processors\MergeIntoOpenApi;
-use OpenApiTests\OpenApiTestCase;
+use OpenApi\Tests\OpenApiTestCase;
 
 class CleanUnmergedTest extends OpenApiTestCase
 {

--- a/tests/Processors/InheritPropertiesTest.php
+++ b/tests/Processors/InheritPropertiesTest.php
@@ -4,7 +4,7 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests\Processors;
+namespace OpenApi\Tests\Processors;
 
 use OpenApi\Analysis;
 use OpenApi\Annotations\Components;
@@ -20,7 +20,7 @@ use OpenApi\Processors\InheritProperties;
 use OpenApi\Processors\InheritTraits;
 use OpenApi\Processors\MergeIntoComponents;
 use OpenApi\Processors\MergeIntoOpenApi;
-use OpenApiTests\OpenApiTestCase;
+use OpenApi\Tests\OpenApiTestCase;
 use const OpenApi\UNDEFINED;
 
 class InheritPropertiesTest extends OpenApiTestCase
@@ -36,9 +36,9 @@ class InheritPropertiesTest extends OpenApiTestCase
     {
         $analysis = $this->analysisFromFixtures(
             [
-                'InheritProperties/Child.php',
+                'AnotherNamespace/Child.php',
                 'InheritProperties/GrandAncestor.php',
-                'InheritProperties/Ancestor.php'
+                'InheritProperties/Ancestor.php',
             ]
         );
         $analysis->process([
@@ -74,9 +74,9 @@ class InheritPropertiesTest extends OpenApiTestCase
     {
         $analysis = $this->analysisFromFixtures([
             // this class has docblocks
-            'InheritProperties/ChildWithDocBlocks.php',
+            'AnotherNamespace/ChildWithDocBlocks.php',
             // this one doesn't
-            'InheritProperties/AncestorWithoutDocBlocks.php'
+            'InheritProperties/AncestorWithoutDocBlocks.php',
         ]);
         $analysis->process([
             new MergeIntoOpenApi(),
@@ -102,7 +102,7 @@ class InheritPropertiesTest extends OpenApiTestCase
     }
 
     /**
-     * Tests inherit properties with all of block
+     * Tests inherit properties with all of block.
      */
     public function testInheritPropertiesWithAllOf()
     {
@@ -141,7 +141,7 @@ class InheritPropertiesTest extends OpenApiTestCase
     }
 
     /**
-     * Tests for inherit properties without all of block
+     * Tests for inherit properties without all of block.
      */
     public function testInheritPropertiesWithOutAllOf()
     {
@@ -178,7 +178,7 @@ class InheritPropertiesTest extends OpenApiTestCase
     }
 
     /**
-     * Tests for inherit properties in object with two schemas in the same context
+     * Tests for inherit properties in object with two schemas in the same context.
      */
     public function testInheritPropertiesWitTwoChildSchemas()
     {
@@ -244,7 +244,7 @@ class InheritPropertiesTest extends OpenApiTestCase
         ]);
         $this->validate($analysis);
 
-        $analysis->openapi->info = new Info(['title' => 'test', 'version' => "1.0.0"]);
+        $analysis->openapi->info = new Info(['title' => 'test', 'version' => '1.0.0']);
         $analysis->openapi->paths = [new PathItem(['path' => '/test'])];
         $analysis->validate();
 

--- a/tests/Processors/InheritPropertiesTest.php
+++ b/tests/Processors/InheritPropertiesTest.php
@@ -173,7 +173,7 @@ class InheritPropertiesTest extends OpenApiTestCase
 
         $this->assertCount(2, $extendedSchema->allOf);
 
-        $this->assertEquals($extendedSchema->allOf[0]->ref, Components::SCHEMA_REF . 'Base');
+        $this->assertEquals($extendedSchema->allOf[0]->ref, Components::SCHEMA_REF.'Base');
         $this->assertEquals($extendedSchema->allOf[1]->properties[0]->property, 'extendedProperty');
     }
 
@@ -209,7 +209,7 @@ class InheritPropertiesTest extends OpenApiTestCase
         $this->assertSame(UNDEFINED, $extendedSchema->properties);
 
         $this->assertCount(2, $extendedSchema->allOf);
-        $this->assertEquals($extendedSchema->allOf[0]->ref, Components::SCHEMA_REF . 'Base');
+        $this->assertEquals($extendedSchema->allOf[0]->ref, Components::SCHEMA_REF.'Base');
         $this->assertEquals($extendedSchema->allOf[1]->properties[0]->property, 'nested');
         $this->assertEquals($extendedSchema->allOf[1]->properties[1]->property, 'extendedProperty');
 

--- a/tests/Processors/MergeIntoComponentsTest.php
+++ b/tests/Processors/MergeIntoComponentsTest.php
@@ -4,13 +4,13 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests\Processors;
+namespace OpenApi\Tests\Processors;
 
 use OpenApi\Analysis;
 use OpenApi\Annotations\OpenApi;
 use OpenApi\Annotations\Response;
 use OpenApi\Processors\MergeIntoComponents;
-use OpenApiTests\OpenApiTestCase;
+use OpenApi\Tests\OpenApiTestCase;
 use const OpenApi\UNDEFINED;
 
 class MergeIntoComponentsTest extends OpenApiTestCase

--- a/tests/Processors/MergeIntoOpenApiTest.php
+++ b/tests/Processors/MergeIntoOpenApiTest.php
@@ -4,13 +4,13 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests\Processors;
+namespace OpenApi\Tests\Processors;
 
 use OpenApi\Analysis;
 use OpenApi\Annotations\Info;
 use OpenApi\Annotations\OpenApi;
 use OpenApi\Processors\MergeIntoOpenApi;
-use OpenApiTests\OpenApiTestCase;
+use OpenApi\Tests\OpenApiTestCase;
 use const OpenApi\UNDEFINED;
 
 class MergeIntoOpenApiTest extends OpenApiTestCase

--- a/tests/Processors/MergeJsonContentTest.php
+++ b/tests/Processors/MergeJsonContentTest.php
@@ -4,14 +4,13 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests\Processors;
+namespace OpenApi\Tests\Processors;
 
 use OpenApi\Analysis;
 use OpenApi\Annotations\Parameter;
 use OpenApi\Annotations\Response;
-use OpenApi\Logger;
 use OpenApi\Processors\MergeJsonContent;
-use OpenApiTests\OpenApiTestCase;
+use OpenApi\Tests\OpenApiTestCase;
 use const OpenApi\UNDEFINED;
 
 class MergeJsonContentTest extends OpenApiTestCase

--- a/tests/Processors/MergeXmlContentTest.php
+++ b/tests/Processors/MergeXmlContentTest.php
@@ -4,13 +4,13 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests\Processors;
+namespace OpenApi\Tests\Processors;
 
 use OpenApi\Analysis;
 use OpenApi\Annotations\Parameter;
 use OpenApi\Annotations\Response;
 use OpenApi\Processors\MergeXmlContent;
-use OpenApiTests\OpenApiTestCase;
+use OpenApi\Tests\OpenApiTestCase;
 use const OpenApi\UNDEFINED;
 
 class MergeXmlContentTest extends OpenApiTestCase
@@ -52,7 +52,6 @@ END;
         $analysis->process(new MergeXmlContent());
         $this->assertCount(2, $response->content);
     }
-
 
     public function testParameter()
     {

--- a/tests/Processors/OperationIdTest.php
+++ b/tests/Processors/OperationIdTest.php
@@ -4,14 +4,14 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests\Processors;
+namespace OpenApi\Tests\Processors;
 
 use OpenApi\Annotations\Delete;
 use OpenApi\Annotations\Get;
 use OpenApi\Annotations\Operation;
 use OpenApi\Annotations\Post;
 use OpenApi\Processors\OperationId;
-use OpenApiTests\OpenApiTestCase;
+use OpenApi\Tests\OpenApiTestCase;
 
 class OperationIdTest extends OpenApiTestCase
 {
@@ -29,14 +29,14 @@ class OperationIdTest extends OpenApiTestCase
 
         $this->assertSame('entity/{id}', $operations[0]->path);
         $this->assertInstanceOf(Get::class, $operations[0]);
-        $this->assertSame('OpenApiTests\Fixtures\Processors\EntityControllerClass::getEntry', $operations[0]->operationId);
+        $this->assertSame('OpenApi\Tests\Fixtures\Processors\EntityControllerClass::getEntry', $operations[0]->operationId);
 
         $this->assertSame('entity/{id}', $operations[1]->path);
         $this->assertInstanceOf(Post::class, $operations[1]);
-        $this->assertSame('OpenApiTests\Fixtures\Processors\EntityControllerInterface::updateEntity', $operations[1]->operationId);
+        $this->assertSame('OpenApi\Tests\Fixtures\Processors\EntityControllerInterface::updateEntity', $operations[1]->operationId);
 
         $this->assertSame('entities/{id}', $operations[2]->path);
         $this->assertInstanceOf(Delete::class, $operations[2]);
-        $this->assertSame('OpenApiTests\Fixtures\Processors\EntityControllerTrait::deleteEntity', $operations[2]->operationId);
+        $this->assertSame('OpenApi\Tests\Fixtures\Processors\EntityControllerTrait::deleteEntity', $operations[2]->operationId);
     }
 }

--- a/tests/RefTest.php
+++ b/tests/RefTest.php
@@ -4,7 +4,7 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests;
+namespace OpenApi\Tests;
 
 use OpenApi\Analysis;
 use OpenApi\Annotations\Info;

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -1,6 +1,10 @@
 <?php declare(strict_types=1);
 
-namespace OpenApiTests;
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests;
 
 use OpenApi\Annotations;
 use OpenApi\Annotations\OpenApi;
@@ -38,11 +42,11 @@ class SerializerTest extends OpenApiTestCase
         $resp->content = [$content];
         $resp->x = [];
         $resp->x['repository'] = 'def';
-    
+
         $respRange = new Annotations\Response([]);
         $respRange->response = '4XX';
         $respRange->description = 'Client error response';
-        
+
         $path->post->responses = [$resp, $respRange];
 
         $expected = new Annotations\OpenApi([]);
@@ -151,9 +155,9 @@ JSON;
         $this->assertJsonStringEqualsJsonString(file_get_contents($spec), $openapi->toJson());
     }
 
-
     /**
      * Test for correct deserialize schemas 'allOf' property.
+     *
      * @throws \Exception
      */
     public function testDeserializeAllOfProperty()

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -149,7 +149,7 @@ JSON;
     public function testPetstoreExample()
     {
         $serializer = new Serializer();
-        $spec = __DIR__ . '/../Examples/petstore.swagger.io/petstore.swagger.io.json';
+        $spec = __DIR__.'/../Examples/petstore.swagger.io/petstore.swagger.io.json';
         $openapi = $serializer->deserializeFile($spec);
         $this->assertInstanceOf(OpenApi::class, $openapi);
         $this->assertJsonStringEqualsJsonString(file_get_contents($spec), $openapi->toJson());

--- a/tests/StaticAnalyserTest.php
+++ b/tests/StaticAnalyserTest.php
@@ -4,10 +4,9 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests;
+namespace OpenApi\Tests;
 
 use OpenApi\Analyser;
-use OpenApi\Annotations\Property;
 use OpenApi\Context;
 use OpenApi\StaticAnalyser;
 
@@ -125,24 +124,24 @@ class StaticAnalyserTest extends OpenApiTestCase
         $backup = Analyser::$whitelist;
         Analyser::$whitelist = ['OpenApi\Annotations\\'];
         $analyser = new StaticAnalyser();
-        $defaultAnalysis = $analyser->fromFile(__DIR__.'/Fixtures/ThirdPartyAnnotations.php');
+        $defaultAnalysis = $analyser->fromFile(__DIR__ . '/Fixtures/ThirdPartyAnnotations.php');
         $this->assertCount(3, $defaultAnalysis->annotations, 'Only read the @OA annotations, skip the others.');
 
         // Allow the analyser to parse 3rd party annotations, which might
         // contain useful info that could be extracted with a custom processor
-        Analyser::$whitelist[] = 'Laminas\Form\Annotation';
-        $openapi = \OpenApi\scan(__DIR__.'/Fixtures/ThirdPartyAnnotations.php');
+        Analyser::$whitelist[] = 'AnotherNamespace\Annotations';
+        $openapi = \OpenApi\scan(__DIR__ . '/Fixtures/ThirdPartyAnnotations.php');
         $this->assertSame('api/3rd-party', $openapi->paths[0]->path);
-        $this->assertCount(10, $openapi->_unmerged);
+        $this->assertCount(4, $openapi->_unmerged);
         Analyser::$whitelist = $backup;
         $analysis = $openapi->_analysis;
-        $annotations = $analysis->getAnnotationsOfType('Laminas\Form\Annotation\Name');
-        $this->assertCount(1, $annotations);
+        $annotations = $analysis->getAnnotationsOfType('AnotherNamespace\Annotations\Unrelated');
+        $this->assertCount(4, $annotations);
         $context = $analysis->getContext($annotations[0]);
         $this->assertInstanceOf('OpenApi\Context', $context);
         $this->assertSame('ThirdPartyAnnotations', $context->class);
-        $this->assertSame('\OpenApiTests\Fixtures\ThirdPartyAnnotations', $context->fullyQualifiedName($context->class));
-        $this->assertCount(2, $context->annotations);
+        $this->assertSame('\OpenApi\Tests\Fixtures\ThirdPartyAnnotations', $context->fullyQualifiedName($context->class));
+        $this->assertCount(1, $context->annotations);
     }
 
     public function testAnonymousClassProducesNoError()
@@ -156,7 +155,7 @@ class StaticAnalyserTest extends OpenApiTestCase
     }
 
     /**
-     * dataprovider
+     * dataprovider.
      */
     public function descriptions()
     {
@@ -165,18 +164,18 @@ class StaticAnalyserTest extends OpenApiTestCase
                 ['classes', 'class'],
                 'User',
                 'Parser/User.php',
-                '\OpenApiTests\Fixtures\Parser\User',
-                '\OpenApiTests\Fixtures\Parser\Sub\SubClass',
+                '\OpenApi\Tests\Fixtures\Parser\User',
+                '\OpenApi\Tests\Fixtures\Parser\Sub\SubClass',
                 ['getFirstName'],
                 null,
-                ['\OpenApiTests\Fixtures\Parser\HelloTrait'], // use ... as ...
+                ['\OpenApi\Tests\Fixtures\Parser\HelloTrait'], // use ... as ...
             ],
             'interface' => [
                 ['interfaces', 'interface'],
                 'UserInterface',
                 'Parser/UserInterface.php',
-                '\OpenApiTests\Fixtures\Parser\UserInterface',
-                ['\OpenApiTests\Fixtures\Parser\OtherInterface'],
+                '\OpenApi\Tests\Fixtures\Parser\UserInterface',
+                ['\OpenApi\Tests\Fixtures\Parser\OtherInterface'],
                 null,
                 null,
                 null,
@@ -185,11 +184,11 @@ class StaticAnalyserTest extends OpenApiTestCase
                 ['traits', 'trait'],
                 'HelloTrait',
                 'Parser/HelloTrait.php',
-                '\OpenApiTests\Fixtures\Parser\HelloTrait',
+                '\OpenApi\Tests\Fixtures\Parser\HelloTrait',
                 null,
                 null,
                 null,
-                ['\OpenApiTests\Fixtures\Parser\OtherTrait', '\OpenApiTests\Fixtures\Parser\AsTrait'],
+                ['\OpenApi\Tests\Fixtures\Parser\OtherTrait', '\OpenApi\Tests\Fixtures\Parser\AsTrait'],
             ],
         ];
     }
@@ -201,7 +200,7 @@ class StaticAnalyserTest extends OpenApiTestCase
     {
         $analysis = $this->analysisFromFixtures($fixture);
 
-        list ($pType, $sType) = $type;
+        list($pType, $sType) = $type;
         $description = $analysis->$pType[$fqdn];
 
         $this->assertSame($name, $description[$sType]);

--- a/tests/StaticAnalyserTest.php
+++ b/tests/StaticAnalyserTest.php
@@ -124,13 +124,13 @@ class StaticAnalyserTest extends OpenApiTestCase
         $backup = Analyser::$whitelist;
         Analyser::$whitelist = ['OpenApi\Annotations\\'];
         $analyser = new StaticAnalyser();
-        $defaultAnalysis = $analyser->fromFile(__DIR__ . '/Fixtures/ThirdPartyAnnotations.php');
+        $defaultAnalysis = $analyser->fromFile(__DIR__.'/Fixtures/ThirdPartyAnnotations.php');
         $this->assertCount(3, $defaultAnalysis->annotations, 'Only read the @OA annotations, skip the others.');
 
         // Allow the analyser to parse 3rd party annotations, which might
         // contain useful info that could be extracted with a custom processor
         Analyser::$whitelist[] = 'AnotherNamespace\Annotations';
-        $openapi = \OpenApi\scan(__DIR__ . '/Fixtures/ThirdPartyAnnotations.php');
+        $openapi = \OpenApi\scan(__DIR__.'/Fixtures/ThirdPartyAnnotations.php');
         $this->assertSame('api/3rd-party', $openapi->paths[0]->path);
         $this->assertCount(4, $openapi->_unmerged);
         Analyser::$whitelist = $backup;

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -10,7 +10,7 @@ class UtilTest extends OpenApiTestCase
 {
     public function testExclude()
     {
-        $openapi = \OpenApi\scan(__DIR__ . '/Fixtures', [
+        $openapi = \OpenApi\scan(__DIR__.'/Fixtures', [
             'exclude' => [
                 'Customer.php',
                 'CustomerInterface.php',

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -4,13 +4,13 @@
  * @license Apache 2.0
  */
 
-namespace OpenApiTests;
+namespace OpenApi\Tests;
 
 class UtilTest extends OpenApiTestCase
 {
     public function testExclude()
     {
-        $openapi = \OpenApi\scan(__DIR__.'/Fixtures', [
+        $openapi = \OpenApi\scan(__DIR__ . '/Fixtures', [
             'exclude' => [
                 'Customer.php',
                 'CustomerInterface.php',
@@ -20,7 +20,7 @@ class UtilTest extends OpenApiTestCase
                 'Processors',
                 'UsingRefs.php',
                 'UsingPhpDoc.php',
-            ]
+            ],
         ]);
         $this->assertSame('Fixture for ParserTest', $openapi->info->title, 'No errors about duplicate @OA\Info() annotations');
     }


### PR DESCRIPTION
Switch to [php-cs-fixer](https://github.com/FriendsOfPhp/PHP-CS-Fixer) for code style checks.
* there are a lot more options
* it allows to fix things automatically

This branch also includes some namespace cleanup for tests and fixtures that used to annoy PHPStorm...