### PR TITLE
TokenScanner: fix handling of named arguments with reserved keywords

### DIFF
--- a/src/Analysers/TokenScanner.php
+++ b/src/Analysers/TokenScanner.php
@@ -50,6 +50,15 @@ class TokenScanner
         };
 
         while (false !== ($token = $this->nextToken($tokens))) {
+            // named arguments
+            $nextToken = $this->nextToken($tokens);
+            if ($nextToken === ':' || $nextToken === false) {
+                continue;
+            }
+            do {
+                $prevToken = prev($tokens);
+            } while ($token !== $prevToken);
+
             if (!is_array($token)) {
                 switch ($token) {
                     case '{':
@@ -197,14 +206,13 @@ class TokenScanner
             $lastToken = $token;
         }
 
-        /* @phpstan-ignore-next-line */
         return $units;
     }
 
     /**
      * Get the next token that is not whitespace or comment.
      *
-     * @return string|array
+     * @return string|array|false
      */
     protected function nextToken(array &$tokens)
     {
@@ -368,7 +376,6 @@ class TokenScanner
             }
         }
 
-        /* @phpstan-ignore-next-line */
         return $properties;
     }
 }

--- a/tests/Analysers/TokenScannerTest.php
+++ b/tests/Analysers/TokenScannerTest.php
@@ -144,22 +144,6 @@ class TokenScannerTest extends OpenApiTestCase
                     'methods' => ['foo', 'bar'],
                     'properties' => [],
                 ],
-                'OpenApi\\Tests\\Fixtures\\PHP\\ReservedWordsAttr' => [
-                    'uses' => [],
-                    'interfaces' => [],
-                    'traits' => [],
-                    'enums' => [],
-                    'methods' => ['__construct'],
-                    'properties' => [],
-                ],
-                'OpenApi\\Tests\\Fixtures\\PHP\\UserlandClass' => [
-                    'uses' => [],
-                    'interfaces' => [],
-                    'traits' => [],
-                    'enums' => [],
-                    'methods' => [],
-                    'properties' => [],
-                ],
             ],
         ];
 
@@ -264,6 +248,26 @@ class TokenScannerTest extends OpenApiTestCase
                     'traits' => [],
                     'enums' => [],
                     'methods' => ['useFoo', 'foo'],
+                    'properties' => [],
+                ],
+                'OpenApi\\Tests\\Fixtures\\PHP\\ReservedWordsAttr' => [
+                    'uses' => [
+                        'OA' => 'OpenApi\Annotations',
+                    ],
+                    'interfaces' => [],
+                    'traits' => [],
+                    'enums' => [],
+                    'methods' => ['__construct'],
+                    'properties' => [],
+                ],
+                'OpenApi\\Tests\\Fixtures\\PHP\\UserlandClass' => [
+                    'uses' => [
+                        'OA' => 'OpenApi\Annotations',
+                    ],
+                    'interfaces' => [],
+                    'traits' => [],
+                    'enums' => [],
+                    'methods' => [],
                     'properties' => [],
                 ],
             ],

--- a/tests/Analysers/TokenScannerTest.php
+++ b/tests/Analysers/TokenScannerTest.php
@@ -144,6 +144,22 @@ class TokenScannerTest extends OpenApiTestCase
                     'methods' => ['foo', 'bar'],
                     'properties' => [],
                 ],
+                'OpenApi\\Tests\\Fixtures\\PHP\\ReservedWordsAttr' => [
+                    'uses' => [],
+                    'interfaces' => [],
+                    'traits' => [],
+                    'enums' => [],
+                    'methods' => ['__construct'],
+                    'properties' => [],
+                ],
+                'OpenApi\\Tests\\Fixtures\\PHP\\UserlandClass' => [
+                    'uses' => [],
+                    'interfaces' => [],
+                    'traits' => [],
+                    'enums' => [],
+                    'methods' => [],
+                    'properties' => [],
+                ],
             ],
         ];
 

--- a/tests/Fixtures/PHP/Php8NamedArguments.php
+++ b/tests/Fixtures/PHP/Php8NamedArguments.php
@@ -22,3 +22,33 @@ class Php8NamedArguments
     {
     }
 }
+
+#[\Attribute]
+class ReservedWordsAttr
+{
+    public function __construct(
+        $abstract = null,
+        $namespace = null,
+        $use = null,
+        $class = null,
+        $interface = null,
+        $extends = null,
+        $implements = null,
+        $function = null
+    ) {
+    }
+}
+
+#[ReservedWordsAttr(
+    abstract: 'example',            // No space
+    namespace : 'example',          // One space
+    use /* comment */ : 'example',  // Comment
+    class : 'example',
+    interface : 'example',
+    extends : 'example',
+    implements : 'example',
+    function : 'example'
+)]
+class UserlandClass
+{
+}

--- a/tests/Fixtures/PHP/php8.php
+++ b/tests/Fixtures/PHP/php8.php
@@ -31,3 +31,33 @@ class Decorated
     {
     }
 }
+
+#[\Attribute]
+class ReservedWordsAttr
+{
+    public function __construct(
+        $abstract = null,
+        $namespace = null,
+        $use = null,
+        $class = null,
+        $interface = null,
+        $extends = null,
+        $implements = null,
+        $function = null
+    ) {
+    }
+}
+
+#[ReservedWordsAttr(
+    abstract: 'example',            // No space
+    namespace : 'example',          // One space
+    use /* comment */ : 'example',  // Comment
+    class : 'example',
+    interface : 'example',
+    extends : 'example',
+    implements : 'example',
+    function : 'example'
+)]
+class UserlandClass
+{
+}

--- a/tests/Fixtures/PHP/php8.php
+++ b/tests/Fixtures/PHP/php8.php
@@ -31,33 +31,3 @@ class Decorated
     {
     }
 }
-
-#[\Attribute]
-class ReservedWordsAttr
-{
-    public function __construct(
-        $abstract = null,
-        $namespace = null,
-        $use = null,
-        $class = null,
-        $interface = null,
-        $extends = null,
-        $implements = null,
-        $function = null
-    ) {
-    }
-}
-
-#[ReservedWordsAttr(
-    abstract: 'example',            // No space
-    namespace : 'example',          // One space
-    use /* comment */ : 'example',  // Comment
-    class : 'example',
-    interface : 'example',
-    extends : 'example',
-    implements : 'example',
-    function : 'example'
-)]
-class UserlandClass
-{
-}


### PR DESCRIPTION
Reserved keywords such as `class` are legit for named arguments.
Without this fix I get the following error:

```
Message: Uninitialized string offset 1

Class: ErrorException
Code: E_WARNING
File: ./vendor/zircote/swagger-php/src/Analysers/TokenScanner.php:119
```