### PR TITLE
Fix T_ATTRIBUTE

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -25,6 +25,9 @@ if (!defined('T_NAME_QUALIFIED')) {
 if (!defined('T_NAME_FULLY_QUALIFIED')) {
     define('T_NAME_FULLY_QUALIFIED', -5);
 }
+if (!defined('T_ATTRIBUTE')) {
+    define('T_ATTRIBUTE', -6);
+}
 
 if (function_exists('OpenApi\scan') === false) {
     /**


### PR DESCRIPTION
So, this PR fixes issue similar to https://github.com/zircote/swagger-php/issues/839, https://github.com/zircote/swagger-php/pull/837, https://github.com/nikic/PHP-Parser/pull/706 but after bumping to `nikic/php-parser:4.10.0` and `zircote/swagger-php:3.1.0` the error occurs with the token `T_ATTRIBUTE`. See comment (https://github.com/nikic/PHP-Parser/pull/706#issuecomment-696002603)