### PR TITLE
Enables more attribute targets for OpenApi\Attributes\Examples.

### DIFF
--- a/src/Attributes/Examples.php
+++ b/src/Attributes/Examples.php
@@ -8,7 +8,7 @@ namespace OpenApi\Attributes;
 
 use OpenApi\Generator;
 
-#[\Attribute(\Attribute::TARGET_CLASS)]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
 class Examples extends \OpenApi\Annotations\Examples
 {
     /**


### PR DESCRIPTION
This is a suggestion. Is there a reason why Examples attribute can only be attributed to classes? In this PR I enabled the targets methods and properties, just like the OpenApi\Attributes\Schema attribute.