### PR TITLE
Fix constant resolution in files with namespaces

### DIFF
--- a/src/StaticAnalyser.php
+++ b/src/StaticAnalyser.php
@@ -349,6 +349,8 @@ class StaticAnalyser
 
             if ($token[0] === T_NAMESPACE) {
                 $parseContext->namespace = $this->parseNamespace($tokens, $token, $parseContext);
+                $imports['__NAMESPACE__'] = $parseContext->namespace;
+                $analyser->docParser->setImports($imports);
                 continue;
             }
 

--- a/tests/Fixtures/Parser/User.php
+++ b/tests/Fixtures/Parser/User.php
@@ -6,11 +6,15 @@ use OpenApi\Tests\Fixtures\Parser\HelloTrait as Hello;
 use OpenApi\Tests\Fixtures\Parser\Sub\SubClass as ParentClass;
 
 /**
- * @OA\Schema()
+ * @OA\Schema(
+ *     example=User::CONSTANT,
+ * )
  */
 class User extends ParentClass implements \OpenApi\Tests\Fixtures\Parser\UserInterface
 {
     use Hello;
+
+    const CONSTANT = 'value';
 
     /**
      * {@inheritDoc}

--- a/tests/StaticAnalyserTest.php
+++ b/tests/StaticAnalyserTest.php
@@ -7,8 +7,10 @@
 namespace OpenApi\Tests;
 
 use OpenApi\Analyser;
+use OpenApi\Annotations\Schema;
 use OpenApi\Context;
 use OpenApi\StaticAnalyser;
+use OpenApi\Tests\Fixtures\Parser\User;
 
 class StaticAnalyserTest extends OpenApiTestCase
 {
@@ -216,5 +218,14 @@ class StaticAnalyserTest extends OpenApiTestCase
         if (null !== $traits) {
             $this->assertSame($traits, $description['traits']);
         }
+    }
+
+    public function testNamespacedConstAccess()
+    {
+        $analysis = $this->analysisFromFixtures('Parser/User.php');
+        $schemas = $analysis->getAnnotationsOfType(Schema::class, true);
+
+        $this->assertCount(1, $schemas);
+        $this->assertEquals(User::CONSTANT, $schemas[0]->example);
     }
 }


### PR DESCRIPTION
Presumably closes #851 by setting the special import key `__NAMESPACE__` that is considered by the `DocParser` during constant resolution.

The problem specified in #851 is tested for by a modification of `Parser/User.php` fixture, in which a class constant is referenced to provide an example value in `@Schema` class annotation.