### PR TITLE
[PHP 8.2] Fix `${var}` string interpolation deprecation

### DIFF
--- a/tests/Fixtures/PHP/AnonymousFunctions.php
+++ b/tests/Fixtures/PHP/AnonymousFunctions.php
@@ -59,14 +59,14 @@ class AnonymousFunctions
 
     public function dollarCurly1(string $key = 'xx')
     {
-        preg_replace("/:${key}/", 'y', 'abx');
+        preg_replace("/:{$key}/", 'y', 'abx');
 
         $this->shortFn();
     }
 
     public function dollarCurly2(string $key = 'xx')
     {
-        preg_replace("/:${key}/", 'y', 'abx');
+        preg_replace("/:{$key}/", 'y', 'abx');
 
         array_map(static function ($issue) use ($key) {
             return $issue;


### PR DESCRIPTION
PHP 8.2 deprecates `"${var}"` string interpolation pattern.
This fixes all two of such occurrences in `zircote/swagger-php` package.

 - [PHP 8.2: `${var}` string interpolation deprecated](https://php.watch/versions/8.2/${var}-string-interpolation-deprecated)
 - [RFC](https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation)