### PR TITLE
Do not pass the swagger context into doctrines annotation parser

### DIFF
--- a/src/Analyser.php
+++ b/src/Analyser.php
@@ -97,7 +97,7 @@ class Analyser
             if ($context->is('annotations') === false) {
                 $context->annotations = [];
             }
-            $annotations = $this->docParser->parse($comment, $context);
+            $annotations = $this->docParser->parse($comment);
             self::$context = null;
 
             return $annotations;


### PR DESCRIPTION
The context on the doctrine side is of type `string` and only used in case of exceptions
thrown in the parser.