### PR TITLE
Change typehint of Operation tags to string

### DIFF
--- a/src/Attributes/OperationTrait.php
+++ b/src/Attributes/OperationTrait.php
@@ -13,7 +13,7 @@ trait OperationTrait
     /**
      * @param string[]                  $security
      * @param Server[]                  $servers
-     * @param Tag[]                     $tags
+     * @param string[]                  $tags
      * @param Parameter[]               $parameters
      * @param Response[]                $responses
      * @param array<string,string>|null $x


### PR DESCRIPTION
Tags should be an array of strings, not Tag's. This would be a bc-break and it also breaks the openapi generation