### PR TITLE
Fix deprecated error in PHP 8.1/8.2  

### DIFF
--- a/src/Annotations/AbstractAnnotation.php
+++ b/src/Annotations/AbstractAnnotation.php
@@ -136,7 +136,7 @@ abstract class AbstractAnnotation implements JsonSerializable
         foreach (static::$_blacklist as $_property) {
             unset($fields[$_property]);
         }
-        Logger::notice('Ignoring unexpected field "' . $property . '" for ' . $this->identity() . ', expecting "' . implode('", "', array_keys($fields)) . '" in ' . $this->_context);
+        Logger::notice('Ignoring unexpected property "' . $property . '" for ' . $this->identity() . ', expecting "' . implode('", "', array_keys($fields)) . '" in ' . $this->_context);
     }
 
     /**

--- a/src/Annotations/AbstractAnnotation.php
+++ b/src/Annotations/AbstractAnnotation.php
@@ -137,7 +137,6 @@ abstract class AbstractAnnotation implements JsonSerializable
             unset($fields[$_property]);
         }
         Logger::notice('Unexpected field "' . $property . '" for ' . $this->identity() . ', expecting "' . implode('", "', array_keys($fields)) . '" in ' . $this->_context);
-        $this->$property = $value;
     }
 
     /**

--- a/src/Annotations/AbstractAnnotation.php
+++ b/src/Annotations/AbstractAnnotation.php
@@ -136,7 +136,7 @@ abstract class AbstractAnnotation implements JsonSerializable
         foreach (static::$_blacklist as $_property) {
             unset($fields[$_property]);
         }
-        Logger::notice('Unexpected field "' . $property . '" for ' . $this->identity() . ', expecting "' . implode('", "', array_keys($fields)) . '" in ' . $this->_context);
+        Logger::notice('Ignoring unexpected field "' . $property . '" for ' . $this->identity() . ', expecting "' . implode('", "', array_keys($fields)) . '" in ' . $this->_context);
     }
 
     /**

--- a/src/Annotations/Get.php
+++ b/src/Annotations/Get.php
@@ -9,7 +9,6 @@ namespace Swagger\Annotations;
 /**
  * @Annotation
  */
-#[\AllowDynamicProperties]
 class Get extends Operation
 {
     /** @inheritdoc */

--- a/src/Annotations/Get.php
+++ b/src/Annotations/Get.php
@@ -9,6 +9,7 @@ namespace Swagger\Annotations;
 /**
  * @Annotation
  */
+#[\AllowDynamicProperties]
 class Get extends Operation
 {
     /** @inheritdoc */

--- a/src/Context.php
+++ b/src/Context.php
@@ -283,7 +283,7 @@ class Context
         } else {
             $namespace = '\\'; // global namespace
         }
-        if (strcasecmp($class, $this->class) === 0) {
+        if (strcasecmp((string) $class, (string) $this->class) === 0) {
             return $namespace . $this->class;
         }
         $pos = strpos($class, '\\');

--- a/src/Context.php
+++ b/src/Context.php
@@ -33,6 +33,7 @@ namespace Swagger;
  * @property string $property
  * @property Annotations\AbstractAnnotation[] $annotations
  */
+#[\AllowDynamicProperties]
 class Context
 {
     /**

--- a/tests/AbstractAnnotationTest.php
+++ b/tests/AbstractAnnotationTest.php
@@ -18,7 +18,7 @@ class AbstractAnnotationTest extends SwaggerTestCase
 
     public function testInvalidField()
     {
-        $this->assertSwaggerLogEntryStartsWith('Unexpected field "doesnot" for @SWG\Get(), expecting');
+        $this->assertSwaggerLogEntryStartsWith('Ignoring unexpected property "doesnot" for @SWG\Get(), expecting');
         $this->parseComment('@SWG\Get(doesnot="exist")');
     }
 


### PR DESCRIPTION
This PR fixes two deprecated errors in PHP 8.1/8.2.

* `PHP Deprecated:  Creation of dynamic property Swagger\Context::{$prop} is deprecated in swagger-php/src/Context.php on line 53`
* `Deprecated: strcasecmp(): Passing null to parameter #1 ($string1) of type string is deprecated in swagger-php/src/Context.php on line 288`

No more errors when doing `composer test` in PHP 8.1/8.2.

Fixes #1455 