### PR TITLE
Support Multiple Enums class-names in Schema::enum property

### DIFF
--- a/src/Processors/ExpandEnums.php
+++ b/src/Processors/ExpandEnums.php
@@ -79,7 +79,19 @@ class ExpandEnums implements ProcessorInterface
             } else {
                 // might be an array of \UnitEnum::class, string, int, etc...
                 assert(is_array($schema->enum));
-                $cases = $schema->enum;
+
+                $cases = [];
+
+                // transform each Enum cases into UnitEnum
+                foreach ($schema->enum as $enum) {
+                    if (is_a($enum, \UnitEnum::class, true)) {
+                        foreach ($enum::cases() as $case) {
+                            $cases[] = $case;
+                        }
+                    } else {
+                        $cases[] = $enum;
+                    }
+                }
             }
 
             $enums = [];

--- a/src/Processors/ExpandEnums.php
+++ b/src/Processors/ExpandEnums.php
@@ -84,7 +84,7 @@ class ExpandEnums implements ProcessorInterface
 
                 // transform each Enum cases into UnitEnum
                 foreach ($schema->enum as $enum) {
-                    if (is_a($enum, \UnitEnum::class, true)) {
+                    if (is_string($enum) && enum_exists($enum)) {
                         foreach ($enum::cases() as $case) {
                             $cases[] = $case;
                         }

--- a/tests/Fixtures/PHP/Enums/TypeEnumStringBacked.php
+++ b/tests/Fixtures/PHP/Enums/TypeEnumStringBacked.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\PHP\Enums;
+
+use OpenApi\Attributes as OAT;
+
+#[OAT\Schema(type: 'string')]
+enum TypeEnumStringBacked: string
+{
+    case FEATURE = 'feature';
+    case BUG = 'bug';
+    case IMPROVEMENT = 'improvement';
+}

--- a/tests/Fixtures/PHP/ReferencesEnum.php
+++ b/tests/Fixtures/PHP/ReferencesEnum.php
@@ -56,17 +56,17 @@ class ReferencesEnum
         title: 'multipleEnumsClassNames',
         description: 'MultipleEnumsClassNames array',
         type: 'string',
-        enum: [StatusEnumIntegerBacked::class, TypeEnumStringBacked::class],
+        enum: [StatusEnumStringBacked::class, TypeEnumStringBacked::class],
     )]
-    public array $multipleEnumsClassNames;
+    public string $multipleEnumsClassNames;
 
     #[OAT\Property(
         title: 'mixedMultipleEnumsClassNames',
         description: 'MultipleEnumsClassNames array',
         type: 'string',
-        enum: [StatusEnumIntegerBacked::class, TypeEnumStringBacked::class, 'OTHER'],
+        enum: [StatusEnumStringBacked::class, TypeEnumStringBacked::class, 'OTHER'],
     )]
-    public array $mixedMultipleEnumsClassNames;
+    public string $mixedMultipleEnumsClassNames;
 
     /** @var list<string> StatusEnumStringBacked array */
     #[OAT\Property(

--- a/tests/Fixtures/PHP/ReferencesEnum.php
+++ b/tests/Fixtures/PHP/ReferencesEnum.php
@@ -12,6 +12,7 @@ use OpenApi\Tests\Fixtures\PHP\Enums\StatusEnum;
 use OpenApi\Tests\Fixtures\PHP\Enums\StatusEnumBacked;
 use OpenApi\Tests\Fixtures\PHP\Enums\StatusEnumIntegerBacked;
 use OpenApi\Tests\Fixtures\PHP\Enums\StatusEnumStringBacked;
+use OpenApi\Tests\Fixtures\PHP\Enums\TypeEnumStringBacked;
 
 #[OAT\Schema()]
 class ReferencesEnum
@@ -50,6 +51,23 @@ class ReferencesEnum
 
     #[OAT\Property(title: 'statusEnumStringBackedMixed', description: 'Status enum string backed mixed', type: 'string', enum: [StatusEnumStringBacked::DRAFT, StatusEnumStringBacked::ARCHIVED, 'other'], nullable: true)]
     public ?string $statusEnumStringBackedMixed;
+
+    #[OAT\Property(
+        title: 'multipleEnumsClassNames',
+        description: 'MultipleEnumsClassNames array',
+        type: 'string',
+        enum: [StatusEnumIntegerBacked::class, TypeEnumStringBacked::class],
+    )]
+    public array $multipleEnumsClassNames;
+
+    #[OAT\Property(
+        title: 'mixedMultipleEnumsClassNames',
+        description: 'MultipleEnumsClassNames array',
+        type: 'string',
+        enum: [StatusEnumIntegerBacked::class, TypeEnumStringBacked::class, 'OTHER'],
+    )]
+    public array $mixedMultipleEnumsClassNames;
+
 
     /** @var list<string> StatusEnumStringBacked array */
     #[OAT\Property(

--- a/tests/Fixtures/PHP/ReferencesEnum.php
+++ b/tests/Fixtures/PHP/ReferencesEnum.php
@@ -68,7 +68,6 @@ class ReferencesEnum
     )]
     public array $mixedMultipleEnumsClassNames;
 
-
     /** @var list<string> StatusEnumStringBacked array */
     #[OAT\Property(
         title: 'statusEnums',

--- a/tests/Processors/ExpandEnumsTest.php
+++ b/tests/Processors/ExpandEnumsTest.php
@@ -14,6 +14,7 @@ use OpenApi\Tests\Fixtures\PHP\Enums\StatusEnum;
 use OpenApi\Tests\Fixtures\PHP\Enums\StatusEnumBacked;
 use OpenApi\Tests\Fixtures\PHP\Enums\StatusEnumIntegerBacked;
 use OpenApi\Tests\Fixtures\PHP\Enums\StatusEnumStringBacked;
+use OpenApi\Tests\Fixtures\PHP\Enums\TypeEnumStringBacked;
 use OpenApi\Tests\OpenApiTestCase;
 
 class ExpandEnumsTest extends OpenApiTestCase
@@ -135,6 +136,16 @@ class ExpandEnumsTest extends OpenApiTestCase
                 ['PHP/ReferencesEnum.php'],
                 'itemsStatusEnumStringBackedMixed',
                 $mapValues([StatusEnumStringBacked::DRAFT, StatusEnumStringBacked::ARCHIVED, 'other']),
+            ],
+            'multipleEnumsClassNames' => [
+                ['PHP/ReferencesEnum.php'],
+                'multipleEnumsClassNames',
+                array_merge([StatusEnumStringBacked::cases(), TypeEnumStringBacked::cases()]),
+            ],
+            'mixedMultipleEnumsClassNames' => [
+                ['PHP/ReferencesEnum.php'],
+                'mixedMultipleEnumsClassNames',
+                array_merge([StatusEnumStringBacked::cases(), TypeEnumStringBacked::cases(), 'OTHER']),
             ],
         ];
     }

--- a/tests/Processors/ExpandEnumsTest.php
+++ b/tests/Processors/ExpandEnumsTest.php
@@ -140,12 +140,12 @@ class ExpandEnumsTest extends OpenApiTestCase
             'multipleEnumsClassNames' => [
                 ['PHP/ReferencesEnum.php'],
                 'multipleEnumsClassNames',
-                array_merge([StatusEnumStringBacked::cases(), TypeEnumStringBacked::cases()]),
+                $mapValues(array_merge(StatusEnumStringBacked::cases(), TypeEnumStringBacked::cases())),
             ],
             'mixedMultipleEnumsClassNames' => [
                 ['PHP/ReferencesEnum.php'],
                 'mixedMultipleEnumsClassNames',
-                array_merge([StatusEnumStringBacked::cases(), TypeEnumStringBacked::cases(), 'OTHER']),
+                $mapValues(array_merge(StatusEnumStringBacked::cases(), TypeEnumStringBacked::cases(), ['OTHER'])),
             ],
         ];
     }


### PR DESCRIPTION
The expression:
```php
new OA\Items(description: 'Event name', type: 'string', enum: [
      EnumFoo::class,
      EnumBar::class,
      'random-string',
])
```
will be parsed into:
```yml
items:
  description: 'Event name'
  type: string
  enum:
    - EnumFooCase1
    - EnumFooCase2
    - EnumFooCase3
    - EnumBarCase1
    - EnumBarCase2
    - random-string
```
