### PR TITLE
Handle multiple @OA\Examples the same everywhere

### DIFF
--- a/Examples/misc/misc-api.php
+++ b/Examples/misc/misc-api.php
@@ -28,3 +28,21 @@
  *      )
  * )
  */
+
+/**
+ * @OA\Response(
+ *     response=200,
+ *     description="",
+ *     @OA\MediaType(
+ *          mediaType="application/json",
+ *          type="object",
+ *          @OA\Schema(
+ *              @OA\Property(property="name", type="integer", description="demo")
+ *          ),
+ *          @OA\Examples(example=200,value={"name":1}),
+ *          @OA\Examples(example=300,value={"name":1}),
+ *          @OA\Examples(example=400,value={"name":1})
+ *     )
+ *   )
+ */
+

--- a/Examples/misc/misc.yaml
+++ b/Examples/misc/misc.yaml
@@ -29,3 +29,26 @@ paths:
       responses:
         '200':
           description: Success
+components:
+  responses:
+    '200':
+      description: ''
+      content:
+        application/json:
+          schema:
+            properties:
+              name:
+                description: demo
+                type: integer
+            type: object
+          examples:
+            '200':
+              value:
+                name: 1
+            '300':
+              value:
+                name: 1
+            '400':
+              value:
+                name: 1
+          type: object

--- a/src/Annotations/MediaType.php
+++ b/src/Annotations/MediaType.php
@@ -59,7 +59,7 @@ class MediaType extends AbstractAnnotation
      */
     public static $_nested = [
         Schema::class => 'schema',
-        Examples::class => ['examples'],
+        Examples::class => ['examples', 'example'],
     ];
     /**
      * {@inheritdoc}

--- a/src/Annotations/Parameter.php
+++ b/src/Annotations/Parameter.php
@@ -211,7 +211,7 @@ class Parameter extends AbstractAnnotation
      */
     public static $_nested = [
         Schema::class => 'schema',
-        Examples::class => ['examples'],
+        Examples::class => ['examples', 'example'],
     ];
 
     /**


### PR DESCRIPTION
Make `MediaType` and `Parameter` resolve examples the same way as `Components`.

Fixes #869