### PR TITLE
Operation id improvements

### DIFF
--- a/Examples/using-interfaces/using-interfaces.yaml
+++ b/Examples/using-interfaces/using-interfaces.yaml
@@ -7,7 +7,7 @@ paths:
     get:
       tags:
         - Products
-      operationId: 'GET::UsingInterfaces\ProductController::getProduct'
+      operationId: 6a7963b92da560b8d7f16b0fdba847ef
       parameters:
         -
           name: id

--- a/Examples/using-interfaces/using-interfaces.yaml
+++ b/Examples/using-interfaces/using-interfaces.yaml
@@ -7,7 +7,7 @@ paths:
     get:
       tags:
         - Products
-      operationId: 'UsingInterfaces\ProductController::getProduct'
+      operationId: 'GET::UsingInterfaces\ProductController::getProduct'
       parameters:
         -
           name: id

--- a/Examples/using-refs/using-refs.yaml
+++ b/Examples/using-refs/using-refs.yaml
@@ -7,7 +7,7 @@ paths:
     get:
       tags:
         - Products
-      operationId: 'UsingRefs\ProductController::getProduct'
+      operationId: 'GET::UsingRefs\ProductController::getProduct'
       responses:
         default:
           description: 'successful operation'
@@ -18,7 +18,7 @@ paths:
     patch:
       tags:
         - Products
-      operationId: 'UsingRefs\ProductController::updateProduct'
+      operationId: 'PATCH::UsingRefs\ProductController::updateProduct'
       requestBody:
         $ref: '#/components/requestBodies/product_in_body'
       responses:
@@ -35,7 +35,7 @@ paths:
     post:
       tags:
         - Products
-      operationId: 'UsingRefs\ProductController::addProduct'
+      operationId: 'POST::UsingRefs\ProductController::addProduct'
       parameters:
         -
           $ref: '#/components/requestBodies/product_in_body'

--- a/Examples/using-refs/using-refs.yaml
+++ b/Examples/using-refs/using-refs.yaml
@@ -7,7 +7,7 @@ paths:
     get:
       tags:
         - Products
-      operationId: 'GET::UsingRefs\ProductController::getProduct'
+      operationId: ecd4da135afcd55d0c1308b260c38060
       responses:
         default:
           description: 'successful operation'
@@ -18,7 +18,7 @@ paths:
     patch:
       tags:
         - Products
-      operationId: 'PATCH::UsingRefs\ProductController::updateProduct'
+      operationId: ccfcd39d70ad7d7f367a54908d3a0db6
       requestBody:
         $ref: '#/components/requestBodies/product_in_body'
       responses:
@@ -35,7 +35,7 @@ paths:
     post:
       tags:
         - Products
-      operationId: 'POST::UsingRefs\ProductController::addProduct'
+      operationId: ce046e4e523b43847bf9a5066145bda0
       parameters:
         -
           $ref: '#/components/requestBodies/product_in_body'

--- a/Examples/using-traits/using-traits.yaml
+++ b/Examples/using-traits/using-traits.yaml
@@ -7,7 +7,7 @@ paths:
     delete:
       tags:
         - Entities
-      operationId: 'DELETE::UsingTraits\DeleteEntity::deleteEntity'
+      operationId: e87b6b3d88068b6863f408c0ce77528f
       parameters:
         -
           name: id
@@ -23,7 +23,7 @@ paths:
     get:
       tags:
         - Products
-      operationId: 'GET::UsingTraits\ProductController::getProduct'
+      operationId: d3096ee893a30bd6cd88099036a5cb3f
       parameters:
         -
           name: product_id

--- a/Examples/using-traits/using-traits.yaml
+++ b/Examples/using-traits/using-traits.yaml
@@ -7,7 +7,7 @@ paths:
     delete:
       tags:
         - Entities
-      operationId: 'UsingTraits\DeleteEntity::deleteEntity'
+      operationId: 'DELETE::UsingTraits\DeleteEntity::deleteEntity'
       parameters:
         -
           name: id
@@ -23,7 +23,7 @@ paths:
     get:
       tags:
         - Products
-      operationId: 'UsingTraits\ProductController::getProduct'
+      operationId: 'GET::UsingTraits\ProductController::getProduct'
       parameters:
         -
           name: product_id

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -144,6 +144,31 @@ class Generator
         return $this;
     }
 
+    /**
+     * Update/replace an existing processor with a new one.
+     *
+     * @param callable      $processor the new processor
+     * @param null|callable $matcher   Optional matcher callable to identify the processor to replace.
+     *                                 If none given, matching is based on the processors class.
+     */
+    public function updateProcessor(callable $processor, ?callable $matcher = null): Generator
+    {
+        if (!$matcher) {
+            $matcher = $matcher ?: function ($other) use ($processor) {
+                $otherClass = get_class($other);
+
+                return $processor instanceof $otherClass;
+            };
+        }
+
+        $processors = array_map(function ($other) use ($processor, $matcher) {
+            return $matcher($other) ? $processor : $other;
+        }, $this->getProcessors());
+        $this->setProcessors($processors);
+
+        return $this;
+    }
+
     public function getLogger(): ?LoggerInterface
     {
         return $this->logger;

--- a/src/Processors/OperationId.php
+++ b/src/Processors/OperationId.php
@@ -15,6 +15,16 @@ use OpenApi\Generator;
  */
 class OperationId
 {
+    protected $hash;
+
+    /**
+     * @param bool $hash if `true` hash generated ids instead of clear text
+     */
+    public function __construct(bool $hash = false)
+    {
+        $this->hash = $hash;
+    }
+
     public function __invoke(Analysis $analysis)
     {
         $allOperations = $analysis->getAnnotationsOfType(Operation::class);
@@ -26,15 +36,18 @@ class OperationId
             $context = $operation->_context;
             if ($context && $context->method) {
                 $source = $context->class ?? $context->interface ?? $context->trait;
+                $operationId = null;
                 if ($source) {
                     if ($context->namespace) {
-                        $operation->operationId = $context->namespace.'\\'.$source.'::'.$context->method;
+                        $operationId = $context->namespace.'\\'.$source.'::'.$context->method;
                     } else {
-                        $operation->operationId = $source.'::'.$context->method;
+                        $operationId = $source.'::'.$context->method;
                     }
                 } else {
-                    $operation->operationId = $context->method;
+                    $operationId = $context->method;
                 }
+                $operationId = strtoupper($operation->method).'::'.$operationId;
+                $operation->operationId = $this->hash ? md5($operationId) : $operationId;
             }
         }
     }

--- a/src/Processors/OperationId.php
+++ b/src/Processors/OperationId.php
@@ -20,7 +20,7 @@ class OperationId
     /**
      * @param bool $hash if `true` hash generated ids instead of clear text
      */
-    public function __construct(bool $hash = false)
+    public function __construct(bool $hash = true)
     {
         $this->hash = $hash;
     }

--- a/src/Processors/OperationId.php
+++ b/src/Processors/OperationId.php
@@ -25,6 +25,18 @@ class OperationId
         $this->hash = $hash;
     }
 
+    public function isHash(): bool
+    {
+        return $this->hash;
+    }
+
+    public function setHash(bool $hash): OperationId
+    {
+        $this->hash = $hash;
+
+        return $this;
+    }
+
     public function __invoke(Analysis $analysis)
     {
         $allOperations = $analysis->getAnnotationsOfType(Operation::class);

--- a/tests/Fixtures/Processors/EntityControllerInterface.php
+++ b/tests/Fixtures/Processors/EntityControllerInterface.php
@@ -9,7 +9,7 @@ interface EntityControllerInterface
 {
 
     /**
-     * @OA\POST(
+     * @OA\Post(
      *   tags={"EntityController"},
      *   path="entity/{id}",
      *   @OA\Response(

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -8,6 +8,7 @@ namespace OpenApi\Tests;
 
 use OpenApi\Generator;
 use OpenApi\Logger;
+use OpenApi\Processors\OperationId;
 use OpenApi\Util;
 
 class GeneratorTest extends OpenApiTestCase
@@ -56,5 +57,29 @@ class GeneratorTest extends OpenApiTestCase
         (new Generator($this->getPsrLogger(true)))
             ->setAliases(['swg' => 'OpenApi\Annotations'])
             ->generate($this->fixtures('Deprecated.php'));
+    }
+
+    public function processorCases()
+    {
+        return [
+            [new OperationId(false), false],
+            [new OperationId(true), true],
+            [new class(false) extends OperationId {
+            }, false],
+        ];
+    }
+
+    /**
+     * @dataProvider processorCases
+     */
+    public function testUpdateProcessor($p, $expected)
+    {
+        $generator = (new Generator())
+            ->updateProcessor($p);
+        foreach ($generator->getProcessors() as $processor) {
+            if ($processor instanceof OperationId) {
+                $this->assertSpecEquals($expected, $processor->isHash());
+            }
+        }
     }
 }

--- a/tests/Processors/OperationIdTest.php
+++ b/tests/Processors/OperationIdTest.php
@@ -29,14 +29,14 @@ class OperationIdTest extends OpenApiTestCase
 
         $this->assertSame('entity/{id}', $operations[0]->path);
         $this->assertInstanceOf(Get::class, $operations[0]);
-        $this->assertSame('OpenApi\Tests\Fixtures\Processors\EntityControllerClass::getEntry', $operations[0]->operationId);
+        $this->assertSame('GET::OpenApi\Tests\Fixtures\Processors\EntityControllerClass::getEntry', $operations[0]->operationId);
 
         $this->assertSame('entity/{id}', $operations[1]->path);
         $this->assertInstanceOf(Post::class, $operations[1]);
-        $this->assertSame('OpenApi\Tests\Fixtures\Processors\EntityControllerInterface::updateEntity', $operations[1]->operationId);
+        $this->assertSame('POST::OpenApi\Tests\Fixtures\Processors\EntityControllerInterface::updateEntity', $operations[1]->operationId);
 
         $this->assertSame('entities/{id}', $operations[2]->path);
         $this->assertInstanceOf(Delete::class, $operations[2]);
-        $this->assertSame('OpenApi\Tests\Fixtures\Processors\EntityControllerTrait::deleteEntity', $operations[2]->operationId);
+        $this->assertSame('DELETE::OpenApi\Tests\Fixtures\Processors\EntityControllerTrait::deleteEntity', $operations[2]->operationId);
     }
 }

--- a/tests/Processors/OperationIdTest.php
+++ b/tests/Processors/OperationIdTest.php
@@ -22,7 +22,7 @@ class OperationIdTest extends OpenApiTestCase
             'Processors/EntityControllerInterface.php',
             'Processors/EntityControllerTrait.php',
         ]);
-        $analysis->process([new OperationId()]);
+        $analysis->process([new OperationId(false)]);
         $operations = $analysis->getAnnotationsOfType(Operation::class);
 
         $this->assertCount(3, $operations);


### PR DESCRIPTION
Alternative to #916 that allows to configure the behavior of the `OperationId` processor.

Also includes a new method to easily allow updating/replacing a processor.

```
    /**
     * Update/replace an existing processor with a new one.
     *
     * @param callable      $processor the new processor
     * @param null|callable $matcher   Optional matcher callable to identify the processor to replace.
     *                                 If none given, matching is based on the processors class.
     */
    public function updateProcessor(callable $processor, ?callable $matcher = null): Generator
```

```
$generator = (new Generator())
            ->updateProcessor(new OperationId(false));
```