### PR TITLE
Fix arguments exception, resolves #997

### DIFF
--- a/src/Analysis.php
+++ b/src/Analysis.php
@@ -85,7 +85,7 @@ class Analysis
         $this->addAnnotations($annotations, $context);
     }
 
-    public function addAnnotation($annotation, Context $context): void
+    public function addAnnotation($annotation, ?Context $context): void
     {
         if ($this->annotations->contains($annotation)) {
             return;
@@ -125,7 +125,7 @@ class Analysis
         }
     }
 
-    public function addAnnotations(array $annotations, Context $context): void
+    public function addAnnotations(array $annotations, ?Context $context): void
     {
         foreach ($annotations as $annotation) {
             $this->addAnnotation($annotation, $context);


### PR DESCRIPTION
When I updated lib to version 3.3.0 I saw error like this
```
{"message":"OpenApi\\Analysis::addAnnotations(): Argument #2 ($context) must be of type OpenApi\\Context, null given, called in \/app\/vendor\/zircote\/swagger-php\/src\/Analysis.php on line 82"}
```
It happened when you use this lib with [nelmio/api-doc-bundle](https://github.com/nelmio/NelmioApiDocBundle) for symfony
because they use empty constructor
```
$analysis = new Analysis();
$analysis->addAnnotation($this->openApi, null);
```

so I added nullable support and everything works fine  

resolves #997