### PR TITLE
Fix exclusive min/max property type

### DIFF
--- a/src/Annotations/Schema.php
+++ b/src/Annotations/Schema.php
@@ -116,7 +116,7 @@ class Schema extends AbstractAnnotation
     /**
      * See http://json-schema.org/latest/json-schema-validation.html#anchor17.
      *
-     * @var bool
+     * @var number
      */
     public $exclusiveMaximum = Generator::UNDEFINED;
 
@@ -130,7 +130,7 @@ class Schema extends AbstractAnnotation
     /**
      * See http://json-schema.org/latest/json-schema-validation.html#anchor21.
      *
-     * @var bool
+     * @var number
      */
     public $exclusiveMinimum = Generator::UNDEFINED;
 


### PR DESCRIPTION
PHPdoc documented type needs to be `number` not `bool`.

Fixes #966 