### PR TITLE
feat: move OpenApi 3.1.0 conversions to processor

### DIFF
--- a/src/Annotations/AbstractAnnotation.php
+++ b/src/Annotations/AbstractAnnotation.php
@@ -388,15 +388,6 @@ abstract class AbstractAnnotation implements \JsonSerializable
         }
 
         if ($this->_context->version === OpenApi::VERSION_3_1_0) {
-            if (isset($data->minimum) && isset($data->exclusiveMinimum)) {
-                if (true === $data->exclusiveMinimum) {
-                    $data->exclusiveMinimum = $data->minimum;
-                    unset($data->minimum);
-                } elseif (false === $data->exclusiveMinimum) {
-                    unset($data->exclusiveMinimum);
-                }
-            }
-
             if (isset($data->maximum) && isset($data->exclusiveMaximum)) {
                 if (true === $data->exclusiveMaximum) {
                     $data->exclusiveMaximum = $data->maximum;

--- a/src/Annotations/AbstractAnnotation.php
+++ b/src/Annotations/AbstractAnnotation.php
@@ -367,11 +367,8 @@ abstract class AbstractAnnotation implements \JsonSerializable
             }
             if (property_exists($this, 'nullable') && $this->nullable === true) {
                 $ref = ['oneOf' => [$ref]];
-                if ($this->_context->version == OpenApi::VERSION_3_1_0) {
-                    $ref['oneOf'][] = ['type' => 'null'];
-                } else {
-                    $ref['nullable'] = $data->nullable;
-                }
+                $ref['nullable'] = $data->nullable;
+
                 unset($data->nullable);
 
                 // preserve other properties

--- a/src/Annotations/AbstractAnnotation.php
+++ b/src/Annotations/AbstractAnnotation.php
@@ -388,22 +388,6 @@ abstract class AbstractAnnotation implements \JsonSerializable
         }
 
         if ($this->_context->version === OpenApi::VERSION_3_1_0) {
-            if (isset($data->nullable)) {
-                if (true === $data->nullable) {
-                    if (isset($data->oneOf)) {
-                        $data->oneOf[] = ['type' => 'null'];
-                    } elseif (isset($data->anyOf)) {
-                        $data->anyOf[] = ['type' => 'null'];
-                    } elseif (isset($data->allOf)) {
-                        $data->allOf[] = ['type' => 'null'];
-                    } else {
-                        $data->type = (array) $data->type;
-                        $data->type[] = 'null';
-                    }
-                }
-                unset($data->nullable);
-            }
-
             if (isset($data->minimum) && isset($data->exclusiveMinimum)) {
                 if (true === $data->exclusiveMinimum) {
                     $data->exclusiveMinimum = $data->minimum;

--- a/src/Annotations/AbstractAnnotation.php
+++ b/src/Annotations/AbstractAnnotation.php
@@ -387,17 +387,6 @@ abstract class AbstractAnnotation implements \JsonSerializable
             $data = (object) $ref;
         }
 
-        if ($this->_context->version === OpenApi::VERSION_3_1_0) {
-            if (isset($data->maximum) && isset($data->exclusiveMaximum)) {
-                if (true === $data->exclusiveMaximum) {
-                    $data->exclusiveMaximum = $data->maximum;
-                    unset($data->maximum);
-                } elseif (false === $data->exclusiveMaximum) {
-                    unset($data->exclusiveMaximum);
-                }
-            }
-        }
-
         return $data;
     }
 

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -269,6 +269,7 @@ class Generator
                 new Processors\MergeXmlContent(),
                 new Processors\OperationId(),
                 new Processors\CleanUnmerged(),
+                new Processors\OpenApi31Processor(),
             ];
         }
 

--- a/src/Processors/OpenApi31Processor.php
+++ b/src/Processors/OpenApi31Processor.php
@@ -26,6 +26,7 @@ final class OpenApi31Processor implements ProcessorInterface
         foreach ($annotations as $annotation) {
             $this->processNullable($annotation);
             $this->processExclusiveMinimum($annotation);
+            $this->processExclusiveMaximum($annotation);
         }
     }
 
@@ -72,6 +73,20 @@ final class OpenApi31Processor implements ProcessorInterface
             $annotation->minimum = Generator::UNDEFINED;
         } elseif (false === $annotation->exclusiveMinimum) {
             $annotation->exclusiveMinimum = Generator::UNDEFINED;
+        }
+    }
+
+    private function processExclusiveMaximum(OA\Schema $annotation): void
+    {
+        if (Generator::UNDEFINED === $annotation->maximum || Generator::UNDEFINED === $annotation->exclusiveMaximum) {
+            return;
+        }
+
+        if (true === $annotation->exclusiveMaximum) {
+            $annotation->exclusiveMaximum = $annotation->maximum;
+            $annotation->maximum = Generator::UNDEFINED;
+        } elseif (false === $annotation->exclusiveMaximum) {
+            $annotation->exclusiveMaximum = Generator::UNDEFINED;
         }
     }
 }

--- a/src/Processors/OpenApi31Processor.php
+++ b/src/Processors/OpenApi31Processor.php
@@ -25,6 +25,7 @@ final class OpenApi31Processor implements ProcessorInterface
 
         foreach ($annotations as $annotation) {
             $this->processNullable($annotation);
+            $this->processExclusiveMinimum($annotation);
         }
     }
 
@@ -57,6 +58,20 @@ final class OpenApi31Processor implements ProcessorInterface
         } elseif (!Generator::isDefault($annotation->type)) {
             $annotation->type = (array) $annotation->type;
             $annotation->type[] = 'null';
+        }
+    }
+
+    private function processExclusiveMinimum(OA\Schema $annotation): void
+    {
+        if (Generator::UNDEFINED === $annotation->minimum || Generator::UNDEFINED === $annotation->exclusiveMinimum) {
+            return;
+        }
+
+        if (true === $annotation->exclusiveMinimum) {
+            $annotation->exclusiveMinimum = $annotation->minimum;
+            $annotation->minimum = Generator::UNDEFINED;
+        } elseif (false === $annotation->exclusiveMinimum) {
+            $annotation->exclusiveMinimum = Generator::UNDEFINED;
         }
     }
 }

--- a/src/Processors/OpenApi31Processor.php
+++ b/src/Processors/OpenApi31Processor.php
@@ -64,7 +64,7 @@ final class OpenApi31Processor implements ProcessorInterface
 
     private function processExclusiveMinimum(OA\Schema $annotation): void
     {
-        if (Generator::UNDEFINED === $annotation->minimum || Generator::UNDEFINED === $annotation->exclusiveMinimum) {
+        if (Generator::isDefault($annotation->minimum) || Generator::isDefault($annotation->exclusiveMinimum)) {
             return;
         }
 
@@ -78,7 +78,7 @@ final class OpenApi31Processor implements ProcessorInterface
 
     private function processExclusiveMaximum(OA\Schema $annotation): void
     {
-        if (Generator::UNDEFINED === $annotation->maximum || Generator::UNDEFINED === $annotation->exclusiveMaximum) {
+        if (Generator::isDefault($annotation->maximum) || Generator::isDefault($annotation->exclusiveMaximum)) {
             return;
         }
 

--- a/src/Processors/OpenApi31Processor.php
+++ b/src/Processors/OpenApi31Processor.php
@@ -20,19 +20,16 @@ final class OpenApi31Processor implements ProcessorInterface
             return;
         }
 
-        $annotations = $analysis->getAnnotationsOfType(OA\AbstractAnnotation::class);
+        /** @var OA\Schema[] $annotations */
+        $annotations = $analysis->getAnnotationsOfType(OA\Schema::class);
 
         foreach ($annotations as $annotation) {
-            $this->convertNullable($annotation);
+            $this->processNullable($annotation);
         }
     }
 
-    private function convertNullable(OA\AbstractAnnotation $annotation): void
+    private function processNullable(OA\Schema $annotation): void
     {
-        if (!property_exists($annotation, 'nullable')) {
-            return;
-        }
-
         $nullable = $annotation->nullable;
         $annotation->nullable = Generator::UNDEFINED; // Unregister nullable property
 
@@ -40,7 +37,7 @@ final class OpenApi31Processor implements ProcessorInterface
             return;
         }
 
-        if (property_exists($annotation, 'ref') && !Generator::isDefault($annotation->ref)) {
+        if (!Generator::isDefault($annotation->ref)) {
             if (!property_exists($annotation, 'oneOf')) {
                 return;
             }
@@ -51,13 +48,13 @@ final class OpenApi31Processor implements ProcessorInterface
             return;
         }
 
-        if (property_exists($annotation, 'oneOf') && is_array($annotation->oneOf)) {
+        if (is_array($annotation->oneOf)) {
             $annotation->oneOf[] = new OA\Schema(['type' => 'null']);
-        } elseif (property_exists($annotation, 'anyOf') && is_array($annotation->anyOf)) {
+        } elseif (is_array($annotation->anyOf)) {
             $annotation->anyOf[] = new OA\Schema(['type' => 'null']);
-        } elseif (property_exists($annotation, 'allOf') && is_array($annotation->allOf)) {
+        } elseif (is_array($annotation->allOf)) {
             $annotation->allOf[] = new OA\Schema(['type' => 'null']);
-        } elseif (property_exists($annotation, 'type') && !Generator::isDefault($annotation->type)) {
+        } elseif (!Generator::isDefault($annotation->type)) {
             $annotation->type = (array) $annotation->type;
             $annotation->type[] = 'null';
         }

--- a/src/Processors/OpenApi31Processor.php
+++ b/src/Processors/OpenApi31Processor.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Processors;
+
+use OpenApi\Analysis;
+use OpenApi\Annotations as OA;
+use OpenApi\Generator;
+
+final class OpenApi31Processor implements ProcessorInterface
+{
+    public function __invoke(Analysis $analysis)
+    {
+        if ($analysis->openapi->openapi !== OA\OpenApi::VERSION_3_1_0) {
+            return;
+        }
+
+        $annotations = $analysis->getAnnotationsOfType(OA\AbstractAnnotation::class);
+
+        foreach ($annotations as $annotation) {
+            $this->convertNullable($annotation);
+        }
+    }
+
+    private function convertNullable(OA\AbstractAnnotation $annotation): void
+    {
+        if (!property_exists($annotation, 'nullable')) {
+            return;
+        }
+
+        $nullable = $annotation->nullable;
+        $annotation->nullable = Generator::UNDEFINED; // Unregister nullable property
+
+        if (true !== $nullable) {
+            return;
+        }
+
+        if (property_exists($annotation, 'ref') && !Generator::isDefault($annotation->ref)) {
+            if (!property_exists($annotation, 'oneOf')) {
+                return;
+            }
+
+            $annotation->oneOf = [new OA\Schema(['ref' => $annotation->ref]), new OA\Schema(['type' => 'null'])];
+            $annotation->ref = Generator::UNDEFINED;
+
+            return;
+        }
+
+        if (property_exists($annotation, 'oneOf') && is_array($annotation->oneOf)) {
+            $annotation->oneOf[] = new OA\Schema(['type' => 'null']);
+        } elseif (property_exists($annotation, 'anyOf') && is_array($annotation->anyOf)) {
+            $annotation->anyOf[] = new OA\Schema(['type' => 'null']);
+        } elseif (property_exists($annotation, 'allOf') && is_array($annotation->allOf)) {
+            $annotation->allOf[] = new OA\Schema(['type' => 'null']);
+        } elseif (property_exists($annotation, 'type') && !Generator::isDefault($annotation->type)) {
+            $annotation->type = (array) $annotation->type;
+            $annotation->type[] = 'null';
+        }
+    }
+}

--- a/src/Processors/OpenApi31Processor.php
+++ b/src/Processors/OpenApi31Processor.php
@@ -24,10 +24,20 @@ final class OpenApi31Processor implements ProcessorInterface
         $annotations = $analysis->getAnnotationsOfType(OA\Schema::class);
 
         foreach ($annotations as $annotation) {
+            $this->processReference($annotation);
             $this->processNullable($annotation);
             $this->processExclusiveMinimum($annotation);
             $this->processExclusiveMaximum($annotation);
         }
+    }
+
+    private function processReference(OA\Schema $annotation): void
+    {
+        if (Generator::isDefault($annotation->ref)) {
+            return;
+        }
+
+
     }
 
     private function processNullable(OA\Schema $annotation): void
@@ -40,7 +50,7 @@ final class OpenApi31Processor implements ProcessorInterface
         }
 
         if (!Generator::isDefault($annotation->ref)) {
-            if (!property_exists($annotation, 'oneOf')) {
+            if (!Generator::isDefault($annotation->oneOf)) {
                 return;
             }
 

--- a/tests/Fixtures/Scratch/NullRef31.php
+++ b/tests/Fixtures/Scratch/NullRef31.php
@@ -45,7 +45,8 @@ class NullRef31
                 description: 'Ref plus response',
                 content: new OAT\JsonContent(
                     ref: '#/components/schemas/repository',
-                    description: 'The repository',
+                    description: 'Will either respond with something or null',
+                    example: 'Some example about the content',
                     nullable: true
                 )
             ),

--- a/tests/Fixtures/Scratch/NullRef31.yaml
+++ b/tests/Fixtures/Scratch/NullRef31.yaml
@@ -23,11 +23,12 @@ paths:
           description: 'Ref plus response'
           content:
             application/json:
+              example: 'Some example about the content'
               schema:
                 oneOf:
-                  - { $ref: '#/components/schemas/repository', description: 'The repository' }
+                  - { $ref: '#/components/schemas/repository' }
                   - { type: 'null' }
-                description: 'The repository'
+                description: 'Will either respond with something or null'
 components:
   schemas:
     repository: {  }


### PR DESCRIPTION
related to https://github.com/zircote/swagger-php/issues/1528

Moved logic to processor:
- Processing of `nullable` property for 3.1.0
- Processing of `minimum` &  `exclusiveMinimum` property for 3.1.0
- Processing of `maximum` &  `exclusiveMaximum` property for 3.1.0