### PR TITLE
Don't crash when ref is null

### DIFF
--- a/src/Annotations/AbstractAnnotation.php
+++ b/src/Annotations/AbstractAnnotation.php
@@ -396,7 +396,7 @@ abstract class AbstractAnnotation implements \JsonSerializable
                 }
             }
         }
-        if (property_exists($this, 'ref') && $this->ref !== UNDEFINED) {
+        if (property_exists($this, 'ref') && $this->ref !== UNDEFINED && $this->ref !== null) {
             if (substr($this->ref, 0, 2) === '#/' && count($parents) > 0 && $parents[0] instanceof OpenApi) {
                 // Internal reference
                 try {


### PR DESCRIPTION
If ref is set to null, then generating documentation will cause an exception: `substr() expects parameter 1 to be string, null given` on line 400
This happens for example in `nelmio/api-doc-bundle` when you ref from annotation defined documentation to one stored in config files.

This change will fix the problem by handling null the same as undefined values.