### PR TITLE
Update `jsonSerialize` return (`Operation`)

### DIFF
--- a/src/Annotations/Operation.php
+++ b/src/Annotations/Operation.php
@@ -194,7 +194,7 @@ abstract class Operation extends AbstractAnnotation
      * @inheritdoc
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $data = parent::jsonSerialize();
 


### PR DESCRIPTION
When I execute my test with the last version of packages + PHP 8.3, I have this warning : 

> 1x: Method "JsonSerializable::jsonSerialize()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "OpenApi\Annotations\Operation" now to avoid errors or add an explicit @return annotation to suppress this message.