### PR TITLE
Wrong DocParser Exception without context

### DIFF
--- a/src/Analysers/DocBlockParser.php
+++ b/src/Analysers/DocBlockParser.php
@@ -51,7 +51,7 @@ class DocBlockParser
                 $context->annotations = [];
             }
 
-            return $this->docParser->parse($comment);
+            return $this->docParser->parse($comment, $context);
         } catch (\Exception $e) {
             if (preg_match('/^(.+) at position ([0-9]+) in ' . preg_quote((string) $context, '/') . '\.$/', $e->getMessage(), $matches)) {
                 $errorMessage = $matches[1];

--- a/src/Analysers/DocBlockParser.php
+++ b/src/Analysers/DocBlockParser.php
@@ -51,7 +51,7 @@ class DocBlockParser
                 $context->annotations = [];
             }
 
-            return $this->docParser->parse($comment, $context);
+            return $this->docParser->parse($comment, $context->getDebugLocation());
         } catch (\Exception $e) {
             if (preg_match('/^(.+) at position ([0-9]+) in ' . preg_quote((string) $context, '/') . '\.$/', $e->getMessage(), $matches)) {
                 $errorMessage = $matches[1];


### PR DESCRIPTION
Added $context param to DocParser->parse to keep context in exception.
According to:
- https://github.com/doctrine/annotations/blob/1.7/lib/Doctrine/Common/Annotations/DocParser.php#L440
- https://github.com/doctrine/annotations/blob/1.7/lib/Doctrine/Common/Annotations/DocParser.php#L342

Full path of misstype:
> [Syntax Error] Expected Doctrine\Common\Annotations\DocLexer::T_CLOSE_PARENTHESIS, got 'description' in \App\Http\Controllers\Api\V1\SmsSenderNamesController->getSenderNames() in /var/www/API_public/laravel-app/app/Http/Controllers/Api/V1/SmsSenderNamesController.php on line 18:12

much better then:

> [Syntax Error] Expected Doctrine\Common\Annotations\DocLexer::T_CLOSE_PARENTHESIS, got 'description' at position 132.