### PR TITLE
Fix nullable processor call

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -286,7 +286,7 @@ class Generator
         return $this->processorPipeline->walk($walker);
     }
 
-    public function setProcessorPipeline(Pipeline $processor): Generator
+    public function setProcessorPipeline(?Pipeline $processor): Generator
     {
         $this->processorPipeline = $processor;
 
@@ -427,13 +427,15 @@ class Generator
                 'version' => null,
             ];
 
+        $processorPipeline = $config['processor'] ??
+            $config['processors'] ? new Pipeline($config['processors']) : null;
+
         return (new Generator($config['logger']))
             ->setVersion($config['version'])
             ->setAliases($config['aliases'])
             ->setNamespaces($config['namespaces'])
             ->setAnalyser($config['analyser'])
-            ->setProcessorPipeline($config['processor'])
-            ->setProcessorPipeline(new Pipeline($config['processors']))
+            ->setProcessorPipeline($processorPipeline)
             ->generate($sources, $config['analysis'], $config['validate']);
     }
 


### PR DESCRIPTION
fixes #1603 

The options `processors` was nullable before, now this throws an error, because the parameters of the generator setter are not nullable. Also, the set method for `setProcessorPipline` was executed twice, which makes the first call redundant. 

Now not provided options for `processor` and `processors` should work, with `processor` having priority over `processors`.