### PR TITLE
Fix promoted properties sharing context

### DIFF
--- a/src/Analysers/AttributeAnnotationFactory.php
+++ b/src/Analysers/AttributeAnnotationFactory.php
@@ -80,6 +80,9 @@ class AttributeAnnotationFactory implements AnnotationFactoryInterface
                                 $instance->nullable = $nullable ?: Generator::UNDEFINED;
 
                                 if ($rp->isPromoted()) {
+                                    // ensure each property has its own context
+                                    $instance->_context = new Context([], $instance->_context);
+
                                     // promoted parameter - docblock is available via class/property
                                     if ($comment = $rp->getDeclaringClass()->getProperty($rp->getName())->getDocComment()) {
                                         $instance->_context->comment = $comment;

--- a/tests/Analysers/ReflectionAnalyserTest.php
+++ b/tests/Analysers/ReflectionAnalyserTest.php
@@ -195,8 +195,17 @@ class ReflectionAnalyserTest extends OpenApiTestCase
 
         /** @var OA\Property[] $properties */
         $properties = $analysis->getAnnotationsOfType(OA\Property::class);
-        $this->assertCount(2, $properties);
-        $this->assertEquals('id', $properties[0]->property);
-        $this->assertEquals('labels', $properties[1]->property);
+
+        [$tags, $id, $labels] = $properties;
+
+        $this->assertCount(3, $properties);
+        $this->assertEquals('tags', $tags->property);
+        $this->assertEquals('id', $id->property);
+        $this->assertEquals('labels', $labels->property);
+
+        // regression: check doc blocks
+        $this->assertStringContainsString('Label List', $labels->_context->comment);
+        $this->assertStringContainsString('Tag List', $tags->_context->comment);
+        $this->assertEmpty($id->_context->comment);
     }
 }

--- a/tests/Analysers/TokenScannerTest.php
+++ b/tests/Analysers/TokenScannerTest.php
@@ -232,7 +232,7 @@ class TokenScannerTest extends OpenApiTestCase
                     'traits' => [],
                     'enums' => [],
                     'methods' => ['__construct'],
-                    'properties' => ['labels', 'id'],
+                    'properties' => ['labels', 'tags', 'id'],
                 ],
             ],
         ];

--- a/tests/Fixtures/PHP/Php8PromotedProperties.php
+++ b/tests/Fixtures/PHP/Php8PromotedProperties.php
@@ -23,6 +23,13 @@ class Php8PromotedProperties
          * @OA\Property()
          */
         public ?array $labels,
+        /**
+         * Tag List.
+         *
+         * @var array<int,string>
+         */
+        #[OAT\Property()]
+        public array $tags,
         #[OAT\Property()]
         public int $id,
     ) {


### PR DESCRIPTION
A reproduction of the bug described in my comment here:  https://github.com/zircote/swagger-php/issues/1419#issuecomment-2200163118

Added regression test + fixed it with a clone of context. Tests passing. However - suggestions for alternative fixes are very welcome.