### PR TITLE
Fix skip closing curly brace

### DIFF
--- a/src/Analysers/TokenScanner.php
+++ b/src/Analysers/TokenScanner.php
@@ -52,7 +52,7 @@ class TokenScanner
         while (false !== ($token = $this->nextToken($tokens))) {
             // named arguments
             $nextToken = $this->nextToken($tokens);
-            if ($nextToken === ':' || $nextToken === false) {
+            if (($token !== '}' && $nextToken === ':') || $nextToken === false) {
                 continue;
             }
             do {

--- a/tests/Analysers/TokenScannerTest.php
+++ b/tests/Analysers/TokenScannerTest.php
@@ -297,6 +297,25 @@ class TokenScannerTest extends OpenApiTestCase
             ],
         ];
 
+        yield 'CurlyBrace' => [
+            'PHP/MultipleFunctions.php',
+            [
+                'OpenApi\Tests\Fixtures\PHP\MultipleFunctions' => [
+                    'uses' => [
+                        'OA' => 'OpenApi\Annotations',
+                    ],
+                    'interfaces' => [],
+                    'traits' => [],
+                    'enums' => [],
+                    'methods' => [
+                        'first',
+                        'second',
+                    ],
+                    'properties' => [],
+                ],
+            ],
+        ];
+
         yield 'namespaces1' => [
             'PHP/namespaces1.php',
             [

--- a/tests/Fixtures/PHP/MultipleFunctions.php
+++ b/tests/Fixtures/PHP/MultipleFunctions.php
@@ -19,11 +19,10 @@ class MultipleFunctions
         $prefix = '1';
         $category->name = '1';
 
-        return isset($category->{'name'.$prefix}) && $category->{'name'.$prefix}
-            ? $category->{'name'.$prefix}
+        return isset($category->{'name' . $prefix}) && $category->{'name' . $prefix}
+            ? $category->{'name' . $prefix}
             : $category->name;
     }
-
 
     public function second()
     {

--- a/tests/Fixtures/PHP/MultipleFunctions.php
+++ b/tests/Fixtures/PHP/MultipleFunctions.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\PHP;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Info(title="Test", version="1.0")
+ */
+class MultipleFunctions
+{
+    public function first()
+    {
+        $category = new \stdClass();
+        $prefix = '1';
+        $category->name = '1';
+
+        return isset($category->{'name'.$prefix}) && $category->{'name'.$prefix}
+            ? $category->{'name'.$prefix}
+            : $category->name;
+    }
+
+
+    public function second()
+    {
+
+    }
+}


### PR DESCRIPTION
The following expression:

```php
isset($category->{'name'.$prefix}) && $category->{'name'.$prefix} ? $category->{'name'.$prefix} : $category->name;
```

will result in an error if the code contains an opening curly brace followed by a closing curly brace and a colon first. In this case, it won't recognize the closing curly brace correctly and will fail to generate all subsequent endpoints.