### PR TITLE
Includes 'example' argument in Examples attribute constructor (PHP 8.1)

### DIFF
--- a/src/Attributes/Examples.php
+++ b/src/Attributes/Examples.php
@@ -16,6 +16,7 @@ class Examples extends \OpenApi\Annotations\Examples
      * @param Attachable[]|null         $attachables
      */
     public function __construct(
+        ?string $example = null,
         ?string $summary = null,
         ?string $description = null,
         ?string $value = null,
@@ -26,6 +27,7 @@ class Examples extends \OpenApi\Annotations\Examples
         ?array $attachables = null
     ) {
         parent::__construct([
+            'example' => $example ?? Generator::UNDEFINED,
             'summary' => $summary ?? Generator::UNDEFINED,
             'description' => $description ?? Generator::UNDEFINED,
             'value' => $value ?? Generator::UNDEFINED,


### PR DESCRIPTION
I had to include "$example" argument to OpenApi\Attributes\Examples constructor, because the library was complaining it was missing. Here's an example where it complained:

```php
    #[OA\Get(
        path: '/api/v1/activation-codes/{id}/modules',
        summary: 'Gets activation code modules',
        operationId: 'listmodules',
        tags: ['Activation Codes'],
        parameters: [new OA\Parameter(ref: '#/components/parameters/ActivationCodeIdRequiredInPath')],
        responses: [
            new OA\Response(
                response: 200,
                description: 'Successful operation.',
                content: new OA\JsonContent(
                    ref: '#/components/schemas/ModuleListResponse',
                    examples: [new OA\Examples(
                        summary: '2 activation code modules found',
                        value: ''
                    )]
                )
            ),
            new OA\Response(response: 204, ref: '#/components/responses/SuccessfulEmptyList'),
        ]
    )]
    public function listModules(Request $request, $id)
    {
        return ContentResource::toJson(
            resources: $this->activationCodeService->findAllModules(
                id: $id,
                load: $request->load,
                paginate: $request->paginate
            ),
            message: __('One or more ActivationCode Module found.')
        );
    }
```
More specifically, this part of the code above:

```php
                    examples: [new OA\Examples(
                        summary: '2 activation code modules found',
                        value: ''
                    )]
```

After the changes of this PR, now I can simply specify the "example" field of `OA\Example()` and the error is gone:

```php
                    examples: [new OA\Examples(
                        example: 'TwoActivationCodeModulesFound',
                        summary: '2 activation code modules found',
                        value: ''
                    )]
```