### PR TITLE
Initialise optional context properties with `null`

### DIFF
--- a/src/Analysers/ReflectionAnalyser.php
+++ b/src/Analysers/ReflectionAnalyser.php
@@ -86,9 +86,9 @@ class ReflectionAnalyser implements AnalyserInterface
         $contextType = $rc->isInterface() ? 'interface' : ($rc->isTrait() ? 'trait' : ((method_exists($rc, 'isEnum') && $rc->isEnum()) ? 'enum' : 'class'));
         $context = new Context([
             $contextType => $rc->getShortName(),
-            'namespace' => $rc->getNamespaceName() ?: Generator::UNDEFINED,
-            'comment' => $rc->getDocComment() ?: Generator::UNDEFINED,
-            'filename' => $rc->getFileName() ?: Generator::UNDEFINED,
+            'namespace' => $rc->getNamespaceName() ?: null,
+            'comment' => $rc->getDocComment() ?: null,
+            'filename' => $rc->getFileName() ?: null,
             'line' => $rc->getStartLine(),
             'annotations' => [],
             'scanned' => $details,
@@ -120,8 +120,8 @@ class ReflectionAnalyser implements AnalyserInterface
             if (in_array($method->name, $details['methods'])) {
                 $definition['methods'][$method->getName()] = $ctx = new Context([
                     'method' => $method->getName(),
-                    'comment' => $method->getDocComment() ?: Generator::UNDEFINED,
-                    'filename' => $method->getFileName() ?: Generator::UNDEFINED,
+                    'comment' => $method->getDocComment() ?: null,
+                    'filename' => $method->getFileName() ?: null,
                     'line' => $method->getStartLine(),
                     'annotations' => [],
                 ], $context);
@@ -135,7 +135,7 @@ class ReflectionAnalyser implements AnalyserInterface
             if (in_array($property->name, $details['properties'])) {
                 $definition['properties'][$property->getName()] = $ctx = new Context([
                     'property' => $property->getName(),
-                    'comment' => $property->getDocComment() ?: Generator::UNDEFINED,
+                    'comment' => $property->getDocComment() ?: null,
                     'annotations' => [],
                 ], $context);
                 if ($property->isStatic()) {
@@ -161,7 +161,7 @@ class ReflectionAnalyser implements AnalyserInterface
             foreach ($this->annotationFactories as $annotationFactory) {
                 $definition['constants'][$constant->getName()] = $ctx = new Context([
                     'constant' => $constant->getName(),
-                    'comment' => $constant->getDocComment() ?: Generator::UNDEFINED,
+                    'comment' => $constant->getDocComment() ?: null,
                     'annotations' => [],
                 ], $context);
                 foreach ($annotationFactory->build($constant, $ctx) as $annotation) {


### PR DESCRIPTION
Initialise optional context properties with `null` rather than `Generator::UNDEFINED`