### PR TITLE
Update type-hinting on security property for operations.

### DIFF
--- a/src/Attributes/OperationTrait.php
+++ b/src/Attributes/OperationTrait.php
@@ -11,7 +11,7 @@ use OpenApi\Generator;
 trait OperationTrait
 {
     /**
-     * @param array|null                $security
+     * @param array                     $security
      * @param Server[]                  $servers
      * @param string[]                  $tags
      * @param Parameter[]               $parameters

--- a/src/Attributes/OperationTrait.php
+++ b/src/Attributes/OperationTrait.php
@@ -11,7 +11,7 @@ use OpenApi\Generator;
 trait OperationTrait
 {
     /**
-     * @param array<string,array>|null  $security
+     * @param array|null                $security
      * @param Server[]                  $servers
      * @param string[]                  $tags
      * @param Parameter[]               $parameters

--- a/src/Attributes/OperationTrait.php
+++ b/src/Attributes/OperationTrait.php
@@ -11,7 +11,7 @@ use OpenApi\Generator;
 trait OperationTrait
 {
     /**
-     * @param string[]                  $security
+     * @param array<string,array>|null  $security
      * @param Server[]                  $servers
      * @param string[]                  $tags
      * @param Parameter[]               $parameters


### PR DESCRIPTION
We just updated versions of PhpStan, and the latest version is spitting this error back at us repeatedly: 

```
Parameter $security of attribute class OpenApi\Attributes\Get constructor expects array<string>|null, array<string, array> given.
```

Basically, the parameter I'm passing is:

```
security: [
  [
    'ApiKey': []
  ]
]
```

...which is correct as per the spec, but the hinting in the docblock is expecting an array of strings, when it's really a multidimensional array.

I think this should resolve that issue from the static typing side.