### PR TITLE
Allow "processor" to be passed as scan options

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -444,7 +444,7 @@ class Generator
             ];
 
         $processorPipeline = $config['processor'] ??
-            $config['processors'] ? new Pipeline($config['processors']) : null;
+            ($config['processors'] ? new Pipeline($config['processors']) : null);
 
         return (new Generator($config['logger']))
             ->setVersion($config['version'])

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -34,7 +34,7 @@ class GeneratorTest extends OpenApiTestCase
 
         $this->assertSpecEquals(file_get_contents(sprintf('%s/%s.yaml', $sourceDir, basename($sourceDir))), $openapi);
     }
-    
+
     /**
      * @dataProvider sourcesProvider
      */

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -34,6 +34,18 @@ class GeneratorTest extends OpenApiTestCase
 
         $this->assertSpecEquals(file_get_contents(sprintf('%s/%s.yaml', $sourceDir, basename($sourceDir))), $openapi);
     }
+    
+    /**
+     * @dataProvider sourcesProvider
+     */
+    public function testScanConfig(string $sourceDir, iterable $sources): void
+    {
+        $analyzer = $this->getAnalyzer();
+        $processor = (new Generator())->getProcessorPipeline();
+        $openapi = Generator::scan($sources, ['processor' => $processor, 'analyser' => $analyzer]);
+
+        $this->assertSpecEquals(file_get_contents(sprintf('%s/%s.yaml', $sourceDir, basename($sourceDir))), $openapi);
+    }
 
     public function testScanInvalidSource(): void
     {


### PR DESCRIPTION
Fixes issue with parsing 'processor' config option, it would always fall through to `new Pipeline($config['processors'])` which would throw as its null

```
TypeError: OpenApi\Pipeline::__construct(): Argument #1 ($pipes) must be of type array, null given
```

current code worked when passing 'processors', but removed support for 'processor' option.

https://github.com/zircote/swagger-php/commit/2d983ce67b9eb7e18403ae7bc5e765f8ce7b8d56
