### PR TITLE
type deprecation fix for preg_match and preg_split for php 8.1

### DIFF
--- a/src/Context.php
+++ b/src/Context.php
@@ -209,7 +209,7 @@ class Context
      */
     public function phpdocContent()
     {
-        $comment = preg_split('/(\n|\r\n)/', $this->comment);
+        $comment = preg_split('/(\n|\r\n)/', (string) $this->comment);
         $comment[0] = preg_replace('/[ \t]*\\/\*\*/', '', $comment[0]); // strip '/**'
         $i = count($comment) -1;
         $comment[$i] = preg_replace('/\*\/[ \t]*$/', '', $comment[$i]); // strip '*/'

--- a/src/Processors/AugmentProperties.php
+++ b/src/Processors/AugmentProperties.php
@@ -58,7 +58,7 @@ class AugmentProperties
                 $property->property = $context->property;
             }
 
-            if (preg_match('/@var\s+(?<type>[^\s]+)([ \t])?(?<description>.+)?$/im', $context->comment, $varMatches)) {
+            if (preg_match('/@var\s+(?<type>[^\s]+)([ \t])?(?<description>.+)?$/im', (string) $context->comment, $varMatches)) {
                 if ($property->description === null && isset($varMatches['description'])) {
                     $property->description = trim($varMatches['description']);
                 }


### PR DESCRIPTION
This is to fix the deprecations with php 8.1
```
php.INFO: Deprecated: preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated {"exception":"[object] (ErrorException(code: 0): Deprecated: preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated at /vendor/zircote/swagger-php/src/Processors/AugmentProperties.php:61)"} []
```
```
php.INFO: Deprecated: preg_split(): Passing null to parameter #2 ($subject) of type string is deprecated {"exception":"[object] (ErrorException(code: 0): Deprecated: preg_split(): Passing null to parameter #2 ($subject) of type string is deprecated at /vendor/zircote/swagger-php/src/Context.php:212)"} []
```