### PR TITLE
hash operationId from generated swagger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /docs/node_modules/*
 .phpunit.result.cache
 /.php_cs.cache
+.idea/

--- a/Examples/using-interfaces/using-interfaces.yaml
+++ b/Examples/using-interfaces/using-interfaces.yaml
@@ -7,7 +7,7 @@ paths:
     get:
       tags:
         - Products
-      operationId: 'UsingInterfaces\ProductController::getProduct'
+      operationId: '330fe5a2e8123ccccf5dac56f09e6ce0'
       parameters:
         -
           name: id

--- a/Examples/using-refs/using-refs.yaml
+++ b/Examples/using-refs/using-refs.yaml
@@ -7,7 +7,7 @@ paths:
     get:
       tags:
         - Products
-      operationId: 'UsingRefs\ProductController::getProduct'
+      operationId: '648d8a6fe9d3c958781da70c3ee142d1'
       responses:
         default:
           description: 'successful operation'
@@ -18,7 +18,7 @@ paths:
     patch:
       tags:
         - Products
-      operationId: 'UsingRefs\ProductController::updateProduct'
+      operationId: '2b0d92c60e55f1525ed390ce9fba2f90'
       requestBody:
         $ref: '#/components/requestBodies/product_in_body'
       responses:
@@ -35,7 +35,7 @@ paths:
     post:
       tags:
         - Products
-      operationId: 'UsingRefs\ProductController::addProduct'
+      operationId: '51e51052137774055a8ddfe0428c52e8'
       parameters:
         -
           $ref: '#/components/requestBodies/product_in_body'

--- a/Examples/using-traits/using-traits.yaml
+++ b/Examples/using-traits/using-traits.yaml
@@ -7,7 +7,7 @@ paths:
     delete:
       tags:
         - Entities
-      operationId: 'UsingTraits\DeleteEntity::deleteEntity'
+      operationId: '489b960a9e004c04db5a54b622025b6b'
       parameters:
         -
           name: id
@@ -23,7 +23,7 @@ paths:
     get:
       tags:
         - Products
-      operationId: 'UsingTraits\ProductController::getProduct'
+      operationId: '122d5b0a38c3c9d221495de58a88e9b6'
       parameters:
         -
           name: product_id

--- a/src/Processors/OperationId.php
+++ b/src/Processors/OperationId.php
@@ -27,13 +27,14 @@ class OperationId
                 $source = $context->class ?? $context->interface ?? $context->trait;
                 if ($source) {
                     if ($context->namespace) {
-                        $operation->operationId = $context->namespace.'\\'.$source.'::'.$context->method;
+                        $operationId = $context->namespace.'\\'.$source.'::'.$context->method;
                     } else {
-                        $operation->operationId = $source.'::'.$context->method;
+                        $operationId = $source.'::'.$context->method;
                     }
                 } else {
-                    $operation->operationId = $context->method;
+                    $operationId = $context->method;
                 }
+                $operation->operationId = \md5($operationId);
             }
         }
     }

--- a/tests/Processors/OperationIdTest.php
+++ b/tests/Processors/OperationIdTest.php
@@ -29,14 +29,14 @@ class OperationIdTest extends OpenApiTestCase
 
         $this->assertSame('entity/{id}', $operations[0]->path);
         $this->assertInstanceOf(Get::class, $operations[0]);
-        $this->assertSame('OpenApi\Tests\Fixtures\Processors\EntityControllerClass::getEntry', $operations[0]->operationId);
+        $this->assertSame(\md5('OpenApi\Tests\Fixtures\Processors\EntityControllerClass::getEntry'), $operations[0]->operationId);
 
         $this->assertSame('entity/{id}', $operations[1]->path);
         $this->assertInstanceOf(Post::class, $operations[1]);
-        $this->assertSame('OpenApi\Tests\Fixtures\Processors\EntityControllerInterface::updateEntity', $operations[1]->operationId);
+        $this->assertSame(\md5('OpenApi\Tests\Fixtures\Processors\EntityControllerInterface::updateEntity'), $operations[1]->operationId);
 
         $this->assertSame('entities/{id}', $operations[2]->path);
         $this->assertInstanceOf(Delete::class, $operations[2]);
-        $this->assertSame('OpenApi\Tests\Fixtures\Processors\EntityControllerTrait::deleteEntity', $operations[2]->operationId);
+        $this->assertSame(\md5('OpenApi\Tests\Fixtures\Processors\EntityControllerTrait::deleteEntity'), $operations[2]->operationId);
     }
 }


### PR DESCRIPTION
When i generated the first time a swagger doc. the operationId was indicate tree structure of our class 
like :  `App\Foo\Faa\ClassController::__invoke`

I think we should hide tree structure for a  public doc 

The first and quick idea i found, is to hash the operationId