### PR TITLE
Skip inherited interfaces when expanding

### DIFF
--- a/Examples/using-interfaces/Product.php
+++ b/Examples/using-interfaces/Product.php
@@ -5,7 +5,7 @@ namespace OpenApi\Examples\UsingInterfaces;
 /**
  * @OA\Schema(title="Product model")
  */
-class Product implements ProductInterface, ColorInterface
+class Product implements ProductInterface
 {
 
     /**
@@ -22,13 +22,5 @@ class Product implements ProductInterface, ColorInterface
     public function getName()
     {
         return 'kettle';
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function getColor()
-    {
-        return 'green';
     }
 }

--- a/Examples/using-interfaces/using-interfaces.yaml
+++ b/Examples/using-interfaces/using-interfaces.yaml
@@ -67,7 +67,6 @@ components:
               example: blue
     Product:
       title: 'Product model'
-      type: object
       allOf:
         -
           $ref: '#/components/schemas/ProductInterface'
@@ -78,9 +77,6 @@ components:
               type: integer
               format: int64
               example: 1
-            color:
-              description: 'The product color.'
-              example: blue
     ProductInterface:
       properties:
         name:

--- a/src/Processors/ExpandInterfaces.php
+++ b/src/Processors/ExpandInterfaces.php
@@ -29,6 +29,16 @@ class ExpandInterfaces
             if ($schema->_context->is('class')) {
                 $className = $schema->_context->fullyQualifiedName($schema->_context->class);
                 $interfaces = $analysis->getInterfacesOfClass($className, true);
+
+                if (class_exists($className) && ($parent = get_parent_class($className)) && ($inherited = array_keys(class_implements($parent)))) {
+                    // strip interfaces we inherit from anchestor
+                    foreach (array_keys($interfaces) as $interface) {
+                        if (in_array(ltrim($interface, '\\'), $inherited)) {
+                            unset($interfaces[$interface]);
+                        }
+                    }
+                }
+
                 $existing = [];
                 foreach ($interfaces as $interface) {
                     $interfaceName = $interface['context']->fullyQualifiedName($interface['interface']);

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -27,6 +27,7 @@ class UtilTest extends OpenApiTestCase
             'Parser',
             'Analysers',
             'Processors',
+            'TypedProperties.php',
             'UsingRefs.php',
             'UsingPhpDoc.php',
             'UsingCustomAttachables',


### PR DESCRIPTION
Fixes #1201 