### PR TITLE
Limit `AugmentSchemas` processor to actual `Schema` instances only

### DIFF
--- a/Examples/misc/misc.yaml
+++ b/Examples/misc/misc.yaml
@@ -25,7 +25,6 @@ paths:
                 properties:
                   type: { type: string }
                   color: { type: string }
-                type: object
       responses:
         '200':
           description: Success

--- a/src/Processors/AugmentSchemas.php
+++ b/src/Processors/AugmentSchemas.php
@@ -19,7 +19,7 @@ class AugmentSchemas
 {
     public function __invoke(Analysis $analysis)
     {
-        $schemas = $analysis->getAnnotationsOfType(Schema::class);
+        $schemas = $analysis->getAnnotationsOfType(Schema::class, true);
         // Use the class names for @OA\Schema()
         foreach ($schemas as $schema) {
             if ($schema->schema === UNDEFINED) {


### PR DESCRIPTION
Set the `strict` flag when calling `getAnnotationsOfType()` to only process actual `Schema` instances.

Fixes #890 