### PR TITLE
Allow to specify a `before` processor classname when adding a new pro…

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -298,10 +298,25 @@ class Generator
         return $this;
     }
 
-    public function addProcessor(callable $processor): Generator
+    /**
+     * @param class-string|null $before
+     */
+    public function addProcessor(callable $processor, ?string $before = null): Generator
     {
         $processors = $this->getProcessors();
-        $processors[] = $processor;
+        if (!$before) {
+            $processors[] = $processor;
+        } else {
+            $tmp = [];
+            foreach ($processors as $current) {
+                if ($current instanceof $before) {
+                    $tmp[] = $processor;
+                }
+                $tmp[] = $current;
+            }
+            $processors = $tmp;
+        }
+
         $this->setProcessors($processors);
 
         return $this;


### PR DESCRIPTION
Add an easy way to add a new processor before another one (based on class name of the `before` processor).