### PR TITLE
Update `jsonSerialize` return

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -64,7 +64,7 @@ return (new PhpCsFixer\Config())
         'nullable_type_declaration_for_default_null_value' => true,
 
         'no_empty_phpdoc' => true,
-        'no_superfluous_phpdoc_tags' => true,
+        'no_superfluous_phpdoc_tags' => ['allow_mixed' => true],
         'phpdoc_align' => true,
         'general_phpdoc_tag_rename' => true,
         'phpdoc_inline_tag_normalizer' => true,

--- a/src/Annotations/AbstractAnnotation.php
+++ b/src/Annotations/AbstractAnnotation.php
@@ -284,6 +284,9 @@ abstract class AbstractAnnotation implements \JsonSerializable
         return $properties;
     }
 
+    /**
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {


### PR DESCRIPTION
When I execute my test with the last version of packages + PHP 8.3, I have warnings like this one : 

> 1x: Method "JsonSerializable::jsonSerialize()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "OpenApi\Annotations\AbstractAnnotation" now to avoid errors or add an explicit @return annotation to suppress this message.