### PR TITLE
Fix lost type 'object' when create new allOfPropertiesSchema

### DIFF
--- a/src/Processors/AugmentSchemas.php
+++ b/src/Processors/AugmentSchemas.php
@@ -131,6 +131,7 @@ class AugmentSchemas implements ProcessorInterface
                 }
                 if (!$allOfPropertiesSchema) {
                     $allOfPropertiesSchema = new OA\Schema([
+                        'type'       => 'object',                                   
                         'properties' => [],
                         '_context' => new Context(['generated' => true], $schema->_context),
                     ]);


### PR DESCRIPTION
When merge allOf,  a new schema "allOfPropertiesSchema" will be created, but this schema lost ”type“ property. This not feed the rules, and will cause some question when I use generate tool to create web api code which based the result json.