### PR TITLE
Do not return annotations merged into an explicit parent in AttributeAnnotationFactory

### DIFF
--- a/src/Analysers/AttributeAnnotationFactory.php
+++ b/src/Analysers/AttributeAnnotationFactory.php
@@ -120,22 +120,27 @@ class AttributeAnnotationFactory implements AnnotationFactoryInterface
             return get_class($annotation) != get_class($possibleParent)
                 && ($explicitParent || ($isAttachable && $isParentAllowed));
         };
+
+        $annotationsWithoutParent = [];
         foreach ($annotations as $index => $annotation) {
+            $mergedIntoParent = false;
+
             for ($ii = 0; $ii < count($annotations); ++$ii) {
                 if ($ii === $index) {
                     continue;
                 }
                 $possibleParent = $annotations[$ii];
                 if ($isParent($annotation, $possibleParent)) {
+                    $mergedIntoParent = true; //
                     $possibleParent->merge([$annotation]);
                 }
             }
+
+            if (!$mergedIntoParent) {
+                $annotationsWithoutParent[] = $annotation;
+            }
         }
 
-        $annotations = array_filter($annotations, function ($a) {
-            return !$a instanceof Attachable;
-        });
-
-        return $annotations;
+        return $annotationsWithoutParent;
     }
 }


### PR DESCRIPTION
I was looking for a solution to fix https://github.com/nelmio/NelmioApiDocBundle/issues/1993 (explanation of root issue in https://github.com/zircote/swagger-php/issues/1220#issuecomment-1116895871), and I couldn't find an easy one from NelmioApiDocBundle without duplicating a lot of code and making things more likely to break later.

I believe the best solution would be to not return annotations that are already merged in `AttributeAnnotationFactory` so that these may not be merged again later.
This should have no repercussion on zircote/swagger-php internals as attributes returned by `AttributeAnnotationFactory` are passed to `Analysis::addAnnotations` which visits recursively passed annotations and so is able to find merged attributes from their newly defined parents.

What do you think? Would that be an acceptable fix for you? 