### PR TITLE
Update $_required typehint

### DIFF
--- a/src/Annotations/AbstractAnnotation.php
+++ b/src/Annotations/AbstractAnnotation.php
@@ -49,7 +49,7 @@ abstract class AbstractAnnotation implements \JsonSerializable
     /**
      * The properties which are required by [the spec](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md).
      *
-     * @var array
+     * @var string[]
      */
     public static $_required = [];
 


### PR DESCRIPTION
[NelmioApiDocBundle](https://github.com/nelmio/NelmioApiDocBundle) is currently attempting to upgrade PHPStan to level 6.

Our annotations which extend `AbstractAnnotation` are generating errors. A simple typehint fixes this which is the reason for this PR :)

https://github.com/nelmio/NelmioApiDocBundle/blob/a585e502725d7e3cfcec25f7a3d59443842006da/src/Annotation/Model.php#L30

```
 ------ -------------------------------------------------------------------------------------------------------------------- 
  Line   Annotation/Model.php                                                                                                
 ------ -------------------------------------------------------------------------------------------------------------------- 
  30     Property Nelmio\ApiDocBundle\Annotation\Model::$_required type has no value type specified in iterable type array.  
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                           
 ------ -------------------------------------------------------------------------------------------------------------------- 
```