### PR TITLE
Fix misc example annotations

### DIFF
--- a/Examples/misc/misc-api.php
+++ b/Examples/misc/misc-api.php
@@ -35,13 +35,12 @@
  *     description="",
  *     @OA\MediaType(
  *          mediaType="application/json",
- *          type="object",
  *          @OA\Schema(
  *              @OA\Property(property="name", type="integer", description="demo")
  *          ),
- *          @OA\Examples(example=200,value={"name":1}),
- *          @OA\Examples(example=300,value={"name":1}),
- *          @OA\Examples(example=400,value={"name":1})
+ *          @OA\Examples(example=200, summary="", value={"name":1}),
+ *          @OA\Examples(example=300, summary="", value={"name":1}),
+ *          @OA\Examples(example=400, summary="", value={"name":1})
  *     )
  *   )
  */

--- a/Examples/misc/misc.yaml
+++ b/Examples/misc/misc.yaml
@@ -43,12 +43,14 @@ components:
             type: object
           examples:
             '200':
+              summary: ''
               value:
                 name: 1
             '300':
+              summary: ''
               value:
                 name: 1
             '400':
+              summary: ''
               value:
                 name: 1
-          type: object

--- a/tests/ExamplesTest.php
+++ b/tests/ExamplesTest.php
@@ -6,8 +6,6 @@
 
 namespace OpenApi\Tests;
 
-use OpenApi\Logger;
-
 class ExamplesTest extends OpenApiTestCase
 {
     public function exampleMappings()
@@ -34,9 +32,6 @@ class ExamplesTest extends OpenApiTestCase
      */
     public function testExamples($example, $spec)
     {
-        Logger::getInstance()->log = function ($entry, $type) {
-            // ignore
-        };
         $path = __DIR__.'/../Examples/'.$example;
         $openapi = \OpenApi\scan($path, []);
         $this->assertSpecEquals(file_get_contents($path.'/'.$spec), $openapi, 'Examples/'.$example.'/'.$spec);


### PR DESCRIPTION
Turns out the `Examples` annotation requires a `summary` property...

This also re-enables the check for logged warnings/errors in the `ExamplesTest`