### PR TITLE
Refactor strategy determining the root annotation in a context

### DIFF
--- a/src/Annotations/AbstractAnnotation.php
+++ b/src/Annotations/AbstractAnnotation.php
@@ -9,8 +9,6 @@ namespace OpenApi\Annotations;
 use OpenApi\Context;
 use OpenApi\Generator;
 use OpenApi\Util;
-use OpenApi\Annotations\Schema as AnnotationSchema;
-use OpenApi\Attributes\Schema as AttributeSchema;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -563,44 +561,6 @@ abstract class AbstractAnnotation implements \JsonSerializable
         }
 
         return $this->_identity($properties);
-    }
-
-    /**
-     * An annotation is a root if it is the top-level / outermost annotation in a PHP docblock.
-     */
-    public function isRoot(): bool
-    {
-        if (!$this->_context) {
-            return true;
-        }
-
-        if (1 == count($this->_context->annotations)) {
-            return true;
-        }
-
-        // find best match
-        $matchPriorityMap = [
-            Operation::class => false,
-            Property::class => false,
-            Parameter::class => false,
-            AnnotationSchema::class => true,
-            AttributeSchema::class => true,
-        ];
-        foreach ($matchPriorityMap as $className => $strict) {
-            foreach ($this->_context->annotations as $annotation) {
-                if ($strict) {
-                    if ($className == get_class($annotation)) {
-                        return  $annotation === $this;
-                    }
-                } else {
-                    if ($annotation instanceof $className) {
-                        return  $annotation === $this;
-                    }
-                }
-            }
-        }
-
-        return false;
     }
 
     /**

--- a/src/Processors/AugmentProperties.php
+++ b/src/Processors/AugmentProperties.php
@@ -20,6 +20,8 @@ use OpenApi\Util;
  */
 class AugmentProperties
 {
+    use DocblockTrait;
+
     public function __invoke(Analysis $analysis)
     {
         $refs = [];
@@ -58,7 +60,7 @@ class AugmentProperties
             if (Generator::isDefault($property->description) && isset($varMatches['description'])) {
                 $property->description = trim($varMatches['description']);
             }
-            if (Generator::isDefault($property->description) && $property->isRoot()) {
+            if (Generator::isDefault($property->description) && $this->isRoot($property)) {
                 $property->description = $context->phpdocContent();
             }
 

--- a/src/Processors/DocBlockDescriptions.php
+++ b/src/Processors/DocBlockDescriptions.php
@@ -18,6 +18,8 @@ use OpenApi\Generator;
  */
 class DocBlockDescriptions
 {
+    use DocblockTrait;
+
     /**
      * Checks if the annotation has a summary and/or description property
      * and uses the text in the comment block (above the annotations) as summary and/or description.
@@ -32,7 +34,7 @@ class DocBlockDescriptions
                 // only annotations with context
                 continue;
             }
-            if (!$annotation->isRoot()) {
+            if (!$this->isRoot($annotation)) {
                 // only top-level annotations
                 continue;
             }

--- a/src/Processors/DocBlockDescriptions.php
+++ b/src/Processors/DocBlockDescriptions.php
@@ -49,7 +49,7 @@ class DocBlockDescriptions
         }
     }
 
-    private function description($annotation): void
+    protected function description($annotation): void
     {
         if (!Generator::isDefault($annotation->description)) {
             if ($annotation->description === null) {
@@ -61,7 +61,7 @@ class DocBlockDescriptions
         $annotation->description = $annotation->_context->phpdocContent();
     }
 
-    private function summaryAndDescription($annotation): void
+    protected function summaryAndDescription($annotation): void
     {
         $ignoreSummary = !Generator::isDefault($annotation->summary);
         $ignoreDescription = !Generator::isDefault($annotation->description);

--- a/src/Processors/DocblockTrait.php
+++ b/src/Processors/DocblockTrait.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace OpenApi\Processors;
+
+use OpenApi\Annotations\AbstractAnnotation;
+use OpenApi\Annotations\Operation;
+use OpenApi\Annotations\Parameter;
+use OpenApi\Annotations\Property;
+use OpenApi\Annotations\Schema as AnnotationSchema;
+use OpenApi\Attributes\Schema as AttributeSchema;
+
+trait DocblockTrait
+{
+    /**
+     * An annotation is a root if it is the top-level / outermost annotation in a PHP docblock.
+     */
+    public function isRoot(AbstractAnnotation $annotation): bool
+    {
+        if (!$annotation->_context) {
+            return true;
+        }
+
+        if (1 == count($annotation->_context->annotations)) {
+            return true;
+        }
+
+        // find best match
+        $matchPriorityMap = [
+            Operation::class => false,
+            Property::class => false,
+            Parameter::class => false,
+            AnnotationSchema::class => true,
+            AttributeSchema::class => true,
+        ];
+        foreach ($matchPriorityMap as $className => $strict) {
+            foreach ($annotation->_context->annotations as $contextAnnotation) {
+                if ($strict) {
+                    if ($className == get_class($contextAnnotation)) {
+                        return  $annotation === $contextAnnotation;
+                    }
+                } else {
+                    if ($contextAnnotation instanceof $className) {
+                        return  $annotation === $contextAnnotation;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Fixtures/Apis/Attributes/basic.php
+++ b/tests/Fixtures/Apis/Attributes/basic.php
@@ -9,6 +9,9 @@ namespace OpenApi\Tests\Fixtures\Apis\Attributes;
 use OpenApi\Attributes as OAT;
 use OpenApi\Tests\Fixtures\Attributes as OAF;
 
+/**
+ * The Spec.
+ */
 #[OAT\OpenApi(openapi: '3.1.0', security: [['bearerAuth' => []]])]
 #[OAT\Info(
     version: '1.0.0',
@@ -17,9 +20,9 @@ use OpenApi\Tests\Fixtures\Attributes as OAF;
 )]
 #[OAT\License(name: 'MIT', identifier: 'MIT')]
 #[OAT\Server(url: 'https://localhost/api', description: 'API server')]
+#[OAT\SecurityScheme(securityScheme: 'bearerAuth', type: 'http', scheme: 'bearer', description: 'Basic Auth')]
 #[OAT\Tag(name: 'products', description: 'All about products')]
 #[OAT\Tag(name: 'catalog', description: 'Catalog API')]
-#[OAT\SecurityScheme(securityScheme: 'bearerAuth', type: 'http', scheme: 'bearer')]
 class OpenApiSpec
 {
 }
@@ -32,10 +35,16 @@ class OpenApiSpec
     url: 'https://example.com',
     description: 'The production server.'
 )]
+/**
+ * A Server.
+ */
 class Server
 {
 }
 
+/**
+ * A Colour.
+ */
 #[OAT\Schema()]
 enum Colour
 {
@@ -48,6 +57,9 @@ interface ProductInterface
 {
 }
 
+/**
+ * A Name.
+ */
 #[OAT\Schema()]
 trait NameTrait
 {
@@ -55,15 +67,24 @@ trait NameTrait
     public $name;
 }
 
-#[OAT\Schema(title: 'Product', description: 'Product')]
+/**
+ * A Product description ignored.
+ */
+#[OAT\Schema(title: 'Product', description: 'A Product.')]
 class Product implements ProductInterface
 {
     use NameTrait;
 
+    /**
+     * The kind.
+     */
     #[OAT\Property(property: 'kind')]
     public const KIND = 'Virtual';
 
     #[OAT\Property(description: 'The id.', format: 'int64', example: 1)]
+    /**
+     * The id.
+     */
     public $id;
 
     public function __construct(
@@ -75,8 +96,14 @@ class Product implements ProductInterface
     }
 }
 
+/**
+ * The Controller.
+ */
 class ProductController
 {
+    /**
+     * Get a product.
+     */
     #[OAT\Get(path: '/products/{product_id}', tags: ['products'], operationId: 'getProducts')]
     #[OAT\Response(
         response: 200,
@@ -110,6 +137,9 @@ class ProductController
             )
         )]
     )]
+    /**
+     * Add a product.
+     */
     public function addProduct()
     {
     }
@@ -130,6 +160,9 @@ class ProductController
             ]
         )
     )]
+    /**
+     * Get all.
+     */
     #[OAT\Response(response: 401, description: 'oops')]
     public function getAll()
     {

--- a/tests/Fixtures/Apis/DocBlocks/basic.php
+++ b/tests/Fixtures/Apis/DocBlocks/basic.php
@@ -9,6 +9,8 @@ namespace OpenApi\Tests\Fixtures\Apis\DocBlocks;
 use OpenApi\Annotations as OA;
 
 /**
+ * The Spec.
+ *
  * @OA\OpenApi(
  *     security={{"bearerAuth": {}}}
  * )
@@ -22,6 +24,12 @@ use OpenApi\Annotations as OA;
  *     url="https://localhost/api",
  *     description="API server"
  * )
+ * @OA\SecurityScheme(
+ *     securityScheme="bearerAuth",
+ *     type="http",
+ *     scheme="bearer",
+ *     description="Basic Auth"
+ * )
  * @OA\Tag(
  *     name="products",
  *     description="All about products"
@@ -30,17 +38,14 @@ use OpenApi\Annotations as OA;
  *     name="catalog",
  *     description="Catalog API"
  * )
- * @OA\SecurityScheme(
- *     securityScheme="bearerAuth",
- *     type="http",
- *     scheme="bearer",
- * )
  */
 class OpenApiSpec
 {
 }
 
 /**
+ * A Server.
+ *
  * @OA\Server(
  *     url="https://example.localhost",
  *     description="The local environment."
@@ -55,6 +60,8 @@ class Server
 }
 
 /**
+ * A Colour.
+ *
  * @OA\Schema()
  */
 enum Colour
@@ -69,6 +76,8 @@ interface ProductInterface
 }
 
 /**
+ * A Name.
+ *
  * @OA\Schema
  */
 trait NameTrait
@@ -82,8 +91,9 @@ trait NameTrait
 }
 
 /**
+ * A Product.
+ *
  * @OA\Schema(
- *     description="Product",
  *     title="Product"
  * )
  */
@@ -108,6 +118,8 @@ class Product implements ProductInterface
     public $id;
 
     /**
+     * The kind.
+     *
      * @OA\Property(property="kind")
      */
     public const KIND = 'Virtual';
@@ -121,9 +133,14 @@ class Product implements ProductInterface
     }
 }
 
+/**
+ * The Controller.
+ */
 class ProductController
 {
     /**
+     * Get a product.
+     *
      * @OA\Get(
      *     tags={"products"},
      *     path="/products/{product_id}",
@@ -158,6 +175,8 @@ class ProductController
     }
 
     /**
+     * Add a product.
+     *
      * @OA\Post(
      *     path="/products",
      *     tags={"products"},
@@ -186,6 +205,8 @@ class ProductController
     }
 
     /**
+     * Get all.
+     *
      * @OA\Get(
      *     tags={"products", "catalog"},
      *     path="/products",

--- a/tests/Fixtures/Apis/Mixed/basic.php
+++ b/tests/Fixtures/Apis/Mixed/basic.php
@@ -10,6 +10,8 @@ use OpenApi\Annotations as OA;
 use OpenApi\Attributes as OAT;
 
 /**
+ * The Spec.
+ *
  * @OA\OpenApi(
  *     openapi="3.1.0",
  *     @OA\Info(
@@ -23,11 +25,12 @@ use OpenApi\Attributes as OAT;
  *     securityScheme="bearerAuth",
  *     type="http",
  *     scheme="bearer",
+ *     description="Basic Auth"
  * )
  */
+#[OAT\Server(url: 'https://localhost/api', description: 'API server')]
 #[OAT\Tag(name: 'products', description: 'All about products')]
 #[OAT\Tag(name: 'catalog', description: 'Catalog API')]
-#[OAT\Server(url: 'https://localhost/api', description: 'API server')]
 class OpenApiSpec
 {
 }
@@ -36,6 +39,9 @@ class OpenApiSpec
     url: 'https://example.localhost',
     description: 'The local environment.'
 )]
+/**
+ * A Server.
+ */
 #[OAT\Server(
     url: 'https://example.com',
     description: 'The production server.'
@@ -44,6 +50,9 @@ class Server
 {
 }
 
+/**
+ * A Colour.
+ */
 #[OAT\Schema()]
 enum Colour
 {
@@ -56,6 +65,9 @@ interface ProductInterface
 {
 }
 
+/**
+ * A Name.
+ */
 #[OAT\Schema()]
 trait NameTrait
 {
@@ -66,11 +78,17 @@ trait NameTrait
     public $name;
 }
 
-#[OAT\Schema(title: 'Product', description: 'Product', attachables: [new OAT\Attachable()])]
+#[OAT\Schema(title: 'Product', attachables: [new OAT\Attachable()])]
+/**
+ * A Product.
+ */
 class Product implements ProductInterface
 {
     use NameTrait;
 
+    /**
+     * The kind.
+     */
     #[OAT\Property(property: 'kind')]
     public const KIND = 'Virtual';
 
@@ -94,8 +112,14 @@ class Product implements ProductInterface
     public Colour $colour;
 }
 
+/**
+ * The Controller.
+ */
 class ProductController
 {
+    /**
+     * Get a product.
+     */
     #[OAT\Get(
         path: '/products/{product_id}',
         tags: ['products'],
@@ -118,6 +142,8 @@ class ProductController
     }
 
     /**
+     * Add a product.
+     *
      * @OA\Post(
      *     path="/products",
      *     tags={"products"},
@@ -142,6 +168,9 @@ class ProductController
     {
     }
 
+    /**
+     * Get all.
+     */
     #[OAT\Get(path: '/products', tags: ['products', 'catalog'], operationId: 'getAll')]
     #[OAT\Response(
         response: 200,

--- a/tests/Fixtures/Apis/basic.yaml
+++ b/tests/Fixtures/Apis/basic.yaml
@@ -20,6 +20,7 @@ paths:
     get:
       tags:
         - products
+      summary: 'Get a product.'
       operationId: getProducts
       parameters:
         -
@@ -49,6 +50,7 @@ paths:
       tags:
         - products
         - catalog
+      summary: 'Get all.'
       operationId: getAll
       responses:
         '200':
@@ -67,6 +69,7 @@ paths:
       tags:
         - products
       summary: 'Add products'
+      description: 'Add a product.'
       operationId: addProducts
       requestBody:
         description: 'New product'
@@ -111,19 +114,21 @@ paths:
 components:
   schemas:
     Colour:
+      description: 'A Colour.'
       type: string
       enum:
         - GREEN
         - BLUE
         - RED
     NameTrait:
+      description: 'A Name.'
       properties:
         name:
           description: 'The name.'
       type: object
     Product:
       title: Product
-      description: Product
+      description: 'A Product.'
       type: object
       allOf:
         -
@@ -147,11 +152,13 @@ components:
             releasedAt:
               type: string
             kind:
+              description: 'The kind.'
               type: string
               const: Virtual
   securitySchemes:
     bearerAuth:
       type: http
+      description: 'Basic Auth'
       scheme: bearer
 security:
   -

--- a/tests/Processors/ExpandClassesTest.php
+++ b/tests/Processors/ExpandClassesTest.php
@@ -55,6 +55,7 @@ class ExpandClassesTest extends OpenApiTestCase
 
         /** @var Schema[] $schemas */
         $schemas = $analysis->getAnnotationsOfType(Schema::class);
+        $this->assertCount(4, $schemas);
         $childSchema = $schemas[0];
         $this->assertSame('Child', $childSchema->schema);
         $this->assertCount(1, $childSchema->properties);


### PR DESCRIPTION
Fixes #1226

This changes the way the code determines what is the root annotation in a context. The proposed new way is that an annotation is the root if:
* it is the only annotation
* it is the best match of being an instance **or** subclass of one of these classes (in priority order)
  * `OA\Operation`
  * `OA\Property`
  * `OA\Parameter`
  or (lowest priority) of type `OpenApi\Annotations\Schema`or `OpenApi\Attributes\Schema`. In this case the exact class is required.
