### PR TITLE
Improve OAS3 compatibility

### DIFF
--- a/Examples/example-object/example-object.php
+++ b/Examples/example-object/example-object.php
@@ -25,7 +25,7 @@ use OpenApi\Annotations as OA;
  *                     property="name",
  *                     type="string"
  *                 ),
- *                 example={"id": 10, "name": "Jessica Smith"}
+ *                 example={"id": "a3fb6", "name": "Jessica Smith"}
  *             )
  *         )
  *     ),

--- a/Examples/example-object/example-object.yaml
+++ b/Examples/example-object/example-object.yaml
@@ -17,7 +17,7 @@ paths:
                   type: string
               type: object
               example:
-                id: 10
+                id: a3fb6
                 name: 'Jessica Smith'
       responses:
         '200':

--- a/Examples/misc/misc.yaml
+++ b/Examples/misc/misc.yaml
@@ -21,7 +21,6 @@ paths:
           in: query
           content:
             application/json:
-              mediaType: application/json
               schema:
                 properties:
                   type: { type: string }

--- a/Examples/petstore-3.0/petstore-3.0.yaml
+++ b/Examples/petstore-3.0/petstore-3.0.yaml
@@ -595,8 +595,6 @@ components:
           type: integer
           format: int64
         category:
-          title: Category
-          description: 'Category relation'
           $ref: '#/components/schemas/Category'
         name:
           title: 'Pet name'

--- a/Examples/using-interfaces/ProductController.php
+++ b/Examples/using-interfaces/ProductController.php
@@ -9,6 +9,15 @@ class ProductController
      * @OA\Get(
      *   tags={"Products"},
      *   path="/products/{id}",
+     *   @OA\Parameter(
+     *     description="ID of product to return",
+     *     in="path",
+     *     name="id",
+     *     required=true,
+     *     @OA\Schema(
+     *       type="string"
+     *     )
+     *   ),
      *   @OA\Response(
      *       response="default",
      *       description="successful operation",

--- a/Examples/using-interfaces/using-interfaces-inherit.yaml
+++ b/Examples/using-interfaces/using-interfaces-inherit.yaml
@@ -8,6 +8,14 @@ paths:
       tags:
         - Products
       operationId: 'UsingInterfaces\ProductController::getProduct'
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID of product to return'
+          required: true
+          schema:
+            type: string
       responses:
         default:
           description: 'successful operation'

--- a/Examples/using-interfaces/using-interfaces-merge.yaml
+++ b/Examples/using-interfaces/using-interfaces-merge.yaml
@@ -8,6 +8,14 @@ paths:
       tags:
         - Products
       operationId: 'UsingInterfaces\ProductController::getProduct'
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID of product to return'
+          required: true
+          schema:
+            type: string
       responses:
         default:
           description: 'successful operation'

--- a/Examples/using-refs/ProductController.php
+++ b/Examples/using-refs/ProductController.php
@@ -30,7 +30,7 @@ class ProductController
      * @OA\Patch(
      *   tags={"Products"},
      *   path="/products/{product_id}",
-     *   @OA\Parameter(ref="#/components/requestBodies/product_in_body"),
+     *   @OA\RequestBody(ref="#/components/requestBodies/product_in_body"),
      *   @OA\Response(
      *       response="default",
      *       description="successful operation",

--- a/Examples/using-refs/using-refs.yaml
+++ b/Examples/using-refs/using-refs.yaml
@@ -19,9 +19,8 @@ paths:
       tags:
         - Products
       operationId: 'UsingRefs\ProductController::updateProduct'
-      parameters:
-        -
-          $ref: '#/components/requestBodies/product_in_body'
+      requestBody:
+        $ref: '#/components/requestBodies/product_in_body'
       responses:
         default:
           description: 'successful operation'

--- a/Examples/using-traits/DeleteEntity.php
+++ b/Examples/using-traits/DeleteEntity.php
@@ -13,6 +13,15 @@ trait DeleteEntity {
      * @OA\Delete(
      *   tags={"Entities"},
      *   path="/entities/{id}",
+     *   @OA\Parameter(
+     *     description="ID of entity to delete",
+     *     in="path",
+     *     name="id",
+     *     required=true,
+     *     @OA\Schema(
+     *       type="string"
+     *     )
+     *   ),
      *   @OA\Response(
      *       response="default",
      *       description="successful operation"

--- a/Examples/using-traits/ProductController.php
+++ b/Examples/using-traits/ProductController.php
@@ -13,6 +13,15 @@ class ProductController
      * @OA\Get(
      *   tags={"Products"},
      *   path="/products/{product_id}",
+     *   @OA\Parameter(
+     *     description="ID of product to return",
+     *     in="path",
+     *     name="product_id",
+     *     required=true,
+     *     @OA\Schema(
+     *       type="string"
+     *     )
+     *   ),
      *   @OA\Response(
      *       response="default",
      *       description="successful operation"

--- a/Examples/using-traits/using-traits-inherit.yaml
+++ b/Examples/using-traits/using-traits-inherit.yaml
@@ -8,6 +8,14 @@ paths:
       tags:
         - Entities
       operationId: 'UsingTraits\DeleteEntity::deleteEntity'
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID of entity to delete'
+          required: true
+          schema:
+            type: string
       responses:
         default:
           description: 'successful operation'
@@ -16,6 +24,14 @@ paths:
       tags:
         - Products
       operationId: 'UsingTraits\ProductController::getProduct'
+      parameters:
+        -
+          name: product_id
+          in: path
+          description: 'ID of product to return'
+          required: true
+          schema:
+            type: string
       responses:
         default:
           description: 'successful operation'

--- a/Examples/using-traits/using-traits-merge.yaml
+++ b/Examples/using-traits/using-traits-merge.yaml
@@ -8,6 +8,14 @@ paths:
       tags:
         - Entities
       operationId: 'UsingTraits\DeleteEntity::deleteEntity'
+      parameters:
+        -
+          name: id
+          in: path
+          description: 'ID of entity to delete'
+          required: true
+          schema:
+            type: string
       responses:
         default:
           description: 'successful operation'
@@ -16,6 +24,14 @@ paths:
       tags:
         - Products
       operationId: 'UsingTraits\ProductController::getProduct'
+      parameters:
+        -
+          name: product_id
+          in: path
+          description: 'ID of product to return'
+          required: true
+          schema:
+            type: string
       responses:
         default:
           description: 'successful operation'

--- a/src/Annotations/AbstractAnnotation.php
+++ b/src/Annotations/AbstractAnnotation.php
@@ -317,7 +317,7 @@ abstract class AbstractAnnotation implements JsonSerializable
                 } else {
                     $key = $item->$keyField;
                     if ($key !== UNDEFINED && empty($object->$key)) {
-                        if (method_exists($item, 'jsonSerialize')) {
+                        if ($item instanceof JsonSerializable) {
                             $object->$key = $item->jsonSerialize();
                         } else {
                             $object->$key = $item;
@@ -330,9 +330,8 @@ abstract class AbstractAnnotation implements JsonSerializable
         }
         // $ref
         if (isset($data->ref)) {
-            $dollarRef = '$ref';
-            $data->$dollarRef = $data->ref;
-            unset($data->ref);
+            // OAS 3.0 does not allow $ref to have siblings: http://spec.openapis.org/oas/v3.0.3#fixed-fields-18
+            $data = (object) ['$ref' => $data->ref];
         }
 
         return $data;

--- a/src/Processors/MergeJsonContent.php
+++ b/src/Processors/MergeJsonContent.php
@@ -36,15 +36,15 @@ class MergeJsonContent
             if ($parent->content === UNDEFINED) {
                 $parent->content = [];
             }
-            $parent->content['application/json'] = new MediaType(
-                [
-                'mediaType' => 'application/json',
+            $parent->content['application/json'] = new MediaType([
                 'schema' => $jsonContent,
                 'example' => $jsonContent->example,
                 'examples' => $jsonContent->examples,
                 '_context' => new Context(['generated' => true], $jsonContent->_context),
-                ]
-            );
+            ]);
+            if (!$parent instanceof Parameter) {
+                $parent->content['application/json']->mediaType = 'application/json';
+            }
             $jsonContent->example = UNDEFINED;
             $jsonContent->examples = UNDEFINED;
 

--- a/src/Processors/MergeXmlContent.php
+++ b/src/Processors/MergeXmlContent.php
@@ -36,15 +36,15 @@ class MergeXmlContent
             if ($parent->content === UNDEFINED) {
                 $parent->content = [];
             }
-            $parent->content['application/xml'] = new MediaType(
-                [
-                    'mediaType' => 'application/xml',
-                    'schema' => $xmlContent,
-                    'example' => $xmlContent->example,
-                    'examples' => $xmlContent->examples,
-                    '_context' => new Context(['generated' => true], $xmlContent->_context),
-                ]
-            );
+            $parent->content['application/xml'] = new MediaType([
+                'schema' => $xmlContent,
+                'example' => $xmlContent->example,
+                'examples' => $xmlContent->examples,
+                '_context' => new Context(['generated' => true], $xmlContent->_context),
+            ]);
+            if (!$parent instanceof Parameter) {
+                $parent->content['application/xml']->mediaType = 'application/xml';
+            }
             $xmlContent->example = UNDEFINED;
             $xmlContent->examples = UNDEFINED;
 

--- a/tests/OpenApiTestCase.php
+++ b/tests/OpenApiTestCase.php
@@ -109,9 +109,11 @@ class OpenApiTestCase extends TestCase
 
         if (is_iterable($expected) && is_iterable($spec)) {
             foreach ($expected as $key => $value) {
+                $this->assertArrayHasKey($key, (array) $spec);
                 $this->assertSpecEquals($value, ((array) $spec)[$key], $message, true);
             }
             foreach ($spec as $key => $value) {
+                $this->assertArrayHasKey($key, (array) $expected);
                 $this->assertSpecEquals(((array) $expected)[$key], $value, $message, true);
             }
         } else {

--- a/tests/Processors/MergeJsonContentTest.php
+++ b/tests/Processors/MergeJsonContentTest.php
@@ -58,7 +58,7 @@ END;
         $comment = <<<END
             @OA\Parameter(name="filter",in="query", @OA\JsonContent(
                 @OA\Property(property="type", type="string"),
-                @OA\Property(property="color", type="string"),
+                @OA\Property(property="color", type="string")
             ))
 END;
         $analysis = new Analysis($this->parseComment($comment));
@@ -72,7 +72,7 @@ END;
         $json = json_decode(json_encode($parameter), true);
         $this->assertSame('query', $json['in']);
         $this->assertSame('application/json', array_keys($json['content'])[0]);
-        $this->assertSame('application/json', $json['content']['application/json']['mediaType']);
+        $this->assertArrayNotHasKey('mediaType', $json['content']['application/json']);
     }
 
     public function testNoParent()

--- a/tests/Processors/MergeXmlContentTest.php
+++ b/tests/Processors/MergeXmlContentTest.php
@@ -58,7 +58,7 @@ END;
         $comment = <<<END
             @OA\Parameter(name="filter",in="query", @OA\XmlContent(
                 @OA\Property(property="type", type="string"),
-                @OA\Property(property="color", type="string"),
+                @OA\Property(property="color", type="string")
             ))
 END;
         $analysis = new Analysis($this->parseComment($comment));
@@ -72,7 +72,7 @@ END;
         $json = json_decode(json_encode($parameter), true);
         $this->assertSame('query', $json['in']);
         $this->assertSame('application/xml', array_keys($json['content'])[0]);
-        $this->assertSame('application/xml', $json['content']['application/xml']['mediaType']);
+        $this->assertArrayNotHasKey('mediaType', $json['content']['application/xml']);
     }
 
     public function testNoParent()


### PR DESCRIPTION
Minor changes that make the generated spec more OAS3 conformant.Improve conforming to the OAS3 specs.

Using https://github.com/stoplightio/spectral to fix issues with test annotations and code:

```
for ff in `find Examples -name *.yaml`; do spectral lint $ff; done
```
