### PR TITLE
Map custom nested

### DIFF
--- a/src/Annotations/AbstractAnnotation.php
+++ b/src/Annotations/AbstractAnnotation.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types = 1);
+<?php declare(strict_types=1);
 
 /**
  * @license Apache 2.0
@@ -353,6 +353,7 @@ abstract class AbstractAnnotation implements JsonSerializable
             return true;
         }
         $valid = true;
+
         // Report orphaned annotations
         foreach ($this->_unmerged as $annotation) {
             if (!is_object($annotation)) {
@@ -376,8 +377,8 @@ abstract class AbstractAnnotation implements JsonSerializable
             }
             $valid = false;
         }
-        // Report conflicting key
 
+        // Report conflicting key
         foreach (static::$_nested as $annotationClass => $nested) {
             if (is_string($nested) || count($nested) === 1) {
                 continue;
@@ -402,7 +403,8 @@ abstract class AbstractAnnotation implements JsonSerializable
             }
         }
         if (property_exists($this, 'ref') && $this->ref !== UNDEFINED) {
-            if (substr($this->ref, 0, 2) === '#/' && count($parents) > 0  && $parents[0] instanceof OpenApi) { // Internal reference
+            if (substr($this->ref, 0, 2) === '#/' && count($parents) > 0 && $parents[0] instanceof OpenApi) {
+                // Internal reference
                 try {
                     $parents[0]->ref($this->ref);
                 } catch (Exception $exception) {
@@ -431,6 +433,7 @@ abstract class AbstractAnnotation implements JsonSerializable
                 }
             }
         }
+
         // Report invalid types
         foreach (static::$_types as $property => $type) {
             $value = $this->$property;
@@ -506,6 +509,34 @@ abstract class AbstractAnnotation implements JsonSerializable
     public function identity()
     {
         return $this->_identity([]);
+    }
+
+    /**
+     * Find matching nested details.
+     *
+     * @param string $class the class to match
+     *
+     * @return null|object key/value object or `null`
+     */
+    public static function matchNested($class)
+    {
+        if (array_key_exists($class, static::$_nested)) {
+            return (object) ['key' => $class, 'value' => static::$_nested[$class]];
+        }
+
+        $parent = $class;
+        while ($parent = get_parent_class($parent)) {
+            if ($kvp = static::matchNested($parent)) {
+                return $kvp;
+            }
+
+            // only consider the immediate OpenApi parent
+            if (0 === strpos($parent, 'OpenApi\\Annotations\\')) {
+                return null;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/src/Annotations/OpenApi.php
+++ b/src/Annotations/OpenApi.php
@@ -202,9 +202,9 @@ class OpenApi extends AbstractAnnotation
             }
             $mapping = [];
             if ($container instanceof AbstractAnnotation) {
-                foreach ($container::$_nested as $className => $nested) {
+                foreach ($container::$_nested as $nestedClass => $nested) {
                     if (is_string($nested) === false && count($nested) === 2 && $nested[0] === $property) {
-                        $mapping[$className] = $nested[1];
+                        $mapping[$nestedClass] = $nested[1];
                     }
                 }
             }
@@ -214,9 +214,9 @@ class OpenApi extends AbstractAnnotation
             if (array_key_exists($property, $container)) {
                 return self::resolveRef($ref, $unresolved, $container[$property], []);
             }
-            foreach ($mapping as $className => $keyField) {
+            foreach ($mapping as $nestedClass => $keyField) {
                 foreach ($container as $key => $item) {
-                    if (is_numeric($key) && is_object($item) && $item instanceof $className && (string) $item->$keyField === $property) {
+                    if (is_numeric($key) && is_object($item) && $item instanceof $nestedClass && (string) $item->$keyField === $property) {
                         return self::resolveRef($ref, $unresolved, $item, []);
                     }
                 }

--- a/src/Processors/InheritProperties.php
+++ b/src/Processors/InheritProperties.php
@@ -81,7 +81,7 @@ class InheritProperties
 
         $defaultValues = get_class_vars(Schema::class);
         foreach (array_keys(get_object_vars($currentSchema)) as $property) {
-            $childSchema->{$property} = $defaultValues[$property];
+            $childSchema->$property = $defaultValues[$property];
         }
 
         $childSchema->schema = $currentSchema->schema;

--- a/src/Processors/MergeIntoComponents.php
+++ b/src/Processors/MergeIntoComponents.php
@@ -22,10 +22,10 @@ class MergeIntoComponents
             $components = new Components([]);
             $components->_context->generated = true;
         }
-        $classes = array_keys(Components::$_nested);
+
         foreach ($analysis->annotations as $annotation) {
-            $class = get_class($annotation);
-            if (in_array($class, $classes) && $annotation->_context->is('nested') === false) { // A top level annotation.
+            if (Components::matchNested(get_class($annotation)) && $annotation->_context->is('nested') === false) {
+                // A top level annotation.
                 $components->merge([$annotation], true);
                 $analysis->openapi->components = $components;
             }

--- a/src/Processors/MergeIntoOpenApi.php
+++ b/src/Processors/MergeIntoOpenApi.php
@@ -27,7 +27,6 @@ class MergeIntoOpenApi
 
         // Merge annotations into the target openapi
         $merge = [];
-        $classes = array_keys(OpenApi::$_nested);
         foreach ($analysis->annotations as $annotation) {
             if ($annotation === $openapi) {
                 continue;
@@ -44,8 +43,8 @@ class MergeIntoOpenApi
                         $openapi->paths[] = $path;
                     }
                 }
-            } elseif (in_array(get_class($annotation), $classes) && property_exists($annotation, '_context') && $annotation->_context->is('nested') === false) { // A top level annotation.
-                // Also merge @OA\Info, @OA\Server and other directly nested annotations.
+            } elseif (OpenApi::matchNested(get_class($annotation)) && property_exists($annotation, '_context') && $annotation->_context->is('nested') === false) {
+                // A top level annotation.
                 $merge[] = $annotation;
             }
         }

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -150,11 +150,12 @@ class Serializer
         }
 
         // property is embedded annotation
-        foreach ($annotation::$_nested as $class => $declaration) {
+        // note: this does not support custom nested annotation classes
+        foreach ($annotation::$_nested as $nestedClass => $declaration) {
             // property is an annotation
             if (is_string($declaration) && $declaration === $property) {
                 if (is_object($value)) {
-                    return $this->doDeserialize($value, $class);
+                    return $this->doDeserialize($value, $nestedClass);
                 } else {
                     return $value;
                 }
@@ -164,7 +165,7 @@ class Serializer
             if (is_array($declaration) && count($declaration) === 1 && $declaration[0] === $property) {
                 $annotationArr = [];
                 foreach ($value as $v) {
-                    $annotationArr[] = $this->doDeserialize($v, $class);
+                    $annotationArr[] = $this->doDeserialize($v, $nestedClass);
                 }
 
                 return $annotationArr;
@@ -175,7 +176,7 @@ class Serializer
                 $key = $declaration[1];
                 $annotationHash = [];
                 foreach ($value as $k => $v) {
-                    $annotation = $this->doDeserialize($v, $class);
+                    $annotation = $this->doDeserialize($v, $nestedClass);
                     $annotation->$key = $k;
                     $annotationHash[$k] = $annotation;
                 }

--- a/tests/Annotations/AbstractAnnotationTest.php
+++ b/tests/Annotations/AbstractAnnotationTest.php
@@ -6,6 +6,9 @@
 
 namespace OpenApi\Tests\Annotations;
 
+use OpenApi\Annotations\Get;
+use OpenApi\Annotations\Parameter;
+use OpenApi\Annotations\Schema;
 use OpenApi\Tests\OpenApiTestCase;
 
 class AbstractAnnotationTest extends OpenApiTestCase
@@ -102,4 +105,39 @@ END;
 //        $this->assertOpenApiLogEntryStartsWith('@OA\Parameter(name=123,in="dunno")->type must be "string", "number", "integer", "boolean", "array", "file" when @OA\Parameter()->in != "body" in ');
         $parameter->validate();
     }
+
+    public function nestedMatches()
+    {
+        $parameterMatch = (object) ['key' => Parameter::class, 'value' => ['parameters']];
+
+        return [
+            'unknown' => ['Foo', null],
+            'simple-match' => [Parameter::class, $parameterMatch],
+            'invalid-annotation' => [Schema::class, null],
+            'sub-annotation' => [SubParameter::class, $parameterMatch],
+            'sub-sub-annotation' => [SubSubParameter::class, $parameterMatch],
+            'sub-invalid' => [SubSchema::class, null],
+        ];
+    }
+
+    /**
+     * @dataProvider nestedMatches
+     */
+    public function testMatchNested($class, $expected)
+    {
+        $this->assertEquals($expected, Get::matchNested($class));
+//        $this->assertEquals((object)['key' => Parameter::class, 'value' => ['parameters']], Get::matchNested(SubParameter::class));
+    }
+}
+
+class SubSchema extends Schema
+{
+}
+
+class SubParameter extends Parameter
+{
+}
+
+class SubSubParameter extends Parameter
+{
 }

--- a/tests/Annotations/AbstractAnnotationTest.php
+++ b/tests/Annotations/AbstractAnnotationTest.php
@@ -126,7 +126,6 @@ END;
     public function testMatchNested($class, $expected)
     {
         $this->assertEquals($expected, Get::matchNested($class));
-//        $this->assertEquals((object)['key' => Parameter::class, 'value' => ['parameters']], Get::matchNested(SubParameter::class));
     }
 }
 
@@ -138,6 +137,6 @@ class SubParameter extends Parameter
 {
 }
 
-class SubSubParameter extends Parameter
+class SubSubParameter extends SubParameter
 {
 }

--- a/tests/Annotations/ValidateRelationsTest.php
+++ b/tests/Annotations/ValidateRelationsTest.php
@@ -22,8 +22,8 @@ class ValidateRelationsTest extends OpenApiTestCase
     {
         foreach ($class::$_parents as $parent) {
             $found = false;
-            foreach (array_keys($parent::$_nested) as $nested) {
-                if ($nested === $class) {
+            foreach (array_keys($parent::$_nested) as $nestedClass) {
+                if ($nestedClass === $class) {
                     $found = true;
                     break;
                 }
@@ -41,16 +41,16 @@ class ValidateRelationsTest extends OpenApiTestCase
      */
     public function testNested($class)
     {
-        foreach (array_keys($class::$_nested) as $nested) {
+        foreach (array_keys($class::$_nested) as $nestedClass) {
             $found = false;
-            foreach ($nested::$_parents as $parent) {
+            foreach ($nestedClass::$_parents as $parent) {
                 if ($parent === $class) {
                     $found = true;
                     break;
                 }
             }
             if ($found === false) {
-                $this->fail($class.' not found in '.$nested."::\$parent. Found:\n  ".implode("\n  ", $nested::$_parents));
+                $this->fail($class.' not found in '.$nestedClass."::\$parent. Found:\n  ".implode("\n  ", $nestedClass::$_parents));
             }
         }
     }

--- a/tests/OpenApiTestCase.php
+++ b/tests/OpenApiTestCase.php
@@ -204,7 +204,7 @@ class OpenApiTestCase extends TestCase
                 continue;
             }
             $class = $entry->getBasename('.php');
-            if (in_array($class, ['AbstractAnnotation','Operation'])) {
+            if (in_array($class, ['AbstractAnnotation', 'Operation'])) {
                 continue;
             }
             $classes[] = ['OpenApi\\Annotations\\'.$class];

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -201,4 +201,13 @@ JSON;
             $this->assertSame('#/components/schemas/SomeSchema', $allOfItem->ref);
         }
     }
+
+    /**
+     * @dataProvider allAnnotationClasses
+     */
+    public function testValidAnnotationsListComplete($annotation)
+    {
+        $staticProperties = (new \ReflectionClass((Serializer::class)))->getStaticProperties();
+        $this->assertArrayHasKey($annotation, array_flip($staticProperties['VALID_ANNOTATIONS']));
+    }
 }


### PR DESCRIPTION
Alternative PR to #815 which improves on the actual matching.

Refactor of $_nested processing to allow custom nested annotations to work out-of-the-box.
Part of some more clean up in preparation for a more modular internal setup...
Also fixes an issue someone commented on a while back, however I cannot seem to find it any more :/