### PR TITLE
Fix double '\' when handling classes in the global namespace

### DIFF
--- a/src/Analysers/ReflectionAnalyser.php
+++ b/src/Analysers/ReflectionAnalyser.php
@@ -108,7 +108,7 @@ class ReflectionAnalyser implements AnalyserInterface
             'context' => $context,
         ];
         $normaliseClass = function (string $name): string {
-            return '\\' . $name;
+            return '\\' . ltrim($name, '\\');
         };
         if ($parentClass = $rc->getParentClass()) {
             $definition['extends'] = $normaliseClass($parentClass->getName());


### PR DESCRIPTION
Fixes an edge case of handling class/trait/interface names in the global namespace where names end up with double leading '\'.

Fixes #1324