### PR TITLE
Fix token scanning/parsing for PHP8 named arguments

### DIFF
--- a/src/Analysers/TokenAnalyser.php
+++ b/src/Analysers/TokenAnalyser.php
@@ -135,6 +135,11 @@ class TokenAnalyser implements AnalyserInterface
                     continue;
                 }
 
+                if (!is_array($token)) {
+                    // PHP 8 named argument
+                    continue;
+                }
+
                 $interfaceDefinition = false;
                 $traitDefinition = false;
 
@@ -177,6 +182,12 @@ class TokenAnalyser implements AnalyserInterface
                 $traitDefinition = false;
 
                 $token = $this->nextToken($tokens, $parseContext);
+
+                if (!is_array($token)) {
+                    // PHP 8 named argument
+                    continue;
+                }
+
                 $schemaContext = new Context(['interface' => $token[1], 'line' => $token[2]], $parseContext);
                 if ($interfaceDefinition) {
                     $analysis->addInterfaceDefinition($interfaceDefinition);
@@ -211,6 +222,12 @@ class TokenAnalyser implements AnalyserInterface
                 $interfaceDefinition = false;
 
                 $token = $this->nextToken($tokens, $parseContext);
+
+                if (!is_array($token)) {
+                    // PHP 8 named argument
+                    continue;
+                }
+
                 $schemaContext = new Context(['trait' => $token[1], 'line' => $token[2]], $parseContext);
                 if ($traitDefinition) {
                     $analysis->addTraitDefinition($traitDefinition);

--- a/tests/Analysers/TokenAnalyserTest.php
+++ b/tests/Analysers/TokenAnalyserTest.php
@@ -278,4 +278,16 @@ class TokenAnalyserTest extends OpenApiTestCase
         $infos = $analysis->getAnnotationsOfType(Info::class, true);
         $this->assertCount(1, $infos);
     }
+
+    /**
+     * @requires PHP 8
+     */
+    public function testPhp8NamedArguments()
+    {
+        $analysis = $this->analysisFromFixtures(['PHP/Php8NamedArguments.php'], [], new TokenAnalyser());
+        $schemas = $analysis->getAnnotationsOfType(Schema::class, true);
+
+        $this->assertCount(1, $schemas);
+        $analysis->process((new Generator())->getProcessors());
+    }
 }

--- a/tests/Analysers/TokenScannerTest.php
+++ b/tests/Analysers/TokenScannerTest.php
@@ -159,6 +159,18 @@ class TokenScannerTest extends OpenApiTestCase
                     ],
                 ],
             ],
+            'Php8NamedArguments' => [
+                'PHP/Php8NamedArguments.php',
+                [
+                    'OpenApi\\Tests\\Fixtures\\PHP\\Php8NamedArguments' => [
+                        'uses' => [],
+                        'interfaces' => [],
+                        'traits' => [],
+                        'methods' => ['useFoo', 'foo'],
+                        'properties' => [],
+                    ],
+                ],
+            ],
             'AnonymousFunctions' => [
                 'PHP/AnonymousFunctions.php',
                 [

--- a/tests/Fixtures/PHP/Php8NamedArguments.php
+++ b/tests/Fixtures/PHP/Php8NamedArguments.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\PHP;
+
+/**
+ * @OA\Schema()
+ */
+class Php8NamedArguments
+{
+    public function useFoo(): void
+    {
+        $this->foo(class: 'abc', interface: 'def', trait: 'xyz');
+    }
+
+    public function foo(string $class, string $interface, string $trait): void
+    {
+
+    }
+}

--- a/tests/Fixtures/PHP/php7.php
+++ b/tests/Fixtures/PHP/php7.php
@@ -6,6 +6,8 @@
 
 namespace OpenApi\Tests\Fixtures\PHP;
 
+use PHPUnit\Framework\TestCase;
+
 $a = new class {
     public function foo()
     {
@@ -57,3 +59,5 @@ $f = new class() implements i2 {
 function deng()
 {
 }
+
+$foo = TestCase::class;


### PR DESCRIPTION
In particular handle argument names matching reserved words like 'class',
'interface' or 'trait'!