### PR TITLE
Support array in Examples value (PHP 8.1)

### DIFF
--- a/src/Attributes/Examples.php
+++ b/src/Attributes/Examples.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 /**
  * @license Apache 2.0

--- a/src/Attributes/Examples.php
+++ b/src/Attributes/Examples.php
@@ -16,6 +16,7 @@ class Examples extends \OpenApi\Annotations\Examples
      * @param Attachable[]|null         $attachables
      */
     public function __construct(
+        ?string $example = null,
         ?string $summary = null,
         ?string $description = null,
         ?string $value = null,
@@ -26,6 +27,7 @@ class Examples extends \OpenApi\Annotations\Examples
         ?array $attachables = null
     ) {
         parent::__construct([
+            'example' => $example ?? Generator::UNDEFINED,
             'summary' => $summary ?? Generator::UNDEFINED,
             'description' => $description ?? Generator::UNDEFINED,
             'value' => $value ?? Generator::UNDEFINED,

--- a/src/Attributes/Examples.php
+++ b/src/Attributes/Examples.php
@@ -18,7 +18,6 @@ class Examples extends \OpenApi\Annotations\Examples
      * @param Attachable[]|null         $attachables
      */
     public function __construct(
-        ?string $example = null,
         ?string $summary = null,
         ?string $description = null,
         string|array|null $value = null,
@@ -29,7 +28,6 @@ class Examples extends \OpenApi\Annotations\Examples
         ?array $attachables = null
     ) {
         parent::__construct([
-            'example' => $example ?? Generator::UNDEFINED,
             'summary' => $summary ?? Generator::UNDEFINED,
             'description' => $description ?? Generator::UNDEFINED,
             'value' => $value ?? Generator::UNDEFINED,

--- a/src/Attributes/Examples.php
+++ b/src/Attributes/Examples.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 /**
  * @license Apache 2.0
@@ -19,7 +21,7 @@ class Examples extends \OpenApi\Annotations\Examples
         ?string $example = null,
         ?string $summary = null,
         ?string $description = null,
-        ?string $value = null,
+        string|array|null $value = null,
         ?string $externalValue = null,
         string|object|null $ref = null,
         // annotation


### PR DESCRIPTION
Simply support array instead of just strings in `$value` param in Examples attribute constructor:

```php
    public function __construct(
        ?string $summary = null,
        ?string $description = null,
        string|array|null $value = null,
        ?string $externalValue = null,
        string|object|null $ref = null,
        // annotation
        ?array $x = null,
        ?array $attachables = null
    ) {
        parent::__construct([
            'summary' => $summary ?? Generator::UNDEFINED,
            'description' => $description ?? Generator::UNDEFINED,
            'value' => $value ?? Generator::UNDEFINED,
            'externalValue' => $externalValue ?? Generator::UNDEFINED,
            'ref' => $ref ?? Generator::UNDEFINED,
            'x' => $x ?? Generator::UNDEFINED,
        ]);
        if ($attachables) {
            $this->merge($attachables);
        }
    }
```