### PR TITLE
Allow enums to be specified with an enum array

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ docs/node_modules/
 docs/package-lock.json
 scratch/
 vendor/
+.idea/

--- a/README.md
+++ b/README.md
@@ -129,6 +129,11 @@ and [PHP-CS-Fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer) (PSR-2) tests.
 composer test
 ```
 
+### To run static-analysis execute:
+```bash
+composer analyse
+```
+
 ### Running unit tests only:
 ```bash
 ./bin/phpunit

--- a/docs/reference/annotations.md
+++ b/docs/reference/annotations.md
@@ -940,7 +940,7 @@ Default value is csv.</p></dd>
   <dd><p>No details available.</p><p><i>See</i>: <a href="http://json-schema.org/latest/json-schema-validation.html#anchor45">JSON schema validation</a></p></dd>
   <dt><strong>uniqueItems</strong> : <span style="font-family: monospace;">bool</span></dt>
   <dd><p>No details available.</p><p><i>See</i>: <a href="http://json-schema.org/latest/json-schema-validation.html#anchor49">JSON schema validation</a></p></dd>
-  <dt><strong>enum</strong> : <span style="font-family: monospace;">string[]|int[]|float[]|class-string</span></dt>
+  <dt><strong>enum</strong> : <span style="font-family: monospace;">string[]|int[]|float[]|\UnitEnum[]|class-string</span></dt>
   <dd><p>No details available.</p><p><i>See</i>: <a href="http://json-schema.org/latest/json-schema-validation.html#anchor76">JSON schema validation</a></p></dd>
   <dt><strong>multipleOf</strong> : <span style="font-family: monospace;">int|float</span></dt>
   <dd><p>A numeric instance is valid against "multipleOf" if the result of the division of the instance by this<br />
@@ -1092,7 +1092,7 @@ An object representing a server variable for server URL template substitution.
 <dl>
   <dt><strong>serverVariable</strong> : <span style="font-family: monospace;">string</span></dt>
   <dd><p>The key into Server->variables array.</p></dd>
-  <dt><strong>enum</strong> : <span style="font-family: monospace;">string[]|int[]|float[]|class-string</span></dt>
+  <dt><strong>enum</strong> : <span style="font-family: monospace;">string[]|int[]|float[]|\UnitEnum[]|class-string</span></dt>
   <dd><p>An enumeration of values to be used if the substitution options are from a limited set.</p></dd>
   <dt><strong>default</strong> : <span style="font-family: monospace;">string</span></dt>
   <dd><p>The default value to use for substitution, and to send, if an alternate value is not supplied.<br />

--- a/docs/reference/attributes.md
+++ b/docs/reference/attributes.md
@@ -64,7 +64,7 @@ In addition to this page, there are also a number of [examples](https://github.c
   <dd><p>No details available.</p></dd>
   <dt><strong>pattern</strong> : <span style="font-family: monospace;">string|null</span></dt>
   <dd><p>No details available.</p></dd>
-  <dt><strong>enum</strong> : <span style="font-family: monospace;">string[]|int[]|float[]|class-string</span></dt>
+  <dt><strong>enum</strong> : <span style="font-family: monospace;">string[]|int[]|float[]|\UnitEnum[]|class-string</span></dt>
   <dd><p>No details available.</p></dd>
   <dt><strong>discriminator</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Discriminator|null</span></dt>
   <dd><p>No details available.</p></dd>
@@ -555,7 +555,7 @@ In addition to this page, there are also a number of [examples](https://github.c
   <dd><p>No details available.</p></dd>
   <dt><strong>pattern</strong> : <span style="font-family: monospace;">string|null</span></dt>
   <dd><p>No details available.</p></dd>
-  <dt><strong>enum</strong> : <span style="font-family: monospace;">string[]|int[]|float[]|class-string</span></dt>
+  <dt><strong>enum</strong> : <span style="font-family: monospace;">string[]|int[]|float[]|\UnitEnum[]|class-string</span></dt>
   <dd><p>No details available.</p></dd>
   <dt><strong>discriminator</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Discriminator|null</span></dt>
   <dd><p>No details available.</p></dd>
@@ -642,7 +642,7 @@ In addition to this page, there are also a number of [examples](https://github.c
   <dd><p>No details available.</p></dd>
   <dt><strong>pattern</strong> : <span style="font-family: monospace;">string|null</span></dt>
   <dd><p>No details available.</p></dd>
-  <dt><strong>enum</strong> : <span style="font-family: monospace;">string[]|int[]|float[]|class-string</span></dt>
+  <dt><strong>enum</strong> : <span style="font-family: monospace;">string[]|int[]|float[]|\UnitEnum[]|class-string</span></dt>
   <dd><p>No details available.</p></dd>
   <dt><strong>discriminator</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Discriminator|null</span></dt>
   <dd><p>No details available.</p></dd>
@@ -1137,7 +1137,7 @@ In addition to this page, there are also a number of [examples](https://github.c
   <dd><p>No details available.</p></dd>
   <dt><strong>pattern</strong> : <span style="font-family: monospace;">string|null</span></dt>
   <dd><p>No details available.</p></dd>
-  <dt><strong>enum</strong> : <span style="font-family: monospace;">string[]|int[]|float[]|class-string</span></dt>
+  <dt><strong>enum</strong> : <span style="font-family: monospace;">string[]|int[]|float[]|\UnitEnum[]|class-string</span></dt>
   <dd><p>No details available.</p></dd>
   <dt><strong>discriminator</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Discriminator|null</span></dt>
   <dd><p>No details available.</p></dd>
@@ -1337,7 +1337,7 @@ In addition to this page, there are also a number of [examples](https://github.c
   <dd><p>No details available.</p></dd>
   <dt><strong>pattern</strong> : <span style="font-family: monospace;">string|null</span></dt>
   <dd><p>No details available.</p></dd>
-  <dt><strong>enum</strong> : <span style="font-family: monospace;">string[]|int[]|float[]|class-string</span></dt>
+  <dt><strong>enum</strong> : <span style="font-family: monospace;">string[]|int[]|float[]|\UnitEnum[]|class-string</span></dt>
   <dd><p>No details available.</p></dd>
   <dt><strong>discriminator</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Discriminator|null</span></dt>
   <dd><p>No details available.</p></dd>
@@ -1460,7 +1460,7 @@ In addition to this page, there are also a number of [examples](https://github.c
   <dd><p>No details available.</p></dd>
   <dt><strong>default</strong> : <span style="font-family: monospace;">string|null</span></dt>
   <dd><p>No details available.</p></dd>
-  <dt><strong>enum</strong> : <span style="font-family: monospace;">string[]|int[]|float[]|class-string|null</span></dt>
+  <dt><strong>enum</strong> : <span style="font-family: monospace;">string[]|int[]|float[]|\UnitEnum[]|class-string|null</span></dt>
   <dd><p>No details available.</p></dd>
   <dt><strong>variables</strong> : <span style="font-family: monospace;">array|null</span></dt>
   <dd><p>No details available.</p></dd>
@@ -1630,7 +1630,7 @@ In addition to this page, there are also a number of [examples](https://github.c
   <dd><p>No details available.</p></dd>
   <dt><strong>pattern</strong> : <span style="font-family: monospace;">string|null</span></dt>
   <dd><p>No details available.</p></dd>
-  <dt><strong>enum</strong> : <span style="font-family: monospace;">string[]|int[]|float[]|class-string</span></dt>
+  <dt><strong>enum</strong> : <span style="font-family: monospace;">string[]|int[]|float[]|\UnitEnum[]|class-string</span></dt>
   <dd><p>No details available.</p></dd>
   <dt><strong>discriminator</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Discriminator|null</span></dt>
   <dd><p>No details available.</p></dd>

--- a/src/Annotations/Schema.php
+++ b/src/Annotations/Schema.php
@@ -201,7 +201,7 @@ class Schema extends AbstractAnnotation
     /**
      * @see [JSON schema validation](http://json-schema.org/latest/json-schema-validation.html#anchor76)
      *
-     * @var string[]|int[]|float[]|class-string
+     * @var string[]|int[]|float[]|\UnitEnum[]|class-string
      */
     public $enum = Generator::UNDEFINED;
 

--- a/src/Annotations/ServerVariable.php
+++ b/src/Annotations/ServerVariable.php
@@ -27,7 +27,7 @@ class ServerVariable extends AbstractAnnotation
     /**
      * An enumeration of values to be used if the substitution options are from a limited set.
      *
-     * @var string[]|int[]|float[]|class-string
+     * @var string[]|int[]|float[]|\UnitEnum[]|class-string
      */
     public $enum = Generator::UNDEFINED;
 

--- a/src/Attributes/AdditionalProperties.php
+++ b/src/Attributes/AdditionalProperties.php
@@ -12,16 +12,16 @@ use OpenApi\Generator;
 class AdditionalProperties extends \OpenApi\Annotations\AdditionalProperties
 {
     /**
-     * @param string[]                                  $required
-     * @param Property[]                                $properties
-     * @param int|float                                 $maximum
-     * @param int|float                                 $minimum
-     * @param string[]|int[]|float[]|class-string       $enum
-     * @param array<Schema|\OpenApi\Annotations\Schema> $allOf
-     * @param array<Schema|\OpenApi\Annotations\Schema> $anyOf
-     * @param array<Schema|\OpenApi\Annotations\Schema> $oneOf
-     * @param array<string,mixed>|null                  $x
-     * @param Attachable[]|null                         $attachables
+     * @param string[]                                        $required
+     * @param Property[]                                      $properties
+     * @param int|float                                       $maximum
+     * @param int|float                                       $minimum
+     * @param string[]|int[]|float[]|\UnitEnum[]|class-string $enum
+     * @param array<Schema|\OpenApi\Annotations\Schema>       $allOf
+     * @param array<Schema|\OpenApi\Annotations\Schema>       $anyOf
+     * @param array<Schema|\OpenApi\Annotations\Schema>       $oneOf
+     * @param array<string,mixed>|null                        $x
+     * @param Attachable[]|null                               $attachables
      */
     public function __construct(
         // schema

--- a/src/Attributes/Items.php
+++ b/src/Attributes/Items.php
@@ -12,16 +12,16 @@ use OpenApi\Generator;
 class Items extends \OpenApi\Annotations\Items
 {
     /**
-     * @param string[]                                  $required
-     * @param Property[]                                $properties
-     * @param int|float                                 $maximum
-     * @param int|float                                 $minimum
-     * @param string[]|int[]|float[]|class-string       $enum
-     * @param array<Schema|\OpenApi\Annotations\Schema> $allOf
-     * @param array<Schema|\OpenApi\Annotations\Schema> $anyOf
-     * @param array<Schema|\OpenApi\Annotations\Schema> $oneOf
-     * @param array<string,mixed>|null                  $x
-     * @param Attachable[]|null                         $attachables
+     * @param string[]                                        $required
+     * @param Property[]                                      $properties
+     * @param int|float                                       $maximum
+     * @param int|float                                       $minimum
+     * @param string[]|int[]|float[]|\UnitEnum[]|class-string $enum
+     * @param array<Schema|\OpenApi\Annotations\Schema>       $allOf
+     * @param array<Schema|\OpenApi\Annotations\Schema>       $anyOf
+     * @param array<Schema|\OpenApi\Annotations\Schema>       $oneOf
+     * @param array<string,mixed>|null                        $x
+     * @param Attachable[]|null                               $attachables
      */
     public function __construct(
         // schema

--- a/src/Attributes/JsonContent.php
+++ b/src/Attributes/JsonContent.php
@@ -12,17 +12,17 @@ use OpenApi\Generator;
 class JsonContent extends \OpenApi\Annotations\JsonContent
 {
     /**
-     * @param array<string,Examples>                    $examples
-     * @param string[]                                  $required
-     * @param Property[]                                $properties
-     * @param int|float                                 $maximum
-     * @param int|float                                 $minimum
-     * @param string[]|int[]|float[]|class-string       $enum
-     * @param array<Schema|\OpenApi\Annotations\Schema> $allOf
-     * @param array<Schema|\OpenApi\Annotations\Schema> $anyOf
-     * @param array<Schema|\OpenApi\Annotations\Schema> $oneOf
-     * @param array<string,mixed>|null                  $x
-     * @param Attachable[]|null                         $attachables
+     * @param array<string,Examples>                          $examples
+     * @param string[]                                        $required
+     * @param Property[]                                      $properties
+     * @param int|float                                       $maximum
+     * @param int|float                                       $minimum
+     * @param string[]|int[]|float[]|\UnitEnum[]|class-string $enum
+     * @param array<Schema|\OpenApi\Annotations\Schema>       $allOf
+     * @param array<Schema|\OpenApi\Annotations\Schema>       $anyOf
+     * @param array<Schema|\OpenApi\Annotations\Schema>       $oneOf
+     * @param array<string,mixed>|null                        $x
+     * @param Attachable[]|null                               $attachables
      */
     public function __construct(
         ?array $examples = null,

--- a/src/Attributes/Property.php
+++ b/src/Attributes/Property.php
@@ -12,16 +12,16 @@ use OpenApi\Generator;
 class Property extends \OpenApi\Annotations\Property
 {
     /**
-     * @param string[]                                  $required
-     * @param Property[]                                $properties
-     * @param int|float                                 $maximum
-     * @param int|float                                 $minimum
-     * @param string[]|int[]|float[]|class-string       $enum
-     * @param array<Schema|\OpenApi\Annotations\Schema> $allOf
-     * @param array<Schema|\OpenApi\Annotations\Schema> $anyOf
-     * @param array<Schema|\OpenApi\Annotations\Schema> $oneOf
-     * @param array<string,mixed>|null                  $x
-     * @param Attachable[]|null                         $attachables
+     * @param string[]                                        $required
+     * @param Property[]                                      $properties
+     * @param int|float                                       $maximum
+     * @param int|float                                       $minimum
+     * @param string[]|int[]|float[]|\UnitEnum[]|class-string $enum
+     * @param array<Schema|\OpenApi\Annotations\Schema>       $allOf
+     * @param array<Schema|\OpenApi\Annotations\Schema>       $anyOf
+     * @param array<Schema|\OpenApi\Annotations\Schema>       $oneOf
+     * @param array<string,mixed>|null                        $x
+     * @param Attachable[]|null                               $attachables
      */
     public function __construct(
         ?string $property = null,

--- a/src/Attributes/Schema.php
+++ b/src/Attributes/Schema.php
@@ -12,17 +12,17 @@ use OpenApi\Generator;
 class Schema extends \OpenApi\Annotations\Schema
 {
     /**
-     * @param string[]                                  $required
-     * @param Property[]                                $properties
-     * @param int|float                                 $maximum
-     * @param int|float                                 $minimum
-     * @param string[]|int[]|float[]|class-string       $enum
-     * @param array<Schema|\OpenApi\Annotations\Schema> $allOf
-     * @param array<Schema|\OpenApi\Annotations\Schema> $anyOf
-     * @param array<Schema|\OpenApi\Annotations\Schema> $oneOf
-     * @param mixed                                     $const
-     * @param array<string,mixed>|null                  $x
-     * @param Attachable[]|null                         $attachables
+     * @param string[]                                        $required
+     * @param Property[]                                      $properties
+     * @param int|float                                       $maximum
+     * @param int|float                                       $minimum
+     * @param string[]|int[]|float[]|\UnitEnum[]|class-string $enum
+     * @param array<Schema|\OpenApi\Annotations\Schema>       $allOf
+     * @param array<Schema|\OpenApi\Annotations\Schema>       $anyOf
+     * @param array<Schema|\OpenApi\Annotations\Schema>       $oneOf
+     * @param mixed                                           $const
+     * @param array<string,mixed>|null                        $x
+     * @param Attachable[]|null                               $attachables
      */
     public function __construct(
         // schema

--- a/src/Attributes/ServerVariable.php
+++ b/src/Attributes/ServerVariable.php
@@ -12,9 +12,9 @@ use OpenApi\Generator;
 class ServerVariable extends \OpenApi\Annotations\ServerVariable
 {
     /**
-     * @param string[]|int[]|float[]|class-string|null $enum
-     * @param array<string,mixed>|null                 $x
-     * @param Attachable[]|null                        $attachables
+     * @param string[]|int[]|float[]|\UnitEnum[]|class-string|null $enum
+     * @param array<string,mixed>|null                             $x
+     * @param Attachable[]|null                                    $attachables
      */
     public function __construct(
         ?string $serverVariable = null,

--- a/src/Attributes/XmlContent.php
+++ b/src/Attributes/XmlContent.php
@@ -12,17 +12,17 @@ use OpenApi\Generator;
 class XmlContent extends \OpenApi\Annotations\XmlContent
 {
     /**
-     * @param array<string,Examples>                    $examples
-     * @param string[]                                  $required
-     * @param int|float                                 $maximum
-     * @param int|float                                 $minimum
-     * @param Property[]                                $properties
-     * @param string[]|int[]|float[]|class-string       $enum
-     * @param array<Schema|\OpenApi\Annotations\Schema> $allOf
-     * @param array<Schema|\OpenApi\Annotations\Schema> $anyOf
-     * @param array<Schema|\OpenApi\Annotations\Schema> $oneOf
-     * @param array<string,mixed>|null                  $x
-     * @param Attachable[]|null                         $attachables
+     * @param array<string,Examples>                          $examples
+     * @param string[]                                        $required
+     * @param int|float                                       $maximum
+     * @param int|float                                       $minimum
+     * @param Property[]                                      $properties
+     * @param string[]|int[]|float[]|\UnitEnum[]|class-string $enum
+     * @param array<Schema|\OpenApi\Annotations\Schema>       $allOf
+     * @param array<Schema|\OpenApi\Annotations\Schema>       $anyOf
+     * @param array<Schema|\OpenApi\Annotations\Schema>       $oneOf
+     * @param array<string,mixed>|null                        $x
+     * @param Attachable[]|null                               $attachables
      */
     public function __construct(
         ?array $examples = null,

--- a/tests/Fixtures/PHP/ReferencesEnum.php
+++ b/tests/Fixtures/PHP/ReferencesEnum.php
@@ -17,9 +17,12 @@ class ReferencesEnum
     #[Property(title: 'statusEnum', description: 'Status enum', type: 'string', enum: StatusEnum::class, nullable: false)]
     public string $statusEnum;
 
+    #[Property(title: 'statusEnumMixed', description: 'Status enum mixed', type: 'string', enum: [StatusEnum::DRAFT, StatusEnum::ARCHIVED, 'OTHER'], nullable: false)]
+    public string $statusEnumMixed;
+
     /**
      * @OA\Property(title="statusEnumBacked",
-     *     description="Status enum backend",
+     *     description="Status enum backed",
      *     type="int",
      *     enum="\OpenApi\Tests\Fixtures\PHP\StatusEnumBacked",
      *     nullable="false"
@@ -27,18 +30,24 @@ class ReferencesEnum
      */
     public int $statusEnumBacked;
 
-    #[Property(title: 'statusEnumIntegerBacked', description: 'Status enum integer backend', type: 'int', enum: StatusEnumIntegerBacked::class, nullable: true)]
+    #[Property(title: 'statusEnumBackedMixed', description: 'Status enum backed mixed', type: 'int', enum: [StatusEnumBacked::DRAFT, StatusEnumBacked::ARCHIVED, 9], nullable: false)]
+    public int $statusEnumBackedMixed;
+
+    #[Property(title: 'statusEnumIntegerBacked', description: 'Status enum integer backed', type: 'int', enum: StatusEnumIntegerBacked::class, nullable: true)]
     public ?int $statusEnumIntegerBacked;
 
     /**
      * @OA\Property(title="statusEnumStringBacked",
-     *     description="Status enum string backend",
+     *     description="Status enum string backed",
      *     type="string",
      *     enum="\OpenApi\Tests\Fixtures\PHP\StatusEnumStringBacked",
      *     nullable="true"
      * )
      */
     public ?string $statusEnumStringBacked;
+
+    #[Property(title: 'statusEnumStringBackedMixed', description: 'Status enum string backed mixed', type: 'string', enum: [StatusEnumStringBacked::DRAFT, StatusEnumStringBacked::ARCHIVED, 'other'], nullable: true)]
+    public ?string $statusEnumStringBackedMixed;
 
     /** @var list<string> StatusEnumStringBacked array */
     #[Property(
@@ -48,4 +57,13 @@ class ReferencesEnum
         items: new Items(title: 'itemsStatusEnumStringBacked', type: 'string', enum: StatusEnumStringBacked::class)
     )]
     public array $statusEnums;
+
+    /** @var list<string> StatusEnumStringBacked array */
+    #[Property(
+        title: 'statusEnumsMixed',
+        description: 'StatusEnumStringBacked array mixed',
+        type: 'array',
+        items: new Items(title: 'itemsStatusEnumStringBackedMixed', type: 'string', enum: [StatusEnumStringBacked::DRAFT, StatusEnumStringBacked::ARCHIVED, 'other'])
+    )]
+    public array $statusEnumsMixed;
 }

--- a/tests/Processors/ExpandEnumsTest.php
+++ b/tests/Processors/ExpandEnumsTest.php
@@ -72,15 +72,9 @@ class ExpandEnumsTest extends OpenApiTestCase
             return [];
         }
 
-        $mapNames = function (array $enums): array {
-            return array_map(function ($c) {
-                return $c->name;
-            }, $enums);
-        };
-
         $mapValues = function (array $enums): array {
             return array_map(function ($c) {
-                return $c->value;
+                return is_a($c, \UnitEnum::class) ? $c->value ?? $c->name : $c;
             }, $enums);
         };
 
@@ -88,19 +82,38 @@ class ExpandEnumsTest extends OpenApiTestCase
             'statusEnum' => [
                 ['PHP/ReferencesEnum.php'],
                 'statusEnum',
-                $mapNames(StatusEnum::cases()),
+                $mapValues(StatusEnum::cases()),
+            ],
+            'statusEnumMixed' => [
+                ['PHP/ReferencesEnum.php'],
+                'statusEnumMixed',
+                $mapValues([StatusEnum::DRAFT, StatusEnum::ARCHIVED, 'OTHER']),
             ],
             'statusEnumBacked' => [
                 ['PHP/ReferencesEnum.php'],
                 'statusEnumBacked',
                 $mapValues(StatusEnumBacked::cases()),
             ],
+            'statusEnumBackedMixed' => [
+                ['PHP/ReferencesEnum.php'],
+                'statusEnumBackedMixed',
+                $mapValues([StatusEnumBacked::DRAFT, StatusEnumBacked::ARCHIVED, 9]),
+            ],
             'statusEnumIntegerBacked' => [
                 ['PHP/ReferencesEnum.php'],
                 'statusEnumIntegerBacked',
                 $mapValues(StatusEnumIntegerBacked::cases()),
             ],
-            'statusEnumStringBacked' => [['PHP/ReferencesEnum.php'], 'statusEnumStringBacked', $mapValues(StatusEnumStringBacked::cases())],
+            'statusEnumStringBacked' => [
+                ['PHP/ReferencesEnum.php'],
+                'statusEnumStringBacked',
+                $mapValues(StatusEnumStringBacked::cases()),
+            ],
+            'statusEnumStringBackedMixed' => [
+                ['PHP/ReferencesEnum.php'],
+                'statusEnumStringBackedMixed',
+                $mapValues([StatusEnumStringBacked::DRAFT, StatusEnumStringBacked::ARCHIVED, 'other']),
+            ],
             'statusEnums' => [
                 ['PHP/ReferencesEnum.php'],
                 'statusEnums',
@@ -110,6 +123,16 @@ class ExpandEnumsTest extends OpenApiTestCase
                 ['PHP/ReferencesEnum.php'],
                 'itemsStatusEnumStringBacked',
                 $mapValues(StatusEnumStringBacked::cases()),
+            ],
+            'statusEnumsMixed' => [
+                ['PHP/ReferencesEnum.php'],
+                'statusEnumsMixed',
+                Generator::UNDEFINED,
+            ],
+            'itemsStatusEnumStringBackedMixed' => [
+                ['PHP/ReferencesEnum.php'],
+                'itemsStatusEnumStringBackedMixed',
+                $mapValues([StatusEnumStringBacked::DRAFT, StatusEnumStringBacked::ARCHIVED, 'other']),
             ],
         ];
     }


### PR DESCRIPTION
I had the need to show just a subset of an enum

It showed correctly in swaggerui, but phpstan and psalm were throwing errors because I couldn't use a \BackedEnum (in my case) to pass to the $enum property

But when I tried to test it, it didnt have the expected result, so I changed the code a bit to be able to parse enums/strings/etc in an array

I used this commit as a starting place https://github.com/zircote/swagger-php/commit/48a769243b4024f3611ab9e8b137a9720d19a3bb