### PR TITLE
Change enum type from string[] to string[]|int[]|float[]

### DIFF
--- a/docs/reference/annotations.md
+++ b/docs/reference/annotations.md
@@ -146,7 +146,7 @@ On top of this subset, there are extensions provided by this specification to al
 #### Properties
 ---
 <dl>
-  <dt><strong>ref</strong> : <span style="font-family: monospace;">string</span></dt>
+  <dt><strong>ref</strong> : <span style="font-family: monospace;">string|object</span></dt>
   <dd><p>No details available.</p><p><i>See</i>: <a href="https://swagger.io/docs/specification/using-ref/">Using refs</a></p></dd>
   <dt><strong>example</strong> : <span style="font-family: monospace;">string</span></dt>
   <dd><p>The key into `#/components/examples`.</p></dd>
@@ -294,7 +294,7 @@ A map between the scope name and a short description for it.</p></dd>
 #### Properties
 ---
 <dl>
-  <dt><strong>ref</strong> : <span style="font-family: monospace;">string</span></dt>
+  <dt><strong>ref</strong> : <span style="font-family: monospace;">string|object</span></dt>
   <dd><p>No details available.</p><p><i>See</i>: <a href="https://swagger.io/docs/specification/using-ref/">Using refs</a></p></dd>
   <dt><strong>header</strong> : <span style="font-family: monospace;">string</span></dt>
   <dd><p>No details available.</p></dd>
@@ -431,7 +431,7 @@ accessing values in an operation and using them as parameters while invoking the
 #### Properties
 ---
 <dl>
-  <dt><strong>ref</strong> : <span style="font-family: monospace;">string</span></dt>
+  <dt><strong>ref</strong> : <span style="font-family: monospace;">string|object</span></dt>
   <dd><p>No details available.</p><p><i>See</i>: <a href="https://swagger.io/docs/specification/using-ref/">Using refs</a></p></dd>
   <dt><strong>link</strong> : <span style="font-family: monospace;">string</span></dt>
   <dd><p>The key into MediaType->links array.</p></dd>
@@ -576,7 +576,7 @@ A unique parameter is defined by a combination of a name and location.
 #### Properties
 ---
 <dl>
-  <dt><strong>ref</strong> : <span style="font-family: monospace;">string</span></dt>
+  <dt><strong>ref</strong> : <span style="font-family: monospace;">string|object</span></dt>
   <dd><p>No details available.</p><p><i>See</i>: <a href="https://swagger.io/docs/specification/using-ref/">Using refs</a></p></dd>
   <dt><strong>parameter</strong> : <span style="font-family: monospace;">string</span></dt>
   <dd><p>The key into <code>Components::parameters</code> or <code>PathItem::parameters</code> array.</p></dd>
@@ -706,7 +706,7 @@ The path itself is still exposed to the documentation viewer but they will not k
 #### Properties
 ---
 <dl>
-  <dt><strong>ref</strong> : <span style="font-family: monospace;">string</span></dt>
+  <dt><strong>ref</strong> : <span style="font-family: monospace;">string|object</span></dt>
   <dd><p>No details available.</p><p><i>See</i>: <a href="https://swagger.io/docs/specification/using-ref/">Using refs</a></p></dd>
   <dt><strong>path</strong> : <span style="font-family: monospace;">string</span></dt>
   <dd><p>Key for the Path Object (OpenApi->paths array).</p></dd>
@@ -811,7 +811,7 @@ Describes a single request body.
 #### Properties
 ---
 <dl>
-  <dt><strong>ref</strong> : <span style="font-family: monospace;">string</span></dt>
+  <dt><strong>ref</strong> : <span style="font-family: monospace;">string|object</span></dt>
   <dd><p>No details available.</p><p><i>See</i>: <a href="https://swagger.io/docs/specification/using-ref/">Using refs</a></p></dd>
   <dt><strong>request</strong> : <span style="font-family: monospace;">string</span></dt>
   <dd><p>Request body model name.</p></dd>
@@ -848,7 +848,7 @@ static links to operations based on the response.
 #### Properties
 ---
 <dl>
-  <dt><strong>ref</strong> : <span style="font-family: monospace;">string</span></dt>
+  <dt><strong>ref</strong> : <span style="font-family: monospace;">string|object</span></dt>
   <dd><p>No details available.</p><p><i>See</i>: <a href="https://swagger.io/docs/specification/using-ref/">Using refs</a></p></dd>
   <dt><strong>response</strong> : <span style="font-family: monospace;">string|int</span></dt>
   <dd><p>The key into Operations->responses array.<br />
@@ -884,7 +884,7 @@ On top of this subset, there are extensions provided by this specification to al
 #### Properties
 ---
 <dl>
-  <dt><strong>ref</strong> : <span style="font-family: monospace;">string</span></dt>
+  <dt><strong>ref</strong> : <span style="font-family: monospace;">string|object</span></dt>
   <dd><p>No details available.</p><p><i>See</i>: <a href="https://swagger.io/docs/specification/using-ref/">Using refs</a></p></dd>
   <dt><strong>schema</strong> : <span style="font-family: monospace;">string</span></dt>
   <dd><p>The key into Components->schemas array.</p></dd>
@@ -940,9 +940,9 @@ Default value is csv.</p></dd>
   <dd><p>No details available.</p><p><i>See</i>: <a href="http://json-schema.org/latest/json-schema-validation.html#anchor45">JSON schema validation</a></p></dd>
   <dt><strong>uniqueItems</strong> : <span style="font-family: monospace;">bool</span></dt>
   <dd><p>No details available.</p><p><i>See</i>: <a href="http://json-schema.org/latest/json-schema-validation.html#anchor49">JSON schema validation</a></p></dd>
-  <dt><strong>enum</strong> : <span style="font-family: monospace;">string[]</span></dt>
+  <dt><strong>enum</strong> : <span style="font-family: monospace;">string[]|int[]|float[]</span></dt>
   <dd><p>No details available.</p><p><i>See</i>: <a href="http://json-schema.org/latest/json-schema-validation.html#anchor76">JSON schema validation</a></p></dd>
-  <dt><strong>multipleOf</strong> : <span style="font-family: monospace;">number</span></dt>
+  <dt><strong>multipleOf</strong> : <span style="font-family: monospace;">int|float</span></dt>
   <dd><p>A numeric instance is valid against "multipleOf" if the result of the division of the instance by this<br />
 property's value is an integer.</p></dd>
   <dt><strong>readOnly</strong> : <span style="font-family: monospace;">bool</span></dt>
@@ -1018,7 +1018,7 @@ defined by this property's value.</p></dd>
 #### Properties
 ---
 <dl>
-  <dt><strong>ref</strong> : <span style="font-family: monospace;">string</span></dt>
+  <dt><strong>ref</strong> : <span style="font-family: monospace;">string|object</span></dt>
   <dd><p>No details available.</p><p><i>See</i>: <a href="https://swagger.io/docs/specification/using-ref/">Using refs</a></p></dd>
   <dt><strong>securityScheme</strong> : <span style="font-family: monospace;">string</span></dt>
   <dd><p>The key into OpenApi->security array.</p></dd>

--- a/docs/reference/attributes.md
+++ b/docs/reference/attributes.md
@@ -22,7 +22,7 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 ---
 <dl>
-  <dt><strong>ref</strong> : <span style="font-family: monospace;">string|null</span></dt>
+  <dt><strong>ref</strong> : <span style="font-family: monospace;">object|string|null</span></dt>
   <dd><p>No details available.</p></dd>
   <dt><strong>schema</strong> : <span style="font-family: monospace;">string|null</span></dt>
   <dd><p>No details available.</p></dd>
@@ -64,7 +64,7 @@ In addition to this page, there are also a number of [examples](https://github.c
   <dd><p>No details available.</p></dd>
   <dt><strong>pattern</strong> : <span style="font-family: monospace;">string|null</span></dt>
   <dd><p>No details available.</p></dd>
-  <dt><strong>enum</strong> : <span style="font-family: monospace;">string[]</span></dt>
+  <dt><strong>enum</strong> : <span style="font-family: monospace;">string[]|int[]|float[]</span></dt>
   <dd><p>No details available.</p></dd>
   <dt><strong>discriminator</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Discriminator|null</span></dt>
   <dd><p>No details available.</p></dd>
@@ -272,7 +272,7 @@ In addition to this page, there are also a number of [examples](https://github.c
   <dd><p>No details available.</p></dd>
   <dt><strong>externalValue</strong> : <span style="font-family: monospace;">string|null</span></dt>
   <dd><p>No details available.</p></dd>
-  <dt><strong>ref</strong> : <span style="font-family: monospace;">string|null</span></dt>
+  <dt><strong>ref</strong> : <span style="font-family: monospace;">object|string|null</span></dt>
   <dd><p>No details available.</p></dd>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,string&gt;|null</span></dt>
   <dd><p>No details available.</p></dd>
@@ -445,7 +445,7 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 ---
 <dl>
-  <dt><strong>ref</strong> : <span style="font-family: monospace;">string|null</span></dt>
+  <dt><strong>ref</strong> : <span style="font-family: monospace;">object|string|null</span></dt>
   <dd><p>No details available.</p></dd>
   <dt><strong>header</strong> : <span style="font-family: monospace;">string|null</span></dt>
   <dd><p>No details available.</p></dd>
@@ -513,7 +513,7 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 ---
 <dl>
-  <dt><strong>ref</strong> : <span style="font-family: monospace;">string|null</span></dt>
+  <dt><strong>ref</strong> : <span style="font-family: monospace;">object|string|null</span></dt>
   <dd><p>No details available.</p></dd>
   <dt><strong>schema</strong> : <span style="font-family: monospace;">string|null</span></dt>
   <dd><p>No details available.</p></dd>
@@ -555,7 +555,7 @@ In addition to this page, there are also a number of [examples](https://github.c
   <dd><p>No details available.</p></dd>
   <dt><strong>pattern</strong> : <span style="font-family: monospace;">string|null</span></dt>
   <dd><p>No details available.</p></dd>
-  <dt><strong>enum</strong> : <span style="font-family: monospace;">string[]</span></dt>
+  <dt><strong>enum</strong> : <span style="font-family: monospace;">string[]|int[]|float[]</span></dt>
   <dd><p>No details available.</p></dd>
   <dt><strong>discriminator</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Discriminator|null</span></dt>
   <dd><p>No details available.</p></dd>
@@ -598,9 +598,9 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 ---
 <dl>
-  <dt><strong>examples</strong> : <span style="font-family: monospace;">array|null</span></dt>
+  <dt><strong>examples</strong> : <span style="font-family: monospace;">array&lt;string,Examples&gt;</span></dt>
   <dd><p>No details available.</p></dd>
-  <dt><strong>ref</strong> : <span style="font-family: monospace;">string|null</span></dt>
+  <dt><strong>ref</strong> : <span style="font-family: monospace;">object|string|null</span></dt>
   <dd><p>No details available.</p></dd>
   <dt><strong>schema</strong> : <span style="font-family: monospace;">string|null</span></dt>
   <dd><p>No details available.</p></dd>
@@ -642,7 +642,7 @@ In addition to this page, there are also a number of [examples](https://github.c
   <dd><p>No details available.</p></dd>
   <dt><strong>pattern</strong> : <span style="font-family: monospace;">string|null</span></dt>
   <dd><p>No details available.</p></dd>
-  <dt><strong>enum</strong> : <span style="font-family: monospace;">string[]</span></dt>
+  <dt><strong>enum</strong> : <span style="font-family: monospace;">string[]|int[]|float[]</span></dt>
   <dd><p>No details available.</p></dd>
   <dt><strong>discriminator</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Discriminator|null</span></dt>
   <dd><p>No details available.</p></dd>
@@ -720,7 +720,7 @@ In addition to this page, there are also a number of [examples](https://github.c
   <dd><p>No details available.</p></dd>
   <dt><strong>operationRef</strong> : <span style="font-family: monospace;">string|null</span></dt>
   <dd><p>No details available.</p></dd>
-  <dt><strong>ref</strong> : <span style="font-family: monospace;">string|null</span></dt>
+  <dt><strong>ref</strong> : <span style="font-family: monospace;">object|string|null</span></dt>
   <dd><p>No details available.</p></dd>
   <dt><strong>operationId</strong> : <span style="font-family: monospace;">string|null</span></dt>
   <dd><p>No details available.</p></dd>
@@ -878,7 +878,7 @@ In addition to this page, there are also a number of [examples](https://github.c
   <dd><p>No details available.</p></dd>
   <dt><strong>allowEmptyValue</strong> : <span style="font-family: monospace;">bool|null</span></dt>
   <dd><p>No details available.</p></dd>
-  <dt><strong>ref</strong> : <span style="font-family: monospace;">string|null</span></dt>
+  <dt><strong>ref</strong> : <span style="font-family: monospace;">object|string|null</span></dt>
   <dd><p>No details available.</p></dd>
   <dt><strong>schema</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Schema|null</span></dt>
   <dd><p>No details available.</p></dd>
@@ -1007,7 +1007,7 @@ In addition to this page, there are also a number of [examples](https://github.c
   <dd><p>No details available.</p></dd>
   <dt><strong>allowEmptyValue</strong> : <span style="font-family: monospace;">bool|null</span></dt>
   <dd><p>No details available.</p></dd>
-  <dt><strong>ref</strong> : <span style="font-family: monospace;">string|null</span></dt>
+  <dt><strong>ref</strong> : <span style="font-family: monospace;">object|string|null</span></dt>
   <dd><p>No details available.</p></dd>
   <dt><strong>schema</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Schema|null</span></dt>
   <dd><p>No details available.</p></dd>
@@ -1095,7 +1095,7 @@ In addition to this page, there are also a number of [examples](https://github.c
 <dl>
   <dt><strong>property</strong> : <span style="font-family: monospace;">string|null</span></dt>
   <dd><p>No details available.</p></dd>
-  <dt><strong>ref</strong> : <span style="font-family: monospace;">string|null</span></dt>
+  <dt><strong>ref</strong> : <span style="font-family: monospace;">object|string|null</span></dt>
   <dd><p>No details available.</p></dd>
   <dt><strong>schema</strong> : <span style="font-family: monospace;">string|null</span></dt>
   <dd><p>No details available.</p></dd>
@@ -1137,7 +1137,7 @@ In addition to this page, there are also a number of [examples](https://github.c
   <dd><p>No details available.</p></dd>
   <dt><strong>pattern</strong> : <span style="font-family: monospace;">string|null</span></dt>
   <dd><p>No details available.</p></dd>
-  <dt><strong>enum</strong> : <span style="font-family: monospace;">string[]</span></dt>
+  <dt><strong>enum</strong> : <span style="font-family: monospace;">string[]|int[]|float[]</span></dt>
   <dd><p>No details available.</p></dd>
   <dt><strong>discriminator</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Discriminator|null</span></dt>
   <dd><p>No details available.</p></dd>
@@ -1231,7 +1231,7 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 ---
 <dl>
-  <dt><strong>ref</strong> : <span style="font-family: monospace;">string|null</span></dt>
+  <dt><strong>ref</strong> : <span style="font-family: monospace;">object|string|null</span></dt>
   <dd><p>No details available.</p></dd>
   <dt><strong>request</strong> : <span style="font-family: monospace;">string|null</span></dt>
   <dd><p>No details available.</p></dd>
@@ -1262,7 +1262,7 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 ---
 <dl>
-  <dt><strong>ref</strong> : <span style="font-family: monospace;">string|null</span></dt>
+  <dt><strong>ref</strong> : <span style="font-family: monospace;">object|string|null</span></dt>
   <dd><p>No details available.</p></dd>
   <dt><strong>response</strong> : <span style="font-family: monospace;">string|int|null</span></dt>
   <dd><p>No details available.</p></dd>
@@ -1295,7 +1295,7 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 ---
 <dl>
-  <dt><strong>ref</strong> : <span style="font-family: monospace;">string|null</span></dt>
+  <dt><strong>ref</strong> : <span style="font-family: monospace;">object|string|null</span></dt>
   <dd><p>No details available.</p></dd>
   <dt><strong>schema</strong> : <span style="font-family: monospace;">string|null</span></dt>
   <dd><p>No details available.</p></dd>
@@ -1337,7 +1337,7 @@ In addition to this page, there are also a number of [examples](https://github.c
   <dd><p>No details available.</p></dd>
   <dt><strong>pattern</strong> : <span style="font-family: monospace;">string|null</span></dt>
   <dd><p>No details available.</p></dd>
-  <dt><strong>enum</strong> : <span style="font-family: monospace;">string[]</span></dt>
+  <dt><strong>enum</strong> : <span style="font-family: monospace;">string[]|int[]|float[]</span></dt>
   <dd><p>No details available.</p></dd>
   <dt><strong>discriminator</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Discriminator|null</span></dt>
   <dd><p>No details available.</p></dd>
@@ -1386,7 +1386,7 @@ In addition to this page, there are also a number of [examples](https://github.c
 #### Parameters
 ---
 <dl>
-  <dt><strong>ref</strong> : <span style="font-family: monospace;">string|null</span></dt>
+  <dt><strong>ref</strong> : <span style="font-family: monospace;">object|string|null</span></dt>
   <dd><p>No details available.</p></dd>
   <dt><strong>securityScheme</strong> : <span style="font-family: monospace;">string|null</span></dt>
   <dd><p>No details available.</p></dd>
@@ -1460,7 +1460,7 @@ In addition to this page, there are also a number of [examples](https://github.c
   <dd><p>No details available.</p></dd>
   <dt><strong>default</strong> : <span style="font-family: monospace;">string|null</span></dt>
   <dd><p>No details available.</p></dd>
-  <dt><strong>enum</strong> : <span style="font-family: monospace;">string[]|null</span></dt>
+  <dt><strong>enum</strong> : <span style="font-family: monospace;">string[]|int[]|float[]|null</span></dt>
   <dd><p>No details available.</p></dd>
   <dt><strong>variables</strong> : <span style="font-family: monospace;">array|null</span></dt>
   <dd><p>No details available.</p></dd>
@@ -1588,7 +1588,7 @@ In addition to this page, there are also a number of [examples](https://github.c
 <dl>
   <dt><strong>examples</strong> : <span style="font-family: monospace;">array&lt;string,Examples&gt;</span></dt>
   <dd><p>No details available.</p></dd>
-  <dt><strong>ref</strong> : <span style="font-family: monospace;">string|null</span></dt>
+  <dt><strong>ref</strong> : <span style="font-family: monospace;">object|string|null</span></dt>
   <dd><p>No details available.</p></dd>
   <dt><strong>schema</strong> : <span style="font-family: monospace;">string|null</span></dt>
   <dd><p>No details available.</p></dd>
@@ -1630,7 +1630,7 @@ In addition to this page, there are also a number of [examples](https://github.c
   <dd><p>No details available.</p></dd>
   <dt><strong>pattern</strong> : <span style="font-family: monospace;">string|null</span></dt>
   <dd><p>No details available.</p></dd>
-  <dt><strong>enum</strong> : <span style="font-family: monospace;">string[]</span></dt>
+  <dt><strong>enum</strong> : <span style="font-family: monospace;">string[]|int[]|float[]</span></dt>
   <dd><p>No details available.</p></dd>
   <dt><strong>discriminator</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Discriminator|null</span></dt>
   <dd><p>No details available.</p></dd>

--- a/src/Annotations/Schema.php
+++ b/src/Annotations/Schema.php
@@ -199,7 +199,7 @@ class Schema extends AbstractAnnotation
     /**
      * @see [JSON schema validation](http://json-schema.org/latest/json-schema-validation.html#anchor76)
      *
-     * @var string[]
+     * @var string[]|int[]|float[]
      */
     public $enum = Generator::UNDEFINED;
 

--- a/src/Annotations/ServerVariable.php
+++ b/src/Annotations/ServerVariable.php
@@ -25,9 +25,9 @@ class ServerVariable extends AbstractAnnotation
     public $serverVariable = Generator::UNDEFINED;
 
     /**
-     * An enumeration of string values to be used if the substitution options are from a limited set.
+     * An enumeration of values to be used if the substitution options are from a limited set.
      *
-     * @var string[]
+     * @var string[]|int[]|float[]
      */
     public $enum = Generator::UNDEFINED;
 

--- a/src/Attributes/AdditionalProperties.php
+++ b/src/Attributes/AdditionalProperties.php
@@ -16,7 +16,7 @@ class AdditionalProperties extends \OpenApi\Annotations\AdditionalProperties
      * @param Property[]                $properties
      * @param int|float                 $maximum
      * @param int|float                 $minimum
-     * @param string[]                  $enum
+     * @param string[]|int[]|float[]    $enum
      * @param Schema[]                  $allOf
      * @param Schema[]                  $anyOf
      * @param Schema[]                  $oneOf

--- a/src/Attributes/Items.php
+++ b/src/Attributes/Items.php
@@ -16,7 +16,7 @@ class Items extends \OpenApi\Annotations\Items
      * @param Property[]                $properties
      * @param int|float                 $maximum
      * @param int|float                 $minimum
-     * @param string[]                  $enum
+     * @param string[]|int[]|float[]    $enum
      * @param Schema[]                  $allOf
      * @param Schema[]                  $anyOf
      * @param Schema[]                  $oneOf

--- a/src/Attributes/JsonContent.php
+++ b/src/Attributes/JsonContent.php
@@ -17,7 +17,7 @@ class JsonContent extends \OpenApi\Annotations\JsonContent
      * @param Property[]                $properties
      * @param int|float                 $maximum
      * @param int|float                 $minimum
-     * @param string[]                  $enum
+     * @param string[]|int[]|float[]    $enum
      * @param Schema[]                  $allOf
      * @param Schema[]                  $anyOf
      * @param Schema[]                  $oneOf

--- a/src/Attributes/Property.php
+++ b/src/Attributes/Property.php
@@ -16,7 +16,7 @@ class Property extends \OpenApi\Annotations\Property
      * @param Property[]                $properties
      * @param int|float                 $maximum
      * @param int|float                 $minimum
-     * @param string[]                  $enum
+     * @param string[]|int[]|float[]    $enum
      * @param Schema[]                  $allOf
      * @param Schema[]                  $anyOf
      * @param Schema[]                  $oneOf

--- a/src/Attributes/Schema.php
+++ b/src/Attributes/Schema.php
@@ -16,7 +16,7 @@ class Schema extends \OpenApi\Annotations\Schema
      * @param Property[]                $properties
      * @param int|float                 $maximum
      * @param int|float                 $minimum
-     * @param string[]                  $enum
+     * @param string[]|int[]|float[]    $enum
      * @param Schema[]                  $allOf
      * @param Schema[]                  $anyOf
      * @param Schema[]                  $oneOf

--- a/src/Attributes/ServerVariable.php
+++ b/src/Attributes/ServerVariable.php
@@ -12,9 +12,9 @@ use OpenApi\Generator;
 class ServerVariable extends \OpenApi\Annotations\ServerVariable
 {
     /**
-     * @param string[]|null             $enum
-     * @param array<string,string>|null $x
-     * @param Attachable[]|null         $attachables
+     * @param string[]|int[]|float[]|null $enum
+     * @param array<string,string>|null   $x
+     * @param Attachable[]|null           $attachables
      */
     public function __construct(
         ?string $serverVariable = null,

--- a/src/Attributes/XmlContent.php
+++ b/src/Attributes/XmlContent.php
@@ -17,7 +17,7 @@ class XmlContent extends \OpenApi\Annotations\XmlContent
      * @param int|float                 $maximum
      * @param int|float                 $minimum
      * @param Property[]                $properties
-     * @param string[]                  $enum
+     * @param string[]|int[]|float[]    $enum
      * @param Schema[]                  $allOf
      * @param Schema[]                  $anyOf
      * @param Schema[]                  $oneOf


### PR DESCRIPTION
At the moment you can only use strings in enum, if you use integer or floats, static code analyzers such as Psalm will trigger an error.

E.g. 
When defining an enum of integer values like the one below:
`#[OA\Property(enum: [123, 456, 789], default: 123)]`

Psalm will trigger an InvalidScalarArgument  (https://psalm.dev/docs/running_psalm/issues/InvalidScalarArgument/)
`Argument 1 of OpenApi\Attributes\Property::__construct expects array<array-key, string>|null, array{123, 456, 789} provided`

Thanks @tm1000 for pointing in this direction