### PR TITLE
Bump php version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         }
     },
     "require": {
-        "php": ">=7.2",
+        "php": ">=8.1",
         "ext-json": "*",
         "psr/log": "^1.1 || ^2.0 || ^3.0",
         "symfony/deprecation-contracts": "^2 || ^3",


### PR DESCRIPTION
Bump PHP version to last maintained one : https://www.php.net/supported-versions.php

(I can remove CI for 7.x versions in this PR or in another one)