### PR TITLE
deprecation notice addressed

### DIFF
--- a/src/Annotations/AbstractAnnotation.php
+++ b/src/Annotations/AbstractAnnotation.php
@@ -271,6 +271,7 @@ abstract class AbstractAnnotation implements \JsonSerializable
 
     /**
      * Customize the way json_encode() renders the annotations.
+     * @return mixed
      */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()


### PR DESCRIPTION
Small change to suppress deprecation notice for library since Symfony5 calls for action for that. As library is compatible with PHP versions before 8.0 only option to maintain that is to add `@return mixed` doc annotation instead return type hint.