### PR TITLE
Fix Schema inheritance issue.

### DIFF
--- a/src/Analysis.php
+++ b/src/Analysis.php
@@ -7,7 +7,6 @@
 namespace OpenApi;
 
 use OpenApi\Annotations as OA;
-use OpenApi\Attributes as OAT;
 
 /**
  * Result of the analyser.
@@ -338,7 +337,7 @@ class Analysis
                 $definition = $definitions[$fqdn];
                 if (is_iterable($definition['context']->annotations)) {
                     foreach (array_reverse($definition['context']->annotations) as $annotation) {
-                        if (in_array(get_class($annotation), [OA\Schema::class, OAT\Schema::class]) && !$annotation->_aux) {
+                        if (($annotation instanceof OA\Schema) && !$annotation->_aux) {
                             return $annotation;
                         }
                     }


### PR DESCRIPTION
Fix issue described in https://github.com/zircote/swagger-php/issues/1311#issuecomment-1252435696

> > 
> 
> it doesn't have #[\OA\Schema] but it have an extended Attribute :
> 
> ```
> #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
> class ApiExceptionAttribute extends \OpenApi\Attributes\Schema
> {}
> 
> 
> #[ApiExceptionAttribute]
> class Class{}
> ```
> 
> It doesn't work when I do it like this. Using "type" works only if I use directly `\OpenApi\Attributes\Schema`
