### PR TITLE
Minor documentation fixes for v4 migration guide

### DIFF
--- a/docs/guide/migrating-to-v4.md
+++ b/docs/guide/migrating-to-v4.md
@@ -4,7 +4,7 @@
 * As of PHP 8.1 annotations may be used as
   [PHP attributes](https://www.php.net/manual/en/language.attributes.overview.php) instead.
   That means all references to annotations in this document also apply to attributes.
-* Annotations now **must be** associated  with a structural element (class, trait, interface), a method, property or const.
+* Annotations now **must be** associated with a structural element (class, trait, interface), a method, property or const.
 * A new annotation `PathParameter` was added for improved framework support.
 * A new annotation `Attachable` was added to simplify custom processing.
   `Attachable` can be used to attach arbitrary data to any given annotation.
@@ -105,7 +105,7 @@ as private and exclude them under certain conditions from the spec (via a custom
 
 ## Removed deprecated elements
 ### `\Openapi\Analysis::processors()`
-Processors have been moved into the `Generator` class incl. some new convenicen methods.
+Processors have been moved into the `Generator` class incl. some new convenience methods.
 ### `\Openapi\Analyser::$whitelist`
 This has been replaced with the `Generator` `namespaces` property.
 ### `\Openapi\Analyser::$defaultImports`

--- a/docs/guide/migrating-to-v4.md
+++ b/docs/guide/migrating-to-v4.md
@@ -86,8 +86,9 @@ class MyController
         #[OA\PathParameter] string $product_id)
     {
     }
+}
 ```
-Here it avoid having to duplicate details about the `$product_id` parameter and the simple use of the attribute
+Here it avoids having to duplicate details about the `$product_id` parameter and the simple use of the attribute
 will pick up typehints automatically.
 
 ## The `Attachable` annotation
@@ -134,5 +135,4 @@ $analysis = (new Generator())
 
         return $analysis;
     });
-
 ```


### PR DESCRIPTION
This guide was very helpful in a recent upgrade I just completed!

I noticed a typo for the word `convenience`. I made a few other minor edits here, as well.