### PR TITLE
Add more processor related methods to Generator

### DIFF
--- a/Examples/processors/schema-query-parameter/scan.php
+++ b/Examples/processors/schema-query-parameter/scan.php
@@ -1,6 +1,6 @@
 <?php
 
-require __DIR__ . '/../../vendor/autoload.php';
+require __DIR__ . '/../../../vendor/autoload.php';
 // also load our custom processor...
 require __DIR__ . '/SchemaQueryParameter.php';
 
@@ -21,5 +21,5 @@ $openapi = (new OpenApi\Generator())
             ->setProcessors($processors)
             ->generate([__DIR__ . '/app']);
 $spec = json_encode($openapi, JSON_PRETTY_PRINT);
-file_put_contents(__DIR__ . '/schema-query-parameter-processor.json', $spec);
+file_put_contents(__DIR__ . '/schema-query-parameter.json', $spec);
 //echo $spec;

--- a/Examples/processors/schema-query-parameter/schema-query-parameter.json
+++ b/Examples/processors/schema-query-parameter/schema-query-parameter.json
@@ -10,7 +10,7 @@
                 "tags": [
                     "Products"
                 ],
-                "operationId": "App\\ProductController::getProduct",
+                "operationId": "399b71a7672f0a46be1b5f4c120c355d",
                 "responses": {
                     "200": {
                         "description": "A single product",
@@ -31,7 +31,7 @@
                     "Products"
                 ],
                 "summary": "Controller that takes all `Product` properties as query parameter.",
-                "operationId": "App\\ProductController::findProducts",
+                "operationId": "178f74de3417eec20dee95709821e6ca",
                 "parameters": [
                     {
                         "name": "id",

--- a/bin/openapi
+++ b/bin/openapi
@@ -1,8 +1,8 @@
 #!/usr/bin/env php
 <?php
 use OpenApi\Logger;
-use OpenApi\Analysis;
-use const OpenApi\UNDEFINED;
+use OpenApi\Generator;
+use OpenApi\Util;
 use const OpenApi\COLOR_RED;
 use const OpenApi\COLOR_YELLOW;
 use const OpenApi\COLOR_STOP;
@@ -220,6 +220,7 @@ if ($options['pattern']) {
     $pattern = $options['pattern'];
 }
 
+$generator = new Generator();
 foreach ($options["processor"] as $processor) {
     $class = '\OpenApi\Processors\\'.$processor;
     if (class_exists($class)) {
@@ -227,10 +228,10 @@ foreach ($options["processor"] as $processor) {
     } elseif (class_exists($processor)) {
         $processor = new $processor();
     }
-    Analysis::registerProcessor($processor);
+    $generator->addProcessor($processor);
 }
 
-$openapi = OpenApi\Generator::scan(OpenApi\Util::finder($paths, $exclude, $pattern));
+$openapi = $generator->generate(Util::finder($paths, $exclude, $pattern));
 
 if ($exit !== 0) {
     error_log('');

--- a/src/Analysis.php
+++ b/src/Analysis.php
@@ -439,6 +439,8 @@ class Analysis
      * Get direct access to the processors array.
      *
      * @return array reference
+     *
+     * @deprecated Superseded by `Generator` methods
      */
     public static function &processors()
     {
@@ -469,6 +471,8 @@ class Analysis
      * Register a processor.
      *
      * @param \Closure $processor
+     *
+     * @deprecated Superseded by `Generator` methods
      */
     public static function registerProcessor($processor): void
     {
@@ -479,6 +483,8 @@ class Analysis
      * Unregister a processor.
      *
      * @param \Closure $processor
+     *
+     * @deprecated Superseded by `Generator` methods
      */
     public static function unregisterProcessor($processor): void
     {

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -144,6 +144,30 @@ class Generator
         return $this;
     }
 
+    public function addProcessor(callable $processor): Generator
+    {
+        $processors = $this->getProcessors();
+        $processors[] = $processor;
+        $this->setProcessors($processors);
+
+        return $this;
+    }
+
+    public function removeProcessor(callable $processor, bool $silent = false): Generator
+    {
+        $processors = $this->getProcessors();
+        if (false === ($key = array_search($processor, $processors, true))) {
+            if ($silent) {
+                return $this;
+            }
+            throw new \InvalidArgumentException('Processor not found');
+        }
+        unset($processors[$key]);
+        $this->setProcessors($processors);
+
+        return $this;
+    }
+
     /**
      * Update/replace an existing processor with a new one.
      *

--- a/tests/CommandlineInterfaceTest.php
+++ b/tests/CommandlineInterfaceTest.php
@@ -33,4 +33,11 @@ class CommandlineInterfaceTest extends OpenApiTestCase
         unlink($filename);
         $this->assertSpecEquals(file_get_contents($path . '/petstore-simple.yaml'), $yaml);
     }
+
+    public function testAddProcessor()
+    {
+        $path = __DIR__ . '/../Examples/swagger-spec/petstore-simple';
+        exec(__DIR__ . '/../bin/openapi --processor OperationId --format yaml ' . escapeshellarg($path) . ' 2> /dev/null', $output, $retval);
+        $this->assertSame(0, $retval);
+    }
 }

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -6,6 +6,7 @@
 
 namespace OpenApi\Tests;
 
+use OpenApi\Analysis;
 use OpenApi\Generator;
 use OpenApi\Logger;
 use OpenApi\Processors\OperationId;
@@ -81,5 +82,27 @@ class GeneratorTest extends OpenApiTestCase
                 $this->assertSpecEquals($expected, $processor->isHash());
             }
         }
+    }
+
+    public function testAddProcessor()
+    {
+        $generator = new Generator();
+        $processors = $generator->getProcessors();
+        $generator->addProcessor(function (Analysis $analysis) {
+        });
+
+        $this->assertLessThan(count($generator->getProcessors()), count($processors));
+    }
+
+    public function testRemoveProcessor()
+    {
+        $generator = new Generator();
+        $processors = $generator->getProcessors();
+        $processor = function (Analysis $analysis) {
+        };
+        $generator->addProcessor($processor);
+        $generator->removeProcessor($processor);
+
+        $this->assertEquals($processors, $generator->getProcessors());
     }
 }


### PR DESCRIPTION
* adds non static methods for adding/removing processors.
* deprecates `Analysis::processors()`, `Analysis::registerProcessor()` and `Analysis::unregisterProcessor()`
* also includes a fix for the `schema-query-parameter` processor sample code