### PR TITLE
handle nullable typed arrays

### DIFF
--- a/src/Processors/AugmentProperties.php
+++ b/src/Processors/AugmentProperties.php
@@ -83,9 +83,12 @@ class AugmentProperties
                 }
             } elseif (preg_match('/@var\s+(?<type>[^\s]+)([ \t])?(?<description>.+)?$/im', $comment, $varMatches)) {
                 if ($property->type === Generator::UNDEFINED) {
-                    preg_match('/^([^\[]+)(.*$)/', trim($varMatches['type']), $typeMatches);
-                    $isNullable = $this->isNullable($typeMatches[1]);
-                    $type = $this->stripNull($typeMatches[1]);
+                    $allTypes = trim($varMatches['type']);
+                    $isNullable = $this->isNullable($allTypes);
+                    $allTypes = $this->stripNull($allTypes);
+                    preg_match('/^([^\[]+)(.*$)/', trim($allTypes), $typeMatches);
+                    $type = $typeMatches[1];
+
                     if (array_key_exists(strtolower($type), static::$types) === false) {
                         $key = strtolower($context->fullyQualifiedName($type));
                         if ($property->ref === Generator::UNDEFINED && $typeMatches[2] === '' && array_key_exists($key, $refs)) {

--- a/tests/Fixtures/Customer.php
+++ b/tests/Fixtures/Customer.php
@@ -83,6 +83,12 @@ class Customer
     public $bestFriend;
 
     /**
+     * @OA\Property()
+     * @var Customer[]|null
+     */
+    public $endorsedFriends;
+
+    /**
      * for ContextTest
      */
     public function testResolvingFullyQualifiedNames()

--- a/tests/Processors/AugmentPropertiesTest.php
+++ b/tests/Processors/AugmentPropertiesTest.php
@@ -35,6 +35,7 @@ class AugmentPropertiesTest extends OpenApiTestCase
         $submittedBy = $customer->properties[6];
         $friends = $customer->properties[7];
         $bestFriend = $customer->properties[8];
+        $endorsedFriends = $customer->properties[9];
 
         // Verify no values where defined in the annotation.
         $this->assertSame(Generator::UNDEFINED, $firstName->property);
@@ -58,6 +59,10 @@ class AugmentPropertiesTest extends OpenApiTestCase
         $this->assertSame(Generator::UNDEFINED, $bestFriend->property);
         $this->assertSame(Generator::UNDEFINED, $bestFriend->nullable);
         $this->assertSame(Generator::UNDEFINED, $bestFriend->allOf);
+
+        $this->assertSame(Generator::UNDEFINED, $endorsedFriends->property);
+        $this->assertSame(Generator::UNDEFINED, $endorsedFriends->nullable);
+        $this->assertSame(Generator::UNDEFINED, $endorsedFriends->allOf);
 
         $analysis->process(new AugmentProperties());
 
@@ -118,6 +123,11 @@ class AugmentPropertiesTest extends OpenApiTestCase
         $this->assertSame('bestFriend', $bestFriend->property);
         $this->assertTrue($bestFriend->nullable);
         $this->assertSame('#/components/schemas/Customer', $bestFriend->oneOf[0]->ref);
+
+        $this->assertSame('endorsedFriends', $endorsedFriends->property);
+        $this->assertSame('array', $endorsedFriends->type);
+        $this->assertTrue($endorsedFriends->nullable);
+        $this->assertSame('#/components/schemas/Customer', $endorsedFriends->items->ref);
     }
 
     public function testTypedProperties()

--- a/tests/Processors/AugmentSchemasTest.php
+++ b/tests/Processors/AugmentSchemasTest.php
@@ -26,7 +26,7 @@ class AugmentSchemasTest extends OpenApiTestCase
         $this->assertSame(Generator::UNDEFINED, $customer->properties, 'Sanity check. @OA\Property\'s not yet merged ');
         $analysis->process(new AugmentSchemas());
         $this->assertSame('Customer', $customer->schema, '@OA\Schema()->schema based on classname');
-        $this->assertCount(9, $customer->properties, '@OA\Property()s are merged into the @OA\Schema of the class');
+        $this->assertCount(10, $customer->properties, '@OA\Property()s are merged into the @OA\Schema of the class');
     }
 
     public function testAugmentSchemasForInterface()


### PR DESCRIPTION
i noticed that we had some fields in our openapi doc that had no type. with some digging, i realized that it was the case for all things that are a typed array that is also nullable. for example `Customer[]|null`.

as a workaround, it works correctly when flipping the order to `null|Customer[]`. but that seems unexpected.

i added a test to prove the problem, and a proposal how to fix it.