### PR TITLE
Use `AbstractAnnotation::isRoot()` as strict check in `Analysis::getAnnotationsOfType()`

### DIFF
--- a/src/Analysis.php
+++ b/src/Analysis.php
@@ -297,28 +297,22 @@ class Analysis
     }
 
     /**
-     * @param string|array $classes One ore more class names
-     * @param bool         $strict  in non-strict mode child classes are also detected
+     * @param class-string|array<class-string> $classes one or more class names
+     * @param bool                             $strict  in non-strict mode child classes are also detected
      *
      * @return OA\AbstractAnnotation[]
      */
     public function getAnnotationsOfType($classes, bool $strict = false): array
     {
+        $unique = new \SplObjectStorage();
         $annotations = [];
-        if ($strict) {
-            foreach ((array) $classes as $class) {
-                foreach ($this->annotations as $annotation) {
-                    if (get_class($annotation) === $class) {
-                        $annotations[] = $annotation;
-                    }
-                }
-            }
-        } else {
-            foreach ((array) $classes as $class) {
-                foreach ($this->annotations as $annotation) {
-                    if ($annotation instanceof $class) {
-                        $annotations[] = $annotation;
-                    }
+
+        foreach ((array) $classes as $class) {
+            /** @var OA\AbstractAnnotation $annotation */
+            foreach ($this->annotations as $annotation) {
+                if ($annotation instanceof $class && (!$strict || ($annotation->isRoot($class) && !$unique->contains($annotation)))) {
+                    $unique->attach($annotation);
+                    $annotations[] = $annotation;
                 }
             }
         }

--- a/tests/Fixtures/Scratch/AttributeInheritance.php
+++ b/tests/Fixtures/Scratch/AttributeInheritance.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Scratch;
+
+use OpenApi\Attributes as OAT;
+
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY)]
+class AttributeInheritanceSchema extends OAT\Schema
+{
+}
+
+#[OAT\Schema]
+class Base
+{
+    #[OAT\Property]
+    public int $id;
+}
+
+#[AttributeInheritanceSchema]
+class Child1 extends Base
+{
+    #[OAT\Property]
+    public string $name;
+}
+
+#[OAT\Schema]
+class Child2 extends Base
+{
+    #[OAT\Property]
+    public string $title;
+}
+
+#[OAT\Info(
+    title: 'Attribute Inheritance Scratch',
+    version: '1.0'
+)]
+#[OAT\Get(
+    path: '/api/endpoint',
+    description: 'An endpoint',
+    responses: [new OAT\Response(response: 200, description: 'OK')]
+)]
+class AttributeInheritanceEndpoint
+{
+}

--- a/tests/Fixtures/Scratch/AttributeInheritance.yaml
+++ b/tests/Fixtures/Scratch/AttributeInheritance.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.0
+info:
+  title: 'Attribute Inheritance Scratch'
+  version: '1.0'
+paths:
+  /api/endpoint:
+    get:
+      description: 'An endpoint'
+      responses:
+        '200':
+          description: OK
+components:
+  schemas:
+    Base:
+      properties:
+        id:
+          type: integer
+      type: object
+    Child1:
+      type: object
+      allOf:
+        -
+          $ref: '#/components/schemas/Base'
+        -
+          properties:
+            name:
+              type: string
+    Child2:
+      type: object
+      allOf:
+        -
+          $ref: '#/components/schemas/Base'
+        -
+          properties:
+            title:
+              type: string


### PR DESCRIPTION
Fixes #1424
