### PR TITLE
Add support for generator  / processor configuration

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -180,11 +180,18 @@ class Generator
         return $this;
     }
 
+    public function getDefaultConfig(): array
+    {
+        return [
+            'operationId' => [
+                'hash' => true,
+            ],
+        ];
+    }
+
     public function getConfig(): array
     {
-        return $this->config + [
-                'operationId' => ['hash' => true],
-            ];
+        return $this->config + $this->getDefaultConfig();
     }
 
     /**
@@ -205,38 +212,37 @@ class Generator
     public function getProcessors(): array
     {
         if (null === $this->processors) {
-            $defaultProcessors = [
-                Processors\DocBlockDescriptions::class,
-                Processors\MergeIntoOpenApi::class,
-                Processors\MergeIntoComponents::class,
-                Processors\ExpandClasses::class,
-                Processors\ExpandInterfaces::class,
-                Processors\ExpandTraits::class,
-                Processors\ExpandEnums::class,
-                Processors\AugmentSchemas::class,
-                Processors\AugmentProperties::class,
-                Processors\BuildPaths::class,
-                Processors\AugmentParameters::class,
-                Processors\AugmentRefs::class,
-                Processors\MergeJsonContent::class,
-                Processors\MergeXmlContent::class,
-                Processors\OperationId::class,
-                Processors\CleanUnmerged::class,
+            $this->processors = [
+                new Processors\DocBlockDescriptions(),
+                new Processors\MergeIntoOpenApi(),
+                new Processors\MergeIntoComponents(),
+                new Processors\ExpandClasses(),
+                new Processors\ExpandInterfaces(),
+                new Processors\ExpandTraits(),
+                new Processors\ExpandEnums(),
+                new Processors\AugmentSchemas(),
+                new Processors\AugmentProperties(),
+                new Processors\BuildPaths(),
+                new Processors\AugmentParameters(),
+                new Processors\AugmentRefs(),
+                new Processors\MergeJsonContent(),
+                new Processors\MergeXmlContent(),
+                new Processors\OperationId(),
+                new Processors\CleanUnmerged(),
             ];
-            $this->processors = [];
-            $config = $this->getConfig();
-            foreach ($defaultProcessors as $processor) {
-                $rc = new \ReflectionClass($processor);
-                $this->processors[] = $instance = new $processor();
+        }
 
-                // optional config
-                $processorKey = lcfirst($rc->getShortName());
-                if (array_key_exists($processorKey, $config)) {
-                    foreach ($config[$processorKey] as $name => $value) {
-                        $setter = 'set' . ucfirst($name);
-                        if (method_exists($instance, $setter)) {
-                            $instance->{$setter}($value);
-                        }
+        $config = $this->getConfig();
+        foreach ($this->processors as $processor) {
+            $rc = new \ReflectionClass($processor);
+
+            // apply config
+            $processorKey = lcfirst($rc->getShortName());
+            if (array_key_exists($processorKey, $config)) {
+                foreach ($config[$processorKey] as $name => $value) {
+                    $setter = 'set' . ucfirst($name);
+                    if (method_exists($processor, $setter)) {
+                        $processor->{$setter}($value);
                     }
                 }
             }

--- a/src/Processors/ExpandClasses.php
+++ b/src/Processors/ExpandClasses.php
@@ -33,7 +33,7 @@ class ExpandClasses
                     $ancestorSchema = $analysis->getSchemaForSource($ancestor['context']->fullyQualifiedName($ancestor['class']));
                     if ($ancestorSchema) {
                         $refPath = !Generator::isDefault($ancestorSchema->schema) ? $ancestorSchema->schema : $ancestor['class'];
-                        $this->inheritFrom($schema, $ancestorSchema, $refPath, $ancestor['context']);
+                        $this->inheritFrom($analysis, $schema, $ancestorSchema, $refPath, $ancestor['context']);
 
                         // one ancestor is enough
                         break;

--- a/src/Processors/ExpandClasses.php
+++ b/src/Processors/ExpandClasses.php
@@ -12,9 +12,9 @@ use OpenApi\Attributes\Schema as AttributeSchema;
 use OpenApi\Generator;
 
 /**
- * Iterate over the chain of anchestors of a schema and:
- * - merge anchestor annotations/methods/properties into the schema if the anchestor doesn't have a schema itself
- * - inherit from the anchestor if it has a schema (allOf) and stop.
+ * Iterate over the chain of ancestors of a schema and:
+ * - merge ancestor annotations/methods/properties into the schema if the ancestor doesn't have a schema itself
+ * - inherit from the ancestor if it has a schema (allOf) and stop.
  */
 class ExpandClasses
 {
@@ -27,20 +27,20 @@ class ExpandClasses
 
         foreach ($schemas as $schema) {
             if ($schema->_context->is('class')) {
-                $anchestors = $analysis->getSuperClasses($schema->_context->fullyQualifiedName($schema->_context->class));
+                $ancestors = $analysis->getSuperClasses($schema->_context->fullyQualifiedName($schema->_context->class));
                 $existing = [];
-                foreach ($anchestors as $anchestor) {
-                    $anchestorSchema = $analysis->getSchemaForSource($anchestor['context']->fullyQualifiedName($anchestor['class']));
-                    if ($anchestorSchema) {
-                        $refPath = !Generator::isDefault($anchestorSchema->schema) ? $anchestorSchema->schema : $anchestor['class'];
-                        $this->inheritFrom($analysis, $schema, $anchestorSchema, $refPath, $anchestor['context']);
+                foreach ($ancestors as $ancestor) {
+                    $ancestorSchema = $analysis->getSchemaForSource($ancestor['context']->fullyQualifiedName($ancestor['class']));
+                    if ($ancestorSchema) {
+                        $refPath = !Generator::isDefault($ancestorSchema->schema) ? $ancestorSchema->schema : $ancestor['class'];
+                        $this->inheritFrom($schema, $ancestorSchema, $refPath, $ancestor['context']);
 
-                        // one anchestor is enough
+                        // one ancestor is enough
                         break;
                     } else {
-                        $this->mergeAnnotations($schema, $anchestor, $existing);
-                        $this->mergeMethods($schema, $anchestor, $existing);
-                        $this->mergeProperties($schema, $anchestor, $existing);
+                        $this->mergeAnnotations($schema, $ancestor, $existing);
+                        $this->mergeMethods($schema, $ancestor, $existing);
+                        $this->mergeProperties($schema, $ancestor, $existing);
                     }
                 }
             }

--- a/src/Processors/ExpandInterfaces.php
+++ b/src/Processors/ExpandInterfaces.php
@@ -31,7 +31,7 @@ class ExpandInterfaces
                 $interfaces = $analysis->getInterfacesOfClass($className, true);
 
                 if (class_exists($className) && ($parent = get_parent_class($className)) && ($inherited = array_keys(class_implements($parent)))) {
-                    // strip interfaces we inherit from anchestor
+                    // strip interfaces we inherit from ancestor
                     foreach (array_keys($interfaces) as $interface) {
                         if (in_array(ltrim($interface, '\\'), $inherited)) {
                             unset($interfaces[$interface]);

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -50,8 +50,7 @@ class GeneratorTest extends OpenApiTestCase
     public function processorCases(): iterable
     {
         return [
-            [new OperationId(false), false],
-            [new OperationId(true), true],
+            [new OperationId(), true],
             [new class(false) extends OperationId {
             }, false],
         ];
@@ -115,5 +114,22 @@ class GeneratorTest extends OpenApiTestCase
 
         (new Generator())->removeProcessor(function () {
         });
+    }
+
+    public function testConfig()
+    {
+        $assertOperationId = function (Generator $generator, bool $expected) {
+            foreach ($generator->getProcessors() as $processor) {
+                if ($processor instanceof OperationId) {
+                    $this->assertEquals($expected, $processor->isHash());
+                }
+            }
+        };
+
+        $generator = new Generator();
+        $assertOperationId($generator, true);
+
+        $generator->setConfig(['operationId' => ['hash' => false]]);
+        $assertOperationId($generator, false);
     }
 }

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -116,20 +116,34 @@ class GeneratorTest extends OpenApiTestCase
         });
     }
 
+    protected function assertOperationIdHash(Generator $generator, bool $expected)
+    {
+        foreach ($generator->getProcessors() as $processor) {
+            if ($processor instanceof OperationId) {
+                $this->assertEquals($expected, $processor->isHash());
+            }
+        }
+    }
+
     public function testConfig()
     {
-        $assertOperationId = function (Generator $generator, bool $expected) {
-            foreach ($generator->getProcessors() as $processor) {
-                if ($processor instanceof OperationId) {
-                    $this->assertEquals($expected, $processor->isHash());
-                }
-            }
-        };
-
         $generator = new Generator();
-        $assertOperationId($generator, true);
+        $this->assertOperationIdHash($generator, true);
 
         $generator->setConfig(['operationId' => ['hash' => false]]);
-        $assertOperationId($generator, false);
+        $this->assertOperationIdHash($generator, false);
+    }
+
+    public function testCallableProcessor()
+    {
+        $generator = new Generator();
+        // not the default
+        $operationId = new OperationId(false);
+        $generator->addProcessor(function (Analysis $analysis) use ($operationId) {
+            $operationId($analysis);
+        });
+
+        $this->assertOperationIdHash($generator, true);
+        $this->assertFalse($operationId->isHash());
     }
 }


### PR DESCRIPTION
Allows to configure processors (and the `Generator` itself).

To kick things of the only option is to toggle the `OperationId` processor `hash` flag.

Default config:
```php
[
    'operationId' => [
        'hash' => false
    ]
]
```
Top level key must match the processor class name (with a lower case'd first char).
Settings are applied via `setXXX()` methods, so unless there is a matching method for the config option nothing will happen.

A minor BC break is that the config is applied each time `Generator::getProcessors()` is called. This allows to also configure custom processors the same way. 

For obvious reasons, `callable` processors are skipped :)

The actual BC break is that swappng the `OperationId` processor for an instance with different configuration wil no longer have any effect.
On the plus side it is a lot simpler to just call `setConfig()` than swapping a processor.