### PR TITLE
Avoid unguarded use of `enum_exists`

### DIFF
--- a/src/Processors/ExpandEnums.php
+++ b/src/Processors/ExpandEnums.php
@@ -84,7 +84,7 @@ class ExpandEnums implements ProcessorInterface
 
                 // transform each Enum cases into UnitEnum
                 foreach ($schema->enum as $enum) {
-                    if (is_string($enum) && enum_exists($enum)) {
+                    if (is_a($enum, \UnitEnum::class, true)) {
                         foreach ($enum::cases() as $case) {
                             $cases[] = $case;
                         }

--- a/src/Processors/ExpandEnums.php
+++ b/src/Processors/ExpandEnums.php
@@ -84,7 +84,7 @@ class ExpandEnums implements ProcessorInterface
 
                 // transform each Enum cases into UnitEnum
                 foreach ($schema->enum as $enum) {
-                    if (is_a($enum, \UnitEnum::class, true)) {
+                    if (is_string($enum) && function_exists('enum_exists') && enum_exists($enum)) {
                         foreach ($enum::cases() as $case) {
                             $cases[] = $case;
                         }


### PR DESCRIPTION
Fixes #1484 