### PR TITLE
Fix Discriminator Attribute mapping property type hint

### DIFF
--- a/src/Attributes/Discriminator.php
+++ b/src/Attributes/Discriminator.php
@@ -12,12 +12,13 @@ use OpenApi\Generator;
 class Discriminator extends \OpenApi\Annotations\Discriminator
 {
     /**
+     * @param string[]|null $mapping
      * @param array<string,string>|null $x
      * @param Attachable[]|null         $attachables
      */
     public function __construct(
         ?string $propertyName = null,
-        ?string $mapping = null,
+        ?array $mapping = null,
         // annotation
         ?array $x = null,
         ?array $attachables = null

--- a/src/Attributes/Discriminator.php
+++ b/src/Attributes/Discriminator.php
@@ -12,7 +12,7 @@ use OpenApi\Generator;
 class Discriminator extends \OpenApi\Annotations\Discriminator
 {
     /**
-     * @param string[]|null $mapping
+     * @param string[]|null             $mapping
      * @param array<string,string>|null $x
      * @param Attachable[]|null         $attachables
      */


### PR DESCRIPTION
In OpenApi\Annotations\Discriminator $mapping typehint string[]