### PR TITLE
Add @see support to annotation property docblocks

### DIFF
--- a/docs/reference/annotations.md
+++ b/docs/reference/annotations.md
@@ -27,23 +27,23 @@ referenced from properties outside the components object.
 #### Properties
 <dl>
   <dt><strong>schemas</strong> : <span style="font-family: monospace;">Schema[]</span></dt>
-  <dd>Reusable Schemas.</dd>
+  <dd><p>Reusable Schemas.</p></dd>
   <dt><strong>responses</strong> : <span style="font-family: monospace;">Response[]</span></dt>
-  <dd>Reusable Responses.</dd>
+  <dd><p>Reusable Responses.</p></dd>
   <dt><strong>parameters</strong> : <span style="font-family: monospace;">Parameter[]</span></dt>
-  <dd>Reusable Parameters.</dd>
-  <dt><strong>examples</strong> : <span style="font-family: monospace;">array</span></dt>
-  <dd>Reusable Examples.</dd>
+  <dd><p>Reusable Parameters.</p></dd>
+  <dt><strong>examples</strong> : <span style="font-family: monospace;">Examples[]</span></dt>
+  <dd><p>Reusable Examples.</p></dd>
   <dt><strong>requestBodies</strong> : <span style="font-family: monospace;">RequestBody[]</span></dt>
-  <dd>Reusable Request Bodys.</dd>
+  <dd><p>Reusable Request Bodys.</p></dd>
   <dt><strong>headers</strong> : <span style="font-family: monospace;">Header[]</span></dt>
-  <dd>Reusable Headers.</dd>
+  <dd><p>Reusable Headers.</p></dd>
   <dt><strong>securitySchemes</strong> : <span style="font-family: monospace;">SecurityScheme[]</span></dt>
-  <dd>Reusable Security Schemes.</dd>
+  <dd><p>Reusable Security Schemes.</p></dd>
   <dt><strong>links</strong> : <span style="font-family: monospace;">Link[]</span></dt>
-  <dd>Reusable Links.</dd>
+  <dd><p>Reusable Links.</p></dd>
   <dt><strong>callbacks</strong> : <span style="font-family: monospace;">callable[]</span></dt>
-  <dd>Reusable Callbacks.</dd>
+  <dd><p>Reusable Callbacks.</p></dd>
 </dl>
 
 #### Reference
@@ -56,11 +56,11 @@ Contact information for the exposed API.
 #### Properties
 <dl>
   <dt><strong>name</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>The identifying name of the contact person/organization.</dd>
+  <dd><p>The identifying name of the contact person/organization.</p></dd>
   <dt><strong>url</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>The URL pointing to the contact information.</dd>
+  <dd><p>The URL pointing to the contact information.</p></dd>
   <dt><strong>email</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>The email address of the contact person/organization.</dd>
+  <dd><p>The email address of the contact person/organization.</p></dd>
 </dl>
 
 #### Reference
@@ -73,7 +73,7 @@ Contact information for the exposed API.
 #### Properties
 <dl>
   <dt><strong>method</strong></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [Discriminator](https://github.com/zircote/swagger-php/tree/master/src/Annotations/Discriminator.php)
@@ -87,9 +87,9 @@ On top of this subset, there are extensions provided by this specification to al
 #### Properties
 <dl>
   <dt><strong>propertyName</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>The name of the property in the payload that will hold the discriminator value.</dd>
+  <dd><p>The name of the property in the payload that will hold the discriminator value.</p></dd>
   <dt><strong>mapping</strong> : <span style="font-family: monospace;">string[]</span></dt>
-  <dd>An object to hold mappings between payload values and schema names or references.</dd>
+  <dd><p>An object to hold mappings between payload values and schema names or references.</p></dd>
 </dl>
 
 #### Reference
@@ -103,32 +103,32 @@ On top of this subset, there are extensions provided by this specification to al
 #### Properties
 <dl>
   <dt><strong>ref</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p><p><i>See</i>: <a href="https://swagger.io/docs/specification/using-ref/">Using refs</a></p></dd>
   <dt><strong>example</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>The key into `#/components/examples`.</dd>
+  <dd><p>The key into `#/components/examples`.</p></dd>
   <dt><strong>summary</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>Short description for the example.</dd>
+  <dd><p>Short description for the example.</p></dd>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>Embedded literal example.<br />
+  <dd><p>Embedded literal example.<br />
 <br />
 The value field and externalValue field are mutually exclusive.<br />
 <br />
-To represent examples of media types that cannot naturally represented<br />
-in JSON or YAML, use a string value to contain the example, escaping where necessary.</dd>
+To represent examples of media types that cannot naturally be represented<br />
+in JSON or YAML, use a string value to contain the example, escaping where necessary.</p></dd>
   <dt><strong>value</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>Embedded literal example.<br />
+  <dd><p>Embedded literal example.<br />
 <br />
 The value field and externalValue field are mutually exclusive.<br />
 <br />
-To represent examples of media types that cannot naturally represented<br />
-in JSON or YAML, use a string value to contain the example, escaping where necessary.</dd>
+To represent examples of media types that cannot naturally be represented<br />
+in JSON or YAML, use a string value to contain the example, escaping where necessary.</p></dd>
   <dt><strong>externalValue</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>A URL that points to the literal example.<br />
+  <dd><p>A URL that points to the literal example.<br />
 <br />
 This provides the capability to reference examples that cannot easily be included<br />
 in JSON or YAML documents.<br />
 <br />
-The value field and externalValue field are mutually exclusive.</dd>
+The value field and externalValue field are mutually exclusive.</p></dd>
 </dl>
 
 ## [ExternalDocumentation](https://github.com/zircote/swagger-php/tree/master/src/Annotations/ExternalDocumentation.php)
@@ -138,9 +138,9 @@ Allows referencing an external resource for extended documentation.
 #### Properties
 <dl>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>A short description of the target documentation. GFM syntax can be used for rich text representation.</dd>
+  <dd><p>A short description of the target documentation. GFM syntax can be used for rich text representation.</p></dd>
   <dt><strong>url</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>The URL for the target documentation.</dd>
+  <dd><p>The URL for the target documentation.</p></dd>
 </dl>
 
 #### Reference
@@ -153,21 +153,25 @@ Configuration details for a supported OAuth Flow.
 #### Properties
 <dl>
   <dt><strong>authorizationUrl</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>The authorization url to be used for this flow.<br />
+  <dd><p>The authorization url to be used for this flow.<br />
 <br />
-This must be in the form of a url.</dd>
+This must be in the form of a url.</p></dd>
   <dt><strong>tokenUrl</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>The token URL to be used for this flow.<br />
+  <dd><p>The token URL to be used for this flow.<br />
 <br />
-This must be in the form of a url.</dd>
+This must be in the form of a url.</p></dd>
   <dt><strong>refreshUrl</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>The URL to be used for obtaining refresh tokens.<br />
+  <dd><p>The URL to be used for obtaining refresh tokens.<br />
 <br />
-This must be in the form of a url.</dd>
+This must be in the form of a url.</p></dd>
   <dt><strong>flow</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>Flow name. One of ['implicit', 'password', 'authorizationCode', 'clientCredentials'].</dd>
+  <dd><p>Flow name.<br />
+<br />
+One of ['implicit', 'password', 'authorizationCode', 'clientCredentials'].</p></dd>
   <dt><strong>scopes</strong></dt>
-  <dd>The available scopes for the OAuth2 security scheme. A map between the scope name and a short description for it.</dd>
+  <dd><p>The available scopes for the OAuth2 security scheme.<br />
+<br />
+A map between the scope name and a short description for it.</p></dd>
 </dl>
 
 #### Reference
@@ -180,7 +184,7 @@ This must be in the form of a url.</dd>
 #### Properties
 <dl>
   <dt><strong>method</strong></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [Head](https://github.com/zircote/swagger-php/tree/master/src/Annotations/Head.php)
@@ -190,7 +194,7 @@ This must be in the form of a url.</dd>
 #### Properties
 <dl>
   <dt><strong>method</strong></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [Header](https://github.com/zircote/swagger-php/tree/master/src/Annotations/Header.php)
@@ -200,28 +204,28 @@ This must be in the form of a url.</dd>
 #### Properties
 <dl>
   <dt><strong>ref</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p><p><i>See</i>: <a href="https://swagger.io/docs/specification/using-ref/">Using refs</a></p></dd>
   <dt><strong>header</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>No details available.</dd>
-  <dt><strong>required</strong> : <span style="font-family: monospace;">bool</span></dt>
-  <dd>A brief description of the parameter.<br />
+  <dd><p>A brief description of the parameter.<br />
 <br />
 This could contain examples of use.<br />
-CommonMark syntax MAY be used for rich text representation.</dd>
+CommonMark syntax MAY be used for rich text representation.</p></dd>
+  <dt><strong>required</strong> : <span style="font-family: monospace;">bool</span></dt>
+  <dd><p>No details available.</p></dd>
   <dt><strong>schema</strong> : <span style="font-family: monospace;">\OpenApi\Annotations\Schema</span></dt>
-  <dd>Schema object.</dd>
+  <dd><p>Schema object.</p></dd>
   <dt><strong>deprecated</strong> : <span style="font-family: monospace;">bool</span></dt>
-  <dd>Specifies that a parameter is deprecated and SHOULD be transitioned out of usage.</dd>
+  <dd><p>Specifies that a parameter is deprecated and SHOULD be transitioned out of usage.</p></dd>
   <dt><strong>allowEmptyValue</strong> : <span style="font-family: monospace;">bool</span></dt>
-  <dd>Sets the ability to pass empty-valued parameters.<br />
+  <dd><p>Sets the ability to pass empty-valued parameters.<br />
 <br />
 This is valid only for query parameters and allows sending a parameter with an empty value.<br />
 <br />
 Default value is false.<br />
 <br />
-If style is used, and if behavior is n/a (cannot be serialized), the value of allowEmptyValue SHALL be ignored.</dd>
+If style is used, and if behavior is n/a (cannot be serialized), the value of allowEmptyValue SHALL be ignored.</p></dd>
 </dl>
 
 #### Reference
@@ -236,21 +240,21 @@ The metadata may be used by the clients if needed and may be presented in editin
 #### Properties
 <dl>
   <dt><strong>title</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>The title of the application.</dd>
+  <dd><p>The title of the application.</p></dd>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>A short description of the application.<br />
+  <dd><p>A short description of the application.<br />
 <br />
-CommonMark syntax may be used for rich text representation.</dd>
+CommonMark syntax may be used for rich text representation.</p></dd>
   <dt><strong>termsOfService</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>A URL to the Terms of Service for the API.<br />
+  <dd><p>A URL to the Terms of Service for the API.<br />
 <br />
-Must be in the format of a url.</dd>
+Must be in the format of a url.</p></dd>
   <dt><strong>contact</strong> : <span style="font-family: monospace;">Contact</span></dt>
-  <dd>The contact information for the exposed API.</dd>
+  <dd><p>The contact information for the exposed API.</p></dd>
   <dt><strong>license</strong> : <span style="font-family: monospace;">License</span></dt>
-  <dd>The license information for the exposed API.</dd>
+  <dd><p>The license information for the exposed API.</p></dd>
   <dt><strong>version</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>The version of the OpenAPI document (which is distinct from the OpenAPI Specification version or the API implementation version).</dd>
+  <dd><p>The version of the OpenAPI document (which is distinct from the OpenAPI Specification version or the API implementation version).</p></dd>
 </dl>
 
 #### Reference
@@ -269,7 +273,7 @@ Use as `@OA\Schema` inside a `Response` and `MediaType`->`'application/json'` wi
 #### Properties
 <dl>
   <dt><strong>examples</strong> : <span style="font-family: monospace;">array</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [License](https://github.com/zircote/swagger-php/tree/master/src/Annotations/License.php)
@@ -279,13 +283,13 @@ License information for the exposed API.
 #### Properties
 <dl>
   <dt><strong>name</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>The license name used for the API.</dd>
+  <dd><p>The license name used for the API.</p></dd>
   <dt><strong>identifier</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>An SPDX license expression for the API. The `identifier` field is mutually exclusive of the `url` field.</dd>
+  <dd><p>An SPDX license expression for the API. The `identifier` field is mutually exclusive of the `url` field.</p></dd>
   <dt><strong>url</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>A URL to the license used for the API. This MUST be in the form of a URL.<br />
+  <dd><p>A URL to the license used for the API. This MUST be in the form of a URL.<br />
 <br />
-The `url` field is mutually exclusive of the `identifier` field.</dd>
+The `url` field is mutually exclusive of the `identifier` field.</p></dd>
 </dl>
 
 #### Reference
@@ -307,35 +311,35 @@ accessing values in an operation and using them as parameters while invoking the
 #### Properties
 <dl>
   <dt><strong>ref</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p><p><i>See</i>: <a href="https://swagger.io/docs/specification/using-ref/">Using refs</a></p></dd>
   <dt><strong>link</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>The key into MediaType->links array.</dd>
+  <dd><p>The key into MediaType->links array.</p></dd>
   <dt><strong>operationRef</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>A relative or absolute reference to an OA operation.<br />
+  <dd><p>A relative or absolute reference to an OA operation.<br />
 <br />
 This field is mutually exclusive of the <code>operationId</code> field, and must point to an Operation object.<br />
 <br />
-Relative values may be used to locate an existing Operation object in the OpenAPI definition.</dd>
+Relative values may be used to locate an existing Operation object in the OpenAPI definition.</p></dd>
   <dt><strong>operationId</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>The name of an existing, resolvable OA operation, as defined with a unique <code>operationId</code>.<br />
+  <dd><p>The name of an existing, resolvable OA operation, as defined with a unique <code>operationId</code>.<br />
 <br />
-This field is mutually exclusive of the <code>operationRef</code> field.</dd>
+This field is mutually exclusive of the <code>operationRef</code> field.</p></dd>
   <dt><strong>parameters</strong></dt>
-  <dd>A map representing parameters to pass to an operation as specified with operationId or identified via<br />
+  <dd><p>A map representing parameters to pass to an operation as specified with operationId or identified via<br />
 operationRef.<br />
 <br />
 The key is the parameter name to be used, whereas the value can be a constant or an expression to<br />
 be evaluated and passed to the linked operation.<br />
 The parameter name can be qualified using the parameter location [{in}.]{name} for operations<br />
-that use the same parameter name in different locations (e.g. path.id).</dd>
+that use the same parameter name in different locations (e.g. path.id).</p></dd>
   <dt><strong>requestBody</strong></dt>
-  <dd>A literal value or {expression} to use as a request body when calling the target operation.</dd>
+  <dd><p>A literal value or {expression} to use as a request body when calling the target operation.</p></dd>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>A description of the link.<br />
+  <dd><p>A description of the link.<br />
 <br />
-CommonMark syntax may be used for rich text representation.</dd>
+CommonMark syntax may be used for rich text representation.</p></dd>
   <dt><strong>server</strong> : <span style="font-family: monospace;">Server</span></dt>
-  <dd>A server object to be used by the target operation.</dd>
+  <dd><p>A server object to be used by the target operation.</p></dd>
 </dl>
 
 #### Reference
@@ -348,32 +352,32 @@ Each Media Type object provides schema and examples for the media type identifie
 #### Properties
 <dl>
   <dt><strong>mediaType</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>The key into Operation->content array.</dd>
+  <dd><p>The key into Operation->content array.</p></dd>
   <dt><strong>schema</strong> : <span style="font-family: monospace;">Schema</span></dt>
-  <dd>The schema defining the type used for the request body.</dd>
+  <dd><p>The schema defining the type used for the request body.</p></dd>
   <dt><strong>example</strong></dt>
-  <dd>Example of the media type.<br />
+  <dd><p>Example of the media type.<br />
 <br />
 The example object should be in the correct format as specified by the media type.<br />
 The example object is mutually exclusive of the examples object.<br />
 <br />
 Furthermore, if referencing a schema which contains an example,<br />
-the example value shall override the example provided by the schema.</dd>
-  <dt><strong>examples</strong> : <span style="font-family: monospace;">array</span></dt>
-  <dd>Examples of the media type.<br />
+the example value shall override the example provided by the schema.</p></dd>
+  <dt><strong>examples</strong> : <span style="font-family: monospace;">Examples[]</span></dt>
+  <dd><p>Examples of the media type.<br />
 <br />
 Each example object should match the media type and specified schema if present.<br />
 The examples object is mutually exclusive of the example object.<br />
 <br />
 Furthermore, if referencing a schema which contains an example,<br />
-the examples value shall override the example provided by the schema.</dd>
-  <dt><strong>encoding</strong></dt>
-  <dd>A map between a property name and its encoding information.<br />
+the examples value shall override the example provided by the schema.</p></dd>
+  <dt><strong>encoding</strong> : <span style="font-family: monospace;">array</span></dt>
+  <dd><p>A map between a property name and its encoding information.<br />
 <br />
 The key, being the property name, must exist in the schema as a property.<br />
 <br />
 The encoding object shall only apply to requestBody objects when the media type is multipart or<br />
-application/x-www-form-urlencoded.</dd>
+application/x-www-form-urlencoded.</p></dd>
 </dl>
 
 #### Reference
@@ -385,23 +389,26 @@ This is the root document object for the API specification.
 
 #### Properties
 <dl>
-  <dt><strong>openapi</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>The semantic version number of the OpenAPI Specification version that the OpenAPI document uses.<br />
+  <dt><strong>openapi</strong> : <span style="font-family: monospace;">string|null</span></dt>
+  <dd><p>The semantic version number of the OpenAPI Specification version that the OpenAPI document uses.<br />
 <br />
 The openapi field should be used by tooling specifications and clients to interpret the OpenAPI document.<br />
-This is not related to the API info::version string.</dd>
-  <dt><strong>info</strong> : <span style="font-family: monospace;">Info</span></dt>
-  <dd>Provides metadata about the API. The metadata may be used by tooling as required.</dd>
-  <dt><strong>servers</strong> : <span style="font-family: monospace;">Server[]</span></dt>
-  <dd>An array of <code>@OA\Server</code> objects, which provide connectivity information to a target server.<br />
 <br />
-If not provided, or is an empty array, the default value would be a Server Object with a url value of <code>/</code>.</dd>
+A version specified via `Generator::setVersion()` will overwrite this value.<br />
+<br />
+This is not related to the API info::version string.</p></dd>
+  <dt><strong>info</strong> : <span style="font-family: monospace;">Info</span></dt>
+  <dd><p>Provides metadata about the API. The metadata may be used by tooling as required.</p></dd>
+  <dt><strong>servers</strong> : <span style="font-family: monospace;">Server[]</span></dt>
+  <dd><p>An array of <code>@OA\Server</code> objects, which provide connectivity information to a target server.<br />
+<br />
+If not provided, or is an empty array, the default value would be a Server Object with a url value of <code>/</code>.</p></dd>
   <dt><strong>paths</strong> : <span style="font-family: monospace;">PathItem[]</span></dt>
-  <dd>The available paths and operations for the API.</dd>
+  <dd><p>The available paths and operations for the API.</p></dd>
   <dt><strong>components</strong> : <span style="font-family: monospace;">Components</span></dt>
-  <dd>An element to hold various components for the specification.</dd>
+  <dd><p>An element to hold various components for the specification.</p></dd>
   <dt><strong>security</strong> : <span style="font-family: monospace;">array</span></dt>
-  <dd>Lists the required security schemes to execute this operation.<br />
+  <dd><p>Lists the required security schemes to execute this operation.<br />
 <br />
 The name used for each property must correspond to a security scheme declared<br />
 in the Security Schemes under the Components Object.<br />
@@ -411,16 +418,16 @@ This enables support for scenarios where multiple query parameters or<br />
 HTTP headers are required to convey security information.<br />
 When a list of Security Requirement Objects is defined on the Open API object or<br />
 Operation Object, only one of Security Requirement Objects in the list needs to<br />
-be satisfied to authorize the request.</dd>
+be satisfied to authorize the request.</p></dd>
   <dt><strong>tags</strong> : <span style="font-family: monospace;">Tag[]</span></dt>
-  <dd>A list of tags used by the specification with additional metadata.<br />
+  <dd><p>A list of tags used by the specification with additional metadata.<br />
 <br />
 The order of the tags can be used to reflect on their order by the parsing tools.<br />
 Not all tags that are used by the Operation Object must be declared.<br />
 The tags that are not declared may be organized randomly or based on the tools' logic.<br />
-Each tag name in the list must be unique.</dd>
+Each tag name in the list must be unique.</p></dd>
   <dt><strong>externalDocs</strong> : <span style="font-family: monospace;">ExternalDocumentation</span></dt>
-  <dd>Additional external documentation.</dd>
+  <dd><p>Additional external documentation.</p></dd>
 </dl>
 
 #### Reference
@@ -433,7 +440,7 @@ Each tag name in the list must be unique.</dd>
 #### Properties
 <dl>
   <dt><strong>method</strong></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [Parameter](https://github.com/zircote/swagger-php/tree/master/src/Annotations/Parameter.php)
@@ -445,100 +452,100 @@ A unique parameter is defined by a combination of a name and location.
 #### Properties
 <dl>
   <dt><strong>ref</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p><p><i>See</i>: <a href="https://swagger.io/docs/specification/using-ref/">Using refs</a></p></dd>
   <dt><strong>parameter</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>The key into Components->parameters or PathItem->parameters array.</dd>
+  <dd><p>The key into <code>Components::parameters</code> or <code>PathItem::parameters</code> array.</p></dd>
   <dt><strong>name</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>The (case sensitive) name of the parameter.<br />
+  <dd><p>The (case sensitive) name of the parameter.<br />
 <br />
 If in is "path", the name field must correspond to the associated path segment from the path field in the Paths Object.<br />
 <br />
 If in is "header" and the name field is "Accept", "Content-Type" or "Authorization", the parameter definition shall be ignored.<br />
-For all other cases, the name corresponds to the parameter name used by the in property.</dd>
+For all other cases, the name corresponds to the parameter name used by the in property.</p></dd>
   <dt><strong>in</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>The location of the parameter.<br />
+  <dd><p>The location of the parameter.<br />
 <br />
-Possible values are "query", "header", "path" or "cookie".</dd>
+Possible values are "query", "header", "path" or "cookie".</p></dd>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>A brief description of the parameter.<br />
+  <dd><p>A brief description of the parameter.<br />
 <br />
 This could contain examples of use.<br />
 <br />
-CommonMark syntax may be used for rich text representation.</dd>
+CommonMark syntax may be used for rich text representation.</p></dd>
   <dt><strong>required</strong> : <span style="font-family: monospace;">bool</span></dt>
-  <dd>Determines whether this parameter is mandatory.<br />
+  <dd><p>Determines whether this parameter is mandatory.<br />
 <br />
 If the parameter location is "path", this property is required and its value must be true.<br />
-Otherwise, the property may be included and its default value is false.</dd>
+Otherwise, the property may be included and its default value is false.</p></dd>
   <dt><strong>deprecated</strong> : <span style="font-family: monospace;">bool</span></dt>
-  <dd>Specifies that a parameter is deprecated and should be transitioned out of usage.</dd>
+  <dd><p>Specifies that a parameter is deprecated and should be transitioned out of usage.</p></dd>
   <dt><strong>allowEmptyValue</strong> : <span style="font-family: monospace;">bool</span></dt>
-  <dd>Sets the ability to pass empty-valued parameters.<br />
+  <dd><p>Sets the ability to pass empty-valued parameters.<br />
 <br />
 This is valid only for query parameters and allows sending a parameter with an empty value.<br />
 <br />
 Default value is false.<br />
 <br />
-If style is used, and if behavior is n/a (cannot be serialized), the value of allowEmptyValue shall be ignored.</dd>
+If style is used, and if behavior is n/a (cannot be serialized), the value of allowEmptyValue shall be ignored.</p></dd>
   <dt><strong>style</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>Describes how the parameter value will be serialized depending on the type of the parameter value.<br />
+  <dd><p>Describes how the parameter value will be serialized depending on the type of the parameter value.<br />
 <br />
-Default values (based on value of in): for query - form; for path - simple; for header - simple; for cookie - form.</dd>
+Default values (based on value of in): for query - form; for path - simple; for header - simple; for cookie - form.</p></dd>
   <dt><strong>explode</strong> : <span style="font-family: monospace;">bool</span></dt>
-  <dd>When this is true, parameter values of type array or object generate separate parameters for each value of the array or key-value pair of the map.<br />
+  <dd><p>When this is true, parameter values of type array or object generate separate parameters for each value of the array or key-value pair of the map.<br />
 <br />
 For other types of parameters this property has no effect.<br />
 <br />
 When style is form, the default value is true.<br />
-For all other styles, the default value is false.</dd>
+For all other styles, the default value is false.</p></dd>
   <dt><strong>allowReserved</strong> : <span style="font-family: monospace;">bool</span></dt>
-  <dd>Determines whether the parameter value should allow reserved characters, as defined by RFC3986 :/?#[]@!$&'()*+,;= to be included without percent-encoding.<br />
+  <dd><p>Determines whether the parameter value should allow reserved characters, as defined by RFC3986 :/?#[]@!$&'()*+,;= to be included without percent-encoding.<br />
 <br />
 This property only applies to parameters with an in value of query.<br />
 <br />
-The default value is false.</dd>
+The default value is false.</p></dd>
   <dt><strong>schema</strong> : <span style="font-family: monospace;">Schema</span></dt>
-  <dd>The schema defining the type used for the parameter.</dd>
+  <dd><p>The schema defining the type used for the parameter.</p></dd>
   <dt><strong>example</strong></dt>
-  <dd>Example of the media type.<br />
+  <dd><p>Example of the media type.<br />
 <br />
 The example should match the specified schema and encoding properties if present.<br />
 The example object is mutually exclusive of the examples object.<br />
 Furthermore, if referencing a schema which contains an example, the example value shall override the example provided by the schema.<br />
-To represent examples of media types that cannot naturally be represented in JSON or YAML, a string value can contain the example with escaping where necessary.</dd>
+To represent examples of media types that cannot naturally be represented in JSON or YAML, a string value can contain the example with escaping where necessary.</p></dd>
   <dt><strong>examples</strong> : <span style="font-family: monospace;">array</span></dt>
-  <dd>Examples of the media type.<br />
+  <dd><p>Examples of the media type.<br />
 <br />
 Each example should contain a value in the correct format as specified in the parameter encoding.<br />
 The examples object is mutually exclusive of the example object.<br />
-Furthermore, if referencing a schema which contains an example, the examples value shall override the example provided by the schema.</dd>
+Furthermore, if referencing a schema which contains an example, the examples value shall override the example provided by the schema.</p></dd>
   <dt><strong>content</strong> : <span style="font-family: monospace;">MediaType[]</span></dt>
-  <dd>A map containing the representations for the parameter.<br />
+  <dd><p>A map containing the representations for the parameter.<br />
 <br />
 The key is the media type and the value describes it.<br />
-The map must only contain one entry.</dd>
+The map must only contain one entry.</p></dd>
   <dt><strong>matrix</strong></dt>
-  <dd>Path-style parameters defined by https://tools.ietf.org/html/rfc6570#section-3.2.7.</dd>
+  <dd><p>Path-style parameters defined by RFC6570.</p><p><i>See</i>: <a href="https://tools.ietf.org/html/rfc6570#section-3.2.7">RFC6570</a></p></dd>
   <dt><strong>label</strong></dt>
-  <dd>Label style parameters defined by https://tools.ietf.org/html/rfc6570#section-3.2.5.</dd>
+  <dd><p>Label style parameters defined by RFC6570.</p><p><i>See</i>: <a href="https://tools.ietf.org/html/rfc6570#section-3.2.5">RFC6570</a></p></dd>
   <dt><strong>form</strong></dt>
-  <dd>Form style parameters defined by https://tools.ietf.org/html/rfc6570#section-3.2.8<br />
+  <dd><p>Form style parameters defined by RFC6570.<br />
 <br />
-This option replaces collectionFormat with a csv (when explode is false) or multi (when explode is true) value from OpenAPI 2.0.</dd>
+This option replaces collectionFormat with a csv (when explode is false) or multi (when explode is true) value from OpenAPI 2.0.</p><p><i>See</i>: <a href="https://tools.ietf.org/html/rfc6570#section-3.2.8">RFC6570</a></p></dd>
   <dt><strong>simple</strong> : <span style="font-family: monospace;">array</span></dt>
-  <dd>Simple style parameters defined by https://tools.ietf.org/html/rfc6570#section-3.2.2<br />
+  <dd><p>Simple style parameters defined by RFC6570.<br />
 <br />
-This option replaces collectionFormat with a csv value from OpenAPI 2.0.</dd>
+This option replaces collectionFormat with a csv value from OpenAPI 2.0.</p><p><i>See</i>: <a href="https://tools.ietf.org/html/rfc6570#section-3.2.2">RFC6570</a></p></dd>
   <dt><strong>spaceDelimited</strong> : <span style="font-family: monospace;">array</span></dt>
-  <dd>Space separated array values.<br />
+  <dd><p>Space separated array values.<br />
 <br />
-This option replaces collectionFormat equal to ssv from OpenAPI 2.0.</dd>
+This option replaces collectionFormat equal to ssv from OpenAPI 2.0.</p></dd>
   <dt><strong>pipeDelimited</strong> : <span style="font-family: monospace;">array</span></dt>
-  <dd>Pipe separated array values.<br />
+  <dd><p>Pipe separated array values.<br />
 <br />
-This option replaces collectionFormat equal to pipes from OpenAPI 2.0.</dd>
+This option replaces collectionFormat equal to pipes from OpenAPI 2.0.</p></dd>
   <dt><strong>deepObject</strong></dt>
-  <dd>Provides a simple way of rendering nested objects using form parameters.</dd>
+  <dd><p>Provides a simple way of rendering nested objects using form parameters.</p></dd>
 </dl>
 
 #### Reference
@@ -551,7 +558,7 @@ This option replaces collectionFormat equal to pipes from OpenAPI 2.0.</dd>
 #### Properties
 <dl>
   <dt><strong>method</strong></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [PathItem](https://github.com/zircote/swagger-php/tree/master/src/Annotations/PathItem.php)
@@ -564,36 +571,36 @@ The path itself is still exposed to the documentation viewer but they will not k
 #### Properties
 <dl>
   <dt><strong>ref</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p><p><i>See</i>: <a href="https://swagger.io/docs/specification/using-ref/">Using refs</a></p></dd>
   <dt><strong>path</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>key for the Path Object (OpenApi->paths array).</dd>
+  <dd><p>key for the Path Object (OpenApi->paths array).</p></dd>
   <dt><strong>summary</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>An optional, string summary, intended to apply to all operations in this path.</dd>
+  <dd><p>An optional, string summary, intended to apply to all operations in this path.</p></dd>
   <dt><strong>get</strong> : <span style="font-family: monospace;">Get</span></dt>
-  <dd>A definition of a GET operation on this path.</dd>
+  <dd><p>A definition of a GET operation on this path.</p></dd>
   <dt><strong>put</strong> : <span style="font-family: monospace;">Put</span></dt>
-  <dd>A definition of a PUT operation on this path.</dd>
+  <dd><p>A definition of a PUT operation on this path.</p></dd>
   <dt><strong>post</strong> : <span style="font-family: monospace;">Post</span></dt>
-  <dd>A definition of a POST operation on this path.</dd>
+  <dd><p>A definition of a POST operation on this path.</p></dd>
   <dt><strong>delete</strong> : <span style="font-family: monospace;">Delete</span></dt>
-  <dd>A definition of a DELETE operation on this path.</dd>
+  <dd><p>A definition of a DELETE operation on this path.</p></dd>
   <dt><strong>options</strong> : <span style="font-family: monospace;">Options</span></dt>
-  <dd>A definition of a OPTIONS operation on this path.</dd>
+  <dd><p>A definition of a OPTIONS operation on this path.</p></dd>
   <dt><strong>head</strong> : <span style="font-family: monospace;">Head</span></dt>
-  <dd>A definition of a HEAD operation on this path.</dd>
+  <dd><p>A definition of a HEAD operation on this path.</p></dd>
   <dt><strong>patch</strong> : <span style="font-family: monospace;">Patch</span></dt>
-  <dd>A definition of a PATCH operation on this path.</dd>
+  <dd><p>A definition of a PATCH operation on this path.</p></dd>
   <dt><strong>trace</strong> : <span style="font-family: monospace;">Trace</span></dt>
-  <dd>A definition of a TRACE operation on this path.</dd>
+  <dd><p>A definition of a TRACE operation on this path.</p></dd>
   <dt><strong>servers</strong> : <span style="font-family: monospace;">Server[]</span></dt>
-  <dd>An alternative server array to service all operations in this path.</dd>
+  <dd><p>An alternative server array to service all operations in this path.</p></dd>
   <dt><strong>parameters</strong> : <span style="font-family: monospace;">Parameter[]</span></dt>
-  <dd>A list of parameters that are applicable for all the operations described under this path.<br />
+  <dd><p>A list of parameters that are applicable for all the operations described under this path.<br />
 <br />
 These parameters can be overridden at the operation level, but cannot be removed there.<br />
 The list must not include duplicated parameters.<br />
 A unique parameter is defined by a combination of a name and location.<br />
-The list can use the Reference Object to link to parameters that are defined at the OpenAPI Object's components/parameters.</dd>
+The list can use the Reference Object to link to parameters that are defined at the OpenAPI Object's components/parameters.</p></dd>
 </dl>
 
 #### Reference
@@ -606,9 +613,9 @@ A `@OA\Request` path parameter.
 #### Properties
 <dl>
   <dt><strong>in</strong></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>required</strong></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [Post](https://github.com/zircote/swagger-php/tree/master/src/Annotations/Post.php)
@@ -618,7 +625,7 @@ A `@OA\Request` path parameter.
 #### Properties
 <dl>
   <dt><strong>method</strong></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [Property](https://github.com/zircote/swagger-php/tree/master/src/Annotations/Property.php)
@@ -628,7 +635,7 @@ A `@OA\Request` path parameter.
 #### Properties
 <dl>
   <dt><strong>property</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>The key into Schema->properties array.</dd>
+  <dd><p>The key into Schema->properties array.</p></dd>
 </dl>
 
 ## [Put](https://github.com/zircote/swagger-php/tree/master/src/Annotations/Put.php)
@@ -638,7 +645,7 @@ A `@OA\Request` path parameter.
 #### Properties
 <dl>
   <dt><strong>method</strong></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [RequestBody](https://github.com/zircote/swagger-php/tree/master/src/Annotations/RequestBody.php)
@@ -648,25 +655,25 @@ Describes a single request body.
 #### Properties
 <dl>
   <dt><strong>ref</strong></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>request</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>Request body model name.</dd>
+  <dd><p>Request body model name.</p></dd>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>A brief description of the parameter.<br />
+  <dd><p>A brief description of the parameter.<br />
 <br />
 This could contain examples of use.<br />
 <br />
-CommonMark syntax may be used for rich text representation.</dd>
+CommonMark syntax may be used for rich text representation.</p></dd>
   <dt><strong>required</strong> : <span style="font-family: monospace;">bool</span></dt>
-  <dd>Determines whether this parameter is mandatory.<br />
+  <dd><p>Determines whether this parameter is mandatory.<br />
 <br />
 If the parameter location is "path", this property is required and its value must be true.<br />
-Otherwise, the property may be included and its default value is false.</dd>
+Otherwise, the property may be included and its default value is false.</p></dd>
   <dt><strong>content</strong> : <span style="font-family: monospace;">array&lt;MediaType&gt;|JsonContent|XmlContent</span></dt>
-  <dd>The content of the request body.<br />
+  <dd><p>The content of the request body.<br />
 <br />
 The key is a media type or media type range and the value describes it. For requests that match multiple keys,<br />
-only the most specific key is applicable. e.g. text/plain overrides text/*.</dd>
+only the most specific key is applicable. e.g. text/plain overrides text/*.</p></dd>
 </dl>
 
 #### Reference
@@ -680,31 +687,33 @@ static links to operations based on the response.
 #### Properties
 <dl>
   <dt><strong>ref</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p><p><i>See</i>: <a href="https://swagger.io/docs/specification/using-ref/">Using refs</a></p></dd>
   <dt><strong>response</strong> : <span style="font-family: monospace;">string|int</span></dt>
-  <dd>The key into Operations->responses array.<br />
+  <dd><p>The key into Operations->responses array.<br />
 <br />
-A HTTP status code or <code>default</code>.</dd>
+A HTTP status code or <code>default</code>.</p></dd>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>A short description of the response.<br />
+  <dd><p>A short description of the response.<br />
 <br />
-CommonMark syntax may be used for rich text representation.</dd>
+CommonMark syntax may be used for rich text representation.</p></dd>
   <dt><strong>headers</strong> : <span style="font-family: monospace;">Header[]</span></dt>
-  <dd>Maps a header name to its definition.<br />
+  <dd><p>Maps a header name to its definition.<br />
 <br />
-RFC7230 states header names are case insensitive. https://tools.ietf.org/html/rfc7230#page-22<br />
-If a response header is defined with the name "Content-Type", it shall be ignored.</dd>
+RFC7230 states header names are case insensitive.<br />
+<br />
+If a response header is defined with the name "Content-Type", it shall be ignored.</p><p><i>See</i>: <a href="https://tools.ietf.org/html/rfc7230#page-22">RFC7230</a></p></dd>
   <dt><strong>content</strong> : <span style="font-family: monospace;">MediaType[]</span></dt>
-  <dd>A map containing descriptions of potential response payloads.<br />
+  <dd><p>A map containing descriptions of potential response payloads.<br />
 <br />
 The key is a media type or media type range and the value describes it.<br />
-For responses that match multiple keys, only the most specific key is applicable. e.g. text/plain overrides<br />
-text/*.</dd>
+<br />
+For responses that match multiple keys, only the most specific key is applicable;<br />
+e.g. <code>text/plain</code> overrides <code>text/*</code>.</p></dd>
   <dt><strong>links</strong> : <span style="font-family: monospace;">array</span></dt>
-  <dd>A map of operations links that can be followed from the response.<br />
+  <dd><p>A map of operations links that can be followed from the response.<br />
 <br />
 The key of the map is a short name for the link, following the naming constraints of the names for Component<br />
-Objects.</dd>
+Objects.</p></dd>
 </dl>
 
 #### Reference
@@ -722,35 +731,35 @@ On top of this subset, there are extensions provided by this specification to al
 #### Properties
 <dl>
   <dt><strong>ref</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p><p><i>See</i>: <a href="https://swagger.io/docs/specification/using-ref/">Using refs</a></p></dd>
   <dt><strong>schema</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>The key into Components->schemas array.</dd>
+  <dd><p>The key into Components->schemas array.</p></dd>
   <dt><strong>title</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>Can be used to decorate a user interface with information about the data produced by this user interface.<br />
+  <dd><p>Can be used to decorate a user interface with information about the data produced by this user interface.<br />
 <br />
-Preferably short; use <code>description</code> for more details.</dd>
+Preferably short; use <code>description</code> for more details.</p></dd>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>A description will provide explanation about the purpose of the instance described by this schema.</dd>
+  <dd><p>A description will provide explanation about the purpose of the instance described by this schema.</p></dd>
   <dt><strong>maxProperties</strong> : <span style="font-family: monospace;">int</span></dt>
-  <dd>An object instance is valid against "maxProperties" if its number of properties is less than, or equal to, the<br />
-value of this property.</dd>
+  <dd><p>An object instance is valid against "maxProperties" if its number of properties is less than, or equal to, the<br />
+value of this property.</p></dd>
   <dt><strong>minProperties</strong> : <span style="font-family: monospace;">int</span></dt>
-  <dd>An object instance is valid against "minProperties" if its number of properties is greater than, or equal to,<br />
-the value of this property.</dd>
+  <dd><p>An object instance is valid against "minProperties" if its number of properties is greater than, or equal to,<br />
+the value of this property.</p></dd>
   <dt><strong>required</strong> : <span style="font-family: monospace;">string[]</span></dt>
-  <dd>An object instance is valid against this property if its property set contains all elements in this property's<br />
-array value.</dd>
+  <dd><p>An object instance is valid against this property if its property set contains all elements in this property's<br />
+array value.</p></dd>
   <dt><strong>properties</strong> : <span style="font-family: monospace;">Property[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>type</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>The type of the schema/property. The value MUST be one of "string", "number", "integer", "boolean", "array" or<br />
-"object".</dd>
+  <dd><p>The type of the schema/property. The value MUST be one of "string", "number", "integer", "boolean", "array" or<br />
+"object".</p></dd>
   <dt><strong>format</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>The extending format for the previously mentioned type. See Data Type Formats for further details.</dd>
+  <dd><p>The extending format for the previously mentioned type. See Data Type Formats for further details.</p></dd>
   <dt><strong>items</strong> : <span style="font-family: monospace;">Items</span></dt>
-  <dd>Required if type is "array". Describes the type of items in the array.</dd>
+  <dd><p>Required if type is "array". Describes the type of items in the array.</p></dd>
   <dt><strong>collectionFormat</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>Determines the format of the array if type array is used.<br />
+  <dd><p>Determines the format of the array if type array is used.<br />
 Possible values are:<br />
 - csv: comma separated values foo,bar.<br />
 - ssv: space separated values foo bar.<br />
@@ -758,99 +767,99 @@ Possible values are:<br />
 - pipes: pipe separated values foo|bar.<br />
 - multi: corresponds to multiple parameter instances instead of multiple values for a single instance foo=bar&foo=baz.<br />
 This is valid only for parameters of type <code>query</code> or <code>formData</code>.<br />
-Default value is csv.</dd>
+Default value is csv.</p></dd>
   <dt><strong>default</strong></dt>
-  <dd>Sets a default value to the parameter. The type of the value depends on the defined type. See<br />
-http://json-schema.org/latest/json-schema-validation.html#anchor101.</dd>
+  <dd><p>Sets a default value to the parameter. The type of the value depends on the defined type.</p><p><i>See</i>: <a href="http://json-schema.org/latest/json-schema-validation.html#anchor101">JSON schema validation</a></p></dd>
   <dt><strong>maximum</strong> : <span style="font-family: monospace;">number</span></dt>
-  <dd>See http://json-schema.org/latest/json-schema-validation.html#anchor17.</dd>
+  <dd><p>No details available.</p><p><i>See</i>: <a href="http://json-schema.org/latest/json-schema-validation.html#anchor17">JSON schema validation</a></p></dd>
   <dt><strong>exclusiveMaximum</strong> : <span style="font-family: monospace;">bool</span></dt>
-  <dd>See http://json-schema.org/latest/json-schema-validation.html#anchor17.</dd>
+  <dd><p>No details available.</p><p><i>See</i>: <a href="http://json-schema.org/latest/json-schema-validation.html#anchor17">JSON schema validation</a></p></dd>
   <dt><strong>minimum</strong> : <span style="font-family: monospace;">number</span></dt>
-  <dd>See http://json-schema.org/latest/json-schema-validation.html#anchor21.</dd>
+  <dd><p>No details available.</p><p><i>See</i>: <a href="http://json-schema.org/latest/json-schema-validation.html#anchor21">JSON schema validation</a></p></dd>
   <dt><strong>exclusiveMinimum</strong> : <span style="font-family: monospace;">bool</span></dt>
-  <dd>See http://json-schema.org/latest/json-schema-validation.html#anchor21.</dd>
+  <dd><p>No details available.</p><p><i>See</i>: <a href="http://json-schema.org/latest/json-schema-validation.html#anchor21">JSON schema validation</a></p></dd>
   <dt><strong>maxLength</strong> : <span style="font-family: monospace;">int</span></dt>
-  <dd>See http://json-schema.org/latest/json-schema-validation.html#anchor26.</dd>
+  <dd><p>No details available.</p><p><i>See</i>: <a href="http://json-schema.org/latest/json-schema-validation.html#anchor26">JSON schema validation</a></p></dd>
   <dt><strong>minLength</strong> : <span style="font-family: monospace;">int</span></dt>
-  <dd>See http://json-schema.org/latest/json-schema-validation.html#anchor29.</dd>
+  <dd><p>No details available.</p><p><i>See</i>: <a href="http://json-schema.org/latest/json-schema-validation.html#anchor29">JSON schema validation</a></p></dd>
   <dt><strong>pattern</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>A string instance is considered valid if the regular expression matches the instance successfully.</dd>
+  <dd><p>A string instance is considered valid if the regular expression matches the instance successfully.</p></dd>
   <dt><strong>maxItems</strong> : <span style="font-family: monospace;">int</span></dt>
-  <dd>See http://json-schema.org/latest/json-schema-validation.html#anchor42.</dd>
+  <dd><p>No details available.</p><p><i>See</i>: <a href="http://json-schema.org/latest/json-schema-validation.html#anchor42">JSON schema validation</a></p></dd>
   <dt><strong>minItems</strong> : <span style="font-family: monospace;">int</span></dt>
-  <dd>See http://json-schema.org/latest/json-schema-validation.html#anchor45.</dd>
+  <dd><p>No details available.</p><p><i>See</i>: <a href="http://json-schema.org/latest/json-schema-validation.html#anchor45">JSON schema validation</a></p></dd>
   <dt><strong>uniqueItems</strong> : <span style="font-family: monospace;">bool</span></dt>
-  <dd>See http://json-schema.org/latest/json-schema-validation.html#anchor49.</dd>
+  <dd><p>No details available.</p><p><i>See</i>: <a href="http://json-schema.org/latest/json-schema-validation.html#anchor49">JSON schema validation</a></p></dd>
   <dt><strong>enum</strong> : <span style="font-family: monospace;">array</span></dt>
-  <dd>See http://json-schema.org/latest/json-schema-validation.html#anchor76.</dd>
+  <dd><p>No details available.</p><p><i>See</i>: <a href="http://json-schema.org/latest/json-schema-validation.html#anchor76">JSON schema validation</a></p></dd>
   <dt><strong>multipleOf</strong> : <span style="font-family: monospace;">number</span></dt>
-  <dd>A numeric instance is valid against "multipleOf" if the result of the division of the instance by this<br />
-property's value is an integer.</dd>
+  <dd><p>A numeric instance is valid against "multipleOf" if the result of the division of the instance by this<br />
+property's value is an integer.</p></dd>
   <dt><strong>discriminator</strong> : <span style="font-family: monospace;">Discriminator</span></dt>
-  <dd>Adds support for polymorphism.<br />
+  <dd><p>Adds support for polymorphism.<br />
 <br />
 The discriminator is an object name that is used to differentiate between other schemas which may satisfy the<br />
-payload description. See Composition and Inheritance for more details.</dd>
+payload description. See Composition and Inheritance for more details.</p></dd>
   <dt><strong>readOnly</strong> : <span style="font-family: monospace;">bool</span></dt>
-  <dd>Declares the property as "read only".<br />
+  <dd><p>Declares the property as "read only".<br />
 <br />
 Relevant only for Schema "properties" definitions.<br />
 <br />
 This means that it may be sent as part of a response but should not be sent as part of the request.<br />
 If the property is marked as readOnly being true and is in the required list, the required will take effect on<br />
 the response only. A property must not be marked as both readOnly and writeOnly being true. Default value is<br />
-false.</dd>
+false.</p></dd>
   <dt><strong>writeOnly</strong> : <span style="font-family: monospace;">bool</span></dt>
-  <dd>Declares the property as "write only".<br />
+  <dd><p>Declares the property as "write only".<br />
 <br />
 Relevant only for Schema "properties" definitions.<br />
 Therefore, it may be sent as part of a request but should not be sent as part of the response.<br />
 If the property is marked as writeOnly being true and is in the required list, the required will take effect on<br />
 the request only. A property must not be marked as both readOnly and writeOnly being true. Default value is<br />
-false.</dd>
+false.</p></dd>
   <dt><strong>xml</strong> : <span style="font-family: monospace;">Xml</span></dt>
-  <dd>This may be used only on properties schemas.<br />
+  <dd><p>This may be used only on properties schemas.<br />
 <br />
 It has no effect on root schemas.<br />
-Adds additional metadata to describe the XML representation of this property.</dd>
+Adds additional metadata to describe the XML representation of this property.</p></dd>
   <dt><strong>externalDocs</strong> : <span style="font-family: monospace;">ExternalDocumentation</span></dt>
-  <dd>Additional external documentation for this schema.</dd>
+  <dd><p>Additional external documentation for this schema.</p></dd>
   <dt><strong>example</strong></dt>
-  <dd>A free-form property to include an example of an instance for this schema.<br />
-To represent examples that cannot be naturally represented in JSON or YAML, a string value can be used to<br />
-contain the example with escaping where necessary.</dd>
+  <dd><p>A free-form property to include an example of an instance for this schema.<br />
+<br />
+To represent examples that cannot naturally be represented in JSON or YAML, a string value can be used to<br />
+contain the example with escaping where necessary.</p></dd>
   <dt><strong>nullable</strong> : <span style="font-family: monospace;">bool</span></dt>
-  <dd>Allows sending a null value for the defined schema.<br />
-Default value is false.</dd>
+  <dd><p>Allows sending a null value for the defined schema.<br />
+Default value is false.</p></dd>
   <dt><strong>deprecated</strong> : <span style="font-family: monospace;">bool</span></dt>
-  <dd>Specifies that a schema is deprecated and should be transitioned out of usage.<br />
-Default value is false.</dd>
+  <dd><p>Specifies that a schema is deprecated and should be transitioned out of usage.<br />
+Default value is false.</p></dd>
   <dt><strong>allOf</strong> : <span style="font-family: monospace;">Schema[]</span></dt>
-  <dd>An instance validates successfully against this property if it validates successfully against all schemas<br />
-defined by this property's value.</dd>
+  <dd><p>An instance validates successfully against this property if it validates successfully against all schemas<br />
+defined by this property's value.</p></dd>
   <dt><strong>anyOf</strong> : <span style="font-family: monospace;">Schema[]</span></dt>
-  <dd>An instance validates successfully against this property if it validates successfully against at least one<br />
-schema defined by this property's value.</dd>
+  <dd><p>An instance validates successfully against this property if it validates successfully against at least one<br />
+schema defined by this property's value.</p></dd>
   <dt><strong>oneOf</strong> : <span style="font-family: monospace;">Schema[]</span></dt>
-  <dd>An instance validates successfully against this property if it validates successfully against exactly one schema<br />
-defined by this property's value.</dd>
+  <dd><p>An instance validates successfully against this property if it validates successfully against exactly one schema<br />
+defined by this property's value.</p></dd>
   <dt><strong>not</strong></dt>
-  <dd>http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.29.</dd>
+  <dd><p>http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.29.</p></dd>
   <dt><strong>additionalProperties</strong> : <span style="font-family: monospace;">bool|AdditionalProperties</span></dt>
-  <dd>http://json-schema.org/latest/json-schema-validation.html#anchor64.</dd>
+  <dd><p>http://json-schema.org/latest/json-schema-validation.html#anchor64.</p></dd>
   <dt><strong>additionalItems</strong></dt>
-  <dd>http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.10.</dd>
+  <dd><p>http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.10.</p></dd>
   <dt><strong>contains</strong></dt>
-  <dd>http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.14.</dd>
+  <dd><p>http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.14.</p></dd>
   <dt><strong>patternProperties</strong></dt>
-  <dd>http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.19.</dd>
+  <dd><p>http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.19.</p></dd>
   <dt><strong>dependencies</strong></dt>
-  <dd>http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.21.</dd>
+  <dd><p>http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.21.</p></dd>
   <dt><strong>propertyNames</strong></dt>
-  <dd>http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.22.</dd>
+  <dd><p>http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.22.</p></dd>
   <dt><strong>const</strong></dt>
-  <dd>http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.24.</dd>
+  <dd><p>http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.24.</p></dd>
 </dl>
 
 #### Reference
@@ -864,27 +873,27 @@ defined by this property's value.</dd>
 #### Properties
 <dl>
   <dt><strong>ref</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p><p><i>See</i>: <a href="https://swagger.io/docs/specification/using-ref/">Using refs</a></p></dd>
   <dt><strong>securityScheme</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>The key into OpenApi->security array.</dd>
+  <dd><p>The key into OpenApi->security array.</p></dd>
   <dt><strong>type</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>The type of the security scheme.</dd>
+  <dd><p>The type of the security scheme.</p></dd>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>A short description for security scheme.</dd>
+  <dd><p>A short description for security scheme.</p></dd>
   <dt><strong>name</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>The name of the header or query parameter to be used.</dd>
+  <dd><p>The name of the header or query parameter to be used.</p></dd>
   <dt><strong>in</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>Required The location of the API key.</dd>
+  <dd><p>Required The location of the API key.</p></dd>
   <dt><strong>flows</strong> : <span style="font-family: monospace;">Flow[]</span></dt>
-  <dd>The flow used by the OAuth2 security scheme.</dd>
+  <dd><p>The flow used by the OAuth2 security scheme.</p></dd>
   <dt><strong>bearerFormat</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>A hint to the client to identify how the bearer token is formatted.<br />
+  <dd><p>A hint to the client to identify how the bearer token is formatted.<br />
 <br />
-Bearer tokens are usually generated by an authorization server, so this information is primarily for documentation purposes.</dd>
+Bearer tokens are usually generated by an authorization server, so this information is primarily for documentation purposes.</p></dd>
   <dt><strong>scheme</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>The name of the HTTP Authorization scheme.</dd>
+  <dd><p>The name of the HTTP Authorization scheme.</p><p><i>See</i>: <a href="https://tools.ietf.org/html/rfc7235#section-5.1">RFC7235</a></p></dd>
   <dt><strong>openIdConnectUrl</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>OpenId Connect URL to discover OAuth2 configuration values. This MUST be in the form of a URL.</dd>
+  <dd><p>OpenId Connect URL to discover OAuth2 configuration values. This MUST be in the form of a URL.</p></dd>
 </dl>
 
 #### Reference
@@ -897,19 +906,19 @@ An object representing a server.
 #### Properties
 <dl>
   <dt><strong>url</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>A URL to the target host.<br />
+  <dd><p>A URL to the target host.<br />
 <br />
 This URL supports Server Variables and may be relative,<br />
 to indicate that the host location is relative to the location where the OpenAPI document is being served.<br />
-Variable substitutions will be made when a variable is named in {brackets}.</dd>
+Variable substitutions will be made when a variable is named in {brackets}.</p></dd>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>An optional string describing the host designated by the URL.<br />
+  <dd><p>An optional string describing the host designated by the URL.<br />
 <br />
-CommonMark syntax may be used for rich text representation.</dd>
+CommonMark syntax may be used for rich text representation.</p></dd>
   <dt><strong>variables</strong> : <span style="font-family: monospace;">array</span></dt>
-  <dd>A map between a variable name and its value.<br />
+  <dd><p>A map between a variable name and its value.<br />
 <br />
-The value is used for substitution in the server's URL template.</dd>
+The value is used for substitution in the server's URL template.</p></dd>
 </dl>
 
 #### Reference
@@ -922,21 +931,21 @@ An object representing a server variable for server URL template substitution.
 #### Properties
 <dl>
   <dt><strong>serverVariable</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>The key into Server->variables array.</dd>
+  <dd><p>The key into Server->variables array.</p></dd>
   <dt><strong>enum</strong> : <span style="font-family: monospace;">string[]</span></dt>
-  <dd>An enumeration of string values to be used if the substitution options are from a limited set.</dd>
+  <dd><p>An enumeration of string values to be used if the substitution options are from a limited set.</p></dd>
   <dt><strong>default</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>The default value to use for substitution, and to send, if an alternate value is not supplied.<br />
+  <dd><p>The default value to use for substitution, and to send, if an alternate value is not supplied.<br />
 <br />
-Unlike the Schema Object's default, this value must be provided by the consumer.</dd>
+Unlike the Schema Object's default, this value must be provided by the consumer.</p></dd>
   <dt><strong>variables</strong> : <span style="font-family: monospace;">array</span></dt>
-  <dd>A map between a variable name and its value.<br />
+  <dd><p>A map between a variable name and its value.<br />
 <br />
-The value is used for substitution in the server's URL template.</dd>
+The value is used for substitution in the server's URL template.</p></dd>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>An optional description for the server variable.<br />
+  <dd><p>An optional description for the server variable.<br />
 <br />
-CommonMark syntax MAY be used for rich text representation.</dd>
+CommonMark syntax MAY be used for rich text representation.</p></dd>
 </dl>
 
 #### Reference
@@ -949,11 +958,11 @@ CommonMark syntax MAY be used for rich text representation.</dd>
 #### Properties
 <dl>
   <dt><strong>name</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>The name of the tag.</dd>
+  <dd><p>The name of the tag.</p></dd>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>A short description for the tag. GFM syntax can be used for rich text representation.</dd>
+  <dd><p>A short description for the tag. GFM syntax can be used for rich text representation.</p></dd>
   <dt><strong>externalDocs</strong> : <span style="font-family: monospace;">ExternalDocumentation</span></dt>
-  <dd>Additional external documentation for this tag.</dd>
+  <dd><p>Additional external documentation for this tag.</p></dd>
 </dl>
 
 #### Reference
@@ -966,7 +975,7 @@ CommonMark syntax MAY be used for rich text representation.</dd>
 #### Properties
 <dl>
   <dt><strong>method</strong></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [Xml](https://github.com/zircote/swagger-php/tree/master/src/Annotations/Xml.php)
@@ -976,28 +985,28 @@ CommonMark syntax MAY be used for rich text representation.</dd>
 #### Properties
 <dl>
   <dt><strong>name</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>Replaces the name of the element/attribute used for the described schema property.<br />
+  <dd><p>Replaces the name of the element/attribute used for the described schema property.<br />
 <br />
 When defined within the Items Object (items), it will affect the name of the individual XML elements within the list.<br />
 When defined alongside type being array (outside the items), it will affect the wrapping element<br />
 and only if wrapped is <code>true</code>.<br />
 <br />
-If wrapped is <code>false</code>, it will be ignored.</dd>
+If wrapped is <code>false</code>, it will be ignored.</p></dd>
   <dt><strong>namespace</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>The URL of the namespace definition. Value SHOULD be in the form of a URL.</dd>
+  <dd><p>The URL of the namespace definition. Value SHOULD be in the form of a URL.</p></dd>
   <dt><strong>prefix</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>The prefix to be used for the name.</dd>
+  <dd><p>The prefix to be used for the name.</p></dd>
   <dt><strong>attribute</strong> : <span style="font-family: monospace;">bool</span></dt>
-  <dd>Declares whether the property definition translates to an attribute instead of an element.<br />
+  <dd><p>Declares whether the property definition translates to an attribute instead of an element.<br />
 <br />
-Default value is <code>false</code>.</dd>
+Default value is <code>false</code>.</p></dd>
   <dt><strong>wrapped</strong> : <span style="font-family: monospace;">bool</span></dt>
-  <dd>MAY be used only for an array definition.<br />
+  <dd><p>MAY be used only for an array definition.<br />
 <br />
 Signifies whether the array is wrapped (for example  <code>&lt;books>&lt;book/>&lt;book/>&lt;/books></code>)<br />
 or unwrapped (<code>&lt;book/>&lt;book/></code>).<br />
 <br />
-Default value is false. The definition takes effect only when defined alongside type being array (outside the items).</dd>
+Default value is false. The definition takes effect only when defined alongside type being array (outside the items).</p></dd>
 </dl>
 
 #### Reference
@@ -1012,6 +1021,6 @@ Use as `@OA\Schema` inside a `Response` and `MediaType`->`'application/xml'` wil
 #### Properties
 <dl>
   <dt><strong>examples</strong> : <span style="font-family: monospace;">array</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 

--- a/docs/reference/attributes.md
+++ b/docs/reference/attributes.md
@@ -14,75 +14,75 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 <dl>
   <dt><strong>ref</strong> : <span style="font-family: monospace;">object|string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>schema</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>title</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>required</strong> : <span style="font-family: monospace;">string[]|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>properties</strong> : <span style="font-family: monospace;">array|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>type</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>format</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>items</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Items|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>collectionFormat</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>default</strong></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>maximum</strong></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>exclusiveMaximum</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>minimum</strong></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>exclusiveMinimum</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>maxLength</strong> : <span style="font-family: monospace;">int|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>minLength</strong> : <span style="font-family: monospace;">int|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>maxItems</strong> : <span style="font-family: monospace;">int|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>minItems</strong> : <span style="font-family: monospace;">int|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>uniqueItems</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>pattern</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>enum</strong> : <span style="font-family: monospace;">array|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>discriminator</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Discriminator|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>readOnly</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>writeOnly</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>xml</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Xml|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>externalDocs</strong> : <span style="font-family: monospace;">OpenApi\Attributes\ExternalDocumentation|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>example</strong></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>nullable</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>deprecated</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>allOf</strong> : <span style="font-family: monospace;">array|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>anyOf</strong> : <span style="font-family: monospace;">array|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>oneOf</strong> : <span style="font-family: monospace;">array|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,string&gt;|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [Attachable](https://github.com/zircote/swagger-php/tree/master/src/Attributes/Attachable.php)
@@ -92,7 +92,7 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 <dl>
   <dt><strong>properties</strong> : <span style="font-family: monospace;">array</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [Components](https://github.com/zircote/swagger-php/tree/master/src/Attributes/Components.php)
@@ -101,8 +101,28 @@ In addition to this page, there are also a number of [examples](https://github.c
 
 #### Parameters
 <dl>
-  <dt><strong>properties</strong> : <span style="font-family: monospace;">array</span></dt>
-  <dd>No details available.</dd>
+  <dt><strong>schemas</strong> : <span style="font-family: monospace;">Schema[]|null</span></dt>
+  <dd><p>No details available.</p></dd>
+  <dt><strong>responses</strong> : <span style="font-family: monospace;">Response[]|null</span></dt>
+  <dd><p>No details available.</p></dd>
+  <dt><strong>parameters</strong> : <span style="font-family: monospace;">Parameter[]|null</span></dt>
+  <dd><p>No details available.</p></dd>
+  <dt><strong>requestBodies</strong> : <span style="font-family: monospace;">Examples[]|null</span></dt>
+  <dd><p>No details available.</p></dd>
+  <dt><strong>examples</strong> : <span style="font-family: monospace;">RequestBody[]|null</span></dt>
+  <dd><p>No details available.</p></dd>
+  <dt><strong>headers</strong> : <span style="font-family: monospace;">Header[]|null</span></dt>
+  <dd><p>No details available.</p></dd>
+  <dt><strong>securitySchemes</strong> : <span style="font-family: monospace;">SecurityScheme[]|null</span></dt>
+  <dd><p>No details available.</p></dd>
+  <dt><strong>links</strong> : <span style="font-family: monospace;">Link[]|null</span></dt>
+  <dd><p>No details available.</p></dd>
+  <dt><strong>callbacks</strong> : <span style="font-family: monospace;">callable[]|null</span></dt>
+  <dd><p>No details available.</p></dd>
+  <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,string&gt;|null</span></dt>
+  <dd><p>No details available.</p></dd>
+  <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [Contact](https://github.com/zircote/swagger-php/tree/master/src/Attributes/Contact.php)
@@ -112,15 +132,15 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 <dl>
   <dt><strong>name</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>url</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>email</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,string&gt;|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [Delete](https://github.com/zircote/swagger-php/tree/master/src/Attributes/Delete.php)
@@ -130,31 +150,33 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 <dl>
   <dt><strong>path</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>operationId</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>summary</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>security</strong> : <span style="font-family: monospace;">array</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>servers</strong> : <span style="font-family: monospace;">Server[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>requestBody</strong> : <span style="font-family: monospace;">OpenApi\Attributes\RequestBody|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>tags</strong> : <span style="font-family: monospace;">string[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>parameters</strong> : <span style="font-family: monospace;">Parameter[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>responses</strong> : <span style="font-family: monospace;">Response[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>externalDocs</strong> : <span style="font-family: monospace;">OpenApi\Attributes\ExternalDocumentation|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
+  <dt><strong>deprecated</strong> : <span style="font-family: monospace;">bool|null</span></dt>
+  <dd><p>No details available.</p></dd>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,string&gt;|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [Discriminator](https://github.com/zircote/swagger-php/tree/master/src/Attributes/Discriminator.php)
@@ -164,13 +186,13 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 <dl>
   <dt><strong>propertyName</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>mapping</strong> : <span style="font-family: monospace;">string[]|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,string&gt;|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [Examples](https://github.com/zircote/swagger-php/tree/master/src/Attributes/Examples.php)
@@ -180,21 +202,21 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 <dl>
   <dt><strong>example</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>summary</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>value</strong> : <span style="font-family: monospace;">array|string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>externalValue</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>ref</strong> : <span style="font-family: monospace;">object|string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,string&gt;|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [ExternalDocumentation](https://github.com/zircote/swagger-php/tree/master/src/Attributes/ExternalDocumentation.php)
@@ -204,13 +226,13 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 <dl>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>url</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,string&gt;|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [Flow](https://github.com/zircote/swagger-php/tree/master/src/Attributes/Flow.php)
@@ -220,19 +242,19 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 <dl>
   <dt><strong>authorizationUrl</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>tokenUrl</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>refreshUrl</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>flow</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>scopes</strong> : <span style="font-family: monospace;">array|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,string&gt;|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [Get](https://github.com/zircote/swagger-php/tree/master/src/Attributes/Get.php)
@@ -242,31 +264,33 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 <dl>
   <dt><strong>path</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>operationId</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>summary</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>security</strong> : <span style="font-family: monospace;">array</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>servers</strong> : <span style="font-family: monospace;">Server[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>requestBody</strong> : <span style="font-family: monospace;">OpenApi\Attributes\RequestBody|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>tags</strong> : <span style="font-family: monospace;">string[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>parameters</strong> : <span style="font-family: monospace;">Parameter[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>responses</strong> : <span style="font-family: monospace;">Response[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>externalDocs</strong> : <span style="font-family: monospace;">OpenApi\Attributes\ExternalDocumentation|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
+  <dt><strong>deprecated</strong> : <span style="font-family: monospace;">bool|null</span></dt>
+  <dd><p>No details available.</p></dd>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,string&gt;|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [Head](https://github.com/zircote/swagger-php/tree/master/src/Attributes/Head.php)
@@ -276,31 +300,33 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 <dl>
   <dt><strong>path</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>operationId</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>summary</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>security</strong> : <span style="font-family: monospace;">array</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>servers</strong> : <span style="font-family: monospace;">Server[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>requestBody</strong> : <span style="font-family: monospace;">OpenApi\Attributes\RequestBody|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>tags</strong> : <span style="font-family: monospace;">string[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>parameters</strong> : <span style="font-family: monospace;">Parameter[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>responses</strong> : <span style="font-family: monospace;">Response[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>externalDocs</strong> : <span style="font-family: monospace;">OpenApi\Attributes\ExternalDocumentation|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
+  <dt><strong>deprecated</strong> : <span style="font-family: monospace;">bool|null</span></dt>
+  <dd><p>No details available.</p></dd>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,string&gt;|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [Header](https://github.com/zircote/swagger-php/tree/master/src/Attributes/Header.php)
@@ -310,23 +336,23 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 <dl>
   <dt><strong>ref</strong> : <span style="font-family: monospace;">object|string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>header</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>required</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>schema</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Schema|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>deprecated</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>allowEmptyValue</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,string&gt;|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [Info](https://github.com/zircote/swagger-php/tree/master/src/Attributes/Info.php)
@@ -336,21 +362,21 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 <dl>
   <dt><strong>version</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>title</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>termsOfService</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>contact</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Contact|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>license</strong> : <span style="font-family: monospace;">OpenApi\Attributes\License|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,string&gt;|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [Items](https://github.com/zircote/swagger-php/tree/master/src/Attributes/Items.php)
@@ -360,77 +386,77 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 <dl>
   <dt><strong>ref</strong> : <span style="font-family: monospace;">object|string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>schema</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>title</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>required</strong> : <span style="font-family: monospace;">string[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>properties</strong> : <span style="font-family: monospace;">Property[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>type</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>format</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>items</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Items|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>collectionFormat</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>default</strong></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>maximum</strong></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>exclusiveMaximum</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>minimum</strong></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>exclusiveMinimum</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>maxLength</strong> : <span style="font-family: monospace;">int|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>minLength</strong> : <span style="font-family: monospace;">int|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>maxItems</strong> : <span style="font-family: monospace;">int|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>minItems</strong> : <span style="font-family: monospace;">int|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>uniqueItems</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>pattern</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>enum</strong> : <span style="font-family: monospace;">array|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>discriminator</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Discriminator|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>readOnly</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>writeOnly</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>xml</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Xml|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>externalDocs</strong> : <span style="font-family: monospace;">OpenApi\Attributes\ExternalDocumentation|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>example</strong></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>nullable</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>deprecated</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>allOf</strong> : <span style="font-family: monospace;">array|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>anyOf</strong> : <span style="font-family: monospace;">array|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>oneOf</strong> : <span style="font-family: monospace;">array|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>additionalProperties</strong> : <span style="font-family: monospace;">OpenApi\Attributes\AdditionalProperties|bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,string&gt;|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [JsonContent](https://github.com/zircote/swagger-php/tree/master/src/Attributes/JsonContent.php)
@@ -440,79 +466,79 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 <dl>
   <dt><strong>examples</strong> : <span style="font-family: monospace;">array&lt;string,Examples&gt;</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>ref</strong> : <span style="font-family: monospace;">object|string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>schema</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>title</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>required</strong> : <span style="font-family: monospace;">string[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>properties</strong> : <span style="font-family: monospace;">Property[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>type</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>format</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>items</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Items|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>collectionFormat</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>default</strong></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>maximum</strong></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>exclusiveMaximum</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>minimum</strong></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>exclusiveMinimum</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>maxLength</strong> : <span style="font-family: monospace;">int|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>minLength</strong> : <span style="font-family: monospace;">int|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>maxItems</strong> : <span style="font-family: monospace;">int|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>minItems</strong> : <span style="font-family: monospace;">int|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>uniqueItems</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>pattern</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>enum</strong> : <span style="font-family: monospace;">array|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>discriminator</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Discriminator|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>readOnly</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>writeOnly</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>xml</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Xml|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>externalDocs</strong> : <span style="font-family: monospace;">OpenApi\Attributes\ExternalDocumentation|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>example</strong></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>nullable</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>deprecated</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>allOf</strong> : <span style="font-family: monospace;">array|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>anyOf</strong> : <span style="font-family: monospace;">array|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>oneOf</strong> : <span style="font-family: monospace;">array|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>additionalProperties</strong> : <span style="font-family: monospace;">OpenApi\Attributes\AdditionalProperties|bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,string&gt;|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [License](https://github.com/zircote/swagger-php/tree/master/src/Attributes/License.php)
@@ -522,15 +548,15 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 <dl>
   <dt><strong>name</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>identifier</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>url</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,string&gt;|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [Link](https://github.com/zircote/swagger-php/tree/master/src/Attributes/Link.php)
@@ -540,17 +566,17 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 <dl>
   <dt><strong>link</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>ref</strong> : <span style="font-family: monospace;">object|string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>operationId</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>parameters</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,string&gt;|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [MediaType](https://github.com/zircote/swagger-php/tree/master/src/Attributes/MediaType.php)
@@ -560,19 +586,19 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 <dl>
   <dt><strong>mediaType</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>schema</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Schema|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>example</strong></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>examples</strong> : <span style="font-family: monospace;">array&lt;string,Examples&gt;</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>encoding</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,string&gt;|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [OpenApi](https://github.com/zircote/swagger-php/tree/master/src/Attributes/OpenApi.php)
@@ -582,19 +608,21 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 <dl>
   <dt><strong>openapi</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>info</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Info|null</span></dt>
-  <dd>No details available.</dd>
-  <dt><strong>servers</strong> : <span style="font-family: monospace;">array|null</span></dt>
-  <dd>No details available.</dd>
-  <dt><strong>tags</strong> : <span style="font-family: monospace;">array|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
+  <dt><strong>servers</strong> : <span style="font-family: monospace;">Server[]|null</span></dt>
+  <dd><p>No details available.</p></dd>
+  <dt><strong>security</strong> : <span style="font-family: monospace;">array|null</span></dt>
+  <dd><p>No details available.</p></dd>
+  <dt><strong>tags</strong> : <span style="font-family: monospace;">Tag[]|null</span></dt>
+  <dd><p>No details available.</p></dd>
   <dt><strong>externalDocs</strong> : <span style="font-family: monospace;">OpenApi\Attributes\ExternalDocumentation|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,string&gt;|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [Options](https://github.com/zircote/swagger-php/tree/master/src/Attributes/Options.php)
@@ -604,31 +632,33 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 <dl>
   <dt><strong>path</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>operationId</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>summary</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>security</strong> : <span style="font-family: monospace;">array</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>servers</strong> : <span style="font-family: monospace;">Server[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>requestBody</strong> : <span style="font-family: monospace;">OpenApi\Attributes\RequestBody|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>tags</strong> : <span style="font-family: monospace;">string[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>parameters</strong> : <span style="font-family: monospace;">Parameter[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>responses</strong> : <span style="font-family: monospace;">Response[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>externalDocs</strong> : <span style="font-family: monospace;">OpenApi\Attributes\ExternalDocumentation|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
+  <dt><strong>deprecated</strong> : <span style="font-family: monospace;">bool|null</span></dt>
+  <dd><p>No details available.</p></dd>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,string&gt;|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [Parameter](https://github.com/zircote/swagger-php/tree/master/src/Attributes/Parameter.php)
@@ -638,29 +668,29 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 <dl>
   <dt><strong>parameter</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>name</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>in</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>required</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>ref</strong> : <span style="font-family: monospace;">object|string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>schema</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Schema|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>examples</strong> : <span style="font-family: monospace;">array&lt;string,Examples&gt;</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>style</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>explode</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,string&gt;|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [Patch](https://github.com/zircote/swagger-php/tree/master/src/Attributes/Patch.php)
@@ -670,31 +700,33 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 <dl>
   <dt><strong>path</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>operationId</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>summary</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>security</strong> : <span style="font-family: monospace;">array</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>servers</strong> : <span style="font-family: monospace;">Server[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>requestBody</strong> : <span style="font-family: monospace;">OpenApi\Attributes\RequestBody|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>tags</strong> : <span style="font-family: monospace;">string[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>parameters</strong> : <span style="font-family: monospace;">Parameter[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>responses</strong> : <span style="font-family: monospace;">Response[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>externalDocs</strong> : <span style="font-family: monospace;">OpenApi\Attributes\ExternalDocumentation|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
+  <dt><strong>deprecated</strong> : <span style="font-family: monospace;">bool|null</span></dt>
+  <dd><p>No details available.</p></dd>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,string&gt;|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [PathItem](https://github.com/zircote/swagger-php/tree/master/src/Attributes/PathItem.php)
@@ -704,9 +736,9 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 <dl>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,string&gt;|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [PathParameter](https://github.com/zircote/swagger-php/tree/master/src/Attributes/PathParameter.php)
@@ -716,29 +748,29 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 <dl>
   <dt><strong>parameter</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>name</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>in</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>required</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>ref</strong> : <span style="font-family: monospace;">object|string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>schema</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Schema|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>examples</strong> : <span style="font-family: monospace;">array&lt;string,Examples&gt;</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>style</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>explode</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,string&gt;|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [Post](https://github.com/zircote/swagger-php/tree/master/src/Attributes/Post.php)
@@ -748,31 +780,33 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 <dl>
   <dt><strong>path</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>operationId</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>summary</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>security</strong> : <span style="font-family: monospace;">array</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>servers</strong> : <span style="font-family: monospace;">Server[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>requestBody</strong> : <span style="font-family: monospace;">OpenApi\Attributes\RequestBody|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>tags</strong> : <span style="font-family: monospace;">string[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>parameters</strong> : <span style="font-family: monospace;">Parameter[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>responses</strong> : <span style="font-family: monospace;">Response[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>externalDocs</strong> : <span style="font-family: monospace;">OpenApi\Attributes\ExternalDocumentation|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
+  <dt><strong>deprecated</strong> : <span style="font-family: monospace;">bool|null</span></dt>
+  <dd><p>No details available.</p></dd>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,string&gt;|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [Property](https://github.com/zircote/swagger-php/tree/master/src/Attributes/Property.php)
@@ -782,79 +816,79 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 <dl>
   <dt><strong>property</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>ref</strong> : <span style="font-family: monospace;">object|string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>schema</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>title</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>required</strong> : <span style="font-family: monospace;">string[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>properties</strong> : <span style="font-family: monospace;">Property[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>type</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>format</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>items</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Items|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>collectionFormat</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>default</strong></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>maximum</strong></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>exclusiveMaximum</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>minimum</strong></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>exclusiveMinimum</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>maxLength</strong> : <span style="font-family: monospace;">int|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>minLength</strong> : <span style="font-family: monospace;">int|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>maxItems</strong> : <span style="font-family: monospace;">int|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>minItems</strong> : <span style="font-family: monospace;">int|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>uniqueItems</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>pattern</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>enum</strong> : <span style="font-family: monospace;">array|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>discriminator</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Discriminator|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>readOnly</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>writeOnly</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>xml</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Xml|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>externalDocs</strong> : <span style="font-family: monospace;">OpenApi\Attributes\ExternalDocumentation|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>example</strong></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>nullable</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>deprecated</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>allOf</strong> : <span style="font-family: monospace;">array|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>anyOf</strong> : <span style="font-family: monospace;">array|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>oneOf</strong> : <span style="font-family: monospace;">array|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>additionalProperties</strong> : <span style="font-family: monospace;">OpenApi\Attributes\AdditionalProperties|bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,string&gt;|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [Put](https://github.com/zircote/swagger-php/tree/master/src/Attributes/Put.php)
@@ -864,31 +898,33 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 <dl>
   <dt><strong>path</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>operationId</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>summary</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>security</strong> : <span style="font-family: monospace;">array</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>servers</strong> : <span style="font-family: monospace;">Server[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>requestBody</strong> : <span style="font-family: monospace;">OpenApi\Attributes\RequestBody|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>tags</strong> : <span style="font-family: monospace;">string[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>parameters</strong> : <span style="font-family: monospace;">Parameter[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>responses</strong> : <span style="font-family: monospace;">Response[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>externalDocs</strong> : <span style="font-family: monospace;">OpenApi\Attributes\ExternalDocumentation|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
+  <dt><strong>deprecated</strong> : <span style="font-family: monospace;">bool|null</span></dt>
+  <dd><p>No details available.</p></dd>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,string&gt;|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [RequestBody](https://github.com/zircote/swagger-php/tree/master/src/Attributes/RequestBody.php)
@@ -897,16 +933,20 @@ In addition to this page, there are also a number of [examples](https://github.c
 
 #### Parameters
 <dl>
+  <dt><strong>ref</strong> : <span style="font-family: monospace;">object|string|null</span></dt>
+  <dd><p>No details available.</p></dd>
+  <dt><strong>request</strong> : <span style="font-family: monospace;">string|null</span></dt>
+  <dd><p>No details available.</p></dd>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>required</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>content</strong> : <span style="font-family: monospace;">array&lt;MediaType&gt;|JsonContent|XmlContent|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,string&gt;|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [Response](https://github.com/zircote/swagger-php/tree/master/src/Attributes/Response.php)
@@ -916,21 +956,21 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 <dl>
   <dt><strong>ref</strong> : <span style="font-family: monospace;">object|string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>response</strong> : <span style="font-family: monospace;">string|int|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>headers</strong> : <span style="font-family: monospace;">Header[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>content</strong></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>links</strong> : <span style="font-family: monospace;">Link[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,string&gt;|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [Schema](https://github.com/zircote/swagger-php/tree/master/src/Attributes/Schema.php)
@@ -940,77 +980,77 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 <dl>
   <dt><strong>ref</strong> : <span style="font-family: monospace;">object|string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>schema</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>title</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>required</strong> : <span style="font-family: monospace;">string[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>properties</strong> : <span style="font-family: monospace;">array|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>type</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>format</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>items</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Items|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>collectionFormat</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>default</strong></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>maximum</strong></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>exclusiveMaximum</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>minimum</strong></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>exclusiveMinimum</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>maxLength</strong> : <span style="font-family: monospace;">int|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>minLength</strong> : <span style="font-family: monospace;">int|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>maxItems</strong> : <span style="font-family: monospace;">int|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>minItems</strong> : <span style="font-family: monospace;">int|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>uniqueItems</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>pattern</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>enum</strong> : <span style="font-family: monospace;">string[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>discriminator</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Discriminator|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>readOnly</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>writeOnly</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>xml</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Xml|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>externalDocs</strong> : <span style="font-family: monospace;">OpenApi\Attributes\ExternalDocumentation|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>example</strong></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>nullable</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>deprecated</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>allOf</strong> : <span style="font-family: monospace;">array|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>anyOf</strong> : <span style="font-family: monospace;">array|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>oneOf</strong> : <span style="font-family: monospace;">array|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>additionalProperties</strong> : <span style="font-family: monospace;">OpenApi\Attributes\AdditionalProperties|bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,string&gt;|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [SecurityScheme](https://github.com/zircote/swagger-php/tree/master/src/Attributes/SecurityScheme.php)
@@ -1020,29 +1060,29 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 <dl>
   <dt><strong>ref</strong> : <span style="font-family: monospace;">object|string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>securityScheme</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>type</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>name</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>in</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>bearerFormat</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>scheme</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>openIdConnectUrl</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>flows</strong> : <span style="font-family: monospace;">Flow[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,string&gt;|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [Server](https://github.com/zircote/swagger-php/tree/master/src/Attributes/Server.php)
@@ -1052,15 +1092,15 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 <dl>
   <dt><strong>url</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>variables</strong> : <span style="font-family: monospace;">ServerVariable[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,string&gt;|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [ServerVariable](https://github.com/zircote/swagger-php/tree/master/src/Attributes/ServerVariable.php)
@@ -1070,19 +1110,19 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 <dl>
   <dt><strong>serverVariable</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>default</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>enum</strong> : <span style="font-family: monospace;">array|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>variables</strong> : <span style="font-family: monospace;">array|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,string&gt;|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [Tag](https://github.com/zircote/swagger-php/tree/master/src/Attributes/Tag.php)
@@ -1092,15 +1132,15 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 <dl>
   <dt><strong>name</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>externalDocs</strong> : <span style="font-family: monospace;">OpenApi\Attributes\ExternalDocumentation|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,string&gt;|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [Trace](https://github.com/zircote/swagger-php/tree/master/src/Attributes/Trace.php)
@@ -1110,31 +1150,33 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 <dl>
   <dt><strong>path</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>operationId</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>summary</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>security</strong> : <span style="font-family: monospace;">array</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>servers</strong> : <span style="font-family: monospace;">Server[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>requestBody</strong> : <span style="font-family: monospace;">OpenApi\Attributes\RequestBody|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>tags</strong> : <span style="font-family: monospace;">string[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>parameters</strong> : <span style="font-family: monospace;">Parameter[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>responses</strong> : <span style="font-family: monospace;">Response[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>externalDocs</strong> : <span style="font-family: monospace;">OpenApi\Attributes\ExternalDocumentation|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
+  <dt><strong>deprecated</strong> : <span style="font-family: monospace;">bool|null</span></dt>
+  <dd><p>No details available.</p></dd>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,string&gt;|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [Xml](https://github.com/zircote/swagger-php/tree/master/src/Attributes/Xml.php)
@@ -1144,19 +1186,19 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 <dl>
   <dt><strong>name</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>namespace</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>prefix</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>attribute</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>wrapped</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,string&gt;|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 
 ## [XmlContent](https://github.com/zircote/swagger-php/tree/master/src/Attributes/XmlContent.php)
@@ -1166,78 +1208,78 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 <dl>
   <dt><strong>examples</strong> : <span style="font-family: monospace;">array&lt;string,Examples&gt;</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>ref</strong> : <span style="font-family: monospace;">object|string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>schema</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>title</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>required</strong> : <span style="font-family: monospace;">string[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>properties</strong> : <span style="font-family: monospace;">Property[]</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>type</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>format</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>items</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Items|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>collectionFormat</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>default</strong></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>maximum</strong></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>exclusiveMaximum</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>minimum</strong></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>exclusiveMinimum</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>maxLength</strong> : <span style="font-family: monospace;">int|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>minLength</strong> : <span style="font-family: monospace;">int|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>maxItems</strong> : <span style="font-family: monospace;">int|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>minItems</strong> : <span style="font-family: monospace;">int|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>uniqueItems</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>pattern</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>enum</strong> : <span style="font-family: monospace;">array|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>discriminator</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Discriminator|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>readOnly</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>writeOnly</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>xml</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Xml|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>externalDocs</strong> : <span style="font-family: monospace;">OpenApi\Attributes\ExternalDocumentation|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>example</strong></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>nullable</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>deprecated</strong> : <span style="font-family: monospace;">bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>allOf</strong> : <span style="font-family: monospace;">array|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>anyOf</strong> : <span style="font-family: monospace;">array|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>oneOf</strong> : <span style="font-family: monospace;">array|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>additionalProperties</strong> : <span style="font-family: monospace;">OpenApi\Attributes\AdditionalProperties|bool|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,string&gt;|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
-  <dd>No details available.</dd>
+  <dd><p>No details available.</p></dd>
 </dl>
 

--- a/docs/refgen.php
+++ b/docs/refgen.php
@@ -114,7 +114,9 @@ EOT;
                 }
 
                 echo '  <dt><strong>' . $parameter . '</strong>' . $var . '</dt>' . PHP_EOL;
-                echo '  <dd>' . self::NO_DETAILS_AVAILABLE . '</dd>' . PHP_EOL;
+                echo '  <dd>';
+                echo '<p>' . self::NO_DETAILS_AVAILABLE . '</p>';
+                echo '</dd>' . PHP_EOL;
             }
             echo '</dl>' . PHP_EOL;
         }
@@ -160,7 +162,21 @@ EOT;
                 }
 
                 echo '  <dt><strong>' . $property . '</strong>' . $var . '</dt>' . PHP_EOL;
-                echo '  <dd>' . nl2br($propertyDocumentation['content'] ?: self::NO_DETAILS_AVAILABLE) . '</dd>' . PHP_EOL;
+                echo '  <dd>';
+                echo '<p>' . nl2br($propertyDocumentation['content'] ?: self::NO_DETAILS_AVAILABLE) . '</p>';
+                if ($propertyDocumentation['see']) {
+                    $links = [];
+                    foreach ($propertyDocumentation['see'] as $see) {
+                        if ($link = $this->linkFromMarkup($see)) {
+                            $links[] = $link;
+                        }
+                    }
+                    if ($links) {
+                        echo '<p><i>See</i>: ' . implode(', ', $links) . '</p>';
+                    }
+                }
+
+                echo '</dd>' . PHP_EOL;
             }
             echo '</dl>' . PHP_EOL;
         }
@@ -175,6 +191,13 @@ EOT;
         echo PHP_EOL;
 
         return ob_get_clean();
+    }
+
+    protected function linkFromMarkup(string $see): ?string
+    {
+        preg_match('/\[([^]]+)]\((.*)\)/', $see, $matches);
+
+        return 3 == count($matches) ? '<a href="'.$matches[2].'">'.$matches[1].'</a>' : null;
     }
 
     protected function getReflectionType(string $fqdn, $rp, bool $preferDefault = false, string $def = ''): string
@@ -200,7 +223,9 @@ EOT;
             $var = array_merge($var, explode('|', $def));
         }
 
-        return implode('|', array_map(function ($item) { return htmlentities($item); }, array_unique($var)));
+        return implode('|', array_map(function ($item) {
+            return htmlentities($item);
+        }, array_unique($var)));
     }
 
     protected function extractDocumentation($docblock): array

--- a/src/Annotations/Components.php
+++ b/src/Annotations/Components.php
@@ -52,7 +52,7 @@ class Components extends AbstractAnnotation
     /**
      * Reusable Examples.
      *
-     * @var array
+     * @var Examples[]
      */
     public $examples = Generator::UNDEFINED;
 

--- a/src/Annotations/Examples.php
+++ b/src/Annotations/Examples.php
@@ -39,7 +39,7 @@ class Examples extends AbstractAnnotation
      *
      * The value field and externalValue field are mutually exclusive.
      *
-     * To represent examples of media types that cannot naturally represented
+     * To represent examples of media types that cannot naturally be represented
      * in JSON or YAML, use a string value to contain the example, escaping where necessary.
      *
      * @var string
@@ -51,7 +51,7 @@ class Examples extends AbstractAnnotation
      *
      * The value field and externalValue field are mutually exclusive.
      *
-     * To represent examples of media types that cannot naturally represented
+     * To represent examples of media types that cannot naturally be represented
      * in JSON or YAML, use a string value to contain the example, escaping where necessary.
      *
      * @var string

--- a/src/Annotations/Flow.php
+++ b/src/Annotations/Flow.php
@@ -45,14 +45,18 @@ class Flow extends AbstractAnnotation
     public $refreshUrl = Generator::UNDEFINED;
 
     /**
-     * Flow name. One of ['implicit', 'password', 'authorizationCode', 'clientCredentials'].
+     * Flow name.
+     *
+     * One of ['implicit', 'password', 'authorizationCode', 'clientCredentials'].
      *
      * @var string
      */
     public $flow = Generator::UNDEFINED;
 
     /**
-     * The available scopes for the OAuth2 security scheme. A map between the scope name and a short description for it.
+     * The available scopes for the OAuth2 security scheme.
+     *
+     * A map between the scope name and a short description for it.
      */
     public $scopes = Generator::UNDEFINED;
 

--- a/src/Annotations/Header.php
+++ b/src/Annotations/Header.php
@@ -27,16 +27,16 @@ class Header extends AbstractAnnotation
     public $header = Generator::UNDEFINED;
 
     /**
-     * @var string
-     */
-    public $description = Generator::UNDEFINED;
-
-    /**
      * A brief description of the parameter.
      *
      * This could contain examples of use.
      * CommonMark syntax MAY be used for rich text representation.
      *
+     * @var string
+     */
+    public $description = Generator::UNDEFINED;
+
+    /**
      * @var bool
      */
     public $required = Generator::UNDEFINED;

--- a/src/Annotations/MediaType.php
+++ b/src/Annotations/MediaType.php
@@ -52,7 +52,7 @@ class MediaType extends AbstractAnnotation
      * Furthermore, if referencing a schema which contains an example,
      * the examples value shall override the example provided by the schema.
      *
-     * @var array
+     * @var Examples[]
      */
     public $examples = Generator::UNDEFINED;
 
@@ -63,6 +63,8 @@ class MediaType extends AbstractAnnotation
      *
      * The encoding object shall only apply to requestBody objects when the media type is multipart or
      * application/x-www-form-urlencoded.
+     *
+     * @var array
      */
     public $encoding = Generator::UNDEFINED;
 

--- a/src/Annotations/Operation.php
+++ b/src/Annotations/Operation.php
@@ -20,7 +20,7 @@ use OpenApi\Generator;
 abstract class Operation extends AbstractAnnotation
 {
     /**
-     * key in the OpenApi "Paths Object" for this operation.
+     * Key in the OpenApi "Paths Object" for this operation.
      *
      * @var string
      */

--- a/src/Annotations/Parameter.php
+++ b/src/Annotations/Parameter.php
@@ -27,7 +27,7 @@ class Parameter extends AbstractAnnotation
     public $ref = Generator::UNDEFINED;
 
     /**
-     * The key into Components->parameters or PathItem->parameters array.
+     * The key into <code>Components::parameters</code> or <code>PathItem::parameters</code> array.
      *
      * @var string
      */
@@ -166,26 +166,34 @@ class Parameter extends AbstractAnnotation
     public $content = Generator::UNDEFINED;
 
     /**
-     * Path-style parameters defined by https://tools.ietf.org/html/rfc6570#section-3.2.7.
+     * Path-style parameters defined by RFC6570.
+     *
+     * @see [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.7)
      */
     public $matrix = Generator::UNDEFINED;
 
     /**
-     * Label style parameters defined by https://tools.ietf.org/html/rfc6570#section-3.2.5.
+     * Label style parameters defined by RFC6570.
+     *
+     * @see [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.5)
      */
     public $label = Generator::UNDEFINED;
 
     /**
-     * Form style parameters defined by https://tools.ietf.org/html/rfc6570#section-3.2.8.
+     * Form style parameters defined by RFC6570.
      *
      * This option replaces collectionFormat with a csv (when explode is false) or multi (when explode is true) value from OpenAPI 2.0.
+     *
+     * @see [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.8)
      */
     public $form = Generator::UNDEFINED;
 
     /**
-     * Simple style parameters defined by https://tools.ietf.org/html/rfc6570#section-3.2.2.
+     * Simple style parameters defined by RFC6570.
      *
      * This option replaces collectionFormat with a csv value from OpenAPI 2.0.
+     *
+     * @see [RFC6570](https://tools.ietf.org/html/rfc6570#section-3.2.2)
      *
      * @var array
      */

--- a/src/Annotations/Response.php
+++ b/src/Annotations/Response.php
@@ -46,8 +46,11 @@ class Response extends AbstractAnnotation
     /**
      * Maps a header name to its definition.
      *
-     * RFC7230 states header names are case insensitive. https://tools.ietf.org/html/rfc7230#page-22
+     * RFC7230 states header names are case insensitive.
+     *
      * If a response header is defined with the name "Content-Type", it shall be ignored.
+     *
+     * @see [RFC7230](https://tools.ietf.org/html/rfc7230#page-22)
      *
      * @var Header[]
      */
@@ -57,8 +60,9 @@ class Response extends AbstractAnnotation
      * A map containing descriptions of potential response payloads.
      *
      * The key is a media type or media type range and the value describes it.
-     * For responses that match multiple keys, only the most specific key is applicable. e.g. text/plain overrides
-     * text/*.
+     *
+     * For responses that match multiple keys, only the most specific key is applicable;
+     * e.g. <code>text/plain</code> overrides <code>text/*</code>.
      *
      * @var MediaType[]
      */

--- a/src/Annotations/Schema.php
+++ b/src/Annotations/Schema.php
@@ -120,48 +120,49 @@ class Schema extends AbstractAnnotation
     public $collectionFormat = Generator::UNDEFINED;
 
     /**
-     * Sets a default value to the parameter. The type of the value depends on the defined type. See
-     * http://json-schema.org/latest/json-schema-validation.html#anchor101.
+     * Sets a default value to the parameter. The type of the value depends on the defined type.
+     *
+     * @see [JSON schema validation](http://json-schema.org/latest/json-schema-validation.html#anchor101)
      */
     public $default = Generator::UNDEFINED;
 
     /**
-     * See http://json-schema.org/latest/json-schema-validation.html#anchor17.
+     * @see [JSON schema validation](http://json-schema.org/latest/json-schema-validation.html#anchor17)
      *
      * @var number
      */
     public $maximum = Generator::UNDEFINED;
 
     /**
-     * See http://json-schema.org/latest/json-schema-validation.html#anchor17.
+     * @see [JSON schema validation](http://json-schema.org/latest/json-schema-validation.html#anchor17)
      *
      * @var bool
      */
     public $exclusiveMaximum = Generator::UNDEFINED;
 
     /**
-     * See http://json-schema.org/latest/json-schema-validation.html#anchor21.
+     * @see [JSON schema validation](http://json-schema.org/latest/json-schema-validation.html#anchor21)
      *
      * @var number
      */
     public $minimum = Generator::UNDEFINED;
 
     /**
-     * See http://json-schema.org/latest/json-schema-validation.html#anchor21.
+     * @see [JSON schema validation](http://json-schema.org/latest/json-schema-validation.html#anchor21)
      *
      * @var bool
      */
     public $exclusiveMinimum = Generator::UNDEFINED;
 
     /**
-     * See http://json-schema.org/latest/json-schema-validation.html#anchor26.
+     * @see [JSON schema validation](http://json-schema.org/latest/json-schema-validation.html#anchor26)
      *
      * @var int
      */
     public $maxLength = Generator::UNDEFINED;
 
     /**
-     * See http://json-schema.org/latest/json-schema-validation.html#anchor29.
+     * @see [JSON schema validation](http://json-schema.org/latest/json-schema-validation.html#anchor29)
      *
      * @var int
      */
@@ -175,28 +176,28 @@ class Schema extends AbstractAnnotation
     public $pattern = Generator::UNDEFINED;
 
     /**
-     * See http://json-schema.org/latest/json-schema-validation.html#anchor42.
+     * @see [JSON schema validation](http://json-schema.org/latest/json-schema-validation.html#anchor42)
      *
      * @var int
      */
     public $maxItems = Generator::UNDEFINED;
 
     /**
-     * See http://json-schema.org/latest/json-schema-validation.html#anchor45.
+     * @see [JSON schema validation](http://json-schema.org/latest/json-schema-validation.html#anchor45)
      *
      * @var int
      */
     public $minItems = Generator::UNDEFINED;
 
     /**
-     * See http://json-schema.org/latest/json-schema-validation.html#anchor49.
+     * @see [JSON schema validation](http://json-schema.org/latest/json-schema-validation.html#anchor49)
      *
      * @var bool
      */
     public $uniqueItems = Generator::UNDEFINED;
 
     /**
-     * See http://json-schema.org/latest/json-schema-validation.html#anchor76.
+     * @see [JSON schema validation](http://json-schema.org/latest/json-schema-validation.html#anchor76)
      *
      * @var array
      */
@@ -267,7 +268,7 @@ class Schema extends AbstractAnnotation
     /**
      * A free-form property to include an example of an instance for this schema.
      *
-     * To represent examples that cannot be naturally represented in JSON or YAML, a string value can be used to
+     * To represent examples that cannot naturally be represented in JSON or YAML, a string value can be used to
      * contain the example with escaping where necessary.
      */
     public $example = Generator::UNDEFINED;

--- a/src/Annotations/SecurityScheme.php
+++ b/src/Annotations/SecurityScheme.php
@@ -76,7 +76,7 @@ class SecurityScheme extends AbstractAnnotation
     /**
      * The name of the HTTP Authorization scheme.
      *
-     * @see https://tools.ietf.org/html/rfc7235#section-5.1
+     * @see [RFC7235](https://tools.ietf.org/html/rfc7235#section-5.1)
      *
      * @var string
      */


### PR DESCRIPTION
Expects markdown and will add all `@see` refs at the end of property definition.
Also adds some more spacing.