### PR TITLE
Oo api

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,35 @@ Visit the [Documentation website](https://zircote.github.io/swagger-php/) for th
 
 Generate always-up-to-date documentation.
 
+#### Using the traditional `scan()` method 
 ```php
 <?php
 require("vendor/autoload.php");
+
 $openapi = \OpenApi\scan('/path/to/project');
+header('Content-Type: application/x-yaml');
+echo $openapi->toYaml();
+```
+#### Using the `Generator` class 
+```php
+<?php
+require("vendor/autoload.php");
+
+$openapi = (new \OpenApi\Generator())
+    // StaticAnalyser is the default
+    ->setAnalyser(new \OpenApi\StaticAnalyser())
+    // same as setting Analyser::$defaultImports
+    ->setNamespaceAliases([
+        'oa' => 'OpenApi\Annotations',
+        'my' => 'My\Annotations',
+    ])
+    // same as setting Analyser::$whitelist
+    ->getNamespaceWhitelist([
+        'OpenApi\Annotations\\',
+        'My\Annotations\\',
+    ])
+    // recursively scan path for `.php` files excluding *tests*
+    ->scan(\OpenApi\Util::finder('/path/to/project', 'tests', '*.php'));
 header('Content-Type: application/x-yaml');
 echo $openapi->toYaml();
 ```

--- a/bin/openapi
+++ b/bin/openapi
@@ -150,7 +150,6 @@ set_error_handler(function ($errno, $errstr, $file, $line) use ($errorTypes, $op
         return; // This error code is not included in error_reporting
     }
     $type = array_key_exists($errno, $errorTypes) ? $errorTypes[$errno] : 'Error';
-    $color = (substr($type, 0, 5) === 'Error') ? COLOR_RED: COLOR_YELLOW;
     error_log(COLOR_RED.$type. ': '.$errstr.COLOR_STOP);
     if ($options['debug']) {
         error_log(' in '.$file.' on line '.$line);
@@ -164,9 +163,6 @@ set_exception_handler(function ($exception) use ($options) {
         error_log($exception);
     } else {
         error_log(COLOR_RED.'Exception: '.$exception->getMessage().COLOR_STOP);
-        // if ($options['debug']) {
-        //     error_log(' in '.$exception->getFile().' on line '.$exception->getLine());
-        // }
     }
     exit($exception->getCode() ?: 1);
 });
@@ -230,7 +226,7 @@ foreach ($options["processor"] as $processor) {
     Analysis::registerProcessor($processor);
 }
 
-$openapi = OpenApi\scan($paths, ['exclude' => $exclude, 'pattern' => $pattern]);
+$openapi = OpenApi\scan($paths, ['exclude' => $exclude, 'pattern' => $pattern, 'logger' => Logger::psrInstance()]);
 
 if ($exit !== 0) {
     error_log('');

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
     "php": ">=7.2",
     "ext-json": "*",
     "doctrine/annotations": "^1.7",
+    "psr/log": "^1.1",
     "symfony/finder": ">=2.2",
     "symfony/yaml": ">=3.3"
   },

--- a/src/Analyser.php
+++ b/src/Analyser.php
@@ -7,7 +7,7 @@
 namespace OpenApi;
 
 use Doctrine\Common\Annotations\AnnotationRegistry;
-use Doctrine\Common\Annotations\DocParser;
+use OpenApi\Analyser\DocBlockParser;
 use Psr\Log\LoggerInterface;
 
 if (class_exists(AnnotationRegistry::class, true)) {
@@ -24,7 +24,7 @@ if (class_exists(AnnotationRegistry::class, true)) {
                     if (!$loaded && $namespace === 'OpenApi\\Annotations\\') {
                         if (in_array(strtolower(substr($class, 20)), ['definition', 'path'])) {
                             // Detected an 2.x annotation?
-                            throw new \Exception('The annotation @SWG\\'.substr($class, 20).'() is deprecated. Found in '.Analyser::$context."\nFor more information read the migration guide: https://github.com/zircote/swagger-php/blob/master/docs/Migrating-to-v3.md");
+                            throw new OpenApiException('The annotation @SWG\\'.substr($class, 20).'() is deprecated. Found in '.Analyser::$context."\nFor more information read the migration guide: https://github.com/zircote/swagger-php/blob/master/docs/Migrating-to-v3.md");
                         }
                     }
 
@@ -38,86 +38,29 @@ if (class_exists(AnnotationRegistry::class, true)) {
 }
 
 /**
- * Extract swagger-php annotations from a [PHPDoc](http://en.wikipedia.org/wiki/PHPDoc) using Doctrine's DocParser.
+ * @deprecated
  */
-class Analyser
+class Analyser extends DocBlockParser
 {
     /**
      * List of namespaces that should be detected by the doctrine annotation parser.
      * Set to false to load all detected classes.
      *
      * @var array|false
+     *
+     * @deprecated
      */
     public static $whitelist = ['OpenApi\\Annotations\\'];
 
     /**
      * Use @OA\* for OpenAPI annotations (unless overwritten by a use statement).
+     *
+     * @deprecated
      */
     public static $defaultImports = ['oa' => 'OpenApi\\Annotations'];
 
-    /**
-     * Allows Annotation classes to know the context of the annotation that is being processed.
-     *
-     * @var null|Context
-     */
-    public static $context;
-
-    /** @var DocParser */
-    public $docParser;
-
-    /** @var LoggerInterface A logger. */
-    protected $logger;
-
-    public function __construct(?DocParser $docParser = null, ?LoggerInterface $logger = null)
+    public function __construct(?LoggerInterface $logger = null)
     {
-        if ($docParser === null) {
-            $docParser = new DocParser();
-            $docParser->setIgnoreNotImportedAnnotations(true);
-            $docParser->setImports(static::$defaultImports);
-        }
-        $this->docParser = $docParser;
-        $this->logger = $logger ?: Logger::psrInstance();
-    }
-
-    /**
-     * Use doctrine to parse the comment block and return the detected annotations.
-     *
-     * @param string  $comment a T_DOC_COMMENT
-     * @param Context $context
-     *
-     * @return array Annotations
-     */
-    public function fromComment(string $comment, ?Context $context = null): array
-    {
-        $context = $context ?: new Context(['logger' => $this->logger]);
-        $context->comment = $comment;
-
-        $context->logger = $context->logger ?: $this->logger;
-
-        try {
-            self::$context = $context;
-            if ($context->is('annotations') === false) {
-                $context->annotations = [];
-            }
-            $annotations = $this->docParser->parse($comment, $context);
-            self::$context = null;
-
-            return $annotations;
-        } catch (\Exception $e) {
-            self::$context = null;
-            if (preg_match('/^(.+) at position ([0-9]+) in '.preg_quote((string) $context, '/').'\.$/', $e->getMessage(), $matches)) {
-                $errorMessage = $matches[1];
-                $errorPos = (int) $matches[2];
-                $atPos = strpos($comment, '@');
-                $context->line += substr_count($comment, "\n", 0, $atPos + $errorPos);
-                $lines = explode("\n", substr($comment, $atPos, $errorPos));
-                $context->character = strlen(array_pop($lines)) + 1; // position starts at 0 character starts at 1
-                $this->logger->warning(new \Exception($errorMessage.' in '.$context, $e->getCode(), $e));
-            } else {
-                $this->logger->warning($e);
-            }
-
-            return [];
-        }
+        parent::__construct(static::$defaultImports, $logger);
     }
 }

--- a/src/Analyser/DocBlockParser.php
+++ b/src/Analyser/DocBlockParser.php
@@ -1,0 +1,88 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Analyser;
+
+use Doctrine\Common\Annotations\DocParser;
+use OpenApi\Context;
+use OpenApi\Logger;
+use Psr\Log\LoggerInterface;
+
+/**
+ * PHP doc block parser.
+ *
+ * @see http://en.wikipedia.org/wiki/PHPDoc
+ */
+class DocBlockParser
+{
+    /**
+     * Current context.
+     *
+     * This is used/referenced  when doctrine instantiates annotation classes as there is no mechanism
+     * to pass the context into doctrine.
+     *
+     * @var null|Context
+     */
+    public static $context;
+
+    /** @var DocParser The doctrine doc parser. */
+    public $docParser;
+
+    /** @var LoggerInterface A logger. */
+    protected $logger;
+
+    public function __construct(array $imports = [], ?LoggerInterface $logger = null)
+    {
+        $docParser = new DocParser();
+        $docParser->setIgnoreNotImportedAnnotations(true);
+        $docParser->setImports($imports);
+        $this->docParser = $docParser;
+        $this->logger = $logger ?: Logger::psrInstance();
+    }
+
+    /**
+     * Use doctrine to parse the comment block and return the detected annotations.
+     *
+     * @param string  $comment a T_DOC_COMMENT
+     * @param Context $context
+     *
+     * @return array Annotations
+     */
+    public function fromComment(string $comment, ?Context $context = null): array
+    {
+        $context = $context ?: new Context(['logger' => $this->logger]);
+        $context->comment = $comment;
+
+        $context->logger = $context->logger ?: $this->logger;
+
+        try {
+            // share context with AbstractAnnotation constructor...
+            self::$context = $context;
+            if ($context->is('annotations') === false) {
+                $context->annotations = [];
+            }
+            $annotations = $this->docParser->parse($comment, $context);
+            self::$context = null;
+
+            return $annotations;
+        } catch (\Exception $e) {
+            self::$context = null;
+            if (preg_match('/^(.+) at position ([0-9]+) in '.preg_quote((string) $context, '/').'\.$/', $e->getMessage(), $matches)) {
+                $errorMessage = $matches[1];
+                $errorPos = (int) $matches[2];
+                $atPos = strpos($comment, '@');
+                $context->line += substr_count($comment, "\n", 0, $atPos + $errorPos);
+                $lines = explode("\n", substr($comment, $atPos, $errorPos));
+                $context->character = strlen(array_pop($lines)) + 1; // position starts at 0 character starts at 1
+                $this->logger->warning(new \Exception($errorMessage.' in '.$context, $e->getCode(), $e));
+            } else {
+                $this->logger->warning($e);
+            }
+
+            return [];
+        }
+    }
+}

--- a/src/Analysis.php
+++ b/src/Analysis.php
@@ -363,14 +363,14 @@ class Analysis
             return $annotation->_context;
         }
         if ($this->annotations->contains($annotation) === false) {
-            throw new \Exception('Annotation not found');
+            throw new OpenApiException('Annotation not found');
         }
         $context = $this->annotations[$annotation];
         if ($context instanceof Context) {
             return $context;
         }
         // Weird, did you use the addAnnotation/addAnnotations methods?
-        throw new \Exception('Annotation has no context');
+        throw new OpenApiExceptionn('Annotation has no context');
     }
 
     /**
@@ -379,7 +379,7 @@ class Analysis
     public function merged(): Analysis
     {
         if ($this->openapi === null) {
-            throw new \Exception('No openapi target set. Run the MergeIntoOpenApi processor');
+            throw new OpenApiException('No openapi target set. Run the MergeIntoOpenApi processor');
         }
         $unmerged = $this->openapi->_unmerged;
         $this->openapi->_unmerged = [];
@@ -486,7 +486,7 @@ class Analysis
         $processors = &self::processors();
         $key = array_search($processor, $processors, true);
         if ($key === false) {
-            throw new \Exception('Given processor was not registered');
+            throw new OpenApiException('Given processor was not registered');
         }
         unset($processors[$key]);
     }

--- a/src/Annotations/AbstractAnnotation.php
+++ b/src/Annotations/AbstractAnnotation.php
@@ -9,6 +9,7 @@ namespace OpenApi\Annotations;
 use OpenApi\Analyser;
 use OpenApi\Context;
 use OpenApi\Logger;
+use OpenApi\OpenApiException;
 use OpenApi\Util;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Yaml\Yaml;
@@ -452,7 +453,7 @@ abstract class AbstractAnnotation implements \JsonSerializable
                     $this->logger->notice($this->identity().'->'.$property.' "'.$value.'" is invalid, expecting "'.implode('", "', $type).'" in '.$this->_context);
                 }
             } else {
-                throw new \Exception('Invalid '.get_class($this).'::$_types['.$property.']');
+                throw new OpenApiException('Invalid '.get_class($this).'::$_types['.$property.']');
             }
         }
         $parents[] = $this;
@@ -613,7 +614,7 @@ abstract class AbstractAnnotation implements \JsonSerializable
             case 'scheme':
                 return in_array($value, ['http', 'https', 'ws', 'wss'], true);
             default:
-                throw new \Exception('Invalid type "'.$type.'"');
+                throw new OpenApiException('Invalid type "'.$type.'"');
         }
     }
 

--- a/src/Annotations/Flow.php
+++ b/src/Annotations/Flow.php
@@ -58,7 +58,7 @@ class Flow extends AbstractAnnotation
     /**
      * {@inheritdoc}
      */
-    public static $_blacklist = ['_context', '_unmerged'];
+    public static $_blacklist = ['_context', '_unmerged', 'logger'];
 
     /**
      * {@inheritdoc}

--- a/src/Annotations/Items.php
+++ b/src/Annotations/Items.php
@@ -49,7 +49,7 @@ class Items extends Schema
 
         $parent = end($parents);
         if ($parent instanceof Schema && $parent->type !== 'array') {
-            $this->logger->notice(('@OA\\Items() parent type must be "array" in '.$this->_context);
+            $this->logger->notice('@OA\\Items() parent type must be "array" in '.$this->_context);
             $valid = false;
         }
 

--- a/src/Annotations/Items.php
+++ b/src/Annotations/Items.php
@@ -6,8 +6,6 @@
 
 namespace OpenApi\Annotations;
 
-use OpenApi\Logger;
-
 /**
  * @Annotation
  * The description of an item in a Schema with type "array"
@@ -51,8 +49,21 @@ class Items extends Schema
 
         $parent = end($parents);
         if ($parent instanceof Schema && $parent->type !== 'array') {
-            Logger::notice('@OA\\Items() parent type must be "array" in '.$this->_context);
+            $this->logger->notice(('@OA\\Items() parent type must be "array" in '.$this->_context);
             $valid = false;
+        }
+
+        if ($this->ref === UNDEFINED) {
+            $parent = end($parents);
+            if (is_object($parent) && ($parent instanceof Parameter && $parent->in !== 'body' || $parent instanceof Header)) {
+                // This is a "Items Object" https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#items-object
+                // A limited subset of JSON-Schema's items object.
+                $allowedTypes = ['string', 'number', 'integer', 'boolean', 'array'];
+                if (in_array($this->type, $allowedTypes) === false) {
+                    $this->logger->notice('@OA\Items()->type="'.$this->type.'" not allowed inside a '.$parent->_identity([]).' must be "'.implode('", "', $allowedTypes).'" in '.$this->_context);
+                    $valid = false;
+                }
+            }
         }
 
         return $valid;

--- a/src/Annotations/OpenApi.php
+++ b/src/Annotations/OpenApi.php
@@ -7,6 +7,7 @@
 namespace OpenApi\Annotations;
 
 use OpenApi\Analysis;
+use OpenApi\OpenApiException;
 use OpenApi\Util;
 
 /**
@@ -149,7 +150,7 @@ class OpenApi extends AbstractAnnotation
             $content = $this->toYaml();
         }
         if (file_put_contents($filename, $content) === false) {
-            throw new \Exception('Failed to saveAs("'.$filename.'", "'.$format.'")');
+            throw new OpenApiException('Failed to saveAs("'.$filename.'", "'.$format.'")');
         }
     }
 
@@ -162,7 +163,7 @@ class OpenApi extends AbstractAnnotation
     {
         if (substr($ref, 0, 2) !== '#/') {
             // @todo Add support for external (http) refs?
-            throw new \Exception('Unsupported $ref "'.$ref.'", it should start with "#/"');
+            throw new OpenApiException('Unsupported $ref "'.$ref.'", it should start with "#/"');
         }
 
         return $this->resolveRef($ref, '#/', $this, []);
@@ -185,7 +186,7 @@ class OpenApi extends AbstractAnnotation
 
         if (is_object($container)) {
             if (property_exists($container, $property) === false) {
-                throw new \Exception('$ref "'.$ref.'" not found');
+                throw new OpenApiException('$ref "'.$ref.'" not found');
             }
             if ($slash === false) {
                 return $container->$property;
@@ -212,6 +213,6 @@ class OpenApi extends AbstractAnnotation
                 }
             }
         }
-        throw new \Exception('$ref "'.$unresolved.'" not found');
+        throw new OpenApiException('$ref "'.$unresolved.'" not found');
     }
 }

--- a/src/Annotations/OpenApi.php
+++ b/src/Annotations/OpenApi.php
@@ -7,7 +7,6 @@
 namespace OpenApi\Annotations;
 
 use OpenApi\Analysis;
-use OpenApi\Logger;
 use OpenApi\Util;
 
 /**
@@ -98,7 +97,7 @@ class OpenApi extends AbstractAnnotation
     /**
      * {@inheritdoc}
      */
-    public static $_blacklist = ['_context', '_unmerged', '_analysis'];
+    public static $_blacklist = ['_context', '_unmerged', '_analysis', 'logger'];
 
     /**
      * {@inheritdoc}
@@ -128,7 +127,7 @@ class OpenApi extends AbstractAnnotation
     public function validate(array $parents = null, array $skip = null, string $ref = ''): bool
     {
         if ($parents !== null || $skip !== null || $ref !== '') {
-            Logger::notice('Nested validation for '.$this->identity().' not allowed');
+            $this->logger->notice('Nested validation for '.$this->identity().' not allowed');
 
             return false;
         }

--- a/src/Annotations/Operation.php
+++ b/src/Annotations/Operation.php
@@ -6,8 +6,6 @@
 
 namespace OpenApi\Annotations;
 
-use OpenApi\Logger;
-
 /**
  * @Annotation
  * Base class for the @OA\Get(),  @OA\Post(),  @OA\Put(),  @OA\Delete(), @OA\Patch(), etc
@@ -193,7 +191,7 @@ abstract class Operation extends AbstractAnnotation
         if ($this->responses !== UNDEFINED) {
             foreach ($this->responses as $response) {
                 if ($response->response !== UNDEFINED && $response->response !== 'default' && preg_match('/^([12345]{1}[0-9]{2})|([12345]{1}XX)$/', (string) $response->response) === 0) {
-                    Logger::notice('Invalid value "'.$response->response.'" for '.$response->_identity([]).'->response, expecting "default", a HTTP Status Code or HTTP Status Code range definition in '.$response->_context);
+                    $this->logger->notice('Invalid value "'.$response->response.'" for '.$response->_identity([]).'->response, expecting "default", a HTTP Status Code or HTTP Status Code range definition in '.$response->_context);
                 }
             }
         }

--- a/src/Annotations/Parameter.php
+++ b/src/Annotations/Parameter.php
@@ -6,8 +6,6 @@
 
 namespace OpenApi\Annotations;
 
-use OpenApi\Logger;
-
 /**
  * @Annotation
  * [A "Parameter Object": https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#parameter-object
@@ -243,7 +241,7 @@ class Parameter extends AbstractAnnotation
         if ($this->ref === UNDEFINED) {
             if ($this->in === 'body') {
                 if ($this->schema === UNDEFINED) {
-                    Logger::notice('Field "schema" is required when '.$this->identity().' is in "'.$this->in.'" in '.$this->_context);
+                    $this->logger->notice('Field "schema" is required when '.$this->identity().' is in "'.$this->in.'" in '.$this->_context);
                     $valid = false;
                 }
             }

--- a/src/Annotations/Schema.php
+++ b/src/Annotations/Schema.php
@@ -6,8 +6,6 @@
 
 namespace OpenApi\Annotations;
 
-use OpenApi\Logger;
-
 /**
  * @Annotation
  * The definition of input and output data types.
@@ -372,7 +370,7 @@ class Schema extends AbstractAnnotation
     public function validate(array $parents = [], array $skip = [], string $ref = ''): bool
     {
         if ($this->type === 'array' && $this->items === UNDEFINED) {
-            Logger::notice('@OA\\Items() is required when '.$this->identity().' has type "array" in '.$this->_context);
+            $this->logger->notice('@OA\\Items() is required when '.$this->identity().' has type "array" in '.$this->_context);
 
             return false;
         }

--- a/src/Context.php
+++ b/src/Context.php
@@ -6,6 +6,8 @@
 
 namespace OpenApi;
 
+use Psr\Log\LoggerInterface;
+
 /**
  * Context.
  *
@@ -20,6 +22,7 @@ namespace OpenApi;
  *      |- propertyContext
  *      |- methodContext
  *
+ * @property LoggerInterface                  $logger
  * @property string                           $comment  The PHP DocComment
  * @property string                           $filename
  * @property int                              $line
@@ -58,6 +61,9 @@ class Context
             $this->$property = $value;
         }
         $this->_parent = $parent;
+        if (!$this->logger || $this->logger === UNDEFINED) {
+            $this->logger = Logger::psrInstance();
+        }
     }
 
     /**
@@ -246,9 +252,9 @@ class Context
     /**
      * Create a Context based on the debug_backtrace.
      */
-    public static function detect(int $index = 0): Context
+    public static function detect(int $index = 0, ?LoggerInterface $logger = null): Context
     {
-        $context = new Context();
+        $context = new Context(['logger' => $logger]);
         $backtrace = debug_backtrace();
         $position = $backtrace[$index];
         if (isset($position['file'])) {

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -38,7 +38,7 @@ class Generator
 
     public function getAnalyser(): StaticAnalyser
     {
-        return $this->analyser ?: new StaticAnalyser($this->logger);
+        return $this->analyser ?: new StaticAnalyser(null, $this->logger);
     }
 
     public function setAnalyser(StaticAnalyser $analyser): Generator

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -28,12 +28,6 @@ class Generator
     /** @var null|callable[] List of configured processors. */
     protected $processors = null;
 
-    /** @var null|array Annotation namespace whitelist. */
-    protected $namespaceWhitelist = null;
-
-    /** @var null|array Annotation namespace aliases. */
-    protected $namespaceAliases = null;
-
     /** @var LoggerInterface The configured logger. */
     protected $logger;
 
@@ -68,30 +62,6 @@ class Generator
     public function setProcessors(?array $processors): Generator
     {
         $this->processors = $processors;
-
-        return $this;
-    }
-
-    public function getNamespaceWhitelist(): ?array
-    {
-        return null !== $this->namespaceWhitelist ? $this->namespaceWhitelist : Analyser::$whitelist;
-    }
-
-    public function setNamespaceWhitelist(?array $namespaceWhitelist): Generator
-    {
-        $this->namespaceWhitelist = $namespaceWhitelist;
-
-        return $this;
-    }
-
-    public function getNamespaceAliases(): ?array
-    {
-        return null !== $this->namespaceAliases ? $this->namespaceAliases : Analyser::$defaultImports;
-    }
-
-    public function setNamespaceAliases(?array $namespaceAliases): Generator
-    {
-        $this->namespaceAliases = $namespaceAliases;
 
         return $this;
     }

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -1,0 +1,147 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi;
+
+use OpenApi\Annotations\OpenApi;
+use Psr\Log\LoggerInterface;
+
+/**
+ * OpenApi spec generator.
+ *
+ * Scans PHP source code and generates OpenApi specifications from the found OpenApi annotations.
+ *
+ * This is an object oriented alternative to using the `\OpenApi\scan()` function and static class properties
+ * of the `Analyzer` and `Analysis` classes.
+ */
+class Generator
+{
+    /** @var string Special value to differentiate between null and undefined. */
+    public const UNDEFINED = '@OA\UNDEFINED🙈';
+
+    /** @var StaticAnalyser The configured analyzer. */
+    protected $analyser;
+
+    /** @var null|callable[] List of configured processors. */
+    protected $processors = null;
+
+    /** @var null|array Annotation namespace whitelist. */
+    protected $namespaceWhitelist = null;
+
+    /** @var null|array Annotation namespace aliases. */
+    protected $namespaceAliases = null;
+
+    /** @var LoggerInterface The configured logger. */
+    protected $logger;
+
+    public function __construct(?LoggerInterface $logger = null)
+    {
+        $this->logger = $logger ?: Logger::psrInstance();
+    }
+
+    public function getAnalyser(): StaticAnalyser
+    {
+        return $this->analyser ?: new StaticAnalyser($this->logger);
+    }
+
+    public function setAnalyser(StaticAnalyser $analyser): Generator
+    {
+        $this->analyser = $analyser;
+
+        return $this;
+    }
+
+    /**
+     * @return callable[]
+     */
+    public function getProcessors(): array
+    {
+        return null !== $this->processors ? $this->processors : Analysis::processors($this->logger);
+    }
+
+    /**
+     * @param null|callable[] $processors
+     */
+    public function setProcessors(?array $processors): Generator
+    {
+        $this->processors = $processors;
+
+        return $this;
+    }
+
+    public function getNamespaceWhitelist(): ?array
+    {
+        return null !== $this->namespaceWhitelist ? $this->namespaceWhitelist : Analyser::$whitelist;
+    }
+
+    public function setNamespaceWhitelist(?array $namespaceWhitelist): Generator
+    {
+        $this->namespaceWhitelist = $namespaceWhitelist;
+
+        return $this;
+    }
+
+    public function getNamespaceAliases(): ?array
+    {
+        return null !== $this->namespaceAliases ? $this->namespaceAliases : Analyser::$defaultImports;
+    }
+
+    public function setNamespaceAliases(?array $namespaceAliases): Generator
+    {
+        $this->namespaceAliases = $namespaceAliases;
+
+        return $this;
+    }
+
+    /**
+     * Scan the given source files.
+     *
+     * @param iterable $sources filenames (`string`) or \SplFileInfo
+     */
+    public function scan(iterable $sources, bool $validate = true, ?Analysis $analysis = null): OpenApi
+    {
+        // preserve originals
+        $whitelist = Analyser::$whitelist;
+        $defaultImports = Analyser::$defaultImports;
+
+        try {
+            $analysis = $analysis ?: new Analysis([], null, $this->logger);
+
+            $this->scanSources($sources, $analysis);
+
+            // post processing
+            $analysis->process($this->getProcessors());
+        } finally {
+            // restore originals
+            Analyser::$whitelist = $whitelist;
+            Analyser::$defaultImports = $defaultImports;
+        }
+
+        // validation
+        if ($validate) {
+            $analysis->validate();
+        }
+
+        return $analysis->openapi;
+    }
+
+    public function scanSources(iterable $sources, Analysis $analysis): void
+    {
+        $analyser = $this->getAnalyser();
+        foreach ($sources as $source) {
+            if (is_iterable($source)) {
+                $this->scanSources($source, $analysis);
+            } else {
+                $source = $source instanceof \SplFileInfo ? $source->getPathname() : realpath($source);
+                if (is_dir($source)) {
+                    $this->scanSources(Util::finder($source), $analysis);
+                } else {
+                    $analysis->addAnalysis($analyser->fromFile($source));
+                }
+            }
+        }
+    }
+}

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -71,7 +71,7 @@ class Generator
      *
      * @param iterable $sources filenames (`string`) or \SplFileInfo
      */
-    public function scan(iterable $sources, bool $validate = true, ?Analysis $analysis = null): OpenApi
+    public function scan(iterable $sources, ?Analysis $analysis = null, bool $validate = true): OpenApi
     {
         // preserve originals
         $whitelist = Analyser::$whitelist;

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -7,6 +7,9 @@
 namespace OpenApi;
 
 use Exception;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 
 /**
  * Logger reports the parser and validation messages.
@@ -21,7 +24,7 @@ class Logger
     public static $instance;
 
     /**
-     * @var callable
+     * @var callable|LoggerInterface
      */
     public $log;
 
@@ -48,8 +51,23 @@ class Logger
         return self::$instance;
     }
 
+    public static function psrInstance(): LoggerInterface
+    {
+        return new class() extends AbstractLogger {
+            public function log($level, $message, array $context = [])
+            {
+                // BC: delegate to the static instance
+                if (in_array($level, [LogLevel::NOTICE, LogLevel::INFO, LogLevel::DEBUG])) {
+                    Logger::notice($message);
+                } else {
+                    Logger::warning($message);
+                }
+            }
+        };
+    }
+
     /**
-     * Log a OpenApi warning.
+     * Log an OpenApi warning.
      *
      * @param Exception|string $entry
      */
@@ -59,7 +77,7 @@ class Logger
     }
 
     /**
-     * Log a OpenApi notice.
+     * Log an OpenApi notice.
      *
      * @param Exception|string $entry
      */

--- a/src/OpenApiException.php
+++ b/src/OpenApiException.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi;
+
+/**
+ * Generic OpenApi exception.
+ */
+class OpenApiException extends \Exception
+{
+}

--- a/src/Processors/AbstractProcessor.php
+++ b/src/Processors/AbstractProcessor.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Processors;
+
+use OpenApi\Logger;
+use Psr\Log\LoggerInterface;
+
+class AbstractProcessor
+{
+    /** @var LoggerInterface A logger. */
+    protected $logger;
+
+    public function __construct(?LoggerInterface $logger = null)
+    {
+        $this->logger = $logger ?: Logger::psrInstance();
+    }
+}

--- a/src/Processors/AugmentParameters.php
+++ b/src/Processors/AugmentParameters.php
@@ -11,7 +11,7 @@ use OpenApi\Analysis;
 /**
  * Use the parameter->name as keyfield (parameter->parameter) when used as reusable component (openapi->components->parameters).
  */
-class AugmentParameters
+class AugmentParameters extends AbstractProcessor
 {
     public function __invoke(Analysis $analysis)
     {

--- a/src/Processors/AugmentProperties.php
+++ b/src/Processors/AugmentProperties.php
@@ -17,7 +17,7 @@ use OpenApi\Util;
 /**
  * Use the property context to extract useful information and inject that into the annotation.
  */
-class AugmentProperties
+class AugmentProperties extends AbstractProcessor
 {
     public static $types = [
         'array' => 'array',
@@ -88,10 +88,13 @@ class AugmentProperties
                         if ($property->ref === UNDEFINED && $typeMatches[2] === '' && array_key_exists($key, $refs)) {
                             if ($isNullable) {
                                 $property->oneOf = [
-                                    new Schema([
-                                        '_context' => $property->_context,
-                                        'ref' => $refs[$key],
-                                    ]),
+                                    new Schema(
+                                        [
+                                            '_context' => $property->_context,
+                                            'ref' => $refs[$key],
+                                        ],
+                                        $this->logger
+                                    ),
                                 ];
                                 $property->nullable = true;
                             } else {
@@ -114,8 +117,9 @@ class AugmentProperties
                             $property->items = new Items(
                                 [
                                     'type' => $property->type,
-                                    '_context' => new Context(['generated' => true], $context),
-                                ]
+                                    '_context' => new Context(['generated' => true, 'logger' => $this->logger], $context),
+                                ],
+                                $this->logger
                             );
                             if ($property->items->type === UNDEFINED) {
                                 $key = strtolower($context->fullyQualifiedName($type));
@@ -180,10 +184,13 @@ class AugmentProperties
     {
         if ($property->nullable === true) {
             $property->oneOf = [
-                new Schema([
-                    '_context' => $property->_context,
-                    'ref' => $ref,
-                ]),
+                new Schema(
+                    [
+                        '_context' => $property->_context,
+                        'ref' => $ref,
+                    ],
+                    $this->logger
+                ),
             ];
         } else {
             $property->ref = $ref;

--- a/src/Processors/AugmentSchemas.php
+++ b/src/Processors/AugmentSchemas.php
@@ -15,7 +15,7 @@ use OpenApi\Annotations\Schema;
  *
  * Merges properties.
  */
-class AugmentSchemas
+class AugmentSchemas extends AbstractProcessor
 {
     public function __invoke(Analysis $analysis)
     {
@@ -59,7 +59,7 @@ class AugmentSchemas
                             }
 
                             if ($schema === null) {
-                                $schema = new Schema(['_context' => $annotation->_context]);
+                                $schema = new Schema(['_context' => $annotation->_context], $this->logger);
                                 $annotation->allOf[] = $schema;
                             }
 
@@ -100,7 +100,7 @@ class AugmentSchemas
                     }
                 }
                 if (!$allOfPropertiesSchema) {
-                    $allOfPropertiesSchema = new Schema(['_context' => $schema->_context, 'properties' => []]);
+                    $allOfPropertiesSchema = new Schema(['_context' => $schema->_context, 'properties' => []], $this->logger);
                     $schema->allOf[] = $allOfPropertiesSchema;
                 }
                 $allOfPropertiesSchema->properties = array_merge($allOfPropertiesSchema->properties, $schema->properties);

--- a/src/Processors/CleanUnmerged.php
+++ b/src/Processors/CleanUnmerged.php
@@ -8,7 +8,7 @@ namespace OpenApi\Processors;
 
 use OpenApi\Analysis;
 
-class CleanUnmerged
+class CleanUnmerged extends AbstractProcessor
 {
     public function __invoke(Analysis $analysis)
     {

--- a/src/Processors/DocBlockDescriptions.php
+++ b/src/Processors/DocBlockDescriptions.php
@@ -14,7 +14,7 @@ use OpenApi\Analysis;
  * And this would be detected
  * as the description.
  */
-class DocBlockDescriptions
+class DocBlockDescriptions extends AbstractProcessor
 {
     /**
      * Checks if the annotation has a summary and/or description property

--- a/src/Processors/ExpandInterfaces.php
+++ b/src/Processors/ExpandInterfaces.php
@@ -12,7 +12,7 @@ use OpenApi\Annotations\Property;
 use OpenApi\Annotations\Schema;
 use OpenApi\Util;
 
-class ExpandInterfaces
+class ExpandInterfaces extends AbstractProcessor
 {
     public function __invoke(Analysis $analysis)
     {
@@ -39,10 +39,13 @@ class ExpandInterfaces
             $schema->allOf = [];
         }
         $refPath = $interfaceSchema->schema !== UNDEFINED ? $interfaceSchema->schema : $interface['interface'];
-        $schema->allOf[] = new Schema([
-            '_context' => $interface['context']->_context,
-            'ref' => Components::SCHEMA_REF.Util::refEncode($refPath),
-        ]);
+        $schema->allOf[] = new Schema(
+            [
+                '_context' => $interface['context']->_context,
+                'ref' => Components::SCHEMA_REF.Util::refEncode($refPath),
+            ],
+            $this->logger
+        );
     }
 
     protected function mergeInterface(Schema $schema, array $interface, array &$existing): void

--- a/src/Processors/ExpandTraits.php
+++ b/src/Processors/ExpandTraits.php
@@ -14,7 +14,7 @@ use const OpenApi\UNDEFINED;
 use OpenApi\Util;
 use Traversable;
 
-class ExpandTraits
+class ExpandTraits extends AbstractProcessor
 {
     public function __invoke(Analysis $analysis)
     {
@@ -44,10 +44,13 @@ class ExpandTraits
         if ($schema->allOf === UNDEFINED) {
             $schema->allOf = [];
         }
-        $schema->allOf[] = new Schema([
-            '_context' => $trait['context']->_context,
-            'ref' => Components::SCHEMA_REF.Util::refEncode($refPath),
-        ]);
+        $schema->allOf[] = new Schema(
+            [
+                '_context' => $trait['context']->_context,
+                'ref' => Components::SCHEMA_REF.Util::refEncode($refPath),
+            ],
+            $this->logger
+        );
     }
 
     protected function mergeTrait(Schema $schema, array $trait, array &$existing): void

--- a/src/Processors/InheritInterfaces.php
+++ b/src/Processors/InheritInterfaces.php
@@ -9,28 +9,26 @@ namespace OpenApi\Processors;
 use OpenApi\Analysis;
 use OpenApi\Annotations\Components;
 use OpenApi\Annotations\Schema;
-use const OpenApi\UNDEFINED;
 use OpenApi\Util;
 
-class InheritTraits extends AbstractProcessor
+class InheritInterfaces extends AbstractProcessor
 {
     public function __invoke(Analysis $analysis)
     {
         $schemas = $analysis->getAnnotationsOfType(Schema::class);
         foreach ($schemas as $schema) {
-            if ($schema->_context->is('class') || $schema->_context->is('trait')) {
-                $source = $schema->_context->class ?: $schema->_context->trait;
-                $traits = $analysis->getTraitsOfClass($schema->_context->fullyQualifiedName($source), true);
-                foreach ($traits as $trait) {
-                    $traitSchema = $analysis->getSchemaForSource($trait['context']->fullyQualifiedName($trait['trait']));
-                    if ($traitSchema) {
-                        $refPath = $traitSchema->schema !== UNDEFINED ? $traitSchema->schema : $trait['trait'];
+            if ($schema->_context->is('class')) {
+                $interfaces = $analysis->getInterfacesOfClass($schema->_context->fullyQualifiedName($schema->_context->class), true);
+                foreach ($interfaces as $interface) {
+                    $inferfaceSchema = $analysis->getSchemaForSource($interface['context']->fullyQualifiedName($interface['interface']));
+                    if ($inferfaceSchema) {
                         if ($schema->allOf === UNDEFINED) {
                             $schema->allOf = [];
                         }
+                        $refPath = $inferfaceSchema->schema !== UNDEFINED ? $inferfaceSchema->schema : $interface['interface'];
                         $schema->allOf[] = new Schema(
                             [
-                                '_context' => $trait['context']->_context,
+                                '_context' => $interface['context']->_context,
                                 'ref' => Components::SCHEMA_REF.Util::refEncode($refPath),
                             ],
                             $this->logger

--- a/src/Processors/InheritProperties.php
+++ b/src/Processors/InheritProperties.php
@@ -18,7 +18,7 @@ use Traversable;
 /**
  * Copy the annotated properties from parent classes;.
  */
-class InheritProperties
+class InheritProperties extends AbstractProcessor
 {
     public function __invoke(Analysis $analysis)
     {
@@ -78,7 +78,7 @@ class InheritProperties
     {
         if ($to->allOf === UNDEFINED) {
             // Move all properties into an `allOf` entry except the `schema` property.
-            $clone = new Schema(['_context' => new Context(['generated' => true], $to->_context)]);
+            $clone = new Schema(['_context' => new Context(['generated' => true, 'logger' => $this->logger], $to->_context)]);
             $clone->mergeProperties($to);
             $hasProperties = false;
             $defaultValues = get_class_vars(Schema::class);
@@ -104,10 +104,13 @@ class InheritProperties
             }
         }
         if ($append) {
-            array_unshift($to->allOf, new Schema([
-                'ref' => Components::SCHEMA_REF.Util::refEncode($from->schema),
-                '_context' => new Context(['generated' => true], $from->_context),
-            ]));
+            array_unshift($to->allOf, new Schema(
+                [
+                    'ref' => Components::SCHEMA_REF.Util::refEncode($from->schema),
+                    '_context' => new Context(['generated' => true, 'logger' => $this->logger], $from->_context),
+                ],
+                $this->logger
+            ));
         }
     }
 }

--- a/src/Processors/MergeInterfaces.php
+++ b/src/Processors/MergeInterfaces.php
@@ -11,7 +11,7 @@ use OpenApi\Annotations\Property;
 use OpenApi\Annotations\Schema;
 use Traversable;
 
-class MergeTraits extends AbstractProcessor
+class MergeInterfaces extends AbstractProcessor
 {
     public function __invoke(Analysis $analysis)
     {
@@ -19,27 +19,16 @@ class MergeTraits extends AbstractProcessor
         foreach ($schemas as $schema) {
             if ($schema->_context->is('class')) {
                 $existing = [];
-                $traits = $analysis->getTraitsOfClass($schema->_context->fullyQualifiedName($schema->_context->class));
-                foreach ($traits as $trait) {
-                    foreach ($trait['context']->annotations as $annotation) {
+                $interfaces = $analysis->getInterfacesOfClass($schema->_context->fullyQualifiedName($schema->_context->class));
+                foreach ($interfaces as $interface) {
+                    foreach ($interface['context']->annotations as $annotation) {
                         if ($annotation instanceof Property && !in_array($annotation->_context->property, $existing)) {
                             $existing[] = $annotation->_context->property;
                             $schema->merge([$annotation], true);
                         }
                     }
 
-                    foreach ($trait['properties'] as $method) {
-                        if (is_array($method->annotations) || $method->annotations instanceof Traversable) {
-                            foreach ($method->annotations as $annotation) {
-                                if ($annotation instanceof Property && !in_array($annotation->_context->property, $existing)) {
-                                    $existing[] = $annotation->_context->property;
-                                    $schema->merge([$annotation], true);
-                                }
-                            }
-                        }
-                    }
-
-                    foreach ($trait['methods'] as $method) {
+                    foreach ($interface['methods'] as $method) {
                         if (is_array($method->annotations) || $method->annotations instanceof Traversable) {
                             foreach ($method->annotations as $annotation) {
                                 if ($annotation instanceof Property && !in_array($annotation->_context->property, $existing)) {

--- a/src/Processors/MergeIntoComponents.php
+++ b/src/Processors/MergeIntoComponents.php
@@ -13,13 +13,13 @@ use OpenApi\UNDEFINED;
 /**
  * Merge reusable annotation into @OA\Schemas.
  */
-class MergeIntoComponents
+class MergeIntoComponents extends AbstractProcessor
 {
     public function __invoke(Analysis $analysis)
     {
         $components = $analysis->openapi->components;
         if ($components === UNDEFINED) {
-            $components = new Components([]);
+            $components = new Components([], $this->logger);
             $components->_context->generated = true;
         }
 

--- a/src/Processors/MergeIntoOpenApi.php
+++ b/src/Processors/MergeIntoOpenApi.php
@@ -13,14 +13,14 @@ use OpenApi\Context;
 /**
  * Merge all @OA\OpenApi annotations into one.
  */
-class MergeIntoOpenApi
+class MergeIntoOpenApi extends AbstractProcessor
 {
     public function __invoke(Analysis $analysis)
     {
         // Auto-create the OpenApi annotation.
         if (!$analysis->openapi) {
-            $context = new Context(['analysis' => $analysis]);
-            $analysis->addAnnotation(new OpenApi(['_context' => $context]), $context);
+            $context = new Context(['analysis' => $analysis, 'logger' => $this->logger]);
+            $analysis->addAnnotation(new OpenApi(['_context' => $context, 'logger' => $this->logger]), $context);
         }
         $openapi = $analysis->openapi;
         $openapi->_analysis = $analysis;

--- a/src/Processors/MergeXmlContent.php
+++ b/src/Processors/MergeXmlContent.php
@@ -13,12 +13,11 @@ use OpenApi\Annotations\RequestBody;
 use OpenApi\Annotations\Response;
 use OpenApi\Annotations\XmlContent;
 use OpenApi\Context;
-use OpenApi\Logger;
 
 /**
  * Split XmlContent into Schema and MediaType.
  */
-class MergeXmlContent
+class MergeXmlContent extends AbstractProcessor
 {
     public function __invoke(Analysis $analysis)
     {
@@ -27,21 +26,24 @@ class MergeXmlContent
             $parent = $xmlContent->_context->nested;
             if (!($parent instanceof Response) && !($parent instanceof RequestBody) && !($parent instanceof Parameter)) {
                 if ($parent) {
-                    Logger::notice('Unexpected '.$xmlContent->identity().' in '.$parent->identity().' in '.$parent->_context);
+                    $this->logger->notice('Unexpected '.$xmlContent->identity().' in '.$parent->identity().' in '.$parent->_context);
                 } else {
-                    Logger::notice('Unexpected '.$xmlContent->identity().' must be nested');
+                    $this->logger->notice('Unexpected '.$xmlContent->identity().' must be nested');
                 }
                 continue;
             }
             if ($parent->content === UNDEFINED) {
                 $parent->content = [];
             }
-            $parent->content['application/xml'] = new MediaType([
-                'schema' => $xmlContent,
-                'example' => $xmlContent->example,
-                'examples' => $xmlContent->examples,
-                '_context' => new Context(['generated' => true], $xmlContent->_context),
-            ]);
+            $parent->content['application/xml'] = new MediaType(
+                [
+                    'schema' => $xmlContent,
+                    'example' => $xmlContent->example,
+                    'examples' => $xmlContent->examples,
+                    '_context' => new Context(['generated' => true, 'logger' => $this->logger], $xmlContent->_context),
+                ],
+                $this->logger
+            );
             if (!$parent instanceof Parameter) {
                 $parent->content['application/xml']->mediaType = 'application/xml';
             }

--- a/src/Processors/OperationId.php
+++ b/src/Processors/OperationId.php
@@ -12,7 +12,7 @@ use OpenApi\Annotations\Operation;
 /**
  * Generate the OperationId based on the context of the OpenApi annotation.
  */
-class OperationId
+class OperationId extends AbstractProcessor
 {
     public function __invoke(Analysis $analysis)
     {

--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -88,7 +88,7 @@ class Serializer
         $logger = $logger ?: ($this->logger ?: Logger::psrInstance());
 
         if (!$this->isValidAnnotationClass($className)) {
-            throw new \Exception($className.' is not defined in OpenApi PHP Annotations');
+            throw new OpenApiException($className.' is not defined in OpenApi PHP Annotations');
         }
 
         return $this->doDeserialize(json_decode($jsonString), $className, $logger);
@@ -104,7 +104,7 @@ class Serializer
         $logger = $logger ?: ($this->logger ?: Logger::psrInstance());
 
         if (!$this->isValidAnnotationClass($className)) {
-            throw new \Exception($className.' is not defined in OpenApi PHP Annotations');
+            throw new OpenApiException($className.' is not defined in OpenApi PHP Annotations');
         }
 
         return $this->doDeserialize(json_decode(file_get_contents($filename)), $className, $logger);

--- a/src/StaticAnalyser.php
+++ b/src/StaticAnalyser.php
@@ -21,11 +21,16 @@ if (!defined('T_NAME_FULLY_QUALIFIED')) {
  */
 class StaticAnalyser
 {
+
+    /** @var Analyser The doc block parser. */
+    protected $analyser;
+
     /** @var LoggerInterface A logger. */
     protected $logger;
 
-    public function __construct(?LoggerInterface $logger = null)
+    public function __construct(?Analyser $analyser = null, ?LoggerInterface $logger = null)
     {
+        $this->analyser = $analyser;
         $this->logger = $logger ?: Logger::psrInstance();
     }
 
@@ -71,7 +76,7 @@ class StaticAnalyser
      */
     protected function fromTokens(array $tokens, Context $parseContext): Analysis
     {
-        $analyser = new Analyser(null, $this->logger);
+        $analyser = $this->analyser ?: new Analyser(null, $this->logger);
         $analysis = new Analysis([], null, $this->logger);
 
         reset($tokens);

--- a/src/Util.php
+++ b/src/Util.php
@@ -132,4 +132,21 @@ class Util
     {
         return str_replace('~1', '/', str_replace('~0', '~', $encoded));
     }
+
+    /**
+     * Shorten class name(s).
+     *
+     * @param array|object|string $classes Class(es) to shorten
+     *
+     * @return string|string[] One or more shortened class names
+     */
+    public static function shorten($classes)
+    {
+        $short = [];
+        foreach ((array) $classes as $class) {
+            $short[] = '@'.str_replace('OpenApi\Annotations\\', 'OA\\', $class);
+        }
+
+        return is_array($classes) ? $short : array_pop($short);
+    }
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -45,6 +45,6 @@ if (!function_exists('OpenApi\\scan')) {
         return (new Generator($logger))
             ->setAnalyser($analyser)
             ->setProcessors($processors)
-            ->scan(Util::finder($directory, $exclude, $pattern), true, $analysis);
+            ->scan(Util::finder($directory, $exclude, $pattern), $analysis);
     }
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -13,23 +13,9 @@ if (defined('OpenApi\\UNDEFINED') === false) {
     /*
      * Special value to differentiate between null and undefined.
      */
-<<<<<<< HEAD
-    define('OpenApi\\UNDEFINED', '@OA\\UNDEFINED🙈');
-    define('OpenApi\\Annotations\\UNDEFINED', UNDEFINED);
-    define('OpenApi\\Processors\\UNDEFINED', UNDEFINED);
-}
-
-// PHP 8.0
-if (!defined('T_NAME_QUALIFIED')) {
-    define('T_NAME_QUALIFIED', -4);
-}
-if (!defined('T_NAME_FULLY_QUALIFIED')) {
-    define('T_NAME_FULLY_QUALIFIED', -5);
-=======
-    define('OpenApi\UNDEFINED', Generator::UNDEFINED);
-    define('OpenApi\Annotations\UNDEFINED', Generator::UNDEFINED);
-    define('OpenApi\Processors\UNDEFINED', Generator::UNDEFINED);
->>>>>>> Add OO version of `\OpenApi\scan()`
+    define('OpenApi\\UNDEFINED', Generator::UNDEFINED);
+    define('OpenApi\\Annotations\\UNDEFINED', Generator::UNDEFINED);
+    define('OpenApi\\Processors\\UNDEFINED', Generator::UNDEFINED);
 }
 
 if (!function_exists('OpenApi\\scan')) {

--- a/src/functions.php
+++ b/src/functions.php
@@ -13,6 +13,7 @@ if (defined('OpenApi\\UNDEFINED') === false) {
     /*
      * Special value to differentiate between null and undefined.
      */
+<<<<<<< HEAD
     define('OpenApi\\UNDEFINED', '@OA\\UNDEFINED🙈');
     define('OpenApi\\Annotations\\UNDEFINED', UNDEFINED);
     define('OpenApi\\Processors\\UNDEFINED', UNDEFINED);
@@ -24,6 +25,11 @@ if (!defined('T_NAME_QUALIFIED')) {
 }
 if (!defined('T_NAME_FULLY_QUALIFIED')) {
     define('T_NAME_FULLY_QUALIFIED', -5);
+=======
+    define('OpenApi\UNDEFINED', Generator::UNDEFINED);
+    define('OpenApi\Annotations\UNDEFINED', Generator::UNDEFINED);
+    define('OpenApi\Processors\UNDEFINED', Generator::UNDEFINED);
+>>>>>>> Add OO version of `\OpenApi\scan()`
 }
 
 if (!function_exists('OpenApi\\scan')) {
@@ -37,27 +43,22 @@ if (!function_exists('OpenApi\\scan')) {
      *                                       analyser: defaults to StaticAnalyser
      *                                       analysis: defaults to a new Analysis
      *                                       processors: defaults to the registered processors in Analysis
+     *                                       logger: PSR Logger
      *
      * @return OpenApi
      */
     function scan($directory, $options = [])
     {
-        $analyser = array_key_exists('analyser', $options) ? $options['analyser'] : new StaticAnalyser();
-        $analysis = array_key_exists('analysis', $options) ? $options['analysis'] : new Analysis();
-        $processors = array_key_exists('processors', $options) ? $options['processors'] : Analysis::processors();
+        $logger = array_key_exists('logger', $options) ? $options['logger'] : Logger::psrInstance();
+        $analyser = array_key_exists('analyser', $options) ? $options['analyser'] : new StaticAnalyser($logger);
+        $analysis = array_key_exists('analysis', $options) ? $options['analysis'] : new Analysis([], null, $logger);
+        $processors = array_key_exists('processors', $options) ? $options['processors'] : Analysis::processors($logger);
         $exclude = array_key_exists('exclude', $options) ? $options['exclude'] : null;
         $pattern = array_key_exists('pattern', $options) ? $options['pattern'] : null;
 
-        // Crawl directory and parse all files
-        $finder = Util::finder($directory, $exclude, $pattern);
-        foreach ($finder as $file) {
-            $analysis->addAnalysis($analyser->fromFile($file->getPathname()));
-        }
-        // Post processing
-        $analysis->process($processors);
-        // Validation (Generate notices & warnings)
-        $analysis->validate();
-
-        return $analysis->openapi;
+        return (new Generator($logger))
+            ->setAnalyser($analyser)
+            ->setProcessors($processors)
+            ->scan(Util::finder($directory, $exclude, $pattern), true, $analysis);
     }
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -36,7 +36,7 @@ if (!function_exists('OpenApi\\scan')) {
     function scan($directory, $options = [])
     {
         $logger = array_key_exists('logger', $options) ? $options['logger'] : Logger::psrInstance();
-        $analyser = array_key_exists('analyser', $options) ? $options['analyser'] : new StaticAnalyser($logger);
+        $analyser = array_key_exists('analyser', $options) ? $options['analyser'] : new StaticAnalyser(null, $logger);
         $analysis = array_key_exists('analysis', $options) ? $options['analysis'] : new Analysis([], null, $logger);
         $processors = array_key_exists('processors', $options) ? $options['processors'] : Analysis::processors($logger);
         $exclude = array_key_exists('exclude', $options) ? $options['exclude'] : null;

--- a/tests/Analyser/DocBlockParserTest.php
+++ b/tests/Analyser/DocBlockParserTest.php
@@ -4,24 +4,13 @@
  * @license Apache 2.0
  */
 
-namespace OpenApi\Tests;
+namespace OpenApi\Tests\Analyser;
 
 use OpenApi\Analyser;
+use OpenApi\Tests\OpenApiTestCase;
 
-class AnalyserTest extends OpenApiTestCase
+class DocBlockParserTest extends OpenApiTestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-        Analyser::$defaultImports['swg'] = 'OpenApi\Annotations';
-    }
-
-    protected function tearDown(): void
-    {
-        unset(Analyser::$defaultImports['swg']);
-        parent::tearDown();
-    }
-
     public function testParseContents()
     {
         $annotations = $this->parseComment('@OA\Parameter(description="This is my parameter")');
@@ -33,7 +22,9 @@ class AnalyserTest extends OpenApiTestCase
 
     public function testDeprecatedAnnotationWarning()
     {
+        Analyser::$defaultImports['swg'] = 'OpenApi\Annotations';
         $this->assertOpenApiLogEntryContains('The annotation @SWG\Definition() is deprecated.');
         $this->parseComment('@SWG\Definition()', $this->getLogger(true));
+        unset(Analyser::$defaultImports['swg']);
     }
 }

--- a/tests/AnalyserTest.php
+++ b/tests/AnalyserTest.php
@@ -34,6 +34,6 @@ class AnalyserTest extends OpenApiTestCase
     public function testDeprecatedAnnotationWarning()
     {
         $this->assertOpenApiLogEntryContains('The annotation @SWG\Definition() is deprecated.');
-        $this->parseComment('@SWG\Definition()', $this->trackingLogger());
+        $this->parseComment('@SWG\Definition()', $this->getLogger(true));
     }
 }

--- a/tests/AnalyserTest.php
+++ b/tests/AnalyserTest.php
@@ -34,6 +34,6 @@ class AnalyserTest extends OpenApiTestCase
     public function testDeprecatedAnnotationWarning()
     {
         $this->assertOpenApiLogEntryContains('The annotation @SWG\Definition() is deprecated.');
-        $this->parseComment('@SWG\Definition()');
+        $this->parseComment('@SWG\Definition()', $this->trackingLogger());
     }
 }

--- a/tests/AnalysisTest.php
+++ b/tests/AnalysisTest.php
@@ -13,7 +13,7 @@ class AnalysisTest extends OpenApiTestCase
     public function testRegisterProcessor()
     {
         $counter = 0;
-        $analysis = new Analysis();
+        $analysis = new Analysis([], null, $this->trackingLogger());
         $analysis->process();
         $this->assertSame(0, $counter);
         $countProcessor = function (Analysis $a) use (&$counter) {

--- a/tests/AnalysisTest.php
+++ b/tests/AnalysisTest.php
@@ -13,7 +13,7 @@ class AnalysisTest extends OpenApiTestCase
     public function testRegisterProcessor()
     {
         $counter = 0;
-        $analysis = new Analysis([], null, $this->trackingLogger());
+        $analysis = new Analysis([], null, $this->getLogger());
         $analysis->process();
         $this->assertSame(0, $counter);
         $countProcessor = function (Analysis $a) use (&$counter) {

--- a/tests/Annotations/AbstractAnnotationTest.php
+++ b/tests/Annotations/AbstractAnnotationTest.php
@@ -24,12 +24,12 @@ class AbstractAnnotationTest extends OpenApiTestCase
     public function testInvalidField()
     {
         $this->assertOpenApiLogEntryContains('Unexpected field "doesnot" for @OA\Get(), expecting');
-        $this->parseComment('@OA\Get(doesnot="exist")', $this->trackingLogger());
+        $this->parseComment('@OA\Get(doesnot="exist")', $this->getLogger(true));
     }
 
     public function testUmergedAnnotation()
     {
-        $logger = $this->trackingLogger();
+        $logger = $this->getLogger(true);
 
         $openapi = $this->createOpenApiWithInfo($logger);
         $openapi->merge($this->parseComment('@OA\Items()', $logger));
@@ -47,7 +47,7 @@ class AbstractAnnotationTest extends OpenApiTestCase
     @OA\Contact(name="second")
 )
 END;
-        $annotations = $this->parseComment($comment, $this->trackingLogger());
+        $annotations = $this->parseComment($comment, $this->getLogger(true));
         $this->assertOpenApiLogEntryContains('Only one @OA\Contact() allowed for @OA\Info() multiple found in:');
         $annotations[0]->validate();
     }
@@ -72,14 +72,14 @@ END;
     @OA\Header(header="X-CSRF-Token", @OA\Schema(type="string"), description="second")
 )
 END;
-        $annotations = $this->parseComment($comment, $this->trackingLogger());
+        $annotations = $this->parseComment($comment, $this->getLogger(true));
         $this->assertOpenApiLogEntryContains('Multiple @OA\Header() with the same header="X-CSRF-Token":');
         $annotations[0]->validate();
     }
 
     public function testRequiredFields()
     {
-        $annotations = $this->parseComment('@OA\Info()', $this->trackingLogger());
+        $annotations = $this->parseComment('@OA\Info()', $this->getLogger(true));
         $info = $annotations[0];
         $this->assertOpenApiLogEntryContains('Missing required field "title" for @OA\Info() in ');
         $this->assertOpenApiLogEntryContains('Missing required field "version" for @OA\Info() in ');
@@ -98,7 +98,7 @@ END;
     )
 )
 END;
-        $annotations = $this->parseComment($comment, $this->trackingLogger());
+        $annotations = $this->parseComment($comment, $this->getLogger(true));
         $parameter = $annotations[0];
         $this->assertOpenApiLogEntryContains('@OA\Parameter(name=123,in="dunno")->name is a "integer", expecting a "string" in ');
         $this->assertOpenApiLogEntryContains('@OA\Parameter(name=123,in="dunno")->in "dunno" is invalid, expecting "query", "header", "path", "cookie" in ');

--- a/tests/Annotations/AbstractAnnotationTest.php
+++ b/tests/Annotations/AbstractAnnotationTest.php
@@ -24,13 +24,15 @@ class AbstractAnnotationTest extends OpenApiTestCase
     public function testInvalidField()
     {
         $this->assertOpenApiLogEntryContains('Unexpected field "doesnot" for @OA\Get(), expecting');
-        $this->parseComment('@OA\Get(doesnot="exist")');
+        $this->parseComment('@OA\Get(doesnot="exist")', $this->trackingLogger());
     }
 
     public function testUmergedAnnotation()
     {
-        $openapi = $this->createOpenApiWithInfo();
-        $openapi->merge($this->parseComment('@OA\Items()'));
+        $logger = $this->trackingLogger();
+
+        $openapi = $this->createOpenApiWithInfo($logger);
+        $openapi->merge($this->parseComment('@OA\Items()', $logger));
         $this->assertOpenApiLogEntryContains('Unexpected @OA\Items(), expected to be inside @OA\\');
         $openapi->validate();
     }
@@ -45,7 +47,7 @@ class AbstractAnnotationTest extends OpenApiTestCase
     @OA\Contact(name="second")
 )
 END;
-        $annotations = $this->parseComment($comment);
+        $annotations = $this->parseComment($comment, $this->trackingLogger());
         $this->assertOpenApiLogEntryContains('Only one @OA\Contact() allowed for @OA\Info() multiple found in:');
         $annotations[0]->validate();
     }
@@ -70,14 +72,14 @@ END;
     @OA\Header(header="X-CSRF-Token", @OA\Schema(type="string"), description="second")
 )
 END;
-        $annotations = $this->parseComment($comment);
+        $annotations = $this->parseComment($comment, $this->trackingLogger());
         $this->assertOpenApiLogEntryContains('Multiple @OA\Header() with the same header="X-CSRF-Token":');
         $annotations[0]->validate();
     }
 
     public function testRequiredFields()
     {
-        $annotations = $this->parseComment('@OA\Info()');
+        $annotations = $this->parseComment('@OA\Info()', $this->trackingLogger());
         $info = $annotations[0];
         $this->assertOpenApiLogEntryContains('Missing required field "title" for @OA\Info() in ');
         $this->assertOpenApiLogEntryContains('Missing required field "version" for @OA\Info() in ');
@@ -96,13 +98,11 @@ END;
     )
 )
 END;
-        $annotations = $this->parseComment($comment);
+        $annotations = $this->parseComment($comment, $this->trackingLogger());
         $parameter = $annotations[0];
         $this->assertOpenApiLogEntryContains('@OA\Parameter(name=123,in="dunno")->name is a "integer", expecting a "string" in ');
         $this->assertOpenApiLogEntryContains('@OA\Parameter(name=123,in="dunno")->in "dunno" is invalid, expecting "query", "header", "path", "cookie" in ');
         $this->assertOpenApiLogEntryContains('@OA\Parameter(name=123,in="dunno")->required is a "string", expecting a "boolean" in ');
-//        $this->assertOpenApiLogEntryStartsWith('@OA\Parameter(name=123,in="dunno")->maximum is a "string", expecting a "number" in ');
-//        $this->assertOpenApiLogEntryStartsWith('@OA\Parameter(name=123,in="dunno")->type must be "string", "number", "integer", "boolean", "array", "file" when @OA\Parameter()->in != "body" in ');
         $parameter->validate();
     }
 

--- a/tests/Annotations/ItemsTest.php
+++ b/tests/Annotations/ItemsTest.php
@@ -33,7 +33,7 @@ class ItemsTest extends OpenApiTestCase
 
     public function testRefDefinitionInProperty()
     {
-        $analyser = new StaticAnalyser($this->getLogger());
+        $analyser = new StaticAnalyser(null, $this->getLogger());
         $analysis = $analyser->fromFile($this->fixtures('UsingVar.php')[0]);
         $analysis->process();
 

--- a/tests/Annotations/ItemsTest.php
+++ b/tests/Annotations/ItemsTest.php
@@ -13,14 +13,14 @@ class ItemsTest extends OpenApiTestCase
 {
     public function testItemTypeArray()
     {
-        $annotations = $this->parseComment('@OA\Items(type="array")');
+        $annotations = $this->parseComment('@OA\Items(type="array")', $this->trackingLogger());
         $this->assertOpenApiLogEntryContains('@OA\Items() is required when @OA\Items() has type "array" in ');
         $annotations[0]->validate();
     }
 
     public function testSchemaTypeArray()
     {
-        $annotations = $this->parseComment('@OA\Schema(type="array")');
+        $annotations = $this->parseComment('@OA\Schema(type="array")', $this->trackingLogger());
         $this->assertOpenApiLogEntryContains('@OA\Items() is required when @OA\Schema() has type "array" in ');
         $annotations[0]->validate();
     }
@@ -33,7 +33,7 @@ class ItemsTest extends OpenApiTestCase
 
     public function testRefDefinitionInProperty()
     {
-        $analyser = new StaticAnalyser();
+        $analyser = new StaticAnalyser($this->trackingLogger());
         $analysis = $analyser->fromFile($this->fixtures('UsingVar.php')[0]);
         $analysis->process();
 

--- a/tests/Annotations/ItemsTest.php
+++ b/tests/Annotations/ItemsTest.php
@@ -13,14 +13,14 @@ class ItemsTest extends OpenApiTestCase
 {
     public function testItemTypeArray()
     {
-        $annotations = $this->parseComment('@OA\Items(type="array")', $this->trackingLogger());
+        $annotations = $this->parseComment('@OA\Items(type="array")', $this->getLogger(true));
         $this->assertOpenApiLogEntryContains('@OA\Items() is required when @OA\Items() has type "array" in ');
         $annotations[0]->validate();
     }
 
     public function testSchemaTypeArray()
     {
-        $annotations = $this->parseComment('@OA\Schema(type="array")', $this->trackingLogger());
+        $annotations = $this->parseComment('@OA\Schema(type="array")', $this->getLogger(true));
         $this->assertOpenApiLogEntryContains('@OA\Items() is required when @OA\Schema() has type "array" in ');
         $annotations[0]->validate();
     }
@@ -33,7 +33,7 @@ class ItemsTest extends OpenApiTestCase
 
     public function testRefDefinitionInProperty()
     {
-        $analyser = new StaticAnalyser($this->trackingLogger());
+        $analyser = new StaticAnalyser($this->getLogger());
         $analysis = $analyser->fromFile($this->fixtures('UsingVar.php')[0]);
         $analysis->process();
 

--- a/tests/Annotations/NestedPropertyTest.php
+++ b/tests/Annotations/NestedPropertyTest.php
@@ -17,11 +17,13 @@ class NestedPropertyTest extends OpenApiTestCase
 {
     public function testNestedProperties()
     {
+        $logger = $this->trackingLogger();
+
         $analysis = $this->analysisFromFixtures('NestedProperty.php');
-        $analysis->process(new MergeIntoOpenApi());
-        $analysis->process(new MergeIntoComponents());
-        $analysis->process(new AugmentSchemas());
-        $analysis->process(new AugmentProperties());
+        $analysis->process(new MergeIntoOpenApi($logger));
+        $analysis->process(new MergeIntoComponents($logger));
+        $analysis->process(new AugmentSchemas($logger));
+        $analysis->process(new AugmentProperties($logger));
 
         $this->assertCount(1, $analysis->openapi->components->schemas);
         $schema = $analysis->openapi->components->schemas[0];

--- a/tests/Annotations/NestedPropertyTest.php
+++ b/tests/Annotations/NestedPropertyTest.php
@@ -17,7 +17,7 @@ class NestedPropertyTest extends OpenApiTestCase
 {
     public function testNestedProperties()
     {
-        $logger = $this->trackingLogger();
+        $logger = $this->getLogger();
 
         $analysis = $this->analysisFromFixtures('NestedProperty.php');
         $analysis->process(new MergeIntoOpenApi($logger));

--- a/tests/Annotations/OperationTest.php
+++ b/tests/Annotations/OperationTest.php
@@ -45,7 +45,7 @@ class OperationTest extends OpenApiTestCase
         // test with Get implementation...
         $operation = new OA\Get([
             'security' => $security,
-        ], $this->trackingLogger());
+        ], $this->getLogger());
         $flags = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
         $json = $operation->toJson($flags);
         $this->assertEquals($expected, $json);

--- a/tests/Annotations/OperationTest.php
+++ b/tests/Annotations/OperationTest.php
@@ -45,7 +45,7 @@ class OperationTest extends OpenApiTestCase
         // test with Get implementation...
         $operation = new OA\Get([
             'security' => $security,
-        ]);
+        ], $this->trackingLogger());
         $flags = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
         $json = $operation->toJson($flags);
         $this->assertEquals($expected, $json);

--- a/tests/Annotations/ResponseTest.php
+++ b/tests/Annotations/ResponseTest.php
@@ -29,7 +29,7 @@ class ResponseTest extends OpenApiTestCase
     {
         $annotations = $this->parseComment(
             '@OA\Get(@OA\Response(response="'.$response.'", description="description"))',
-            $this->trackingLogger()
+            $this->getLogger(true)
         );
         /*
          * @see Annotations/Operation.php:187

--- a/tests/Annotations/ResponseTest.php
+++ b/tests/Annotations/ResponseTest.php
@@ -28,7 +28,8 @@ class ResponseTest extends OpenApiTestCase
     protected function validateMisspelledAnnotation(string $response = '')
     {
         $annotations = $this->parseComment(
-            '@OA\Get(@OA\Response(response="'.$response.'", description="description"))'
+            '@OA\Get(@OA\Response(response="'.$response.'", description="description"))',
+            $this->trackingLogger()
         );
         /*
          * @see Annotations/Operation.php:187

--- a/tests/ConstantsTest.php
+++ b/tests/ConstantsTest.php
@@ -21,7 +21,7 @@ class ConstantsTest extends OpenApiTestCase
         $const = 'OPENAPI_TEST_'.self::$counter;
         $this->assertFalse(defined($const));
         $this->assertOpenApiLogEntryContains("[Semantical Error] Couldn't find constant ".$const);
-        $this->parseComment('@OA\Contact(email='.$const.')');
+        $this->parseComment('@OA\Contact(email='.$const.')', $this->trackingLogger());
 
         define($const, 'me@domain.org');
         $annotations = $this->parseComment('@OA\Contact(email='.$const.')');
@@ -40,7 +40,7 @@ class ConstantsTest extends OpenApiTestCase
     public function testInvalidClass()
     {
         $this->assertOpenApiLogEntryContains("[Semantical Error] Couldn't find constant ConstantsTest::URL");
-        $this->parseComment('@OA\Contact(url=ConstantsTest::URL)');
+        $this->parseComment('@OA\Contact(url=ConstantsTest::URL)', $this->trackingLogger());
     }
 
     public function testAutoloadConstant()
@@ -56,7 +56,7 @@ class ConstantsTest extends OpenApiTestCase
     {
         $backup = Analyser::$whitelist;
         Analyser::$whitelist = false;
-        $analyser = new StaticAnalyser();
+        $analyser = new StaticAnalyser($this->trackingLogger());
         $analysis = $analyser->fromFile(__DIR__.'/Fixtures/Customer.php');
         // @todo Only tests that $whitelist=false doesn't trigger errors,
         // No constants are used, because by default only class constants in the whitelisted namespace are allowed and no class in OpenApi\Annotation namespace has a constant.

--- a/tests/ConstantsTest.php
+++ b/tests/ConstantsTest.php
@@ -21,7 +21,7 @@ class ConstantsTest extends OpenApiTestCase
         $const = 'OPENAPI_TEST_'.self::$counter;
         $this->assertFalse(defined($const));
         $this->assertOpenApiLogEntryContains("[Semantical Error] Couldn't find constant ".$const);
-        $this->parseComment('@OA\Contact(email='.$const.')', $this->trackingLogger());
+        $this->parseComment('@OA\Contact(email='.$const.')', $this->getLogger(true));
 
         define($const, 'me@domain.org');
         $annotations = $this->parseComment('@OA\Contact(email='.$const.')');
@@ -40,7 +40,7 @@ class ConstantsTest extends OpenApiTestCase
     public function testInvalidClass()
     {
         $this->assertOpenApiLogEntryContains("[Semantical Error] Couldn't find constant ConstantsTest::URL");
-        $this->parseComment('@OA\Contact(url=ConstantsTest::URL)', $this->trackingLogger());
+        $this->parseComment('@OA\Contact(url=ConstantsTest::URL)', $this->getLogger(true));
     }
 
     public function testAutoloadConstant()
@@ -56,7 +56,7 @@ class ConstantsTest extends OpenApiTestCase
     {
         $backup = Analyser::$whitelist;
         Analyser::$whitelist = false;
-        $analyser = new StaticAnalyser($this->trackingLogger());
+        $analyser = new StaticAnalyser($this->getLogger());
         $analysis = $analyser->fromFile(__DIR__.'/Fixtures/Customer.php');
         // @todo Only tests that $whitelist=false doesn't trigger errors,
         // No constants are used, because by default only class constants in the whitelisted namespace are allowed and no class in OpenApi\Annotation namespace has a constant.

--- a/tests/ConstantsTest.php
+++ b/tests/ConstantsTest.php
@@ -56,7 +56,7 @@ class ConstantsTest extends OpenApiTestCase
     {
         $backup = Analyser::$whitelist;
         Analyser::$whitelist = false;
-        $analyser = new StaticAnalyser($this->getLogger());
+        $analyser = new StaticAnalyser(null, $this->getLogger());
         $analysis = $analyser->fromFile(__DIR__.'/Fixtures/Customer.php');
         // @todo Only tests that $whitelist=false doesn't trigger errors,
         // No constants are used, because by default only class constants in the whitelisted namespace are allowed and no class in OpenApi\Annotation namespace has a constant.

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -12,7 +12,7 @@ class ContextTest extends OpenApiTestCase
 {
     public function testDetect()
     {
-        $context = Context::detect(0, $this->trackingLogger());
+        $context = Context::detect(0, $this->getLogger());
         $line = __LINE__ - 1;
         $this->assertSame('ContextTest', $context->class);
         $this->assertSame('\OpenApi\Tests\ContextTest', $context->fullyQualifiedName($context->class));
@@ -25,7 +25,7 @@ class ContextTest extends OpenApiTestCase
     public function testFullyQualifiedName()
     {
         $this->assertOpenApiLogEntryContains('Required @OA\PathItem() not found');
-        $openapi = \OpenApi\scan(__DIR__.'/Fixtures/Customer.php', ['logger' => $this->trackingLogger()]);
+        $openapi = \OpenApi\scan(__DIR__.'/Fixtures/Customer.php', ['logger' => $this->getLogger(true)]);
         $context = $openapi->components->schemas[0]->_context;
 
         // resolve with namespace
@@ -51,7 +51,7 @@ class ContextTest extends OpenApiTestCase
      * @OA\Get(path="api/test1", @OA\Response(response="200", description="a response"))
      */
 END,
-            'logger' => $this->trackingLogger(),
+            'logger' => $this->getLogger(),
         ]);
         $this->assertEquals('A single line.', $singleLine->phpdocContent());
 
@@ -65,7 +65,7 @@ END,
  * @OA\Get(path="api/test1", @OA\Response(response="200", description="a response"))
  */
 END,
-            'logger' => $this->trackingLogger(),
+            'logger' => $this->getLogger(),
         ]);
         $this->assertEquals("A description spread across\nmultiple lines.\n\neven blank lines", $multiline->phpdocContent());
 
@@ -77,7 +77,7 @@ END,
  * @OA\Get(path="api/test1", @OA\Response(response="200", description="a response"))
  */
 END,
-            'logger' => $this->trackingLogger(),
+            'logger' => $this->getLogger(),
         ]);
         $this->assertEquals('A single line spread across multiple lines.', $escapedLinebreak->phpdocContent());
     }
@@ -89,12 +89,12 @@ END,
     {
         $single = new Context([
             'comment' => '/** This is a single line DocComment. */',
-            'logger' => $this->trackingLogger(),
+            'logger' => $this->getLogger(),
         ]);
         $this->assertEquals('This is a single line DocComment.', $single->phpdocContent());
         $multi = new Context([
             'comment' => "/**\n * This is a multi-line DocComment.\n */",
-            'logger' => $this->trackingLogger(),
+            'logger' => $this->getLogger(),
         ]);
         $this->assertEquals('This is a multi-line DocComment.', $multi->phpdocContent());
 
@@ -105,7 +105,7 @@ END,
      * This is a description
      */
 END,
-            'logger' => $this->trackingLogger(),
+            'logger' => $this->getLogger(),
         ]);
         $this->assertEquals('This is a summary', $emptyWhiteline->phpdocSummary());
         $periodNewline = new Context(['comment' => <<<END
@@ -114,7 +114,7 @@ END,
      * This is a description
      */
 END,
-            'logger' => $this->trackingLogger(),
+            'logger' => $this->getLogger(),
         ]);
         $this->assertEquals('This is a summary.', $periodNewline->phpdocSummary());
         $multilineSummary = new Context(['comment' => <<<END
@@ -123,7 +123,7 @@ END,
      * but this is part of the summary
      */
 END,
-            'logger' => $this->trackingLogger(),
+            'logger' => $this->getLogger(),
         ]);
     }
 }

--- a/tests/ExamplesTest.php
+++ b/tests/ExamplesTest.php
@@ -33,7 +33,7 @@ class ExamplesTest extends OpenApiTestCase
     public function testExamples($example, $spec)
     {
         $path = __DIR__.'/../Examples/'.$example;
-        $openapi = \OpenApi\scan($path, ['logger' => $this->trackingLogger()]);
+        $openapi = \OpenApi\scan($path, ['logger' => $this->getLogger()]);
         $this->assertSpecEquals(file_get_contents($path.'/'.$spec), $openapi, 'Examples/'.$example.'/'.$spec);
     }
 }

--- a/tests/ExamplesTest.php
+++ b/tests/ExamplesTest.php
@@ -33,7 +33,7 @@ class ExamplesTest extends OpenApiTestCase
     public function testExamples($example, $spec)
     {
         $path = __DIR__.'/../Examples/'.$example;
-        $openapi = \OpenApi\scan($path, []);
+        $openapi = \OpenApi\scan($path, ['logger' => $this->trackingLogger()]);
         $this->assertSpecEquals(file_get_contents($path.'/'.$spec), $openapi, 'Examples/'.$example.'/'.$spec);
     }
 }

--- a/tests/Fixtures/Customer.php
+++ b/tests/Fixtures/Customer.php
@@ -85,6 +85,7 @@ class Customer
      */
     public function testResolvingFullyQualifiedNames()
     {
+        // use all imports
         OpenApiLogger::getInstance();
         Logger::getInstance();
         new OA\Contact([]);

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -35,7 +35,7 @@ class GeneratorTest extends OpenApiTestCase
      */
     public function testScan(string $sourceDir, $sources)
     {
-        $openapi = (new Generator($this->trackingLogger()))
+        $openapi = (new Generator($this->getLogger()))
             ->scan($sources);
 
         $this->assertSpecEquals(file_get_contents(sprintf('%s/%s.yaml', $sourceDir, basename($sourceDir))), $openapi);

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -6,6 +6,7 @@
 
 namespace OpenApi\Tests;
 
+use OpenApi\Analyser\DocBlockParser;
 use OpenApi\Generator;
 use OpenApi\Util;
 
@@ -39,5 +40,15 @@ class GeneratorTest extends OpenApiTestCase
             ->scan($sources);
 
         $this->assertSpecEquals(file_get_contents(sprintf('%s/%s.yaml', $sourceDir, basename($sourceDir))), $openapi);
+    }
+
+    public function testDeprecatedAnnotationWarning()
+    {
+        $logger = $this->getLogger(true);
+        $generator = (new Generator($logger))
+            ->setAliases(['swg' => 'OpenApi\Annotations']);
+        $this->assertOpenApiLogEntryContains('The annotation @SWG\Definition() is deprecated.');
+
+        $this->parseComment('@SWG\Definition()', $logger, new DocBlockParser($generator->getAliases(), $logger));
     }
 }

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests;
+
+use OpenApi\Generator;
+use OpenApi\Util;
+
+class GeneratorTest extends OpenApiTestCase
+{
+    const SOURCE_DIR = __DIR__.'/../Examples/swagger-spec/petstore-simple';
+
+    public function sourcesProvider()
+    {
+        $sourceDir = self::SOURCE_DIR;
+        $sources = [
+            $sourceDir.'/SimplePet.php',
+            $sourceDir.'/SimplePetsController.php',
+            $sourceDir.'/api.php',
+        ];
+
+        return [
+            'dir-list' => [$sourceDir, [$sourceDir]],
+            'file-list' => [$sourceDir, $sources],
+            'finder' => [$sourceDir, Util::finder($sourceDir)],
+            'finder-list' => [$sourceDir, [Util::finder($sourceDir)]],
+        ];
+    }
+
+    /**
+     * @dataProvider sourcesProvider
+     */
+    public function testScan(string $sourceDir, $sources)
+    {
+        $openapi = (new Generator($this->trackingLogger()))
+            ->scan($sources);
+
+        $this->assertSpecEquals(file_get_contents(sprintf('%s/%s.yaml', $sourceDir, basename($sourceDir))), $openapi);
+    }
+}

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -8,7 +8,7 @@ namespace OpenApi\Tests;
 
 use OpenApi\Annotations\Get;
 use OpenApi\Annotations\Post;
-use OpenApi\Logger;
+use OpenApi\Util;
 
 class LoggerTest extends OpenApiTestCase
 {
@@ -25,6 +25,6 @@ class LoggerTest extends OpenApiTestCase
      */
     public function testShorten($classes, $expected)
     {
-        $this->assertEquals($expected, Logger::shorten($classes));
+        $this->assertEquals($expected, Util::shorten($classes));
     }
 }

--- a/tests/OpenApiTestCase.php
+++ b/tests/OpenApiTestCase.php
@@ -217,7 +217,7 @@ class OpenApiTestCase extends TestCase
 
     public function analysisFromFixtures($files): Analysis
     {
-        $analyser = new StaticAnalyser($this->getLogger());
+        $analyser = new StaticAnalyser(null, $this->getLogger());
         $analysis = new Analysis([], null, $this->getLogger());
 
         foreach ((array) $files as $file) {
@@ -229,7 +229,7 @@ class OpenApiTestCase extends TestCase
 
     public function analysisFromCode(string $code, ?Context $context = null)
     {
-        return (new StaticAnalyser($this->getLogger()))
+        return (new StaticAnalyser(null, $this->getLogger()))
             ->fromCode("<?php\n".$code, $context ?: new Context([
                 'logger' => $this->getLogger(),
             ]));

--- a/tests/OpenApiTestCase.php
+++ b/tests/OpenApiTestCase.php
@@ -9,6 +9,7 @@ namespace OpenApi\Tests;
 use DirectoryIterator;
 use Exception;
 use OpenApi\Analyser;
+use OpenApi\Analyser\DocBlockParser;
 use OpenApi\Analysis;
 use OpenApi\Annotations\AbstractAnnotation;
 use OpenApi\Annotations\Info;
@@ -169,13 +170,13 @@ class OpenApiTestCase extends TestCase
      *
      * @return AbstractAnnotation[]
      */
-    protected function parseComment($comment, ?LoggerInterface $logger = null)
+    protected function parseComment($comment, ?LoggerInterface $logger = null, ?DocBlockParser $docBlockParser = null)
     {
         $logger = $logger ?: $this->getLogger();
-        $analyser = new Analyser(null, $logger);
+        $docBlockParser = $docBlockParser ?: new DocBlockParser(Analyser::$defaultImports, $logger);
         $context = Context::detect(1, $logger);
 
-        return $analyser->fromComment("<?php\n/**\n * ".implode("\n * ", explode("\n", $comment))."\n*/", $context);
+        return $docBlockParser->fromComment("<?php\n/**\n * ".implode("\n * ", explode("\n", $comment))."\n*/", $context);
     }
 
     /**
@@ -237,7 +238,7 @@ class OpenApiTestCase extends TestCase
 
     public function analysisFromDockBlock($comment, ?Context $context = null)
     {
-        return (new Analyser(null, $this->getLogger()))
+        return (new DocBlockParser(Analyser::$defaultImports, $this->getLogger()))
             ->fromComment($comment, $context ?: new Context([
                 'logger' => $this->getLogger(),
             ]));

--- a/tests/Processors/AugmentParameterTest.php
+++ b/tests/Processors/AugmentParameterTest.php
@@ -12,7 +12,7 @@ class AugmentParameterTest extends OpenApiTestCase
 {
     public function testAugmentParameter()
     {
-        $openapi = \OpenApi\scan($this->fixtures('UsingRefs.php'));
+        $openapi = \OpenApi\scan($this->fixtures('UsingRefs.php'), ['logger' => $this->trackingLogger()]);
         $this->assertCount(1, $openapi->components->parameters, 'OpenApi contains 1 reusable parameter specification');
         $this->assertEquals('ItemName', $openapi->components->parameters[0]->parameter, 'When no @OA\Parameter()->parameter is specified, use @OA\Parameter()->name');
     }

--- a/tests/Processors/AugmentParameterTest.php
+++ b/tests/Processors/AugmentParameterTest.php
@@ -12,7 +12,7 @@ class AugmentParameterTest extends OpenApiTestCase
 {
     public function testAugmentParameter()
     {
-        $openapi = \OpenApi\scan($this->fixtures('UsingRefs.php'), ['logger' => $this->trackingLogger()]);
+        $openapi = \OpenApi\scan($this->fixtures('UsingRefs.php'), ['logger' => $this->getLogger()]);
         $this->assertCount(1, $openapi->components->parameters, 'OpenApi contains 1 reusable parameter specification');
         $this->assertEquals('ItemName', $openapi->components->parameters[0]->parameter, 'When no @OA\Parameter()->parameter is specified, use @OA\Parameter()->name');
     }

--- a/tests/Processors/AugmentPropertiesTest.php
+++ b/tests/Processors/AugmentPropertiesTest.php
@@ -21,10 +21,12 @@ class AugmentPropertiesTest extends OpenApiTestCase
 {
     public function testAugmentProperties()
     {
+        $logger = $this->trackingLogger();
+
         $analysis = $this->analysisFromFixtures('Customer.php');
-        $analysis->process(new MergeIntoOpenApi());
-        $analysis->process(new MergeIntoComponents());
-        $analysis->process(new AugmentSchemas());
+        $analysis->process(new MergeIntoOpenApi($logger));
+        $analysis->process(new MergeIntoComponents($logger));
+        $analysis->process(new AugmentSchemas($logger));
         $customer = $analysis->openapi->components->schemas[0];
         $firstName = $customer->properties[0];
         $secondName = $customer->properties[1];
@@ -59,7 +61,7 @@ class AugmentPropertiesTest extends OpenApiTestCase
         $this->assertSame(UNDEFINED, $bestFriend->nullable);
         $this->assertSame(UNDEFINED, $bestFriend->allOf);
 
-        $analysis->process(new AugmentProperties());
+        $analysis->process(new AugmentProperties($logger));
 
         $expectedValues = [
             'property' => 'firstname',
@@ -122,10 +124,12 @@ class AugmentPropertiesTest extends OpenApiTestCase
 
     public function testTypedProperties()
     {
+        $logger = $this->trackingLogger();
+
         $analysis = $this->analysisFromFixtures('TypedProperties.php');
-        $analysis->process(new MergeIntoOpenApi());
-        $analysis->process(new MergeIntoComponents());
-        $analysis->process(new AugmentSchemas());
+        $analysis->process(new MergeIntoOpenApi($logger));
+        $analysis->process(new MergeIntoComponents($logger));
+        $analysis->process(new AugmentSchemas($logger));
         [
             $stringType,
             $intType,
@@ -215,7 +219,7 @@ class AugmentPropertiesTest extends OpenApiTestCase
             'type' => UNDEFINED,
         ]);
 
-        $analysis->process(new AugmentProperties());
+        $analysis->process(new AugmentProperties($logger));
 
         $this->assertName($stringType, [
             'property' => 'stringType',

--- a/tests/Processors/AugmentPropertiesTest.php
+++ b/tests/Processors/AugmentPropertiesTest.php
@@ -21,7 +21,7 @@ class AugmentPropertiesTest extends OpenApiTestCase
 {
     public function testAugmentProperties()
     {
-        $logger = $this->trackingLogger();
+        $logger = $this->getLogger();
 
         $analysis = $this->analysisFromFixtures('Customer.php');
         $analysis->process(new MergeIntoOpenApi($logger));
@@ -124,7 +124,7 @@ class AugmentPropertiesTest extends OpenApiTestCase
 
     public function testTypedProperties()
     {
-        $logger = $this->trackingLogger();
+        $logger = $this->getLogger();
 
         $analysis = $this->analysisFromFixtures('TypedProperties.php');
         $analysis->process(new MergeIntoOpenApi($logger));

--- a/tests/Processors/AugmentSchemasTest.php
+++ b/tests/Processors/AugmentSchemasTest.php
@@ -16,7 +16,7 @@ class AugmentSchemasTest extends OpenApiTestCase
 {
     public function testAugmentSchemas()
     {
-        $logger = $this->trackingLogger();
+        $logger = $this->getLogger();
 
         $analysis = $this->analysisFromFixtures('Customer.php');
         $analysis->process(new MergeIntoOpenApi($logger));
@@ -33,7 +33,7 @@ class AugmentSchemasTest extends OpenApiTestCase
 
     public function testAugmentSchemasForInterface()
     {
-        $logger = $this->trackingLogger();
+        $logger = $this->getLogger();
 
         $analysis = $this->analysisFromFixtures('CustomerInterface.php');
         $analysis->process(new MergeIntoOpenApi($logger));

--- a/tests/Processors/AugmentSchemasTest.php
+++ b/tests/Processors/AugmentSchemasTest.php
@@ -16,29 +16,33 @@ class AugmentSchemasTest extends OpenApiTestCase
 {
     public function testAugmentSchemas()
     {
+        $logger = $this->trackingLogger();
+
         $analysis = $this->analysisFromFixtures('Customer.php');
-        $analysis->process(new MergeIntoOpenApi()); // create openapi->components
-        $analysis->process(new MergeIntoComponents()); // Merge standalone Scheme's into openapi->components
+        $analysis->process(new MergeIntoOpenApi($logger));
+        $analysis->process(new MergeIntoComponents($logger));
 
         $this->assertCount(1, $analysis->openapi->components->schemas);
         $customer = $analysis->openapi->components->schemas[0];
         $this->assertSame(UNDEFINED, $customer->schema, 'Sanity check. No scheme was defined');
         $this->assertSame(UNDEFINED, $customer->properties, 'Sanity check. @OA\Property\'s not yet merged ');
-        $analysis->process(new AugmentSchemas());
+        $analysis->process(new AugmentSchemas($logger));
         $this->assertSame('Customer', $customer->schema, '@OA\Schema()->schema based on classname');
         $this->assertCount(9, $customer->properties, '@OA\Property()s are merged into the @OA\Schema of the class');
     }
 
     public function testAugmentSchemasForInterface()
     {
+        $logger = $this->trackingLogger();
+
         $analysis = $this->analysisFromFixtures('CustomerInterface.php');
-        $analysis->process(new MergeIntoOpenApi()); // create openapi->components
-        $analysis->process(new MergeIntoComponents()); // Merge standalone Scheme's into openapi->components
+        $analysis->process(new MergeIntoOpenApi($logger));
+        $analysis->process(new MergeIntoComponents($logger));
 
         $this->assertCount(1, $analysis->openapi->components->schemas);
         $customer = $analysis->openapi->components->schemas[0];
         $this->assertSame(UNDEFINED, $customer->properties, 'Sanity check. @OA\Property\'s not yet merged ');
-        $analysis->process(new AugmentSchemas());
+        $analysis->process(new AugmentSchemas($logger));
         $this->assertCount(9, $customer->properties, '@OA\Property()s are merged into the @OA\Schema of the class');
     }
 }

--- a/tests/Processors/BuildPathsTest.php
+++ b/tests/Processors/BuildPathsTest.php
@@ -20,7 +20,7 @@ class BuildPathsTest extends OpenApiTestCase
 {
     public function testMergePathsWithSamePath()
     {
-        $logger = $this->trackingLogger();
+        $logger = $this->getLogger();
 
         $openapi = new OpenApi([], $logger);
         $openapi->paths = [
@@ -36,7 +36,7 @@ class BuildPathsTest extends OpenApiTestCase
 
     public function testMergeOperationsWithSamePath()
     {
-        $logger = $this->trackingLogger();
+        $logger = $this->getLogger();
 
         $openapi = new OpenApi([], $logger);
         $analysis = new Analysis([

--- a/tests/Processors/BuildPathsTest.php
+++ b/tests/Processors/BuildPathsTest.php
@@ -20,30 +20,32 @@ class BuildPathsTest extends OpenApiTestCase
 {
     public function testMergePathsWithSamePath()
     {
-        $openapi = new OpenApi([]);
+        $logger = $this->trackingLogger();
+
+        $openapi = new OpenApi([], $logger);
         $openapi->paths = [
-            new PathItem(['path' => '/comments']),
-            new PathItem(['path' => '/comments']),
+            new PathItem(['path' => '/comments'], $logger),
+            new PathItem(['path' => '/comments'], $logger),
         ];
-        $analysis = new Analysis([$openapi]);
+        $analysis = new Analysis([$openapi], null, $logger);
         $analysis->openapi = $openapi;
-        $analysis->process(new BuildPaths());
+        $analysis->process(new BuildPaths($logger));
         $this->assertCount(1, $openapi->paths);
         $this->assertSame('/comments', $openapi->paths[0]->path);
     }
 
     public function testMergeOperationsWithSamePath()
     {
-        $openapi = new OpenApi([]);
-        $analysis = new Analysis(
-            [
+        $logger = $this->trackingLogger();
+
+        $openapi = new OpenApi([], $logger);
+        $analysis = new Analysis([
             $openapi,
-            new Get(['path' => '/comments']),
-            new Post(['path' => '/comments']),
-            ]
-        );
-        $analysis->process(new MergeIntoOpenApi());
-        $analysis->process(new BuildPaths());
+            new Get(['path' => '/comments'], $logger),
+            new Post(['path' => '/comments'], $logger),
+        ], null, $logger);
+        $analysis->process(new MergeIntoOpenApi($logger));
+        $analysis->process(new BuildPaths($logger));
         $this->assertCount(1, $openapi->paths);
         $path = $openapi->paths[0];
         $this->assertSame('/comments', $path->path);

--- a/tests/Processors/CleanUnmergedTest.php
+++ b/tests/Processors/CleanUnmergedTest.php
@@ -31,9 +31,11 @@ class CleanUnmergedTest extends OpenApiTestCase
 )
 
 END;
-        $analysis = new Analysis($this->parseComment($comment));
+        $logger = $this->trackingLogger();
+
+        $analysis = new Analysis($this->parseComment($comment), null, $logger);
         $this->assertCount(4, $analysis->annotations);
-        $analysis->process(new MergeIntoOpenApi());
+        $analysis->process(new MergeIntoOpenApi($logger));
         $this->assertCount(5, $analysis->annotations);
         $before = $analysis->split();
         $this->assertCount(3, $before->merged->annotations, 'Generated @OA\OpenApi, @OA\PathItem and @OA\Info');
@@ -42,7 +44,7 @@ END;
         $analysis->validate(); // Validation fails to detect the unmerged annotations.
 
         // CleanUnmerged should place the unmerged annotions into the swagger->_unmerged array.
-        $analysis->process(new CleanUnmerged());
+        $analysis->process(new CleanUnmerged($logger));
         $between = $analysis->split();
         $this->assertCount(3, $between->merged->annotations, 'Generated @OA\OpenApi, @OA\PathItem and @OA\Info');
         $this->assertCount(2, $between->unmerged->annotations, '@OA\License + @OA\Contact');
@@ -56,7 +58,7 @@ END;
         $contact = $analysis->getAnnotationsOfType(Contact::class)[0];
         $analysis->openapi->info->contact = $contact;
         $this->assertCount(1, $license->_unmerged);
-        $analysis->process(new CleanUnmerged());
+        $analysis->process(new CleanUnmerged($logger));
         $this->assertCount(0, $license->_unmerged);
         $after = $analysis->split();
         $this->assertCount(4, $after->merged->annotations, 'Generated @OA\OpenApi, @OA\PathItem, @OA\Info and @OA\Contact');

--- a/tests/Processors/CleanUnmergedTest.php
+++ b/tests/Processors/CleanUnmergedTest.php
@@ -31,7 +31,7 @@ class CleanUnmergedTest extends OpenApiTestCase
 )
 
 END;
-        $logger = $this->trackingLogger();
+        $logger = $this->getLogger(true);
 
         $analysis = new Analysis($this->parseComment($comment), null, $logger);
         $this->assertCount(4, $analysis->annotations);

--- a/tests/Processors/DocBlockDescriptionsTest.php
+++ b/tests/Processors/DocBlockDescriptionsTest.php
@@ -16,11 +16,9 @@ class DocBlockDescriptionsTest extends OpenApiTestCase
     public function testDocBlockDescription()
     {
         $analysis = $this->analysisFromFixtures('UsingPhpDoc.php');
-        $analysis->process(
-            [
-            new DocBlockDescriptions(),
-            ]
-        );
+        $analysis->process([
+            new DocBlockDescriptions($this->trackingLogger()),
+        ]);
         $operations = $analysis->getAnnotationsOfType(Operation::class);
 
         $this->assertSame('api/test1', $operations[0]->path);

--- a/tests/Processors/DocBlockDescriptionsTest.php
+++ b/tests/Processors/DocBlockDescriptionsTest.php
@@ -17,7 +17,7 @@ class DocBlockDescriptionsTest extends OpenApiTestCase
     {
         $analysis = $this->analysisFromFixtures('UsingPhpDoc.php');
         $analysis->process([
-            new DocBlockDescriptions($this->trackingLogger()),
+            new DocBlockDescriptions($this->getLogger()),
         ]);
         $operations = $analysis->getAnnotationsOfType(Operation::class);
 

--- a/tests/Processors/InheritPropertiesTest.php
+++ b/tests/Processors/InheritPropertiesTest.php
@@ -27,28 +27,28 @@ class InheritPropertiesTest extends OpenApiTestCase
 {
     protected function validate(Analysis $analysis)
     {
-        $analysis->openapi->info = new Info(['title' => 'test', 'version' => '1.0.0']);
-        $analysis->openapi->paths = [new PathItem(['path' => '/test'])];
+        $analysis->openapi->info = new Info(['title' => 'test', 'version' => '1.0.0'], $this->trackingLogger());
+        $analysis->openapi->paths = [new PathItem(['path' => '/test'], $this->trackingLogger())];
         $analysis->validate();
     }
 
     public function testInheritProperties()
     {
-        $analysis = $this->analysisFromFixtures(
-            [
-                'AnotherNamespace/Child.php',
-                'InheritProperties/GrandAncestor.php',
-                'InheritProperties/Ancestor.php',
-            ]
-        );
+        $logger = $this->trackingLogger();
+
+        $analysis = $this->analysisFromFixtures([
+            'AnotherNamespace/Child.php',
+            'InheritProperties/GrandAncestor.php',
+            'InheritProperties/Ancestor.php',
+        ]);
         $analysis->process([
-            new MergeIntoOpenApi(),
-            new MergeIntoComponents(),
-            new ExpandInterfaces(),
-            new InheritTraits(),
-            new AugmentSchemas(),
-            new AugmentProperties(),
-            new BuildPaths(),
+            new MergeIntoOpenApi($logger),
+            new MergeIntoComponents($logger),
+            new ExpandInterfaces($logger),
+            new InheritTraits($logger),
+            new AugmentSchemas($logger),
+            new AugmentProperties($logger),
+            new BuildPaths($logger),
         ]);
         $this->validate($analysis);
 
@@ -58,8 +58,8 @@ class InheritPropertiesTest extends OpenApiTestCase
         $this->assertCount(1, $childSchema->properties);
 
         $analysis->process([
-            new InheritProperties(),
-            new CleanUnmerged(),
+            new InheritProperties($logger),
+            new CleanUnmerged($logger),
         ]);
         $this->validate($analysis);
 
@@ -72,6 +72,8 @@ class InheritPropertiesTest extends OpenApiTestCase
      */
     public function testInheritPropertiesWithoutDocBlocks()
     {
+        $logger = $this->trackingLogger();
+
         $analysis = $this->analysisFromFixtures([
             // this class has docblocks
             'AnotherNamespace/ChildWithDocBlocks.php',
@@ -79,15 +81,15 @@ class InheritPropertiesTest extends OpenApiTestCase
             'InheritProperties/AncestorWithoutDocBlocks.php',
         ]);
         $analysis->process([
-            new MergeIntoOpenApi(),
-            new MergeIntoComponents(),
-            new ExpandInterfaces(),
-            new InheritTraits(),
-            new AugmentSchemas(),
-            new AugmentProperties(),
-            new BuildPaths(),
-            new InheritProperties(),
-            new CleanUnmerged(),
+            new MergeIntoOpenApi($logger),
+            new MergeIntoComponents($logger),
+            new ExpandInterfaces($logger),
+            new InheritTraits($logger),
+            new AugmentSchemas($logger),
+            new AugmentProperties($logger),
+            new BuildPaths($logger),
+            new InheritProperties($logger),
+            new CleanUnmerged($logger),
         ]);
         $this->validate($analysis);
 
@@ -97,7 +99,7 @@ class InheritPropertiesTest extends OpenApiTestCase
         $this->assertCount(1, $childSchema->properties);
 
         // no error occurs
-        $analysis->process(new InheritProperties());
+        $analysis->process(new InheritProperties($logger));
         $this->assertCount(1, $childSchema->properties);
     }
 
@@ -106,21 +108,23 @@ class InheritPropertiesTest extends OpenApiTestCase
      */
     public function testInheritPropertiesWithAllOf()
     {
+        $logger = $this->trackingLogger();
+
         $analysis = $this->analysisFromFixtures([
             // this class has all of
             'InheritProperties/Extended.php',
             'InheritProperties/Base.php',
         ]);
         $analysis->process([
-            new MergeIntoOpenApi(),
-            new MergeIntoComponents(),
-            new ExpandInterfaces(),
-            new InheritTraits(),
-            new AugmentSchemas(),
-            new AugmentProperties(),
-            new BuildPaths(),
-            new InheritProperties(),
-            new CleanUnmerged(),
+            new MergeIntoOpenApi($logger),
+            new MergeIntoComponents($logger),
+            new ExpandInterfaces($logger),
+            new InheritTraits($logger),
+            new AugmentSchemas($logger),
+            new AugmentProperties($logger),
+            new BuildPaths($logger),
+            new InheritProperties($logger),
+            new CleanUnmerged($logger),
         ]);
 //        $this->validate($analysis);
 
@@ -145,21 +149,23 @@ class InheritPropertiesTest extends OpenApiTestCase
      */
     public function testInheritPropertiesWithOutAllOf()
     {
+        $logger = $this->trackingLogger();
+
         $analysis = $this->analysisFromFixtures([
             // this class has all of
             'InheritProperties/ExtendedWithoutAllOf.php',
             'InheritProperties/Base.php',
         ]);
         $analysis->process([
-            new MergeIntoOpenApi(),
-            new MergeIntoComponents(),
-            new ExpandInterfaces(),
-            new InheritTraits(),
-            new AugmentSchemas(),
-            new AugmentProperties(),
-            new BuildPaths(),
-            new InheritProperties(),
-            new CleanUnmerged(),
+            new MergeIntoOpenApi($logger),
+            new MergeIntoComponents($logger),
+            new ExpandInterfaces($logger),
+            new InheritTraits($logger),
+            new AugmentSchemas($logger),
+            new AugmentProperties($logger),
+            new BuildPaths($logger),
+            new InheritProperties($logger),
+            new CleanUnmerged($logger),
         ]);
         $this->validate($analysis);
 
@@ -182,21 +188,23 @@ class InheritPropertiesTest extends OpenApiTestCase
      */
     public function testInheritPropertiesWitTwoChildSchemas()
     {
+        $logger = $this->trackingLogger();
+
         $analysis = $this->analysisFromFixtures([
             // this class has all of
             'InheritProperties/ExtendedWithTwoSchemas.php',
             'InheritProperties/Base.php',
         ]);
         $analysis->process([
-            new MergeIntoOpenApi(),
-            new MergeIntoComponents(),
-            new ExpandInterfaces(),
-            new InheritTraits(),
-            new AugmentSchemas(),
-            new AugmentProperties(),
-            new BuildPaths(),
-            new InheritProperties(),
-            new CleanUnmerged(),
+            new MergeIntoOpenApi($logger),
+            new MergeIntoComponents($logger),
+            new ExpandInterfaces($logger),
+            new InheritTraits($logger),
+            new AugmentSchemas($logger),
+            new AugmentProperties($logger),
+            new BuildPaths($logger),
+            new InheritProperties($logger),
+            new CleanUnmerged($logger),
         ]);
         $this->validate($analysis);
 
@@ -225,6 +233,8 @@ class InheritPropertiesTest extends OpenApiTestCase
      */
     public function testPreserveExistingAllOf()
     {
+        $logger = $this->trackingLogger();
+
         $analysis = $this->analysisFromFixtures([
             'InheritProperties/BaseInterface.php',
             'InheritProperties/ExtendsBaseThatImplements.php',
@@ -232,20 +242,20 @@ class InheritPropertiesTest extends OpenApiTestCase
             'InheritProperties/TraitUsedByExtendsBaseThatImplements.php',
         ]);
         $analysis->process([
-            new MergeIntoOpenApi(),
-            new MergeIntoComponents(),
-            new ExpandInterfaces(),
-            new InheritTraits(),
-            new AugmentSchemas(),
-            new AugmentProperties(),
-            new BuildPaths(),
-            new InheritProperties(),
-            new CleanUnmerged(),
+            new MergeIntoOpenApi($logger),
+            new MergeIntoComponents($logger),
+            new ExpandInterfaces($logger),
+            new InheritTraits($logger),
+            new AugmentSchemas($logger),
+            new AugmentProperties($logger),
+            new BuildPaths($logger),
+            new InheritProperties($logger),
+            new CleanUnmerged($logger),
         ]);
         $this->validate($analysis);
 
-        $analysis->openapi->info = new Info(['title' => 'test', 'version' => '1.0.0']);
-        $analysis->openapi->paths = [new PathItem(['path' => '/test'])];
+        $analysis->openapi->info = new Info(['title' => 'test', 'version' => '1.0.0'], $this->trackingLogger());
+        $analysis->openapi->paths = [new PathItem(['path' => '/test'], $this->trackingLogger())];
         $analysis->validate();
 
         /* @var Schema[] $schemas */

--- a/tests/Processors/InheritPropertiesTest.php
+++ b/tests/Processors/InheritPropertiesTest.php
@@ -27,14 +27,14 @@ class InheritPropertiesTest extends OpenApiTestCase
 {
     protected function validate(Analysis $analysis)
     {
-        $analysis->openapi->info = new Info(['title' => 'test', 'version' => '1.0.0'], $this->trackingLogger());
-        $analysis->openapi->paths = [new PathItem(['path' => '/test'], $this->trackingLogger())];
+        $analysis->openapi->info = new Info(['title' => 'test', 'version' => '1.0.0'], $this->getLogger());
+        $analysis->openapi->paths = [new PathItem(['path' => '/test'], $this->getLogger())];
         $analysis->validate();
     }
 
     public function testInheritProperties()
     {
-        $logger = $this->trackingLogger();
+        $logger = $this->getLogger();
 
         $analysis = $this->analysisFromFixtures([
             'AnotherNamespace/Child.php',
@@ -72,7 +72,7 @@ class InheritPropertiesTest extends OpenApiTestCase
      */
     public function testInheritPropertiesWithoutDocBlocks()
     {
-        $logger = $this->trackingLogger();
+        $logger = $this->getLogger();
 
         $analysis = $this->analysisFromFixtures([
             // this class has docblocks
@@ -108,7 +108,7 @@ class InheritPropertiesTest extends OpenApiTestCase
      */
     public function testInheritPropertiesWithAllOf()
     {
-        $logger = $this->trackingLogger();
+        $logger = $this->getLogger();
 
         $analysis = $this->analysisFromFixtures([
             // this class has all of
@@ -149,7 +149,7 @@ class InheritPropertiesTest extends OpenApiTestCase
      */
     public function testInheritPropertiesWithOutAllOf()
     {
-        $logger = $this->trackingLogger();
+        $logger = $this->getLogger();
 
         $analysis = $this->analysisFromFixtures([
             // this class has all of
@@ -188,7 +188,7 @@ class InheritPropertiesTest extends OpenApiTestCase
      */
     public function testInheritPropertiesWitTwoChildSchemas()
     {
-        $logger = $this->trackingLogger();
+        $logger = $this->getLogger();
 
         $analysis = $this->analysisFromFixtures([
             // this class has all of
@@ -233,7 +233,7 @@ class InheritPropertiesTest extends OpenApiTestCase
      */
     public function testPreserveExistingAllOf()
     {
-        $logger = $this->trackingLogger();
+        $logger = $this->getLogger();
 
         $analysis = $this->analysisFromFixtures([
             'InheritProperties/BaseInterface.php',
@@ -254,8 +254,8 @@ class InheritPropertiesTest extends OpenApiTestCase
         ]);
         $this->validate($analysis);
 
-        $analysis->openapi->info = new Info(['title' => 'test', 'version' => '1.0.0'], $this->trackingLogger());
-        $analysis->openapi->paths = [new PathItem(['path' => '/test'], $this->trackingLogger())];
+        $analysis->openapi->info = new Info(['title' => 'test', 'version' => '1.0.0'], $this->getLogger());
+        $analysis->openapi->paths = [new PathItem(['path' => '/test'], $this->getLogger())];
         $analysis->validate();
 
         /* @var Schema[] $schemas */

--- a/tests/Processors/MergeIntoComponentsTest.php
+++ b/tests/Processors/MergeIntoComponentsTest.php
@@ -17,16 +17,16 @@ class MergeIntoComponentsTest extends OpenApiTestCase
 {
     public function testProcessor()
     {
-        $openapi = new OpenApi([]);
-        $response = new Response(['response' => '2xx']);
-        $analysis = new Analysis(
-            [
-                $openapi,
-                $response,
-            ]
-        );
+        $logger = $this->trackingLogger();
+
+        $openapi = new OpenApi([], $logger);
+        $response = new Response(['response' => '2xx'], $logger);
+        $analysis = new Analysis([
+            $openapi,
+            $response,
+        ], null, $logger);
         $this->assertSame(UNDEFINED, $openapi->components);
-        $analysis->process(new MergeIntoComponents());
+        $analysis->process(new MergeIntoComponents($logger));
         $this->assertCount(1, $openapi->components->responses);
         $this->assertSame($response, $openapi->components->responses[0]);
         $this->assertCount(0, $analysis->unmerged()->annotations);

--- a/tests/Processors/MergeIntoComponentsTest.php
+++ b/tests/Processors/MergeIntoComponentsTest.php
@@ -17,7 +17,7 @@ class MergeIntoComponentsTest extends OpenApiTestCase
 {
     public function testProcessor()
     {
-        $logger = $this->trackingLogger();
+        $logger = $this->getLogger();
 
         $openapi = new OpenApi([], $logger);
         $response = new Response(['response' => '2xx'], $logger);

--- a/tests/Processors/MergeIntoOpenApiTest.php
+++ b/tests/Processors/MergeIntoOpenApiTest.php
@@ -17,7 +17,7 @@ class MergeIntoOpenApiTest extends OpenApiTestCase
 {
     public function testProcessor()
     {
-        $logger = $this->trackingLogger();
+        $logger = $this->getLogger();
 
         $openapi = new OpenApi([], $logger);
         $info = new Info([], $logger);

--- a/tests/Processors/MergeIntoOpenApiTest.php
+++ b/tests/Processors/MergeIntoOpenApiTest.php
@@ -17,17 +17,17 @@ class MergeIntoOpenApiTest extends OpenApiTestCase
 {
     public function testProcessor()
     {
-        $openapi = new OpenApi([]);
-        $info = new Info([]);
-        $analysis = new Analysis(
-            [
+        $logger = $this->trackingLogger();
+
+        $openapi = new OpenApi([], $logger);
+        $info = new Info([], $logger);
+        $analysis = new Analysis([
             $openapi,
             $info,
-            ]
-        );
+        ], null, $logger);
         $this->assertSame($openapi, $analysis->openapi);
         $this->assertSame(UNDEFINED, $openapi->info);
-        $analysis->process(new MergeIntoOpenApi());
+        $analysis->process(new MergeIntoOpenApi($logger));
         $this->assertSame($openapi, $analysis->openapi);
         $this->assertSame($info, $openapi->info);
         $this->assertCount(0, $analysis->unmerged()->annotations);

--- a/tests/Processors/MergeJsonContentTest.php
+++ b/tests/Processors/MergeJsonContentTest.php
@@ -24,12 +24,12 @@ class MergeJsonContentTest extends OpenApiTestCase
                 )
             )
 END;
-        $analysis = new Analysis($this->parseComment($comment), null, $this->trackingLogger());
+        $analysis = new Analysis($this->parseComment($comment), null, $this->getLogger());
         $this->assertCount(3, $analysis->annotations);
         $response = $analysis->getAnnotationsOfType(Response::class)[0];
         $this->assertSame(UNDEFINED, $response->content);
         $this->assertCount(1, $response->_unmerged);
-        $analysis->process(new MergeJsonContent($this->trackingLogger()));
+        $analysis->process(new MergeJsonContent($this->getLogger()));
         $this->assertCount(1, $response->content);
         $this->assertCount(0, $response->_unmerged);
         $json = json_decode(json_encode($response), true);
@@ -46,10 +46,10 @@ END;
                 )
             )
 END;
-        $analysis = new Analysis($this->parseComment($comment), null, $this->trackingLogger());
+        $analysis = new Analysis($this->parseComment($comment), null, $this->getLogger());
         $response = $analysis->getAnnotationsOfType(Response::class)[0];
         $this->assertCount(1, $response->content);
-        $analysis->process(new MergeJsonContent($this->trackingLogger()));
+        $analysis->process(new MergeJsonContent($this->getLogger()));
         $this->assertCount(2, $response->content);
     }
 
@@ -61,12 +61,12 @@ END;
                 @OA\Property(property="color", type="string")
             ))
 END;
-        $analysis = new Analysis($this->parseComment($comment), null, $this->trackingLogger());
+        $analysis = new Analysis($this->parseComment($comment), null, $this->getLogger());
         $this->assertCount(4, $analysis->annotations);
         $parameter = $analysis->getAnnotationsOfType(Parameter::class)[0];
         $this->assertSame(UNDEFINED, $parameter->content);
         $this->assertCount(1, $parameter->_unmerged);
-        $analysis->process(new MergeJsonContent($this->trackingLogger()));
+        $analysis->process(new MergeJsonContent($this->getLogger()));
         $this->assertCount(1, $parameter->content);
         $this->assertCount(0, $parameter->_unmerged);
         $json = json_decode(json_encode($parameter), true);
@@ -77,7 +77,7 @@ END;
 
     public function testNoParent()
     {
-        $logger = $this->trackingLogger();
+        $logger = $this->getLogger(true);
 
         $this->assertOpenApiLogEntryContains('Unexpected @OA\JsonContent() must be nested');
         $comment = <<<END
@@ -91,7 +91,7 @@ END;
 
     public function testInvalidParent()
     {
-        $logger = $this->trackingLogger();
+        $logger = $this->getLogger(true);
 
         $this->assertOpenApiLogEntryContains('Unexpected @OA\JsonContent() in @OA\Property() in');
         $comment = <<<END

--- a/tests/Processors/MergeJsonContentTest.php
+++ b/tests/Processors/MergeJsonContentTest.php
@@ -24,12 +24,12 @@ class MergeJsonContentTest extends OpenApiTestCase
                 )
             )
 END;
-        $analysis = new Analysis($this->parseComment($comment));
+        $analysis = new Analysis($this->parseComment($comment), null, $this->trackingLogger());
         $this->assertCount(3, $analysis->annotations);
         $response = $analysis->getAnnotationsOfType(Response::class)[0];
         $this->assertSame(UNDEFINED, $response->content);
         $this->assertCount(1, $response->_unmerged);
-        $analysis->process(new MergeJsonContent());
+        $analysis->process(new MergeJsonContent($this->trackingLogger()));
         $this->assertCount(1, $response->content);
         $this->assertCount(0, $response->_unmerged);
         $json = json_decode(json_encode($response), true);
@@ -46,10 +46,10 @@ END;
                 )
             )
 END;
-        $analysis = new Analysis($this->parseComment($comment));
+        $analysis = new Analysis($this->parseComment($comment), null, $this->trackingLogger());
         $response = $analysis->getAnnotationsOfType(Response::class)[0];
         $this->assertCount(1, $response->content);
-        $analysis->process(new MergeJsonContent());
+        $analysis->process(new MergeJsonContent($this->trackingLogger()));
         $this->assertCount(2, $response->content);
     }
 
@@ -61,12 +61,12 @@ END;
                 @OA\Property(property="color", type="string")
             ))
 END;
-        $analysis = new Analysis($this->parseComment($comment));
+        $analysis = new Analysis($this->parseComment($comment), null, $this->trackingLogger());
         $this->assertCount(4, $analysis->annotations);
         $parameter = $analysis->getAnnotationsOfType(Parameter::class)[0];
         $this->assertSame(UNDEFINED, $parameter->content);
         $this->assertCount(1, $parameter->_unmerged);
-        $analysis->process(new MergeJsonContent());
+        $analysis->process(new MergeJsonContent($this->trackingLogger()));
         $this->assertCount(1, $parameter->content);
         $this->assertCount(0, $parameter->_unmerged);
         $json = json_decode(json_encode($parameter), true);
@@ -77,18 +77,22 @@ END;
 
     public function testNoParent()
     {
+        $logger = $this->trackingLogger();
+
         $this->assertOpenApiLogEntryContains('Unexpected @OA\JsonContent() must be nested');
         $comment = <<<END
             @OA\JsonContent(type="array",
                 @OA\Items(ref="#/components/schemas/repository")
             )
 END;
-        $analysis = new Analysis($this->parseComment($comment));
-        $analysis->process(new MergeJsonContent());
+        $analysis = new Analysis($this->parseComment($comment), null, $logger);
+        $analysis->process(new MergeJsonContent($logger));
     }
 
     public function testInvalidParent()
     {
+        $logger = $this->trackingLogger();
+
         $this->assertOpenApiLogEntryContains('Unexpected @OA\JsonContent() in @OA\Property() in');
         $comment = <<<END
             @OA\Property(
@@ -97,7 +101,7 @@ END;
                 )
             )
 END;
-        $analysis = new Analysis($this->parseComment($comment));
-        $analysis->process(new MergeJsonContent());
+        $analysis = new Analysis($this->parseComment($comment), null, $logger);
+        $analysis->process(new MergeJsonContent($logger));
     }
 }

--- a/tests/Processors/MergeXmlContentTest.php
+++ b/tests/Processors/MergeXmlContentTest.php
@@ -24,12 +24,12 @@ class MergeXmlContentTest extends OpenApiTestCase
                 )
             )
 END;
-        $analysis = new Analysis($this->parseComment($comment), null, $this->trackingLogger());
+        $analysis = new Analysis($this->parseComment($comment), null, $this->getLogger());
         $this->assertCount(3, $analysis->annotations);
         $response = $analysis->getAnnotationsOfType(Response::class)[0];
         $this->assertSame(UNDEFINED, $response->content);
         $this->assertCount(1, $response->_unmerged);
-        $analysis->process(new MergeXmlContent($this->trackingLogger()));
+        $analysis->process(new MergeXmlContent($this->getLogger()));
         $this->assertCount(1, $response->content);
         $this->assertCount(0, $response->_unmerged);
         $json = json_decode(json_encode($response), true);
@@ -46,10 +46,10 @@ END;
                 )
             )
 END;
-        $analysis = new Analysis($this->parseComment($comment), null, $this->trackingLogger());
+        $analysis = new Analysis($this->parseComment($comment), null, $this->getLogger());
         $response = $analysis->getAnnotationsOfType(Response::class)[0];
         $this->assertCount(1, $response->content);
-        $analysis->process(new MergeXmlContent($this->trackingLogger()));
+        $analysis->process(new MergeXmlContent($this->getLogger()));
         $this->assertCount(2, $response->content);
     }
 
@@ -61,12 +61,12 @@ END;
                 @OA\Property(property="color", type="string")
             ))
 END;
-        $analysis = new Analysis($this->parseComment($comment), null, $this->trackingLogger());
+        $analysis = new Analysis($this->parseComment($comment), null, $this->getLogger());
         $this->assertCount(4, $analysis->annotations);
         $parameter = $analysis->getAnnotationsOfType(Parameter::class)[0];
         $this->assertSame(UNDEFINED, $parameter->content);
         $this->assertCount(1, $parameter->_unmerged);
-        $analysis->process(new MergeXmlContent($this->trackingLogger()));
+        $analysis->process(new MergeXmlContent($this->getLogger()));
         $this->assertCount(1, $parameter->content);
         $this->assertCount(0, $parameter->_unmerged);
         $json = json_decode(json_encode($parameter), true);
@@ -77,7 +77,7 @@ END;
 
     public function testNoParent()
     {
-        $logger = $this->trackingLogger();
+        $logger = $this->getLogger(true);
 
         $this->assertOpenApiLogEntryContains('Unexpected @OA\XmlContent() must be nested');
         $comment = <<<END
@@ -91,7 +91,7 @@ END;
 
     public function testInvalidParent()
     {
-        $logger = $this->trackingLogger();
+        $logger = $this->getLogger(true);
         $this->assertOpenApiLogEntryContains('Unexpected @OA\XmlContent() in @OA\Property() in');
         $comment = <<<END
             @OA\Property(

--- a/tests/Processors/MergeXmlContentTest.php
+++ b/tests/Processors/MergeXmlContentTest.php
@@ -24,12 +24,12 @@ class MergeXmlContentTest extends OpenApiTestCase
                 )
             )
 END;
-        $analysis = new Analysis($this->parseComment($comment));
+        $analysis = new Analysis($this->parseComment($comment), null, $this->trackingLogger());
         $this->assertCount(3, $analysis->annotations);
         $response = $analysis->getAnnotationsOfType(Response::class)[0];
         $this->assertSame(UNDEFINED, $response->content);
         $this->assertCount(1, $response->_unmerged);
-        $analysis->process(new MergeXmlContent());
+        $analysis->process(new MergeXmlContent($this->trackingLogger()));
         $this->assertCount(1, $response->content);
         $this->assertCount(0, $response->_unmerged);
         $json = json_decode(json_encode($response), true);
@@ -46,10 +46,10 @@ END;
                 )
             )
 END;
-        $analysis = new Analysis($this->parseComment($comment));
+        $analysis = new Analysis($this->parseComment($comment), null, $this->trackingLogger());
         $response = $analysis->getAnnotationsOfType(Response::class)[0];
         $this->assertCount(1, $response->content);
-        $analysis->process(new MergeXmlContent());
+        $analysis->process(new MergeXmlContent($this->trackingLogger()));
         $this->assertCount(2, $response->content);
     }
 
@@ -61,12 +61,12 @@ END;
                 @OA\Property(property="color", type="string")
             ))
 END;
-        $analysis = new Analysis($this->parseComment($comment));
+        $analysis = new Analysis($this->parseComment($comment), null, $this->trackingLogger());
         $this->assertCount(4, $analysis->annotations);
         $parameter = $analysis->getAnnotationsOfType(Parameter::class)[0];
         $this->assertSame(UNDEFINED, $parameter->content);
         $this->assertCount(1, $parameter->_unmerged);
-        $analysis->process(new MergeXmlContent());
+        $analysis->process(new MergeXmlContent($this->trackingLogger()));
         $this->assertCount(1, $parameter->content);
         $this->assertCount(0, $parameter->_unmerged);
         $json = json_decode(json_encode($parameter), true);
@@ -77,18 +77,21 @@ END;
 
     public function testNoParent()
     {
+        $logger = $this->trackingLogger();
+
         $this->assertOpenApiLogEntryContains('Unexpected @OA\XmlContent() must be nested');
         $comment = <<<END
             @OA\XmlContent(type="array",
                 @OA\Items(ref="#/components/schemas/repository")
             )
 END;
-        $analysis = new Analysis($this->parseComment($comment));
-        $analysis->process(new MergeXmlContent());
+        $analysis = new Analysis($this->parseComment($comment), null, $logger);
+        $analysis->process(new MergeXmlContent($logger));
     }
 
     public function testInvalidParent()
     {
+        $logger = $this->trackingLogger();
         $this->assertOpenApiLogEntryContains('Unexpected @OA\XmlContent() in @OA\Property() in');
         $comment = <<<END
             @OA\Property(
@@ -97,7 +100,7 @@ END;
                 )
             )
 END;
-        $analysis = new Analysis($this->parseComment($comment));
-        $analysis->process(new MergeXmlContent());
+        $analysis = new Analysis($this->parseComment($comment), null, $logger);
+        $analysis->process(new MergeXmlContent($logger));
     }
 }

--- a/tests/Processors/OperationIdTest.php
+++ b/tests/Processors/OperationIdTest.php
@@ -22,7 +22,7 @@ class OperationIdTest extends OpenApiTestCase
             'Processors/EntityControllerInterface.php',
             'Processors/EntityControllerTrait.php',
         ]);
-        $analysis->process([new OperationId($this->trackingLogger())]);
+        $analysis->process([new OperationId($this->getLogger())]);
         $operations = $analysis->getAnnotationsOfType(Operation::class);
 
         $this->assertCount(3, $operations);

--- a/tests/Processors/OperationIdTest.php
+++ b/tests/Processors/OperationIdTest.php
@@ -22,7 +22,7 @@ class OperationIdTest extends OpenApiTestCase
             'Processors/EntityControllerInterface.php',
             'Processors/EntityControllerTrait.php',
         ]);
-        $analysis->process([new OperationId()]);
+        $analysis->process([new OperationId($this->trackingLogger())]);
         $operations = $analysis->getAnnotationsOfType(Operation::class);
 
         $this->assertCount(3, $operations);

--- a/tests/RefTest.php
+++ b/tests/RefTest.php
@@ -26,8 +26,8 @@ class RefTest extends OpenApiTestCase
 )
 END;
         $openapi->merge($this->parseComment($comment));
-        $analysis = new Analysis();
-        $analysis->addAnnotation($openapi, Context::detect());
+        $analysis = new Analysis([], null, $this->trackingLogger());
+        $analysis->addAnnotation($openapi, Context::detect(0, $this->trackingLogger()));
         $analysis->process();
 
         $analysis->validate();

--- a/tests/RefTest.php
+++ b/tests/RefTest.php
@@ -26,8 +26,8 @@ class RefTest extends OpenApiTestCase
 )
 END;
         $openapi->merge($this->parseComment($comment));
-        $analysis = new Analysis([], null, $this->trackingLogger());
-        $analysis->addAnnotation($openapi, Context::detect(0, $this->trackingLogger()));
+        $analysis = new Analysis([], null, $this->getLogger());
+        $analysis->addAnnotation($openapi, Context::detect(0, $this->getLogger()));
         $analysis->process();
 
         $analysis->validate();

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -15,7 +15,7 @@ class SerializerTest extends OpenApiTestCase
 {
     private function getExpected()
     {
-        $logger = $this->trackingLogger();
+        $logger = $this->getLogger();
 
         $path = new Annotations\PathItem([], $logger);
         $path->path = '/products';
@@ -74,7 +74,7 @@ class SerializerTest extends OpenApiTestCase
 
     public function testDeserializeAnnotation()
     {
-        $serializer = new Serializer($this->trackingLogger());
+        $serializer = new Serializer($this->getLogger());
 
         $json = <<<JSON
 {
@@ -150,7 +150,7 @@ JSON;
 
     public function testPetstoreExample()
     {
-        $serializer = new Serializer($this->trackingLogger());
+        $serializer = new Serializer($this->getLogger());
         $spec = __DIR__.'/../Examples/petstore.swagger.io/petstore.swagger.io.json';
         $openapi = $serializer->deserializeFile($spec);
         $this->assertInstanceOf(OpenApi::class, $openapi);
@@ -164,7 +164,7 @@ JSON;
      */
     public function testDeserializeAllOfProperty()
     {
-        $serializer = new Serializer($this->trackingLogger());
+        $serializer = new Serializer($this->getLogger());
         $json = <<<JSON
             {
             	"openapi": "3.0.0",

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -15,16 +15,18 @@ class SerializerTest extends OpenApiTestCase
 {
     private function getExpected()
     {
-        $path = new Annotations\PathItem([]);
+        $logger = $this->trackingLogger();
+
+        $path = new Annotations\PathItem([], $logger);
         $path->path = '/products';
-        $path->post = new Annotations\Post([]);
+        $path->post = new Annotations\Post([], $logger);
         $path->post->tags = ['products'];
         $path->post->summary = 's1';
         $path->post->description = 'd1';
-        $path->post->requestBody = new Annotations\RequestBody([]);
-        $mediaType = new Annotations\MediaType([]);
+        $path->post->requestBody = new Annotations\RequestBody([], $logger);
+        $mediaType = new Annotations\MediaType([], $logger);
         $mediaType->mediaType = 'application/json';
-        $mediaType->schema = new Annotations\Schema([]);
+        $mediaType->schema = new Annotations\Schema([], $logger);
         $mediaType->schema->type = 'object';
         $mediaType->schema->additionalProperties = true;
         $path->post->requestBody->content = [$mediaType];
@@ -32,39 +34,39 @@ class SerializerTest extends OpenApiTestCase
         $path->post->requestBody->x = [];
         $path->post->requestBody->x['repository'] = 'def';
 
-        $resp = new Annotations\Response([]);
+        $resp = new Annotations\Response([], $logger);
         $resp->response = '200';
         $resp->description = 'Success';
-        $content = new Annotations\MediaType([]);
+        $content = new Annotations\MediaType([], $logger);
         $content->mediaType = 'application/json';
-        $content->schema = new Annotations\Schema([]);
+        $content->schema = new Annotations\Schema([], $logger);
         $content->schema->ref = '#/components/schemas/Pet';
         $resp->content = [$content];
         $resp->x = [];
         $resp->x['repository'] = 'def';
 
-        $respRange = new Annotations\Response([]);
+        $respRange = new Annotations\Response([], $logger);
         $respRange->response = '4XX';
         $respRange->description = 'Client error response';
 
         $path->post->responses = [$resp, $respRange];
 
-        $expected = new Annotations\OpenApi([]);
+        $expected = new Annotations\OpenApi([], $logger);
         $expected->openapi = '3.0.0';
         $expected->paths = [
             $path,
         ];
 
-        $info = new Annotations\Info([]);
+        $info = new Annotations\Info([], $logger);
         $info->title = 'Pet store';
         $info->version = '1.0';
         $expected->info = $info;
 
-        $schema = new Annotations\Schema([]);
+        $schema = new Annotations\Schema([], $logger);
         $schema->schema = 'Pet';
         $schema->required = ['name', 'photoUrls'];
 
-        $expected->components = new Annotations\Components([]);
+        $expected->components = new Annotations\Components([], $logger);
         $expected->components->schemas = [$schema];
 
         return $expected;
@@ -72,7 +74,7 @@ class SerializerTest extends OpenApiTestCase
 
     public function testDeserializeAnnotation()
     {
-        $serializer = new Serializer();
+        $serializer = new Serializer($this->trackingLogger());
 
         $json = <<<JSON
 {
@@ -148,7 +150,7 @@ JSON;
 
     public function testPetstoreExample()
     {
-        $serializer = new Serializer();
+        $serializer = new Serializer($this->trackingLogger());
         $spec = __DIR__.'/../Examples/petstore.swagger.io/petstore.swagger.io.json';
         $openapi = $serializer->deserializeFile($spec);
         $this->assertInstanceOf(OpenApi::class, $openapi);
@@ -162,7 +164,7 @@ JSON;
      */
     public function testDeserializeAllOfProperty()
     {
-        $serializer = new Serializer();
+        $serializer = new Serializer($this->trackingLogger());
         $json = <<<JSON
             {
             	"openapi": "3.0.0",

--- a/tests/StaticAnalyserTest.php
+++ b/tests/StaticAnalyserTest.php
@@ -112,7 +112,7 @@ class StaticAnalyserTest extends OpenApiTestCase
     public function testWrongCommentType()
     {
         $logger = $this->getLogger(true);
-        $analyser = new StaticAnalyser($logger);
+        $analyser = new StaticAnalyser(null, $logger);
         $this->assertOpenApiLogEntryContains('Annotations are only parsed inside `/**` DocBlocks');
         $analyser->fromCode("<?php\n/*\n * @OA\Parameter() */", new Context(['logger' => $logger]));
     }
@@ -127,7 +127,7 @@ class StaticAnalyserTest extends OpenApiTestCase
     {
         $backup = Analyser::$whitelist;
         Analyser::$whitelist = ['OpenApi\\Annotations\\'];
-        $analyser = new StaticAnalyser($this->getLogger());
+        $analyser = new StaticAnalyser(null, $this->getLogger());
         $defaultAnalysis = $analyser->fromFile(__DIR__.'/Fixtures/ThirdPartyAnnotations.php');
         $this->assertCount(3, $defaultAnalysis->annotations, 'Only read the @OA annotations, skip the others.');
 
@@ -151,7 +151,7 @@ class StaticAnalyserTest extends OpenApiTestCase
     public function testAnonymousClassProducesNoError()
     {
         try {
-            $analyser = new StaticAnalyser($this->getLogger());
+            $analyser = new StaticAnalyser(null, $this->getLogger());
             $analyser->fromFile($this->fixtures('StaticAnalyser/php7.php')[0]);
             $this->assertNotNull($analyser);
         } catch (\Throwable $t) {

--- a/tests/StaticAnalyserTest.php
+++ b/tests/StaticAnalyserTest.php
@@ -111,7 +111,7 @@ class StaticAnalyserTest extends OpenApiTestCase
 
     public function testWrongCommentType()
     {
-        $logger = $this->trackingLogger();
+        $logger = $this->getLogger(true);
         $analyser = new StaticAnalyser($logger);
         $this->assertOpenApiLogEntryContains('Annotations are only parsed inside `/**` DocBlocks');
         $analyser->fromCode("<?php\n/*\n * @OA\Parameter() */", new Context(['logger' => $logger]));
@@ -127,14 +127,14 @@ class StaticAnalyserTest extends OpenApiTestCase
     {
         $backup = Analyser::$whitelist;
         Analyser::$whitelist = ['OpenApi\\Annotations\\'];
-        $analyser = new StaticAnalyser($this->trackingLogger());
+        $analyser = new StaticAnalyser($this->getLogger());
         $defaultAnalysis = $analyser->fromFile(__DIR__.'/Fixtures/ThirdPartyAnnotations.php');
         $this->assertCount(3, $defaultAnalysis->annotations, 'Only read the @OA annotations, skip the others.');
 
         // Allow the analyser to parse 3rd party annotations, which might
         // contain useful info that could be extracted with a custom processor
         Analyser::$whitelist[] = 'AnotherNamespace\\Annotations\\';
-        $openapi = \OpenApi\scan(__DIR__.'/Fixtures/ThirdPartyAnnotations.php', ['logger' => $this->trackingLogger()]);
+        $openapi = \OpenApi\scan(__DIR__.'/Fixtures/ThirdPartyAnnotations.php', ['logger' => $this->getLogger()]);
         $this->assertSame('api/3rd-party', $openapi->paths[0]->path);
         $this->assertCount(4, $openapi->_unmerged);
         Analyser::$whitelist = $backup;
@@ -151,7 +151,7 @@ class StaticAnalyserTest extends OpenApiTestCase
     public function testAnonymousClassProducesNoError()
     {
         try {
-            $analyser = new StaticAnalyser($this->trackingLogger());
+            $analyser = new StaticAnalyser($this->getLogger());
             $analyser->fromFile($this->fixtures('StaticAnalyser/php7.php')[0]);
             $this->assertNotNull($analyser);
         } catch (\Throwable $t) {

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -26,7 +26,7 @@ class UtilTest extends OpenApiTestCase
                 'UsingRefs.php',
                 'UsingPhpDoc.php',
             ],
-            'logger' => $this->trackingLogger(),
+            'logger' => $this->getLogger(),
         ]);
         $this->assertSame('Fixture for ParserTest', $openapi->info->title, 'No errors about duplicate @OA\Info() annotations');
     }

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -6,6 +6,8 @@
 
 namespace OpenApi\Tests;
 
+use OpenApi\Annotations\Get;
+use OpenApi\Annotations\Post;
 use OpenApi\Util;
 use Symfony\Component\Finder\Finder;
 
@@ -24,6 +26,7 @@ class UtilTest extends OpenApiTestCase
                 'UsingRefs.php',
                 'UsingPhpDoc.php',
             ],
+            'logger' => $this->trackingLogger(),
         ]);
         $this->assertSame('Fixture for ParserTest', $openapi->info->title, 'No errors about duplicate @OA\Info() annotations');
     }
@@ -51,5 +54,21 @@ class UtilTest extends OpenApiTestCase
         $this->assertGreaterThan(0, iterator_count($finder_result), 'There should be at least a few file paths.');
         $finder_result_array = \iterator_to_array($finder_result);
         $this->assertArrayNotHasKey($directory_path, $finder_result_array, 'The directory should not be a path in the finder.');
+    }
+
+    public function shortenFixtures()
+    {
+        return [
+            [Get::class, '@OA\Get'],
+            [[Get::class, Post::class], ['@OA\Get', '@OA\Post']],
+        ];
+    }
+
+    /**
+     * @dataProvider shortenFixtures
+     */
+    public function testShorten($classes, $expected)
+    {
+        $this->assertEquals($expected, Util::shorten($classes));
     }
 }


### PR DESCRIPTION
Adds a OO style way to scan for OpenAPI annotations.

* Adds a new `Generator` class that allows to configure and scan in a non static way
  * Fully BC
  * Only modifies static settings for the duration of the run
  * Allows to override all aspects using fluid setter methods
  * PSR-3 logger support
  * `Generator::scan() accepts` any iterator over source files incl. a Symfony Finder instance
* Migrate to using PSR/LoggerInterface for all logging


To be clear, this is just a proposal and I'd be honestly curious and interested in feedback.

The logger related changes might be controversial (@bfanger and I discussed this before), but I felt this was needed to make the Generator implementation complete.
Test have been updated to allow to test both the default behaviour and injection of a PSR logger instance via an environment variable.
```
export NON_TRACKING_LOGGER=NULL
```

Performance wise this should not have a big impact since ideally there is only a single logger instance that needs to be created upfront.

