### PR TITLE
Adds examples to nested annotations in JsonContent

### DIFF
--- a/src/Annotations/JsonContent.php
+++ b/src/Annotations/JsonContent.php
@@ -41,5 +41,6 @@ class JsonContent extends Schema
         Property::class => ['properties', 'property'],
         ExternalDocumentation::class => 'externalDocs',
         AdditionalProperties::class => 'additionalProperties',
+        Examples::class => ['examples', 'example'],
     ];
 }


### PR DESCRIPTION
Previously we were able to use the `examples={}` syntax for specifying multiple examples for the `JsonContent` tag but now that is not allowed so we have to use `@OA\Examples` instead which is fine but it does not currently render as a dropdown of examples like it used to previously. This change should add back that functionality and allow the dropdown of examples to appear.