### PR TITLE
Deprecate Context::detect

### DIFF
--- a/src/Analysis.php
+++ b/src/Analysis.php
@@ -66,15 +66,17 @@ class Analysis
     public $openapi;
 
     /**
+     * @var Context
+     */
+    protected $context;
+
+    /**
      * Registry for the post-processing operations.
      *
      * @var callable[]
      */
     private static $processors;
 
-    /**
-     * @param null $context
-     */
     public function __construct(array $annotations = [], ?Context $context = null)
     {
         $this->annotations = new \SplObjectStorage();
@@ -84,6 +86,7 @@ class Analysis
             }
             $this->addAnnotations($annotations, $context);
         }
+        $this->context = $context;
     }
 
     public function addAnnotation($annotation, ?Context $context): void
@@ -381,7 +384,7 @@ class Analysis
         }
         $unmerged = $this->openapi->_unmerged;
         $this->openapi->_unmerged = [];
-        $analysis = new Analysis([$this->openapi]);
+        $analysis = new Analysis([$this->openapi], $this->context);
         $this->openapi->_unmerged = $unmerged;
 
         return $analysis;
@@ -405,7 +408,7 @@ class Analysis
     {
         $result = new \stdClass();
         $result->merged = $this->merged();
-        $result->unmerged = new Analysis();
+        $result->unmerged = new Analysis([], $this->context);
         foreach ($this->annotations as $annotation) {
             if ($result->merged->annotations->contains($annotation) === false) {
                 $result->unmerged->annotations->attach($annotation, $this->annotations[$annotation]);

--- a/src/Context.php
+++ b/src/Context.php
@@ -249,6 +249,8 @@ class Context
 
     /**
      * Create a Context based on the debug_backtrace.
+     *
+     * @deprecated
      */
     public static function detect(int $index = 0): Context
     {

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -224,7 +224,7 @@ class Generator
      */
     public function generate(iterable $sources, ?Analysis $analysis = null, bool $validate = true): OpenApi
     {
-        $analysis = $analysis ?: new Analysis();
+        $analysis = $analysis ?: new Analysis([], new Context());
 
         $this->configStack->push($this);
         try {

--- a/src/StaticAnalyser.php
+++ b/src/StaticAnalyser.php
@@ -54,7 +54,7 @@ class StaticAnalyser
     protected function fromTokens(array $tokens, Context $parseContext): Analysis
     {
         $analyser = new Analyser();
-        $analysis = new Analysis();
+        $analysis = new Analysis([], $parseContext);
 
         reset($tokens);
         $token = '';

--- a/tests/AnalysisTest.php
+++ b/tests/AnalysisTest.php
@@ -7,13 +7,14 @@
 namespace OpenApi\Tests;
 
 use OpenApi\Analysis;
+use OpenApi\Context;
 
 class AnalysisTest extends OpenApiTestCase
 {
     public function testRegisterProcessor()
     {
         $counter = 0;
-        $analysis = new Analysis();
+        $analysis = new Analysis([], new Context());
         $analysis->process();
         $this->assertSame(0, $counter);
         $countProcessor = function (Analysis $a) use (&$counter) {

--- a/tests/OpenApiTestCase.php
+++ b/tests/OpenApiTestCase.php
@@ -232,7 +232,7 @@ class OpenApiTestCase extends TestCase
     public function analysisFromFixtures($files): Analysis
     {
         $analyser = new StaticAnalyser();
-        $analysis = new Analysis();
+        $analysis = new Analysis([], new Context());
 
         foreach ((array) $files as $file) {
             $analysis->addAnalysis($analyser->fromFile($this->fixtures($file)[0]));

--- a/tests/Processors/BuildPathsTest.php
+++ b/tests/Processors/BuildPathsTest.php
@@ -11,6 +11,7 @@ use OpenApi\Annotations\Get;
 use OpenApi\Annotations\OpenApi;
 use OpenApi\Annotations\PathItem;
 use OpenApi\Annotations\Post;
+use OpenApi\Context;
 use OpenApi\Generator;
 use OpenApi\Processors\BuildPaths;
 use OpenApi\Processors\MergeIntoOpenApi;
@@ -25,7 +26,7 @@ class BuildPathsTest extends OpenApiTestCase
             new PathItem(['path' => '/comments']),
             new PathItem(['path' => '/comments']),
         ];
-        $analysis = new Analysis([$openapi]);
+        $analysis = new Analysis([$openapi], new Context());
         $analysis->openapi = $openapi;
         $analysis->process(new BuildPaths());
         $this->assertCount(1, $openapi->paths);
@@ -37,10 +38,11 @@ class BuildPathsTest extends OpenApiTestCase
         $openapi = new OpenApi([]);
         $analysis = new Analysis(
             [
-            $openapi,
-            new Get(['path' => '/comments']),
-            new Post(['path' => '/comments']),
-            ]
+                $openapi,
+                new Get(['path' => '/comments']),
+                new Post(['path' => '/comments']),
+            ],
+            new Context()
         );
         $analysis->process(new MergeIntoOpenApi());
         $analysis->process(new BuildPaths());

--- a/tests/Processors/CleanUnmergedTest.php
+++ b/tests/Processors/CleanUnmergedTest.php
@@ -9,6 +9,7 @@ namespace OpenApi\Tests\Processors;
 use OpenApi\Analysis;
 use OpenApi\Annotations\Contact;
 use OpenApi\Annotations\License;
+use OpenApi\Context;
 use OpenApi\Processors\CleanUnmerged;
 use OpenApi\Processors\MergeIntoOpenApi;
 use OpenApi\Tests\OpenApiTestCase;
@@ -31,7 +32,7 @@ class CleanUnmergedTest extends OpenApiTestCase
 )
 
 END;
-        $analysis = new Analysis($this->parseComment($comment));
+        $analysis = new Analysis($this->parseComment($comment), new Context());
         $this->assertCount(4, $analysis->annotations);
         $analysis->process(new MergeIntoOpenApi());
         $this->assertCount(5, $analysis->annotations);

--- a/tests/Processors/MergeIntoComponentsTest.php
+++ b/tests/Processors/MergeIntoComponentsTest.php
@@ -9,6 +9,7 @@ namespace OpenApi\Tests\Processors;
 use OpenApi\Analysis;
 use OpenApi\Annotations\OpenApi;
 use OpenApi\Annotations\Response;
+use OpenApi\Context;
 use OpenApi\Generator;
 use OpenApi\Processors\MergeIntoComponents;
 use OpenApi\Tests\OpenApiTestCase;
@@ -23,7 +24,8 @@ class MergeIntoComponentsTest extends OpenApiTestCase
             [
                 $openapi,
                 $response,
-            ]
+            ],
+            new Context()
         );
         $this->assertSame(Generator::UNDEFINED, $openapi->components);
         $analysis->process(new MergeIntoComponents());

--- a/tests/Processors/MergeIntoOpenApiTest.php
+++ b/tests/Processors/MergeIntoOpenApiTest.php
@@ -9,6 +9,7 @@ namespace OpenApi\Tests\Processors;
 use OpenApi\Analysis;
 use OpenApi\Annotations\Info;
 use OpenApi\Annotations\OpenApi;
+use OpenApi\Context;
 use OpenApi\Generator;
 use OpenApi\Processors\MergeIntoOpenApi;
 use OpenApi\Tests\OpenApiTestCase;
@@ -21,9 +22,10 @@ class MergeIntoOpenApiTest extends OpenApiTestCase
         $info = new Info([]);
         $analysis = new Analysis(
             [
-            $openapi,
-            $info,
-            ]
+                $openapi,
+                $info,
+            ],
+            new Context()
         );
         $this->assertSame($openapi, $analysis->openapi);
         $this->assertSame(Generator::UNDEFINED, $openapi->info);

--- a/tests/Processors/MergeJsonContentTest.php
+++ b/tests/Processors/MergeJsonContentTest.php
@@ -9,6 +9,7 @@ namespace OpenApi\Tests\Processors;
 use OpenApi\Analysis;
 use OpenApi\Annotations\Parameter;
 use OpenApi\Annotations\Response;
+use OpenApi\Context;
 use OpenApi\Generator;
 use OpenApi\Processors\MergeJsonContent;
 use OpenApi\Tests\OpenApiTestCase;
@@ -24,7 +25,7 @@ class MergeJsonContentTest extends OpenApiTestCase
                 )
             )
 END;
-        $analysis = new Analysis($this->parseComment($comment));
+        $analysis = new Analysis($this->parseComment($comment), new Context());
         $this->assertCount(3, $analysis->annotations);
         $response = $analysis->getAnnotationsOfType(Response::class)[0];
         $this->assertSame(Generator::UNDEFINED, $response->content);
@@ -46,7 +47,7 @@ END;
                 )
             )
 END;
-        $analysis = new Analysis($this->parseComment($comment));
+        $analysis = new Analysis($this->parseComment($comment), new Context());
         $response = $analysis->getAnnotationsOfType(Response::class)[0];
         $this->assertCount(1, $response->content);
         $analysis->process(new MergeJsonContent());
@@ -61,7 +62,7 @@ END;
                 @OA\Property(property="color", type="string")
             ))
 END;
-        $analysis = new Analysis($this->parseComment($comment));
+        $analysis = new Analysis($this->parseComment($comment), new Context());
         $this->assertCount(4, $analysis->annotations);
         $parameter = $analysis->getAnnotationsOfType(Parameter::class)[0];
         $this->assertSame(Generator::UNDEFINED, $parameter->content);
@@ -83,7 +84,7 @@ END;
                 @OA\Items(ref="#/components/schemas/repository")
             )
 END;
-        $analysis = new Analysis($this->parseComment($comment));
+        $analysis = new Analysis($this->parseComment($comment), new Context());
         $analysis->process(new MergeJsonContent());
     }
 
@@ -97,7 +98,7 @@ END;
                 )
             )
 END;
-        $analysis = new Analysis($this->parseComment($comment));
+        $analysis = new Analysis($this->parseComment($comment), new Context());
         $analysis->process(new MergeJsonContent());
     }
 }

--- a/tests/Processors/MergeXmlContentTest.php
+++ b/tests/Processors/MergeXmlContentTest.php
@@ -9,6 +9,7 @@ namespace OpenApi\Tests\Processors;
 use OpenApi\Analysis;
 use OpenApi\Annotations\Parameter;
 use OpenApi\Annotations\Response;
+use OpenApi\Context;
 use OpenApi\Generator;
 use OpenApi\Processors\MergeXmlContent;
 use OpenApi\Tests\OpenApiTestCase;
@@ -24,7 +25,7 @@ class MergeXmlContentTest extends OpenApiTestCase
                 )
             )
 END;
-        $analysis = new Analysis($this->parseComment($comment));
+        $analysis = new Analysis($this->parseComment($comment), new Context());
         $this->assertCount(3, $analysis->annotations);
         $response = $analysis->getAnnotationsOfType(Response::class)[0];
         $this->assertSame(Generator::UNDEFINED, $response->content);
@@ -46,7 +47,7 @@ END;
                 )
             )
 END;
-        $analysis = new Analysis($this->parseComment($comment));
+        $analysis = new Analysis($this->parseComment($comment), new Context());
         $response = $analysis->getAnnotationsOfType(Response::class)[0];
         $this->assertCount(1, $response->content);
         $analysis->process(new MergeXmlContent());
@@ -61,7 +62,7 @@ END;
                 @OA\Property(property="color", type="string")
             ))
 END;
-        $analysis = new Analysis($this->parseComment($comment));
+        $analysis = new Analysis($this->parseComment($comment), new Context());
         $this->assertCount(4, $analysis->annotations);
         $parameter = $analysis->getAnnotationsOfType(Parameter::class)[0];
         $this->assertSame(Generator::UNDEFINED, $parameter->content);
@@ -83,7 +84,7 @@ END;
                 @OA\Items(ref="#/components/schemas/repository")
             )
 END;
-        $analysis = new Analysis($this->parseComment($comment));
+        $analysis = new Analysis($this->parseComment($comment), new Context());
         $analysis->process(new MergeXmlContent());
     }
 
@@ -97,7 +98,7 @@ END;
                 )
             )
 END;
-        $analysis = new Analysis($this->parseComment($comment));
+        $analysis = new Analysis($this->parseComment($comment), new Context());
         $analysis->process(new MergeXmlContent());
     }
 }

--- a/tests/RefTest.php
+++ b/tests/RefTest.php
@@ -26,7 +26,7 @@ class RefTest extends OpenApiTestCase
 )
 END;
         $openapi->merge($this->parseComment($comment));
-        $analysis = new Analysis();
+        $analysis = new Analysis([], new Context());
         $analysis->addAnnotation($openapi, Context::detect());
         $analysis->process();
 


### PR DESCRIPTION
Continuing the quest to elimitate static things.

In the long run this will allow to pass around other things in the context, inherited from the `Generator`.

Examples could be processing flags, the target OpenAPI version and other things.