### PR TITLE
Only exit with code > 0 if the logged message was above notice

### DIFF
--- a/bin/openapi
+++ b/bin/openapi
@@ -218,9 +218,6 @@ $openapi = $generator
     ->setAnalyser($analyser)
     ->generate(Util::finder($paths, $exclude, $pattern));
 
-if ($logger->called()) {
-    $logger->notice('', ['prefix' => '']);
-}
 if ($options['output'] === false) {
     if (strtolower($options['format']) === 'json') {
         echo $openapi->toJson();

--- a/bin/openapi
+++ b/bin/openapi
@@ -163,7 +163,12 @@ set_error_handler(function ($errno, $errstr, $file, $line) use ($errorTypes, $op
         return;
     }
     $type = array_key_exists($errno, $errorTypes) ? $errorTypes[$errno] : 'Error';
-    $logger->error($errstr, ['prefix' => $type]);
+    if ($type === 'Deprecated') {
+        $logger->info($errstr, ['prefix' => $type]);
+    } else {
+        $logger->error($errstr, ['prefix' => $type]);
+    }
+
     if ($options['debug']) {
         $logger->info(' in '.$file.' on line '.$line);
     }
@@ -229,4 +234,4 @@ if ($options['output'] === false) {
     }
     $openapi->saveAs($options['output'], $options['format']);
 }
-exit($logger->called() ? 1 : 0);
+exit($logger->loggedMessageAboveNotice() ? 1 : 0);

--- a/src/Loggers/ConsoleLogger.php
+++ b/src/Loggers/ConsoleLogger.php
@@ -23,9 +23,6 @@ class ConsoleLogger extends AbstractLogger implements LoggerInterface
     ];
 
     /** @var bool */
-    protected $called = false;
-
-    /** @var bool */
     protected $loggedMessageAboveNotice = false;
 
     /** @var bool */
@@ -34,11 +31,6 @@ class ConsoleLogger extends AbstractLogger implements LoggerInterface
     public function __construct(bool $debug = false)
     {
         $this->debug = $debug;
-    }
-
-    public function called()
-    {
-        return $this->called;
     }
 
     public function loggedMessageAboveNotice()
@@ -74,8 +66,6 @@ class ConsoleLogger extends AbstractLogger implements LoggerInterface
         if (!in_array($level, self::LOG_LEVELS_UP_TO_NOTICE, true)) {
             $this->loggedMessageAboveNotice = true;
         }
-
-        $this->called = true;
 
         /** @var ?\Exception $exception */
         $exception = $context['exception'] ?? null;

--- a/src/Loggers/ConsoleLogger.php
+++ b/src/Loggers/ConsoleLogger.php
@@ -16,8 +16,17 @@ class ConsoleLogger extends AbstractLogger implements LoggerInterface
     public const COLOR_WARNING = "\033[33m";
     public const COLOR_STOP = "\033[0m";
 
+    private const LOG_LEVELS_UP_TO_NOTICE = [
+        LogLevel::DEBUG,
+        LogLevel::INFO,
+        LogLevel::NOTICE,
+    ];
+
     /** @var bool */
     protected $called = false;
+
+    /** @var bool */
+    protected $loggedMessageAboveNotice = false;
 
     /** @var bool */
     protected $debug;
@@ -30,6 +39,11 @@ class ConsoleLogger extends AbstractLogger implements LoggerInterface
     public function called()
     {
         return $this->called;
+    }
+
+    public function loggedMessageAboveNotice()
+    {
+        return $this->loggedMessageAboveNotice;
     }
 
     /**
@@ -56,6 +70,10 @@ class ConsoleLogger extends AbstractLogger implements LoggerInterface
                 break;
         }
         $stop = !empty($color) ? static::COLOR_STOP : '';
+
+        if (!in_array($level, self::LOG_LEVELS_UP_TO_NOTICE, true)) {
+            $this->loggedMessageAboveNotice = true;
+        }
 
         $this->called = true;
 


### PR DESCRIPTION
This allows to run `bin/openapi` on code that emits errors of type E_DEPRECATED.

Deprecated code should not result in a failing tool, see https://wouterj.nl/2021/11/deprecations-are-not-errors