### PR TITLE
Changed the Util finder method to force a provided instance of Finder…

### DIFF
--- a/src/Util.php
+++ b/src/Util.php
@@ -68,7 +68,8 @@ class Util
     public static function finder($directory, $exclude = null, $pattern = null): Finder
     {
         if ($directory instanceof Finder) {
-            return $directory;
+            // Make sure that the provided Finder only finds files and follows symbolic links.
+            return $directory->files()->followLinks();
         } else {
             $finder = new Finder();
             $finder->sortByName();

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -7,6 +7,7 @@
 namespace OpenApi\Tests;
 
 use OpenApi\Util;
+use Symfony\Component\Finder\Finder;
 
 class UtilTest extends OpenApiTestCase
 {
@@ -35,5 +36,20 @@ class UtilTest extends OpenApiTestCase
     public function testRefDecode()
     {
         $this->assertSame('/blogs/{blog_id}/new~posts', Util::refDecode('~1blogs~1{blog_id}~1new~0posts'));
+    }
+
+    public function testFinder()
+    {
+        // Create a finder for one of the example directories that has a subdirectory.
+        $finder = (new Finder())->in(__DIR__.'/../Examples/using-traits');
+        $this->assertGreaterThan(0, iterator_count($finder), 'There should be at least a few files and a directory.');
+        $finder_array = \iterator_to_array($finder);
+        $directory_path = __DIR__.'/../Examples/using-traits/Decoration';
+        $this->assertArrayHasKey($directory_path, $finder_array, 'The directory should be a path in the finder.');
+        // Use the Util method that should set the finder to only find files, since swagger-php only needs files.
+        $finder_result = Util::finder($finder);
+        $this->assertGreaterThan(0, iterator_count($finder_result), 'There should be at least a few file paths.');
+        $finder_result_array = \iterator_to_array($finder_result);
+        $this->assertArrayNotHasKey($directory_path, $finder_result_array, 'The directory should not be a path in the finder.');
     }
 }


### PR DESCRIPTION
I used the option of passing an instance of Finder to the Util::finder method, since it made selecting multiple directories easy.  It took me a while to figure out why StaticAnalyser->fromFile(...) kept throwing an error because file_get_contents() was being executed on a directory.  To save other developers the time of figuring out that they have to set the Finder to only include paths for files, I figured that I would change Util::finder a little to enforce that, since the scan function is only expecting files anyway. I created a unit test to confirm that my change had the desired effect.