### PR TITLE
Ignore PHP8 attributes

### DIFF
--- a/src/StaticAnalyser.php
+++ b/src/StaticAnalyser.php
@@ -82,6 +82,12 @@ class StaticAnalyser
                 continue;
             }
 
+            if ($token[0] === T_ATTRIBUTE) {
+                // consume
+                $this->parseAttribute($tokens, $token, $parseContext);
+                continue;
+            }
+
             if ($token[0] === T_DOC_COMMENT) {
                 if ($comment) {
                     // 2 Doc-comments in succession?
@@ -417,6 +423,25 @@ class StaticAnalyser
             }
 
             return $token;
+        }
+    }
+
+    private function parseAttribute(array &$tokens, &$token, Context $parseContext): void
+    {
+        $nesting = 1;
+        while ($token !== false) {
+            $token = $this->nextToken($tokens, $parseContext);
+            if (!is_array($token) && '[' === $token) {
+                ++$nesting;
+                continue;
+            }
+
+            if (!is_array($token) && ']' === $token) {
+                --$nesting;
+                if (!$nesting) {
+                    break;
+                }
+            }
         }
     }
 

--- a/tests/Fixtures/StaticAnalyser/Label.php
+++ b/tests/Fixtures/StaticAnalyser/Label.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace OpenApi\Tests\Fixtures\StaticAnalyser;
+
+#[Attribute]
+class Label
+{
+    protected $name;
+
+    public function __construct(string $name, array $numbers)
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/Fixtures/StaticAnalyser/Php8AttrMix.php
+++ b/tests/Fixtures/StaticAnalyser/Php8AttrMix.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace OpenApi\Tests\Fixtures\StaticAnalyser;
+
+/**
+ * @OA\Schema()
+*/
+class Php8AttrMix
+{
+    #[label('Id', [1])]
+    /** @OA\Property() */
+    public string $id = '';
+
+    /** @OA\Property() */
+    #[
+        label('OtherId', [2, 3]),
+        label('OtherId', [2, 3]),
+    ]
+    public string $otherId = '';
+
+}

--- a/tests/Fixtures/StaticAnalyser/php7.php
+++ b/tests/Fixtures/StaticAnalyser/php7.php
@@ -1,33 +1,31 @@
 <?php declare(strict_types=1);
 
-namespace OpenApi\Tests\Fixtures;
+namespace OpenApi\Tests\Fixtures\StaticAnalyser;
 
-$o = new class
+interface foo
 {
+}
+
+$o = new class {
     public function foo()
     {
     }
 };
 
-$o = new class extends stdClass
-{
+$o = new class extends \stdClass {
 };
 
-$o = new class implements foo
-{
+$o = new class implements foo {
 };
 
-$o = new class()
-{
+$o = new class() {
     public function foo()
     {
     }
 };
 
-$o = new class() extends stdClass
-{
+$o = new class() extends \stdClass {
 };
 
-$o = new class() implements foo
-{
+$o = new class() implements foo {
 };

--- a/tests/Fixtures/StaticAnalyser/routes.php
+++ b/tests/Fixtures/StaticAnalyser/routes.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+namespace OpenApi\Tests\Fixtures\StaticAnalyser;
+
 //
 // Allow indentation with tab(s).
 //

--- a/tests/StaticAnalyserTest.php
+++ b/tests/StaticAnalyserTest.php
@@ -7,6 +7,7 @@
 namespace OpenApi\Tests;
 
 use OpenApi\Analyser;
+use OpenApi\Annotations\Property;
 use OpenApi\Annotations\Schema;
 use OpenApi\Context;
 use OpenApi\StaticAnalyser;
@@ -227,5 +228,21 @@ class StaticAnalyserTest extends OpenApiTestCase
 
         $this->assertCount(1, $schemas);
         $this->assertEquals(User::CONSTANT, $schemas[0]->example);
+    }
+
+    /**
+     * @requires PHP 8
+     */
+    public function testPhp8AttributeMix()
+    {
+        $analysis = $this->analysisFromFixtures('StaticAnalyser/Php8AttrMix.php');
+        $schemas = $analysis->getAnnotationsOfType(Schema::class, true);
+
+        $this->assertCount(1, $schemas);
+        $analysis->process();
+        $properties = $analysis->getAnnotationsOfType(Property::class, true);
+        $this->assertCount(2, $properties);
+        $this->assertEquals('id', $properties[0]->property);
+        $this->assertEquals('otherId', $properties[1]->property);
     }
 }


### PR DESCRIPTION
Fix the issue of PHP8 attributes located between docblock and the referenced property/method/class causing the token parser to drop the docblock.

Fixes #906 