### PR TITLE
Added deprecated to OperationTrait

### DIFF
--- a/src/Attributes/OperationTrait.php
+++ b/src/Attributes/OperationTrait.php
@@ -31,10 +31,10 @@ trait OperationTrait
         ?array $parameters = null,
         ?array $responses = null,
         ?ExternalDocumentation $externalDocs = null,
+        ?bool $deprecated = null,
         // annotation
         ?array $x = null,
-        ?array $attachables = null,
-        ?bool $deprecated = null
+        ?array $attachables = null
     ) {
         parent::__construct([
                 'path' => $path ?? Generator::UNDEFINED,
@@ -44,9 +44,9 @@ trait OperationTrait
                 'security' => $security ?? Generator::UNDEFINED,
                 'servers' => $servers ?? Generator::UNDEFINED,
                 'tags' => $tags ?? Generator::UNDEFINED,
+                'deprecated' => $deprecated ?? Generator::UNDEFINED,
                 'x' => $x ?? Generator::UNDEFINED,
                 'value' => $this->combine($requestBody, $responses, $parameters, $externalDocs, $attachables),
-                'deprecated' => $deprecated ?? Generator::UNDEFINED,
             ]);
     }
 }

--- a/src/Attributes/OperationTrait.php
+++ b/src/Attributes/OperationTrait.php
@@ -33,7 +33,8 @@ trait OperationTrait
         ?ExternalDocumentation $externalDocs = null,
         // annotation
         ?array $x = null,
-        ?array $attachables = null
+        ?array $attachables = null,
+        ?bool $deprecated = null
     ) {
         parent::__construct([
                 'path' => $path ?? Generator::UNDEFINED,
@@ -45,6 +46,7 @@ trait OperationTrait
                 'tags' => $tags ?? Generator::UNDEFINED,
                 'x' => $x ?? Generator::UNDEFINED,
                 'value' => $this->combine($requestBody, $responses, $parameters, $externalDocs, $attachables),
+                'deprecated' => $deprecated ?? Generator::UNDEFINED,
             ]);
     }
 }


### PR DESCRIPTION
While migrating my code base from Docblock annotations to Attributes I noticed that `deprecated` was missing from the list os supported parameters on OperationalTrait

See also: https://github.com/zircote/swagger-php/issues/1023#issuecomment-1034146418