### PR TITLE
Add callbacks parameter to OperationTrait

### DIFF
--- a/src/Attributes/OperationTrait.php
+++ b/src/Attributes/OperationTrait.php
@@ -30,6 +30,7 @@ trait OperationTrait
         ?array $tags = null,
         ?array $parameters = null,
         ?array $responses = null,
+        ?array $callbacks = null,
         ?ExternalDocumentation $externalDocs = null,
         ?bool $deprecated = null,
         // annotation
@@ -44,6 +45,7 @@ trait OperationTrait
                 'security' => $security ?? Generator::UNDEFINED,
                 'servers' => $servers ?? Generator::UNDEFINED,
                 'tags' => $tags ?? Generator::UNDEFINED,
+                'callbacks' => $callbacks ?? Generator::UNDEFINED,
                 'deprecated' => $deprecated ?? Generator::UNDEFINED,
                 'x' => $x ?? Generator::UNDEFINED,
                 'value' => $this->combine($requestBody, $responses, $parameters, $externalDocs, $attachables),

--- a/tests/Analysers/TokenScannerTest.php
+++ b/tests/Analysers/TokenScannerTest.php
@@ -38,7 +38,7 @@ class TokenScannerTest extends OpenApiTestCase
                         'interfaces' => [],
                         'traits' => [],
                         'enums' => [],
-                        'methods' => ['getProduct', 'addProduct', 'getAll'],
+                        'methods' => ['getProduct', 'addProduct', 'getAll', 'subscribe'],
                         'properties' => [],
                     ],
                     'OpenApi\\Tests\\Fixtures\\Apis\\DocBlocks\\ProductInterface' => [

--- a/tests/Fixtures/Apis/Attributes/basic.php
+++ b/tests/Fixtures/Apis/Attributes/basic.php
@@ -131,4 +131,54 @@ class ProductController
     public function getAll()
     {
     }
+
+    #[OAT\Post(
+        path: '/subscribe',
+        operationId: 'subscribe',
+        summary: 'Subscribe to product webhook',
+        tags: ['products'],
+        callbacks: [
+            'onChange' => [
+                '{$request.query.callbackUrl}' => [
+                    'post' => [
+                        'requestBody' => new OAT\RequestBody(
+                            description: 'subscription payload',
+                            content: [
+                                new OAT\MediaType(
+                                    mediaType: 'application/json',
+                                    schema: new OAT\Schema(
+                                        properties: [
+                                            new OAT\Property(
+                                                property: 'timestamp',
+                                                description: 'time of change',
+                                                type: 'string',
+                                                format: 'date-time'
+                                            ),
+                                        ]
+                                    )
+                                ),
+                            ]
+                        ),
+                    ],
+                    'responses' => [
+                        '200' => [
+                            'description' => 'Your server implementation should return this HTTP status code if the data was received successfully',
+                        ],
+                    ],
+                ],
+
+            ],
+        ]
+    )]
+    #[OAT\Parameter(
+        name: 'callbackUrl',
+        in: 'query'
+    )]
+    #[OAT\Response(
+        response: 200,
+        description: 'callbackUrl registered'
+    )]
+    public function subscribe()
+    {
+    }
 }

--- a/tests/Fixtures/Apis/DocBlocks/basic.php
+++ b/tests/Fixtures/Apis/DocBlocks/basic.php
@@ -206,4 +206,51 @@ class ProductController
     public function getAll()
     {
     }
+
+    /**
+     * @OA\Post(
+     *     path="/subscribe",
+     *     tags={"products"},
+     *     operationId="subscribe",
+     *     summary="Subscribe to product webhook",
+     *     @OA\Parameter(
+     *         name="callbackUrl",
+     *         in="query"
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="callbackUrl registered"
+     *     ),
+     *     callbacks={
+     *         "onChange": {
+     *             "{$request.query.callbackUrl}": {
+     *                 "post": {
+     *                     "requestBody": @OA\RequestBody(
+     *                         description="subscription payload",
+     *                         @OA\MediaType(
+     *                             mediaType="application/json",
+     *                             @OA\Schema(
+     *                                 @OA\Property(
+     *                                     property="timestamp",
+     *                                     description="time of change",
+     *                                     type="string",
+     *                                     format="date-time"
+     *                                 )
+     *                             )
+     *                         )
+     *                     )
+     *                 },
+     *                 "responses": {
+     *                     "200": {
+     *                         "description": "Your server implementation should return this HTTP status code if the data was received successfully"
+     *                     }
+     *                 }
+     *             }
+     *         }
+     *     }
+     * )
+     */
+    public function subscribe()
+    {
+    }
 }

--- a/tests/Fixtures/Apis/Mixed/basic.php
+++ b/tests/Fixtures/Apis/Mixed/basic.php
@@ -159,4 +159,51 @@ class ProductController
     public function getAll()
     {
     }
+
+    /**
+     * @OA\Post(
+     *     path="/subscribe",
+     *     tags={"products"},
+     *     operationId="subscribe",
+     *     summary="Subscribe to product webhook",
+     *     @OA\Parameter(
+     *         name="callbackUrl",
+     *         in="query"
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="callbackUrl registered"
+     *     ),
+     *     callbacks={
+     *         "onChange": {
+     *             "{$request.query.callbackUrl}": {
+     *                 "post": {
+     *                     "requestBody": @OA\RequestBody(
+     *                         description="subscription payload",
+     *                         @OA\MediaType(
+     *                             mediaType="application/json",
+     *                             @OA\Schema(
+     *                                 @OA\Property(
+     *                                     property="timestamp",
+     *                                     description="time of change",
+     *                                     type="string",
+     *                                     format="date-time"
+     *                                 )
+     *                             )
+     *                         )
+     *                     )
+     *                 },
+     *                 "responses": {
+     *                     "200": {
+     *                         "description": "Your server implementation should return this HTTP status code if the data was received successfully"
+     *                     }
+     *                 }
+     *             }
+     *         }
+     *     }
+     * )
+     */
+    public function subscribe()
+    {
+    }
 }

--- a/tests/Fixtures/Apis/basic.yaml
+++ b/tests/Fixtures/Apis/basic.yaml
@@ -84,6 +84,30 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Product'
+  /subscribe:
+    post:
+      tags:
+        - products
+      summary: 'Subscribe to product webhook'
+      operationId: subscribe
+      parameters:
+        -
+          name: callbackUrl
+          in: query
+      responses:
+        '200':
+          description: 'callbackUrl registered'
+      callbacks:
+        onChange:
+          '{$request.query.callbackUrl}':
+            post:
+              requestBody:
+                description: 'subscription payload'
+                content:
+                  application/json: { schema: { properties: { timestamp: { description: 'time of change', type: string, format: date-time } } } }
+            responses:
+              '200':
+                description: 'Your server implementation should return this HTTP status code if the data was received successfully'
 components:
   schemas:
     Colour:
@@ -115,12 +139,12 @@ components:
               example: null
             colour:
               $ref: '#/components/schemas/Colour'
+            releasedAt:
+              type: string
             id:
               description: 'The id.'
               format: int64
               example: 1
-            releasedAt:
-              type: string
   securitySchemes:
     bearerAuth:
       type: http


### PR DESCRIPTION
"callbacks" parameter is missing on OperationTrait constructor.

I implemented this bugfix based on PR https://github.com/zircote/swagger-php/pull/1191.