### PR TITLE
Add ability to include multiple other directories

### DIFF
--- a/bin/openapi
+++ b/bin/openapi
@@ -13,6 +13,7 @@ error_reporting(E_ALL);
 $options = [
     'output' => false,
     'format' => 'auto',
+    'include' => [],
     'exclude' => [],
     'pattern' => '*.php',
     'bootstrap' => false,
@@ -22,6 +23,7 @@ $options = [
 ];
 $aliases = [
     'o' => 'output',
+    'i' => 'include',
     'e' => 'exclude',
     'n' => 'pattern',
     'b' => 'bootstrap',
@@ -33,6 +35,7 @@ $aliases = [
 $needsArgument = [
     'output',
     'format',
+    'include',
     'exclude',
     'pattern',
     'bootstrap',
@@ -104,8 +107,10 @@ Usage: openapi [--option value] [/path/to/project ...]
 Options:
   --output (-o)     Path to store the generated documentation.
                     ex: --output openapi.yaml
-  --exclude (-e)    Exclude path(s).
-                    ex: --exclude vendor,library/Zend
+  --exclude (-e)    Exclude path(s) or files.
+                    ex: --exclude library/Zend
+  --include (-i)    Include additional path(s).
+                    ex: --include vendor/specific-package
   --pattern (-n)    Pattern of files to scan.
                     ex: --pattern "*.php" or --pattern "/\.(phps|php)$/"
   --bootstrap (-b)  Bootstrap a php file for defining constants, etc.
@@ -215,6 +220,17 @@ if ($options['exclude']) {
     }
 }
 
+$include = null;
+if ($options['include']) {
+    $include = $options['include'];
+    if (strpos($include[0], ',') !== false) {
+        $exploded = explode(',', $include[0]);
+        error_log(COLOR_RED . 'Comma-separated include paths are deprecated, use multiple --include statements: --include ' . $exploded[0] . ' --include ' . $exploded[1]) . COLOR_STOP;
+        $include[0] = array_shift($exploded);
+        $include = array_merge($include, $exploded);
+    }
+}
+
 $pattern = "*.php";
 if ($options['pattern']) {
     $pattern = $options['pattern'];
@@ -230,7 +246,7 @@ foreach ($options["processor"] as $processor) {
     Analysis::registerProcessor($processor);
 }
 
-$openapi = OpenApi\scan($paths, ['exclude' => $exclude, 'pattern' => $pattern]);
+$openapi = OpenApi\scan($paths, ['exclude' => $exclude, 'include' => $include, 'pattern' => $pattern]);
 
 if ($exit !== 0) {
     error_log('');

--- a/src/Util.php
+++ b/src/Util.php
@@ -61,11 +61,12 @@ class Util
      *
      * @param array|Finder|string $directory The directory(s) or filename(s)
      * @param null|array|string   $exclude   The directory(s) or filename(s) to exclude (as absolute or relative paths)
+     * @param null|array|string   $include   The directory(s) to include (as absolute paths) in addition to the root directory
      * @param null|string         $pattern   The pattern of the files to scan
      *
      * @throws InvalidArgumentException
      */
-    public static function finder($directory, $exclude = null, $pattern = null): Finder
+    public static function finder($directory, $exclude = null, $include = null, $pattern = null): Finder
     {
         if ($directory instanceof Finder) {
             return $directory;
@@ -95,10 +96,31 @@ class Util
         } else {
             throw new InvalidArgumentException('Unexpected $directory value:'.gettype($directory));
         }
+
+        if (is_string($include)) {
+            $include = [$include];
+        }
+
+        if (is_string($exclude)) {
+            $exclude = [$exclude];
+        }
+
+        if ($include !== null && $exclude !== null && !empty(array_intersect($include, $exclude))) {
+            throw new InvalidArgumentException('Cannot include and exclude the same paths.');
+        }
+
+        if ($include !== null) {
+            if (is_array($include)) {
+                foreach ($include as $path) {
+                    $finder->in(Util::getRelativePath($path, $directory));
+                }
+            } else {
+                throw new InvalidArgumentException('Unexpected $include value:'.gettype($include));
+            }
+        }
+
         if ($exclude !== null) {
-            if (is_string($exclude)) {
-                $finder->notPath(Util::getRelativePath($exclude, $directory));
-            } elseif (is_array($exclude)) {
+            if (is_array($exclude)) {
                 foreach ($exclude as $path) {
                     $finder->notPath(Util::getRelativePath($path, $directory));
                 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -46,10 +46,11 @@ if (function_exists('OpenApi\scan') === false) {
         $analysis = array_key_exists('analysis', $options) ? $options['analysis'] : new Analysis();
         $processors = array_key_exists('processors', $options) ? $options['processors'] : Analysis::processors();
         $exclude = array_key_exists('exclude', $options) ? $options['exclude'] : null;
+        $include = array_key_exists('include', $options) ? $options['include'] : null;
         $pattern = array_key_exists('pattern', $options) ? $options['pattern'] : null;
 
         // Crawl directory and parse all files
-        $finder = Util::finder($directory, $exclude, $pattern);
+        $finder = Util::finder($directory, $exclude, $include, $pattern);
         foreach ($finder as $file) {
             $analysis->addAnalysis($analyser->fromFile($file->getPathname()));
         }

--- a/tests/AdditionalFixtures/Person.php
+++ b/tests/AdditionalFixtures/Person.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+// NOTE: this file uses "\r\n" linebreaks on purpose
+
+namespace OpenApi\Tests\AdditionalFixtures;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Info(title="Fixture for Inclusion Test", version="test")
+ * @OA\Schema()
+ */
+class Person
+{
+
+    /**
+     * The first name of the customer.
+     *
+     * @var string
+     *
+     * @example John
+     * @OA\Property()
+     */
+    public $firstname;
+
+    /**
+     * @var null|string The second name of the customer.
+     *
+     * @example Allan
+     * @OA\Property()
+     */
+    public $secondname;
+
+    /**
+     * The third name of the customer.
+     *
+     * @var null|string
+     *
+     * @example Peter
+     * @OA\Property()
+     */
+    public $thirdname;
+
+    /**
+     * The unknown name of the customer.
+     *
+     * @var null|unknown
+     *
+     * @example Unknown
+     * @OA\Property()
+     */
+    public $fourthname;
+
+    /**
+     * @var string The lastname of the customer.
+     * @OA\Property()
+     */
+    public $lastname;
+}

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -6,6 +6,7 @@
 
 namespace OpenApi\Tests;
 
+use InvalidArgumentException;
 use OpenApi\Util;
 
 class UtilTest extends OpenApiTestCase
@@ -25,6 +26,52 @@ class UtilTest extends OpenApiTestCase
             ],
         ]);
         $this->assertSame('Fixture for ParserTest', $openapi->info->title, 'No errors about duplicate @OA\Info() annotations');
+    }
+
+    public function testInclude()
+    {
+        $openapi = \OpenApi\scan(__DIR__.'/Fixtures', [
+            'exclude' => [
+                'Customer.php',
+                'CustomerInterface.php',
+                'ThirdPartyAnnotations.php',
+                'GrandAncestor.php',
+                'InheritProperties',
+                'Parser',
+                'Processors',
+                'UsingRefs.php',
+                'UsingPhpDoc.php',
+            ],
+            'include' => [
+                __DIR__.'/AdditionalFixtures',
+            ],
+        ]);
+
+        $this->assertSame('Fixture for Inclusion Test', $openapi->info->title, 'No errors about duplicate @OA\Info() annotations');
+    }
+
+    public function testIncludeAndExclude()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot include and exclude the same paths.');
+
+        \OpenApi\scan(__DIR__.'/Fixtures', [
+            'exclude' => [
+                'Customer.php',
+                'CustomerInterface.php',
+                'ThirdPartyAnnotations.php',
+                'GrandAncestor.php',
+                'InheritProperties',
+                'Parser',
+                'Processors',
+                'UsingRefs.php',
+                'UsingPhpDoc.php',
+                __DIR__.'/AdditionalFixtures',
+            ],
+            'include' => [
+                __DIR__.'/AdditionalFixtures',
+            ],
+        ]);
     }
 
     public function testRefEncode()


### PR DESCRIPTION
### Description
A small change that allows 1-* additional directories to be specified using the `--include` param. In addition to the `--exclude` option this offers a granular way of specifying exactly what should be scanned.



#### Background
The project that we are currently configuring swagger-php within includes an API client package for a downstream API, all the models are defined there and we'd like to create schemas and reference them within our API. 

We came across the problem that we couldn't just include our package without the entire contents of the vendor folder, therefore we built this option so we can simply specify our package to include. We figured this could be useful for others in similar situations also!


