### PR TITLE
Fix TypeError when substr return FALSE

### DIFF
--- a/src/Context.php
+++ b/src/Context.php
@@ -201,7 +201,11 @@ class Context
         if (!$summary) {
             return UNDEFINED;
         }
-        $description = trim(substr($this->phpdocContent(), strlen($summary)));
+        if (false !== ($substr = substr($this->phpdocContent(), strlen($summary)))) {
+            $description = trim($substr);
+        } else {
+            $description = '';
+        }
         if ($description === '') {
             return UNDEFINED;
         }


### PR DESCRIPTION
There is type error on PHP 7.2.32:

> Fatal error: Uncaught TypeError: trim() expects parameter 1 to be string, boolean given in /home/webmaster/data/www/vendor/zircote/swagger-php/src/Context.php:212 Stack trace: #0 /home/webmaster/data/www/vendor/zircote/swagger-php/src/Context.php(212): trim(false) #1 /home/webmaster/data/www/vendor/zircote/swagger-php/src/Processors/AugmentOperations.php(26): OpenApi\Context->phpdocDescription() #2 /home/webmaster/data/www/vendor/zircote/swagger-php/src/Analysis.php(466): OpenApi\Processors\AugmentOperations->__invoke(Object(OpenApi\Analysis)) #3 /home/webmaster/data/www/vendor/zircote/swagger-php/src/functions.php(57): OpenApi\Analysis->process(Array) #4 /home/webmaster/data/www/stolplit.ru/mobile_api/generate_doc.php(27): OpenApi\scan('/home/webmaster...') #5 {main} thrown in /home/webmaster/data/www/vendor/zircote/swagger-php/src/Context.php on line 212

This little patch fixes this issue