### PR TITLE
Allow original backing value in Enum

### DIFF
--- a/src/Processors/ExpandEnums.php
+++ b/src/Processors/ExpandEnums.php
@@ -34,11 +34,21 @@ class ExpandEnums
                 $re = new \ReflectionEnum($schema->_context->fullyQualifiedName($source));
                 $schema->schema = !Generator::isDefault($schema->schema) ? $schema->schema : $re->getShortName();
                 $type = 'string';
+                $schemaType = 'string';
                 if ($re->isBacked() && ($backingType = $re->getBackingType()) && method_exists($backingType, 'getName')) {
-                    $type = !Generator::isDefault($schema->type) ? $schema->type : $backingType->getName();
+                    if (Generator::isDefault($schema->type)) {
+                        $type = $backingType->getName();
+                    } else {
+                        $type = $schema->type;
+                        $schemaType = $schema->type;
+                    }
                 }
-                $schema->enum = array_map(function ($case) use ($re, $type) {
-                    return $re->isBacked() && $type === 'string' ? $case->getBackingValue() : $case->name;
+                $schema->enum = array_map(function ($case) use ($re, $schemaType, $type) {
+                    if ($re->isBacked() && $type === $schemaType) {
+                        return $case->getBackingValue();
+                    }
+
+                    return $case->name;
                 }, $re->getCases());
                 Util::mapNativeType($schema, $type);
             }

--- a/tests/Fixtures/PHP/StatusEnumIntegerBacked.php
+++ b/tests/Fixtures/PHP/StatusEnumIntegerBacked.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace OpenApi\Tests\Fixtures\PHP;
+
+use OpenApi\Attributes\Schema;
+
+#[Schema(type: 'integer')]
+enum StatusEnumIntegerBacked: int
+{
+    case DRAFT = 1;
+    case PUBLISHED = 2;
+    case ARCHIVED = 3;
+}

--- a/tests/Processors/ExpandEnumsTest.php
+++ b/tests/Processors/ExpandEnumsTest.php
@@ -50,11 +50,7 @@ class ExpandEnumsTest extends OpenApiTestCase
         $analysis->process([new ExpandEnums()]);
         $schema = $analysis->getSchemaForSource(StatusEnumIntegerBacked::class);
 
-        self::assertEquals([
-            StatusEnumIntegerBacked::DRAFT->value,
-            StatusEnumIntegerBacked::PUBLISHED->value,
-            StatusEnumIntegerBacked::ARCHIVED->value,
-        ], $schema->enum);
+        self::assertEquals([1, 2, 3], $schema->enum);
     }
 
     public function testExpandBackedStringEnum(): void

--- a/tests/Processors/ExpandEnumsTest.php
+++ b/tests/Processors/ExpandEnumsTest.php
@@ -11,6 +11,7 @@ use OpenApi\Analysers\TokenAnalyser;
 use OpenApi\Processors\ExpandEnums;
 use OpenApi\Tests\Fixtures\PHP\StatusEnum;
 use OpenApi\Tests\Fixtures\PHP\StatusEnumBacked;
+use OpenApi\Tests\Fixtures\PHP\StatusEnumIntegerBacked;
 use OpenApi\Tests\Fixtures\PHP\StatusEnumStringBacked;
 use OpenApi\Tests\OpenApiTestCase;
 
@@ -41,6 +42,19 @@ class ExpandEnumsTest extends OpenApiTestCase
         $schema = $analysis->getSchemaForSource(StatusEnumBacked::class);
 
         self::assertEquals(['DRAFT', 'PUBLISHED', 'ARCHIVED'], $schema->enum);
+    }
+
+    public function testExpandBackedIntegerEnum(): void
+    {
+        $analysis = $this->analysisFromFixtures(['PHP/StatusEnumIntegerBacked.php']);
+        $analysis->process([new ExpandEnums()]);
+        $schema = $analysis->getSchemaForSource(StatusEnumIntegerBacked::class);
+
+        self::assertEquals([
+            StatusEnumIntegerBacked::DRAFT->value,
+            StatusEnumIntegerBacked::PUBLISHED->value,
+            StatusEnumIntegerBacked::ARCHIVED->value,
+        ], $schema->enum);
     }
 
     public function testExpandBackedStringEnum(): void


### PR DESCRIPTION
A `Backed Enum` may be backed by types of int or string

But when I want to use integer in Enum, I saw like this:

<img width="245" alt="image" src="https://user-images.githubusercontent.com/15716336/168948899-ae7770a7-4a65-436e-94d5-a7c485f956a9.png">

-----

These changes can make enum use name or value specifiable.

<img width="623" alt="image" src="https://user-images.githubusercontent.com/15716336/168948745-f5caca7d-bf52-4979-aae5-b44c58282324.png">
