### PR TITLE
Validate that @OA\Items parent has type "array"

### DIFF
--- a/src/Annotations/Items.php
+++ b/src/Annotations/Items.php
@@ -46,18 +46,13 @@ class Items extends Schema
         if (in_array($this, $skip, true)) {
             return true;
         }
+
         $valid = parent::validate($parents, $skip);
-        if ($this->ref === UNDEFINED) {
-            $parent = end($parents);
-            if (is_object($parent) && ($parent instanceof Parameter && $parent->in !== 'body' || $parent instanceof Header)) {
-                // This is a "Items Object" https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#items-object
-                // A limited subset of JSON-Schema's items object.
-                $allowedTypes = ['string', 'number', 'integer', 'boolean', 'array'];
-                if (in_array($this->type, $allowedTypes) === false) {
-                    Logger::notice('@OA\Items()->type="'.$this->type.'" not allowed inside a '.$parent->_identity([]).' must be "'.implode('", "', $allowedTypes).'" in '.$this->_context);
-                    $valid = false;
-                }
-            }
+
+        $parent = end($parents);
+        if ($parent instanceof Schema && $parent->type !== 'array') {
+            Logger::notice('@OA\Items() parent type must be "array" in '.$this->_context);
+            $valid = false;
         }
 
         return $valid;

--- a/tests/AnalyserTest.php
+++ b/tests/AnalyserTest.php
@@ -6,8 +6,22 @@
 
 namespace OpenApi\Tests;
 
+use OpenApi\Analyser;
+
 class AnalyserTest extends OpenApiTestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Analyser::$defaultImports['swg'] = 'OpenApi\Annotations';
+    }
+
+    protected function tearDown(): void
+    {
+        unset(Analyser::$defaultImports['swg']);
+        parent::tearDown();
+    }
+
     public function testParseContents()
     {
         $annotations = $this->parseComment('@OA\Parameter(description="This is my parameter")');
@@ -19,7 +33,6 @@ class AnalyserTest extends OpenApiTestCase
 
     public function testDeprecatedAnnotationWarning()
     {
-        $this->countExceptions = 1;
         $this->assertOpenApiLogEntryContains('The annotation @SWG\Definition() is deprecated.');
         $this->parseComment('@SWG\Definition()');
     }

--- a/tests/Annotations/ItemsTest.php
+++ b/tests/Annotations/ItemsTest.php
@@ -25,12 +25,10 @@ class ItemsTest extends OpenApiTestCase
         $annotations[0]->validate();
     }
 
-    public function testTypeObject()
+    public function testParentTypeArray()
     {
-        $this->countExceptions = 1;
-        $notAllowedInQuery = $this->parseComment('@OA\Parameter(name="param",in="query",@OA\Schema(type="array",@OA\Items(type="object")))');
-        $this->assertOpenApiLogEntryContains('@OA\Items()->type="object" not allowed inside a @OA\Parameter() must be "string", "number", "integer", "boolean", "array" in ');
-        $notAllowedInQuery[0]->validate();
+        $annotations = $this->parseComment('@OA\Items() parent type must be "array"');
+        $annotations[0]->validate();
     }
 
     public function testRefDefinitionInProperty()


### PR DESCRIPTION
Adds validation the the `Items` annotation to check that the parent is of type `"array"`.

Also includes some cleanup of defunct tests and cleanup...

Fixes #846.