### PR TITLE
Revert default OpenAPI version to 3.0.0

### DIFF
--- a/Examples/example-object/example-object.yaml
+++ b/Examples/example-object/example-object.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: 'Example for response examples value'
   version: '1.0'

--- a/Examples/misc/misc.yaml
+++ b/Examples/misc/misc.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: 'Testing annotations from bugreports'
   description: "NOTE:\nThis sentence is on a new line"

--- a/Examples/nesting/nesting.yaml
+++ b/Examples/nesting/nesting.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: 'Nested schemas'
   description: 'An entity controller class.'

--- a/Examples/openapi-spec-attributes/openapi-spec-attributes.yaml
+++ b/Examples/openapi-spec-attributes/openapi-spec-attributes.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: 'Link Example'
   version: 1.0.0

--- a/Examples/openapi-spec/openapi-spec.yaml
+++ b/Examples/openapi-spec/openapi-spec.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: 'Link Example'
   version: 1.0.0

--- a/Examples/petstore-3.0/petstore-3.0.yaml
+++ b/Examples/petstore-3.0/petstore-3.0.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: 'Swagger Petstore'
   description: "This is a sample Petstore server.  You can find\nout more about Swagger at\n[http://swagger.io](http://swagger.io) or on\n[irc.freenode.net, #swagger](http://swagger.io/irc/)."

--- a/Examples/petstore.swagger.io/petstore.swagger.io.json
+++ b/Examples/petstore.swagger.io/petstore.swagger.io.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.1.0",
+    "openapi": "3.0.0",
     "info": {
         "title": "Swagger Petstore",
         "description": "This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.",

--- a/Examples/petstore.swagger.io/petstore.swagger.io.yaml
+++ b/Examples/petstore.swagger.io/petstore.swagger.io.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: 'Swagger Petstore'
   description: 'This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.'

--- a/Examples/processors/schema-query-parameter/schema-query-parameter.yaml
+++ b/Examples/processors/schema-query-parameter/schema-query-parameter.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: 'Example of using a custom processor in swagger-php'
   version: 1.0.0

--- a/Examples/swagger-spec/petstore-simple/petstore-simple.yaml
+++ b/Examples/swagger-spec/petstore-simple/petstore-simple.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: 'Swagger Petstore'
   description: 'A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification'

--- a/Examples/swagger-spec/petstore-with-external-docs/petstore-with-external-docs.yaml
+++ b/Examples/swagger-spec/petstore-with-external-docs/petstore-with-external-docs.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: 'Swagger Petstore'
   description: 'A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification'

--- a/Examples/swagger-spec/petstore/petstore.yaml
+++ b/Examples/swagger-spec/petstore/petstore.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: 'Swagger Petstore'
   license:

--- a/Examples/using-interfaces/using-interfaces.yaml
+++ b/Examples/using-interfaces/using-interfaces.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: 'Example of using interfaces in swagger-php'
   version: 1.0.0

--- a/Examples/using-refs/using-refs.yaml
+++ b/Examples/using-refs/using-refs.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: 'Example of using references in swagger-php'
   version: 1.0.0

--- a/Examples/using-traits/using-traits.yaml
+++ b/Examples/using-traits/using-traits.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: 'Example of using traits in swagger-php'
   version: 1.0.0

--- a/docs/Getting-started.md
+++ b/docs/Getting-started.md
@@ -66,7 +66,7 @@ use OpenApi\Annotations as OA;
 #### swagger-php will generate:
 
 ```yaml
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: "My First API"
   version: "0.1"
@@ -197,7 +197,7 @@ For objects, the key is defined by the field with the same name as the annotatio
 #### Results in:
 
 ```yaml
-openapi: 3.1.0
+openapi: 3.0.0
 paths:
   /products:
     get:
@@ -231,7 +231,7 @@ class Product {
 #### Results in:
 
 ```yaml
-openapi: 3.1.0
+openapi: 3.0.0
 components:
   schemas:
     Product:
@@ -326,7 +326,7 @@ To keep things DRY (Don't Repeat Yourself) the specification includes referencin
 #### Results in:
 
 ```yaml
-openapi: 3.1.0
+openapi: 3.0.0
 components:
   schemas:
     product_id:
@@ -400,7 +400,7 @@ The specification allows for [custom properties](http://swagger.io/specification
 #### Results in:
 
 ```yaml
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: Example
   version: 1

--- a/src/Annotations/OpenApi.php
+++ b/src/Annotations/OpenApi.php
@@ -19,7 +19,7 @@ use OpenApi\Util;
  */
 class OpenApi extends AbstractAnnotation
 {
-    public const DEFAULT_VERSION = '3.1.0';
+    public const DEFAULT_VERSION = '3.0.0';
     /**
      * The semantic version number of the OpenAPI Specification version that the OpenAPI document uses.
      * The openapi field should be used by tooling specifications and clients to interpret the OpenAPI document.

--- a/tests/Fixtures/Apis/basic.yaml
+++ b/tests/Fixtures/Apis/basic.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: 'Basic single file API'
   license:


### PR DESCRIPTION
Hello,

We have two issues opened on NelmioApiDocBundle due to the bump to OpenAPI 3.1.0: https://github.com/nelmio/NelmioApiDocBundle/issues/1943 (PHPStorm leaks memory with 3.1.0), and https://github.com/nelmio/NelmioApiDocBundle/issues/1940 (Swagger-UI does not support 3.1.0 yet).

I believe the bump was done too early as the ecosystem tools are not ready to support 3.1.0 yet, and in my opinion it would be better to stick to 3.0.0 for the time being.

I opened this PR to share my thoughts, and in my opinion only the default version should be reverted, and not the support of 3.1 specific features as they could be used opt-in. But I would also understand if you don't want to revert this as the bump would likely be more difficult to enforce later for BC reasons, if that's the case we would default back to 3.0.0 in NelmioApiDocBundle until `Swagger-UI` adds support for 3.1.0.