### PR TITLE
Allow recursive nesting of AdditionalProperties in Attributes

### DIFF
--- a/docs/reference/attributes.md
+++ b/docs/reference/attributes.md
@@ -152,6 +152,8 @@ schema defined by this property's value.</p></dd>
   <dt><strong>oneOf</strong> : <span style="font-family: monospace;">array&lt;Schema|\OpenApi\Annotations\Schema&gt;</span></dt>
   <dd><p>An instance validates successfully against this property if it validates successfully against exactly one schema<br />
 defined by this property's value.</p></dd>
+  <dt><strong>additionalProperties</strong> : <span style="font-family: monospace;">OpenApi\Attributes\AdditionalProperties|bool|null</span></dt>
+  <dd><p>http://json-schema.org/latest/json-schema-validation.html#anchor64.</p></dd>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />

--- a/src/Attributes/AdditionalProperties.php
+++ b/src/Attributes/AdditionalProperties.php
@@ -99,10 +99,9 @@ class AdditionalProperties extends \OpenApi\Annotations\AdditionalProperties
             'allOf' => $allOf ?? Generator::UNDEFINED,
             'anyOf' => $anyOf ?? Generator::UNDEFINED,
             'oneOf' => $oneOf ?? Generator::UNDEFINED,
-            'additionalProperties' => $additionalProperties ?? Generator::UNDEFINED,
             'x' => $x ?? Generator::UNDEFINED,
             'attachables' => $attachables ?? Generator::UNDEFINED,
-            'value' => $this->combine($items, $discriminator, $externalDocs, $attachables),
+            'value' => $this->combine($items, $discriminator, $externalDocs, $additionalProperties, $attachables),
         ]);
     }
 }

--- a/src/Attributes/AdditionalProperties.php
+++ b/src/Attributes/AdditionalProperties.php
@@ -21,7 +21,6 @@ class AdditionalProperties extends \OpenApi\Annotations\AdditionalProperties
      * @param array<Schema|\OpenApi\Annotations\Schema>              $allOf
      * @param array<Schema|\OpenApi\Annotations\Schema>              $anyOf
      * @param array<Schema|\OpenApi\Annotations\Schema>              $oneOf
-     * @param array<Schema|\OpenApi\Annotations\Schema>              $oneOf
      * @param array<string,mixed>|null                               $x
      * @param Attachable[]|null                                      $attachables
      */

--- a/src/Attributes/AdditionalProperties.php
+++ b/src/Attributes/AdditionalProperties.php
@@ -21,6 +21,7 @@ class AdditionalProperties extends \OpenApi\Annotations\AdditionalProperties
      * @param array<Schema|\OpenApi\Annotations\Schema>              $allOf
      * @param array<Schema|\OpenApi\Annotations\Schema>              $anyOf
      * @param array<Schema|\OpenApi\Annotations\Schema>              $oneOf
+     * @param array<Schema|\OpenApi\Annotations\Schema>              $oneOf
      * @param array<string,mixed>|null                               $x
      * @param Attachable[]|null                                      $attachables
      */
@@ -61,6 +62,7 @@ class AdditionalProperties extends \OpenApi\Annotations\AdditionalProperties
         ?array $allOf = null,
         ?array $anyOf = null,
         ?array $oneOf = null,
+        AdditionalProperties|bool|null $additionalProperties = null,
         // annotation
         ?array $x = null,
         ?array $attachables = null
@@ -98,6 +100,7 @@ class AdditionalProperties extends \OpenApi\Annotations\AdditionalProperties
             'allOf' => $allOf ?? Generator::UNDEFINED,
             'anyOf' => $anyOf ?? Generator::UNDEFINED,
             'oneOf' => $oneOf ?? Generator::UNDEFINED,
+            'additionalProperties' => $additionalProperties ?? Generator::UNDEFINED,
             'x' => $x ?? Generator::UNDEFINED,
             'attachables' => $attachables ?? Generator::UNDEFINED,
             'value' => $this->combine($items, $discriminator, $externalDocs, $attachables),

--- a/tests/Fixtures/Scratch/NestedAdditionalProperties.php
+++ b/tests/Fixtures/Scratch/NestedAdditionalProperties.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Scratch;
+
+use OpenApi\Attributes as OAT;
+
+
+#[OAT\Info(
+    title: 'Nested Additional Properties',
+    version: '1.0'
+)]
+#[OAT\Get(
+    path: '/api/endpoint',
+    description: 'An endpoint',
+    responses: [new OAT\Response(response: 200, description: 'OK')]
+)]
+#[OAT\Schema(
+	additionalProperties: new OAT\AdditionalProperties(
+		additionalProperties: new OAT\AdditionalProperties(
+			type: "string",
+		)
+	),
+    type: 'object'
+)]
+class NestedAdditionalAttributes
+{
+}

--- a/tests/Fixtures/Scratch/NestedAdditionalProperties.php
+++ b/tests/Fixtures/Scratch/NestedAdditionalProperties.php
@@ -8,7 +8,6 @@ namespace OpenApi\Tests\Fixtures\Scratch;
 
 use OpenApi\Attributes as OAT;
 
-
 #[OAT\Info(
     title: 'Nested Additional Properties',
     version: '1.0'

--- a/tests/Fixtures/Scratch/NestedAdditionalProperties.php
+++ b/tests/Fixtures/Scratch/NestedAdditionalProperties.php
@@ -18,11 +18,11 @@ use OpenApi\Attributes as OAT;
     responses: [new OAT\Response(response: 200, description: 'OK')]
 )]
 #[OAT\Schema(
-	additionalProperties: new OAT\AdditionalProperties(
-		additionalProperties: new OAT\AdditionalProperties(
-			type: "string",
-		)
-	),
+    additionalProperties: new OAT\AdditionalProperties(
+        additionalProperties: new OAT\AdditionalProperties(
+            type: 'string',
+        )
+    ),
     type: 'object'
 )]
 class NestedAdditionalAttributes

--- a/tests/Fixtures/Scratch/NestedAdditionalProperties.yaml
+++ b/tests/Fixtures/Scratch/NestedAdditionalProperties.yaml
@@ -1,0 +1,18 @@
+openapi: 3.0.0
+info:
+  title: 'Nested Additional Properties'
+  version: '1.0'
+paths:
+  /api/endpoint:
+    get:
+      description: 'An endpoint'
+      responses:
+        '200':
+          description: OK
+components:
+  schemas:
+    NestedAdditionalAttributes:
+      type: object
+      additionalProperties:
+        additionalProperties:
+          type: string


### PR DESCRIPTION
Since nested AdditionalProperties have been allowed for a while through #706 also allow it through Attributes and not only with annotations.