### PR TITLE
Removed error catching on invalid attributes

### DIFF
--- a/src/Analysers/AttributeAnnotationFactory.php
+++ b/src/Analysers/AttributeAnnotationFactory.php
@@ -38,13 +38,13 @@ class AttributeAnnotationFactory implements AnnotationFactoryInterface
         $annotations = [];
         try {
             foreach ($reflector->getAttributes() as $attribute) {
-                try {
+                if (class_exists($attribute->getName())) {
                     $instance = $attribute->newInstance();
                     if ($instance instanceof OA\AbstractAnnotation) {
                         $annotations[] = $instance;
                     }
-                } catch (\Error $e) {
-                    $context->logger->debug('Could not instantiate attribute: ' . $e->getMessage(), ['exception' => $e]);
+                } else {
+                    $context->logger->debug(sprintf('Could not instantiate attribute "%s", because class not found.', $attribute->getName()));
                 }
             }
 

--- a/tests/Analysers/AttributeAnnotationFactoryTest.php
+++ b/tests/Analysers/AttributeAnnotationFactoryTest.php
@@ -8,6 +8,7 @@ namespace OpenApi\Tests\Analysers;
 
 use OpenApi\Analysers\AttributeAnnotationFactory;
 use OpenApi\Tests\Fixtures\UsingAttributes;
+use OpenApi\Tests\Fixtures\InvalidPropertyAttribute;
 use OpenApi\Tests\OpenApiTestCase;
 
 /**
@@ -21,5 +22,16 @@ class AttributeAnnotationFactoryTest extends OpenApiTestCase
 
         $annotations = (new AttributeAnnotationFactory())->build($rc, $this->getContext());
         $this->assertCount(1, $annotations);
+    }
+
+    public function testErrorOnInvalidAttribute(): void
+    {
+        $instance = new InvalidPropertyAttribute();
+        $rm = new \ReflectionMethod($instance, 'post');
+
+        $this->expectException(\TypeError::class);
+        $this->expectExceptionMessage('OpenApi\Attributes\Property::__construct(): Argument #8 ($required) must be of type ?array, bool given');
+
+        (new AttributeAnnotationFactory())->build($rm, $this->getContext());
     }
 }

--- a/tests/Fixtures/InvalidPropertyAttribute.php
+++ b/tests/Fixtures/InvalidPropertyAttribute.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures;
+
+use OpenApi\Attributes as OA;
+
+class InvalidPropertyAttribute
+{
+    #[OA\Property(required: true)] // required has to be array or null
+    public function post()
+    {
+    }
+}


### PR DESCRIPTION
The error catching in the `AttributeAnnotationFactory` made it hard to find the reason for "ignored" attributes. This change addresses the issues #1267 and #1162.

Instead of catching errors of non existing attribute classes, the existence of the class is checked before the attribute is tried to instantiate. This reveals invalid attribute definitions, but still errors for unknown attributes won't be shown.