### PR TITLE
Allow to set the OpenAPI version

### DIFF
--- a/Examples/example-object/example-object.yaml
+++ b/Examples/example-object/example-object.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: 'Example for response examples value'
   version: '1.0'

--- a/Examples/misc/misc.yaml
+++ b/Examples/misc/misc.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: 'Testing annotations from bugreports'
   description: "NOTE:\nThis sentence is on a new line"
@@ -31,7 +31,6 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/200'
-          description: Success
       security:
         -
           bearerAuth: []
@@ -67,4 +66,3 @@ components:
 security:
   -
     bearerAuth: []
-

--- a/Examples/nesting/nesting.yaml
+++ b/Examples/nesting/nesting.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: 'Nested schemas'
   description: 'An entity controller class.'

--- a/Examples/openapi-spec-attributes/openapi-spec-attributes.yaml
+++ b/Examples/openapi-spec-attributes/openapi-spec-attributes.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: 'Link Example'
   version: 1.0.0

--- a/Examples/openapi-spec/openapi-spec.yaml
+++ b/Examples/openapi-spec/openapi-spec.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: 'Link Example'
   version: 1.0.0

--- a/Examples/petstore-3.0/petstore-3.0.yaml
+++ b/Examples/petstore-3.0/petstore-3.0.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: 'Swagger Petstore'
   description: "This is a sample Petstore server.  You can find\nout more about Swagger at\n[http://swagger.io](http://swagger.io) or on\n[irc.freenode.net, #swagger](http://swagger.io/irc/)."

--- a/Examples/petstore.swagger.io/petstore.swagger.io.yaml
+++ b/Examples/petstore.swagger.io/petstore.swagger.io.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: 'Swagger Petstore'
   description: 'This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.'

--- a/Examples/processors/schema-query-parameter/schema-query-parameter.yaml
+++ b/Examples/processors/schema-query-parameter/schema-query-parameter.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: 'Example of using a custom processor in swagger-php'
   version: 1.0.0

--- a/Examples/swagger-spec/petstore-simple/petstore-simple-3.1.0.yaml
+++ b/Examples/swagger-spec/petstore-simple/petstore-simple-3.1.0.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.0
+openapi: 3.1.0
 info:
   title: 'Swagger Petstore'
   description: 'A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification'
@@ -7,6 +7,7 @@ info:
     name: 'Swagger API Team'
   license:
     name: MIT
+    identifier: MIT
   version: 1.0.0
 servers:
   -

--- a/Examples/swagger-spec/petstore-with-external-docs/petstore-with-external-docs.yaml
+++ b/Examples/swagger-spec/petstore-with-external-docs/petstore-with-external-docs.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: 'Swagger Petstore'
   description: 'A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification'

--- a/Examples/swagger-spec/petstore/petstore.yaml
+++ b/Examples/swagger-spec/petstore/petstore.yaml
@@ -1,9 +1,8 @@
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: 'Swagger Petstore'
   license:
     name: MIT
-    identifier: MIT
   version: 1.0.0
 servers:
   -

--- a/Examples/using-interfaces/using-interfaces.yaml
+++ b/Examples/using-interfaces/using-interfaces.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: 'Example of using interfaces in swagger-php'
   version: 1.0.0

--- a/Examples/using-refs/using-refs.yaml
+++ b/Examples/using-refs/using-refs.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: 'Example of using references in swagger-php'
   version: 1.0.0

--- a/Examples/using-traits/using-traits.yaml
+++ b/Examples/using-traits/using-traits.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: 'Example of using traits in swagger-php'
   version: 1.0.0

--- a/README.md
+++ b/README.md
@@ -10,12 +10,20 @@ For a full list of supported annotations, please have look at the [`OpenApi\Anno
 
 ## Features
 
-- Compatible with the OpenAPI 3.0 specification.
+- Compatible with the OpenAPI **3.0** and **3.1** specification.
 - Extracts information from code & existing phpdoc annotations.
 - Command-line interface available.
 - [Documentation site](https://zircote.github.io/swagger-php/) with a getting started guide.
 - Exceptional error reporting (with hints, context)
 - As of PHP 8.1 all annotations are also available as PHP attributes
+
+## OpenAPI version support
+
+`swagger-php` allows to generate specs either for **OpenAPI 3.0.0** or **OpenAPI 3.1.0**.
+By default the spec will be in version `3.0.0`. The command line option `--version` may be used to change this
+to `3.1.0`.
+
+Programmatically, the method `Generator::setVersion()` can be used to change the version.
 
 ## Installation (with [Composer](https://getcomposer.org))
 

--- a/bin/openapi
+++ b/bin/openapi
@@ -209,7 +209,7 @@ $analyser = $options['legacy']
     : new ReflectionAnalyser([new DocBlockAnnotationFactory(), new AttributeAnnotationFactory()]);
 
 $openapi = $generator
-    ->setOpenApiVersion($options['version'])
+    ->setVersion($options['version'])
     ->setAnalyser($analyser)
     ->generate(Util::finder($paths, $exclude, $pattern));
 

--- a/bin/openapi
+++ b/bin/openapi
@@ -5,6 +5,7 @@ use OpenApi\Analysers\AttributeAnnotationFactory;
 use OpenApi\Analysers\DocBlockAnnotationFactory;
 use OpenApi\Analysers\ReflectionAnalyser;
 use OpenApi\Analysers\TokenAnalyser;
+use OpenApi\Annotations\OpenApi;
 use OpenApi\Generator;
 use OpenApi\Util;
 use OpenApi\Loggers\ConsoleLogger;
@@ -30,6 +31,7 @@ $options = [
     'help' => false,
     'debug' => false,
     'processor' => [],
+    'version' => OpenApi::DEFAULT_VERSION,
 ];
 $aliases = [
     'l' => 'legacy',
@@ -49,6 +51,7 @@ $needsArgument = [
     'pattern',
     'bootstrap',
     'processor',
+    'version',
 ];
 $paths = [];
 $error = false;
@@ -109,6 +112,7 @@ if ($options['help'] === false && $error) {
     // Show help
     $options['help'] = true;
 }
+$defaultVersion = OpenApi::DEFAULT_VERSION;
 if ($options['help']) {
     $help = <<<EOF
 
@@ -127,6 +131,7 @@ Options:
   --processor       Register an additional processor.
   --format          Force yaml or json.
   --debug           Show additional error information.
+  --version         The OpenAPI version; defaults to {$defaultVersion}.
   --help (-h)       Display this help message.
 
 
@@ -204,6 +209,7 @@ $analyser = $options['legacy']
     : new ReflectionAnalyser([new DocBlockAnnotationFactory(), new AttributeAnnotationFactory()]);
 
 $openapi = $generator
+    ->setOpenApiVersion($options['version'])
     ->setAnalyser($analyser)
     ->generate(Util::finder($paths, $exclude, $pattern));
 

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,10 @@
   "config": {
     "bin-dir": "bin",
     "optimize-autoloader": true,
-    "sort-packages": true
+    "sort-packages": true,
+    "allow-plugins": {
+      "composer/package-versions-deprecated": true
+    }
   },
   "minimum-stability": "stable",
   "extra": {

--- a/docs/Getting-started.md
+++ b/docs/Getting-started.md
@@ -66,7 +66,7 @@ use OpenApi\Annotations as OA;
 #### swagger-php will generate:
 
 ```yaml
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: "My First API"
   version: "0.1"
@@ -197,7 +197,7 @@ For objects, the key is defined by the field with the same name as the annotatio
 #### Results in:
 
 ```yaml
-openapi: 3.1.0
+openapi: 3.0.0
 paths:
   /products:
     get:
@@ -231,7 +231,7 @@ class Product {
 #### Results in:
 
 ```yaml
-openapi: 3.1.0
+openapi: 3.0.0
 components:
   schemas:
     Product:
@@ -326,7 +326,7 @@ To keep things DRY (Don't Repeat Yourself) the specification includes referencin
 #### Results in:
 
 ```yaml
-openapi: 3.1.0
+openapi: 3.0.0
 components:
   schemas:
     product_id:
@@ -400,7 +400,7 @@ The specification allows for [custom properties](http://swagger.io/specification
 #### Results in:
 
 ```yaml
-openapi: 3.1.0
+openapi: 3.0.0
 info:
   title: Example
   version: 1

--- a/src/Annotations/AbstractAnnotation.php
+++ b/src/Annotations/AbstractAnnotation.php
@@ -347,11 +347,13 @@ abstract class AbstractAnnotation implements \JsonSerializable
         if (isset($data->ref)) {
             // Only specific https://github.com/OAI/OpenAPI-Specification/blob/3.1.0/versions/3.1.0.md#reference-object
             $ref = ['$ref' => $data->ref];
-            $defaultValues = get_class_vars(get_class($this));
-            foreach (['summary', 'description'] as $prop) {
-                if (property_exists($this, $prop)) {
-                    if ($this->$prop !== $defaultValues[$prop]) {
-                        $ref[$prop] = $data->$prop;
+            if ($this->_context->version == OpenApi::VERSION_3_1_0) {
+                $defaultValues = get_class_vars(get_class($this));
+                foreach (['summary', 'description'] as $prop) {
+                    if (property_exists($this, $prop)) {
+                        if ($this->$prop !== $defaultValues[$prop]) {
+                            $ref[$prop] = $data->$prop;
+                        }
                     }
                 }
             }

--- a/src/Annotations/License.php
+++ b/src/Annotations/License.php
@@ -76,7 +76,7 @@ class License extends AbstractAnnotation
     {
         $data = parent::jsonSerialize();
 
-        if ($this->_context->version == OpenApi::VERSION_3_0_0) {
+        if ($this->_context->isVersion(OpenApi::VERSION_3_0_0)) {
             unset($data->identifier);
         }
 
@@ -90,7 +90,7 @@ class License extends AbstractAnnotation
     {
         $valid = parent::validate($parents, $skip);
 
-        if ($this->_context->version == OpenApi::VERSION_3_1_0) {
+        if ($this->_context->isVersion(OpenApi::VERSION_3_1_0)) {
             if ($this->url !== Generator::UNDEFINED && $this->identifier !== Generator::UNDEFINED) {
                 $this->_context->logger->warning('@OA\\License() url and identifier are mutually exclusive');
                 $valid = false;

--- a/src/Annotations/License.php
+++ b/src/Annotations/License.php
@@ -71,13 +71,30 @@ class License extends AbstractAnnotation
     /**
      * @inheritdoc
      */
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
+    {
+        $data = parent::jsonSerialize();
+
+        if ($this->_context->version == OpenApi::VERSION_3_0_0) {
+            unset($data->identifier);
+        }
+
+        return $data;
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function validate(array $parents = [], array $skip = [], string $ref = ''): bool
     {
         $valid = parent::validate($parents, $skip);
 
-        if ($this->url !== Generator::UNDEFINED && $this->identifier !== Generator::UNDEFINED) {
-            $this->_context->logger->warning('@OA\\License() url and identifier are mutually exclusive');
-            $valid = false;
+        if ($this->_context->version == OpenApi::VERSION_3_1_0) {
+            if ($this->url !== Generator::UNDEFINED && $this->identifier !== Generator::UNDEFINED) {
+                $this->_context->logger->warning('@OA\\License() url and identifier are mutually exclusive');
+                $valid = false;
+            }
         }
 
         return $valid;

--- a/src/Annotations/OpenApi.php
+++ b/src/Annotations/OpenApi.php
@@ -19,8 +19,10 @@ use OpenApi\Util;
  */
 class OpenApi extends AbstractAnnotation
 {
-    public const DEFAULT_VERSION = '3.1.0';
-    public const SUPPORTED_VERSIONS = [self::DEFAULT_VERSION, '3.0.0'];
+    public const VERSION_3_0_0 = '3.0.0';
+    public const VERSION_3_1_0 = '3.1.0';
+    public const DEFAULT_VERSION = self::VERSION_3_1_0;
+    public const SUPPORTED_VERSIONS = [self::VERSION_3_0_0, self::VERSION_3_1_0];
 
     /**
      * The semantic version number of the OpenAPI Specification version that the OpenAPI document uses.

--- a/src/Annotations/OpenApi.php
+++ b/src/Annotations/OpenApi.php
@@ -21,7 +21,7 @@ class OpenApi extends AbstractAnnotation
 {
     public const VERSION_3_0_0 = '3.0.0';
     public const VERSION_3_1_0 = '3.1.0';
-    public const DEFAULT_VERSION = self::VERSION_3_1_0;
+    public const DEFAULT_VERSION = self::VERSION_3_0_0;
     public const SUPPORTED_VERSIONS = [self::VERSION_3_0_0, self::VERSION_3_1_0];
 
     /**

--- a/src/Annotations/OpenApi.php
+++ b/src/Annotations/OpenApi.php
@@ -20,6 +20,8 @@ use OpenApi\Util;
 class OpenApi extends AbstractAnnotation
 {
     public const DEFAULT_VERSION = '3.1.0';
+    public const SUPPORTED_VERSIONS = [self::DEFAULT_VERSION, '3.0.0'];
+
     /**
      * The semantic version number of the OpenAPI Specification version that the OpenAPI document uses.
      * The openapi field should be used by tooling specifications and clients to interpret the OpenAPI document.
@@ -128,6 +130,12 @@ class OpenApi extends AbstractAnnotation
     {
         if ($parents !== null || $skip !== null || $ref !== '') {
             $this->_context->logger->warning('Nested validation for ' . $this->identity() . ' not allowed');
+
+            return false;
+        }
+
+        if (!in_array($this->openapi, self::SUPPORTED_VERSIONS)) {
+            $this->_context->logger->warning('Unsupported OpenAPI version "' . $this->openapi . '". Allowed versions are: ' . implode(', ', self::SUPPORTED_VERSIONS));
 
             return false;
         }

--- a/src/Context.php
+++ b/src/Context.php
@@ -43,6 +43,7 @@ use OpenApi\Loggers\DefaultLogger;
  * @property Annotations\AbstractAnnotation[] $annotations
  * @property \Psr\Log\LoggerInterface         $logger      Guaranteed to be set when using the `Generator`
  * @property array                            $scanned     Details of file scanner when using ReflectionAnalyser
+ * @property string                           $version     The OpenAPI version in use
  */
 class Context
 {

--- a/src/Context.php
+++ b/src/Context.php
@@ -6,6 +6,7 @@
 
 namespace OpenApi;
 
+use OpenApi\Annotations\OpenApi;
 use OpenApi\Loggers\DefaultLogger;
 
 /**
@@ -114,8 +115,9 @@ class Context
     public function isVersion($versions): bool
     {
         $versions = (array) $versions;
+        $currentVersion = $this->version ?: OpenApi::DEFAULT_VERSION;
 
-        return in_array($this->version, $versions);
+        return in_array($currentVersion, $versions);
     }
 
     /**

--- a/src/Context.php
+++ b/src/Context.php
@@ -106,13 +106,16 @@ class Context
         return null;
     }
 
-    public function getRootContext(): Context
+    /**
+     * Check if one of the given version numbers matches the current OpenAPI version.
+     *
+     * @param string|array $versions One or more version numbers
+     */
+    public function isVersion($versions): bool
     {
-        if ($this->_parent !== null) {
-            return $this->_parent->getRootContext();
-        }
+        $versions = (array) $versions;
 
-        return $this;
+        return in_array($this->version, $versions);
     }
 
     /**

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -69,7 +69,8 @@ class Generator
     /** @var null|LoggerInterface PSR logger. */
     protected $logger = null;
 
-    protected $openApiVersion = OpenApi::DEFAULT_VERSION;
+    /** @var string */
+    protected $version = OpenApi::DEFAULT_VERSION;
 
     private $configStack;
 
@@ -262,14 +263,14 @@ class Generator
         return $this->logger ?: new DefaultLogger();
     }
 
-    public function getOpenApiVersion(): string
+    public function getVersion(): string
     {
-        return $this->openApiVersion;
+        return $this->version;
     }
 
-    public function setOpenApiVersion(string $openApiVersion): Generator
+    public function setVersion(string $version): Generator
     {
-        $this->openApiVersion = $openApiVersion;
+        $this->version = $version;
 
         return $this;
     }
@@ -285,9 +286,11 @@ class Generator
                 'processors' => null,
                 'logger' => null,
                 'validate' => true,
+                'version' => OpenApi::DEFAULT_VERSION,
             ];
 
         return (new Generator($config['logger']))
+            ->setVersion($config['version'])
             ->setAliases($config['aliases'])
             ->setNamespaces($config['namespaces'])
             ->setAnalyser($config['analyser'])
@@ -306,7 +309,7 @@ class Generator
     public function withContext(callable $callable)
     {
         $rootContext = new Context([
-            'version' => $this->getOpenApiVersion(),
+            'version' => $this->getVersion(),
             'logger' => $this->getLogger(),
         ]);
         $analysis = new Analysis([], $rootContext);
@@ -333,7 +336,7 @@ class Generator
     public function generate(iterable $sources, ?Analysis $analysis = null, bool $validate = true): ?OpenApi
     {
         $rootContext = new Context([
-            'version' => $this->getOpenApiVersion(),
+            'version' => $this->getVersion(),
             'logger' => $this->getLogger(),
         ]);
         $analysis = $analysis ?: new Analysis([], $rootContext);
@@ -346,7 +349,7 @@ class Generator
             $analysis->process($this->getProcessors());
 
             if ($analysis->openapi) {
-                $analysis->openapi->openapi = $this->openApiVersion;
+                $analysis->openapi->openapi = $this->version;
             }
 
             // validation

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -305,7 +305,10 @@ class Generator
      */
     public function withContext(callable $callable)
     {
-        $rootContext = new Context(['logger' => $this->getLogger()]);
+        $rootContext = new Context([
+            'version' => $this->getOpenApiVersion(),
+            'logger' => $this->getLogger(),
+        ]);
         $analysis = new Analysis([], $rootContext);
 
         $this->configStack->push($this);
@@ -329,7 +332,10 @@ class Generator
      */
     public function generate(iterable $sources, ?Analysis $analysis = null, bool $validate = true): ?OpenApi
     {
-        $rootContext = new Context(['logger' => $this->getLogger()]);
+        $rootContext = new Context([
+            'version' => $this->getOpenApiVersion(),
+            'logger' => $this->getLogger(),
+        ]);
         $analysis = $analysis ?: new Analysis([], $rootContext);
 
         $this->configStack->push($this);

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -69,6 +69,8 @@ class Generator
     /** @var null|LoggerInterface PSR logger. */
     protected $logger = null;
 
+    protected $openApiVersion = OpenApi::DEFAULT_VERSION;
+
     private $configStack;
 
     public function __construct(?LoggerInterface $logger = null)
@@ -260,6 +262,18 @@ class Generator
         return $this->logger ?: new DefaultLogger();
     }
 
+    public function getOpenApiVersion(): string
+    {
+        return $this->openApiVersion;
+    }
+
+    public function setOpenApiVersion(string $openApiVersion): Generator
+    {
+        $this->openApiVersion = $openApiVersion;
+
+        return $this;
+    }
+
     public static function scan(iterable $sources, array $options = []): ?OpenApi
     {
         // merge with defaults
@@ -324,6 +338,10 @@ class Generator
 
             // post processing
             $analysis->process($this->getProcessors());
+
+            if ($analysis->openapi) {
+                $analysis->openapi->openapi = $this->openApiVersion;
+            }
 
             // validation
             if ($validate) {

--- a/tests/Analysers/ReflectionAnalyserTest.php
+++ b/tests/Analysers/ReflectionAnalyserTest.php
@@ -12,6 +12,7 @@ use OpenApi\Analysers\AttributeAnnotationFactory;
 use OpenApi\Analysers\DocBlockAnnotationFactory;
 use OpenApi\Analysers\ReflectionAnalyser;
 use OpenApi\Analysis;
+use OpenApi\Annotations\OpenApi;
 use OpenApi\Annotations\Operation;
 use OpenApi\Annotations\Response;
 use OpenApi\Attributes\Get;
@@ -82,10 +83,12 @@ class ReflectionAnalyserTest extends OpenApiTestCase
     public function testApiDocBlockBasic(AnalyserInterface $analyser)
     {
         $analysis = (new Generator())
+            ->setVersion(OpenApi::VERSION_3_1_0)
             ->withContext(function (Generator $generator) use ($analyser) {
                 $analyser->setGenerator($generator);
-                $analysis = $analyser->fromFile($this->fixture('Apis/DocBlocks/basic.php'), $this->getContext());
+                $analysis = $analyser->fromFile($this->fixture('Apis/DocBlocks/basic.php'), $this->getContext([], $generator->getVersion()));
                 $analysis->process($generator->getProcessors());
+                $analysis->openapi->openapi = $generator->getVersion();
 
                 return $analysis;
             });
@@ -107,12 +110,14 @@ class ReflectionAnalyserTest extends OpenApiTestCase
     {
         /** @var Analysis $analysis */
         $analysis = (new Generator())
+            ->setVersion(OpenApi::VERSION_3_1_0)
             ->addAlias('oaf', 'OpenApi\\Tests\\Annotations')
             ->addNamespace('OpenApi\\Tests\\Annotations\\')
             ->withContext(function (Generator $generator) use ($analyser) {
                 $analyser->setGenerator($generator);
-                $analysis = $analyser->fromFile($this->fixture('Apis/Attributes/basic.php'), $this->getContext());
+                $analysis = $analyser->fromFile($this->fixture('Apis/Attributes/basic.php'), $this->getContext([], $generator->getVersion()));
                 $analysis->process((new Generator())->getProcessors());
+                $analysis->openapi->openapi = $generator->getVersion();
 
                 return $analysis;
             });
@@ -146,10 +151,12 @@ class ReflectionAnalyserTest extends OpenApiTestCase
     public function testApiMixedBasic(AnalyserInterface $analyser)
     {
         $analysis = (new Generator())
+            ->setVersion(OpenApi::VERSION_3_1_0)
             ->withContext(function (Generator $generator) use ($analyser) {
                 $analyser->setGenerator($generator);
-                $analysis = $analyser->fromFile($this->fixture('Apis/Mixed/basic.php'), $this->getContext());
+                $analysis = $analyser->fromFile($this->fixture('Apis/Mixed/basic.php'), $this->getContext([], $generator->getVersion()));
                 $analysis->process((new Generator())->getProcessors());
+                $analysis->openapi->openapi = $generator->getVersion();
 
                 return $analysis;
             });

--- a/tests/Annotations/LicenseTest.php
+++ b/tests/Annotations/LicenseTest.php
@@ -6,15 +6,22 @@
 
 namespace OpenApi\Tests\Annotations;
 
+use OpenApi\Annotations\OpenApi;
 use OpenApi\Tests\OpenApiTestCase;
 
 class LicenseTest extends OpenApiTestCase
 {
-    public function testValidation()
+    public function testValidation3_0_0()
+    {
+        $annotations = $this->annotationsFromDocBlockParser('@OA\License(name="MIT", identifier="MIT", url="http://localhost")', [], OpenApi::VERSION_3_0_0);
+        $annotations[0]->validate();
+    }
+
+    public function testValidation3_1_0()
     {
         $this->assertOpenApiLogEntryContains('@OA\License() url and identifier are mutually exclusive');
 
-        $annotations = $this->annotationsFromDocBlockParser('@OA\License(name="MIT", identifier="MIT", url="http://localhost")');
+        $annotations = $this->annotationsFromDocBlockParser('@OA\License(name="MIT", identifier="MIT", url="http://localhost")', [], OpenApi::VERSION_3_1_0);
         $annotations[0]->validate();
     }
 }

--- a/tests/Annotations/LicenseTest.php
+++ b/tests/Annotations/LicenseTest.php
@@ -12,8 +12,9 @@ class LicenseTest extends OpenApiTestCase
 {
     public function testValidation()
     {
-        $annotations = $this->annotationsFromDocBlockParser('@OA\License(name="MIT", identifier="MIT", url="http://localhost")');
         $this->assertOpenApiLogEntryContains('@OA\License() url and identifier are mutually exclusive');
+
+        $annotations = $this->annotationsFromDocBlockParser('@OA\License(name="MIT", identifier="MIT", url="http://localhost")');
         $annotations[0]->validate();
     }
 }

--- a/tests/Annotations/OpenApiTest.php
+++ b/tests/Annotations/OpenApiTest.php
@@ -23,7 +23,7 @@ class OpenApiTest extends OpenApiTestCase
 
     public function testInvalidVersion()
     {
-        $this->assertOpenApiLogEntryContains('Unsupported OpenAPI version "2". Allowed versions are: 3.1.0, 3.0.0');
+        $this->assertOpenApiLogEntryContains('Unsupported OpenAPI version "2". Allowed versions are: 3.0.0, 3.1.0');
 
         $openapi = new OpenApi(['_context' => $this->getContext()]);
         $openapi->openapi = '2';

--- a/tests/Annotations/OpenApiTest.php
+++ b/tests/Annotations/OpenApiTest.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Annotations;
+
+use OpenApi\Annotations\OpenApi;
+use OpenApi\Tests\OpenApiTestCase;
+
+class OpenApiTest extends OpenApiTestCase
+{
+    public function testValidVersion()
+    {
+        $this->assertOpenApiLogEntryContains('Required @OA\Info() not found');
+        $this->assertOpenApiLogEntryContains('Required @OA\PathItem() not found');
+
+        $openapi = new OpenApi(['_context' => $this->getContext()]);
+        $openapi->openapi = '3.0.0';
+        $openapi->validate();
+    }
+
+    public function testInvalidVersion()
+    {
+        $this->assertOpenApiLogEntryContains('Unsupported OpenAPI version "2". Allowed versions are: 3.1.0, 3.0.0');
+
+        $openapi = new OpenApi(['_context' => $this->getContext()]);
+        $openapi->openapi = '2';
+        $openapi->validate();
+    }
+}

--- a/tests/ExamplesTest.php
+++ b/tests/ExamplesTest.php
@@ -11,6 +11,7 @@ use OpenApi\Analysers\AttributeAnnotationFactory;
 use OpenApi\Analysers\DocBlockAnnotationFactory;
 use OpenApi\Analysers\ReflectionAnalyser;
 use OpenApi\Analysers\TokenAnalyser;
+use OpenApi\Annotations\OpenApi;
 use OpenApi\Generator;
 
 class ExamplesTest extends OpenApiTestCase
@@ -23,18 +24,19 @@ class ExamplesTest extends OpenApiTestCase
         ];
 
         $examples = [
-            'example-object' => ['example-object', 'example-object.yaml'],
-            'misc' => ['misc', 'misc.yaml'],
-            'nesting' => ['nesting', 'nesting.yaml'],
-            'openapi-spec' => ['openapi-spec', 'openapi-spec.yaml'],
-            'petstore-3.0' => ['petstore-3.0', 'petstore-3.0.yaml'],
-            'petstore.swagger.io' => ['petstore.swagger.io', 'petstore.swagger.io.yaml'],
-            'swagger-spec/petstore' => ['swagger-spec/petstore', 'petstore.yaml'],
-            'swagger-spec/petstore-simple' => ['swagger-spec/petstore-simple', 'petstore-simple.yaml'],
-            'swagger-spec/petstore-with-external-docs' => ['swagger-spec/petstore-with-external-docs', 'petstore-with-external-docs.yaml'],
-            'using-interfaces' => ['using-interfaces', 'using-interfaces.yaml'],
-            'using-refs' => ['using-refs', 'using-refs.yaml'],
-            'using-traits' => ['using-traits', 'using-traits.yaml'],
+            'example-object' => [OpenApi::VERSION_3_0_0, 'example-object', 'example-object.yaml'],
+            'misc' => [OpenApi::VERSION_3_0_0, 'misc', 'misc.yaml'],
+            'nesting' => [OpenApi::VERSION_3_0_0, 'nesting', 'nesting.yaml'],
+            'openapi-spec' => [OpenApi::VERSION_3_0_0, 'openapi-spec', 'openapi-spec.yaml'],
+            'petstore-3.0' => [OpenApi::VERSION_3_0_0, 'petstore-3.0', 'petstore-3.0.yaml'],
+            'petstore.swagger.io' => [OpenApi::VERSION_3_0_0, 'petstore.swagger.io', 'petstore.swagger.io.yaml'],
+            'swagger-spec/petstore' => [OpenApi::VERSION_3_0_0, 'swagger-spec/petstore', 'petstore.yaml'],
+            'swagger-spec/petstore-simple' => [OpenApi::VERSION_3_0_0, 'swagger-spec/petstore-simple', 'petstore-simple.yaml'],
+            'swagger-spec/petstore-simple-3.1.0' => [OpenApi::VERSION_3_1_0, 'swagger-spec/petstore-simple', 'petstore-simple-3.1.0.yaml'],
+            'swagger-spec/petstore-with-external-docs' => [OpenApi::VERSION_3_0_0, 'swagger-spec/petstore-with-external-docs', 'petstore-with-external-docs.yaml'],
+            'using-interfaces' => [OpenApi::VERSION_3_0_0, 'using-interfaces', 'using-interfaces.yaml'],
+            'using-refs' => [OpenApi::VERSION_3_0_0, 'using-refs', 'using-refs.yaml'],
+            'using-traits' => [OpenApi::VERSION_3_0_0, 'using-traits', 'using-traits.yaml'],
         ];
 
         foreach ($examples as $ekey => $example) {
@@ -44,7 +46,7 @@ class ExamplesTest extends OpenApiTestCase
         }
 
         if (\PHP_VERSION_ID >= 80100) {
-            yield 'reflection/attribute:openapi-spec-attributes' => ['openapi-spec-attributes', 'openapi-spec-attributes.yaml', new ReflectionAnalyser([new AttributeAnnotationFactory()])];
+            yield 'reflection/attribute:openapi-spec-attributes' => [OpenApi::VERSION_3_0_0, 'openapi-spec-attributes', 'openapi-spec-attributes.yaml', new ReflectionAnalyser([new AttributeAnnotationFactory()])];
         }
     }
 
@@ -53,7 +55,7 @@ class ExamplesTest extends OpenApiTestCase
      *
      * @dataProvider exampleMappings
      */
-    public function testExamples($example, $spec, $analyser)
+    public function testExamples($version, $example, $spec, $analyser)
     {
         // register autoloader for examples that require autoloading due to inheritance, etc.
         $path = $this->example($example);
@@ -64,6 +66,7 @@ class ExamplesTest extends OpenApiTestCase
 
         $path = $this->example($example);
         $openapi = (new Generator())
+            ->setVersion($version)
             ->setAnalyser($analyser)
             ->generate([$path], null, true);
         //file_put_contents($path . '/' . $spec, $openapi->toYaml());

--- a/tests/OpenApiTestCase.php
+++ b/tests/OpenApiTestCase.php
@@ -77,12 +77,12 @@ class OpenApiTestCase extends TestCase
         };
     }
 
-    public function getContext(array $properties = []): Context
+    public function getContext(array $properties = [], string $version = OpenApi::DEFAULT_VERSION): Context
     {
         return new Context(
             [
-            'version' => OpenApi::DEFAULT_VERSION,
-            'logger' => $this->getTrackingLogger(),
+                'version' => $version,
+                'logger' => $this->getTrackingLogger(),
             ] + $properties
         );
     }
@@ -112,7 +112,8 @@ class OpenApiTestCase extends TestCase
      * @param array|OpenApi|\stdClass|string $actual     The generated output
      * @param array|OpenApi|\stdClass|string $expected   The specification
      * @param string                         $message
-     * @param bool                           $normalized flag indicating whether the inputs are already normalized or not
+     * @param bool                           $normalized flag indicating whether the inputs are already normalized or
+     *                                                   not
      */
     protected function assertSpecEquals($actual, $expected, string $message = '', bool $normalized = false): void
     {
@@ -223,13 +224,15 @@ class OpenApiTestCase extends TestCase
         return $analysis;
     }
 
-    protected function annotationsFromDocBlockParser(string $docBlock, array $extraAliases = []): array
+    protected function annotationsFromDocBlockParser(string $docBlock, array $extraAliases = [], string $version = OpenApi::DEFAULT_VERSION): array
     {
-        return (new Generator())->withContext(function (Generator $generator, Analysis $analysis, Context $context) use ($docBlock, $extraAliases) {
-            $docBlockParser = new DocBlockParser($generator->getAliases() + $extraAliases);
+        return (new Generator())
+            ->setVersion($version)
+            ->withContext(function (Generator $generator, Analysis $analysis, Context $context) use ($docBlock, $extraAliases) {
+                $docBlockParser = new DocBlockParser($generator->getAliases() + $extraAliases);
 
-            return $docBlockParser->fromComment($docBlock, $this->getContext());
-        });
+                return $docBlockParser->fromComment($docBlock, $this->getContext([], $generator->getVersion()));
+            });
     }
 
     /**

--- a/tests/OpenApiTestCase.php
+++ b/tests/OpenApiTestCase.php
@@ -79,7 +79,12 @@ class OpenApiTestCase extends TestCase
 
     public function getContext(array $properties = []): Context
     {
-        return new Context(['logger' => $this->getTrackingLogger()] + $properties);
+        return new Context(
+            [
+            'version' => OpenApi::DEFAULT_VERSION,
+            'logger' => $this->getTrackingLogger(),
+            ] + $properties
+        );
     }
 
     public function getAnalyzer(): AnalyserInterface


### PR DESCRIPTION
Allows to toggle the openapi version with only '3.1.0' and '3.0.0' being allowed.

Right now this will not affect the generated spec, but that could be added later if required without affecting the `Generator`