### PR TITLE
Fix a doc link to Annotation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Generate interactive [OpenAPI](https://www.openapis.org) documentation for your RESTful API using [doctrine annotations](https://www.doctrine-project.org/projects/doctrine-annotations/en/latest/index.html).
 
-For a full list of supported annotations, please have look at the [`OpenApi\Annotations` namespace](src/Annotations) or the [documentation website](https://zircote.github.io/swagger-php/Supported-annotations.html).
+For a full list of supported annotations, please have look at the [`OpenApi\Annotations` namespace](src/Annotations) or the [documentation website](https://zircote.github.io/swagger-php/guide/annotations.html).
 
 ## Features
 


### PR DESCRIPTION
I'm not convinced we still promote Annotations over Attributes but dead link is not an answer.