### PR TITLE
fix return type for Symfony debug class

### DIFF
--- a/src/Annotations/AbstractAnnotation.php
+++ b/src/Annotations/AbstractAnnotation.php
@@ -270,6 +270,8 @@ abstract class AbstractAnnotation implements \JsonSerializable
 
     /**
      * Customize the way json_encode() renders the annotations.
+     *
+     * @return mixed
      */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()

--- a/src/Annotations/Operation.php
+++ b/src/Annotations/Operation.php
@@ -167,6 +167,8 @@ abstract class Operation extends AbstractAnnotation
 
     /**
      * @inheritdoc
+     *
+     * @return mixed
      */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()


### PR DESCRIPTION
Stops the annoying symfony deprecation warnings that the return type is missing