### PR TITLE
Allow `Examples` attribute to be repeatable

### DIFF
--- a/src/Attributes/Examples.php
+++ b/src/Attributes/Examples.php
@@ -8,7 +8,7 @@ namespace OpenApi\Attributes;
 
 use OpenApi\Generator;
 
-#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY | \Attribute::IS_REPEATABLE)]
 class Examples extends \OpenApi\Annotations\Examples
 {
     /**


### PR DESCRIPTION
Fixes #1388