### PR TITLE
Move `AugmentTags` after `CleanUnusedComponents`

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -275,10 +275,10 @@ class Generator
                 new Processors\MergeJsonContent(),
                 new Processors\MergeXmlContent(),
                 new Processors\OperationId(),
-                new Processors\AugmentTags(),
                 new Processors\CleanUnmerged(),
                 new Processors\PathFilter(),
                 new Processors\CleanUnusedComponents(),
+                new Processors\AugmentTags(),
             ]);
         }
 

--- a/tests/Fixtures/SurplusTag.php
+++ b/tests/Fixtures/SurplusTag.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures;
+
+use OpenApi\Attributes as OAT;
+
+#[OAT\OpenApi(
+    info: new OAT\Info(
+        title: 'test',
+        description: 'test',
+        version: '2.0.0'
+    ),
+)]
+class SurplusTag
+{
+    #[OAT\Get(path: '/world/', tags: ['tag world'], responses: [new OAT\Response(response: '200', description: 'success')])]
+    #[OAT\Get(path: '/hello/', tags: ['tag hello'], responses: [new OAT\Response(response: '200', description: 'success')])]
+    public function hello(): void
+    {
+    }
+}

--- a/tests/OpenApiTestCase.php
+++ b/tests/OpenApiTestCase.php
@@ -241,11 +241,12 @@ class OpenApiTestCase extends TestCase
         return $processors;
     }
 
-    public function analysisFromFixtures(array $files, array $processors = [], ?AnalyserInterface $analyzer = null): Analysis
+    public function analysisFromFixtures(array $files, array $processors = [], ?AnalyserInterface $analyzer = null, array $config = []): Analysis
     {
         $analysis = new Analysis([], $this->getContext());
 
         (new Generator($this->getTrackingLogger()))
+            ->setConfig($config)
             ->setAnalyser($analyzer ?: $this->getAnalyzer())
             ->setProcessorPipeline(new Pipeline($processors))
             ->generate($this->fixtures($files), $analysis, false);

--- a/tests/Processors/AugmentTagsTest.php
+++ b/tests/Processors/AugmentTagsTest.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Processors;
+
+use OpenApi\Tests\OpenApiTestCase;
+
+class AugmentTagsTest extends OpenApiTestCase
+{
+    /**
+     * @requires PHP 8.1
+     */
+    public function testAugmentTags(): void
+    {
+        $this->skipLegacy();
+
+        $config = [
+            'pathFilter' => ['paths' => ['#^/hello/#']],
+            'cleanUnusedComponents' => ['enabled' => true],
+        ];
+        $analysis = $this->analysisFromFixtures(['SurplusTag.php'], static::processors(), null, $config);
+
+        $this->assertCount(1, $analysis->openapi->tags);
+    }
+}

--- a/tests/Processors/CleanUnusedComponentsTest.php
+++ b/tests/Processors/CleanUnusedComponentsTest.php
@@ -7,29 +7,28 @@
 namespace OpenApi\Tests\Processors;
 
 use OpenApi\Generator;
-use OpenApi\Processors\CleanUnusedComponents;
 use OpenApi\Tests\OpenApiTestCase;
 
 class CleanUnusedComponentsTest extends OpenApiTestCase
 {
     public static function countCases(): iterable
     {
-        $defaultProcessors = static::processors([CleanUnusedComponents::class]);
+        $configEnable = ['cleanUnusedComponents' => ['enabled' => true]];
 
         return [
-            'var-default' => [$defaultProcessors, 'UsingVar.php', 2, 5],
-            'var-clean' => [array_merge($defaultProcessors, [new CleanUnusedComponents(true)]), 'UsingVar.php', 0, 2],
-            'unreferenced-default' => [$defaultProcessors, 'Unreferenced.php', 2, 11],
-            'unreferenced-clean' => [array_merge($defaultProcessors, [new CleanUnusedComponents(true)]), 'Unreferenced.php', 0, 5],
+            'var-default' => [[], 'UsingVar.php', 2, 5],
+            'var-clean' => [$configEnable, 'UsingVar.php', 0, 2],
+            'unreferenced-default' => [[], 'Unreferenced.php', 2, 11],
+            'unreferenced-clean' => [$configEnable, 'Unreferenced.php', 0, 5],
         ];
     }
 
     /**
      * @dataProvider countCases
      */
-    public function testCounts(array $processors, string $fixture, int $expectedSchemaCount, int $expectedAnnotationCount): void
+    public function testCounts(array $config, string $fixture, int $expectedSchemaCount, int $expectedAnnotationCount): void
     {
-        $analysis = $this->analysisFromFixtures([$fixture], $processors);
+        $analysis = $this->analysisFromFixtures([$fixture], static::processors(), null, $config);
 
         if ($expectedSchemaCount === 0) {
             $this->assertTrue(Generator::isDefault($analysis->openapi->components->schemas));


### PR DESCRIPTION
Cleanup of tags can only happen after `CleanUnusedComponents` has run