### PR TITLE
Regression: Fix traits without class-level phpDocs

### DIFF
--- a/Examples/using-traits/Decoration/UndocumentedBell.php
+++ b/Examples/using-traits/Decoration/UndocumentedBell.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace UsingTraits\Decoration;
+
+trait UndocumentedBell {
+
+    public $undocumentedBell;
+}

--- a/Examples/using-traits/SimpleProduct.php
+++ b/Examples/using-traits/SimpleProduct.php
@@ -10,6 +10,7 @@ use UsingTraits\Decoration;
  */
 class SimpleProduct {
     use Decoration\Bells;
+    use Decoration\UndocumentedBell;
 
     /**
      * The unique identifier of a simple product in our catalog.

--- a/src/Processors/ExpandTraits.php
+++ b/src/Processors/ExpandTraits.php
@@ -52,10 +52,12 @@ class ExpandTraits
 
     protected function mergeTrait(Schema $schema, array $trait, array &$existing): void
     {
-        foreach ($trait['context']->annotations as $annotation) {
-            if ($annotation instanceof Property && !in_array($annotation->_context->property, $existing)) {
-                $existing[] = $annotation->_context->property;
-                $schema->merge([$annotation], true);
+        if (is_iterable($trait['context']->annotations)) {
+            foreach ($trait['context']->annotations as $annotation) {
+                if ($annotation instanceof Property && !in_array($annotation->_context->property, $existing)) {
+                    $existing[] = $annotation->_context->property;
+                    $schema->merge([$annotation], true);
+                }
             }
         }
 

--- a/src/Processors/MergeTraits.php
+++ b/src/Processors/MergeTraits.php
@@ -21,10 +21,12 @@ class MergeTraits
                 $existing = [];
                 $traits = $analysis->getTraitsOfClass($schema->_context->fullyQualifiedName($schema->_context->class));
                 foreach ($traits as $trait) {
-                    foreach ($trait['context']->annotations as $annotation) {
-                        if ($annotation instanceof Property && !in_array($annotation->_context->property, $existing)) {
-                            $existing[] = $annotation->_context->property;
-                            $schema->merge([$annotation], true);
+                    if (is_iterable($trait['context']->annotations)) {
+                        foreach ($trait['context']->annotations as $annotation) {
+                            if ($annotation instanceof Property && !in_array($annotation->_context->property, $existing)) {
+                                $existing[] = $annotation->_context->property;
+                                $schema->merge([$annotation], true);
+                            }
                         }
                     }
 


### PR DESCRIPTION
Release v3.2.0 breaks traits without class-level phpDocs. A workaround is to set an empty phpDoc with just a description. This was not an issue with v3.1.0.

Context::annotations is null in cases where class-level phpDocs don't exist. This causes foreach() to throw a warning which in certain environments causes a full crash.