### PR TITLE
allow unused tags to be kept

### DIFF
--- a/src/Processors/AugmentTags.php
+++ b/src/Processors/AugmentTags.php
@@ -17,16 +17,19 @@ class AugmentTags implements ProcessorInterface
 {
 
     /** @var array<string> */
-    protected $unusedTagsToKeepWhitelist = [];
+    protected $whitelist;
 
-    public function __construct(array $unusedTagsToKeepWhitelist = [])
+    public function __construct(array $whitelist = [])
     {
-        $this->unusedTagsToKeepWhitelist = $unusedTagsToKeepWhitelist;
+        $this->whitelist = $whitelist;
     }
 
-    public function setUnusedTagsToKeepWhitelist(array $unusedTagsToKeepWhitelist): AugmentTags
+    /**
+     * Whitelist tags to keep even if not used. <code>*</code> may be used to keep all unused.
+     */
+    public function setWhitelist(array $whitelist): AugmentTags
     {
-        $this->unusedTagsToKeepWhitelist = $unusedTagsToKeepWhitelist;
+        $this->whitelist = $whitelist;
 
         return $this;
     }
@@ -65,8 +68,16 @@ class AugmentTags implements ProcessorInterface
             }
         }
 
-        // remove tags that we don't want to keep (defaults to all unused tags)
-        $tagsToKeep = array_merge($usedTagNames, $this->unusedTagsToKeepWhitelist);
+        $this->removeUnusedTags($usedTagNames, $declaredTags, $analysis);
+    }
+
+    private function removeUnusedTags(array $usedTagNames, array $declaredTags, Analysis $analysis)
+    {
+        if (in_array('*', $this->whitelist)) {
+            return;
+        }
+
+        $tagsToKeep = array_merge($usedTagNames, $this->whitelist);
         foreach ($declaredTags as $tag) {
             if (!in_array($tag->name, $tagsToKeep)) {
                 if (false !== $index = array_search($tag, $analysis->openapi->tags, true)) {

--- a/src/Processors/AugmentTags.php
+++ b/src/Processors/AugmentTags.php
@@ -17,7 +17,7 @@ class AugmentTags implements ProcessorInterface
 {
 
     /** @var array<string>  */
-    protected array $unusedTagsToKeepWhitelist = [];
+    protected $unusedTagsToKeepWhitelist = [];
 
     public function __construct(array $unusedTagsToKeepWhitelist = [])
     {

--- a/src/Processors/AugmentTags.php
+++ b/src/Processors/AugmentTags.php
@@ -16,7 +16,7 @@ use OpenApi\Generator;
 class AugmentTags implements ProcessorInterface
 {
 
-    /** @var array<string>  */
+    /** @var array<string> */
     protected $unusedTagsToKeepWhitelist = [];
 
     public function __construct(array $unusedTagsToKeepWhitelist = [])

--- a/tests/Fixtures/UnusedTags.php
+++ b/tests/Fixtures/UnusedTags.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures;
+
+use OpenApi\Attributes as OAT;
+
+#[OAT\OpenApi(
+    info: new OAT\Info(
+        title: 'test',
+        description: 'test',
+        version: '2.0.0'
+    ),
+    tags: [
+        // definding tag 'other' globally with nice description
+        new OAT\Tag('other', 'Other description'),
+        // making a tag that has no operations referencing it, but we wish to keep it
+        new OAT\Tag('fancy', 'Fancy description'),
+        // making a tag that it not used, but we do not wish to keep
+        new OAT\Tag('notused', 'remove this one'),
+    ]
+)]
+class UnusedTags
+{
+    #[OAT\Get(path: '/other/', tags: ['other'], responses: [new OAT\Response(response: '200', description: 'success')])]
+    public function hello(): void
+    {
+    }
+}

--- a/tests/Processors/AugmentTagsTest.php
+++ b/tests/Processors/AugmentTagsTest.php
@@ -37,4 +37,23 @@ class AugmentTagsTest extends OpenApiTestCase
 
         $this->assertCount(3, $analysis->openapi->tags, 'Expecting 3 unique tags');
     }
+
+    /**
+     * @requires PHP 8.1
+     */
+    public function testAllowUnusedTags(): void
+    {
+        $this->skipLegacy();
+
+        $analysis = $this->analysisFromFixtures(
+            ['UnusedTags.php'],
+            static::processors(),
+            null,
+            [
+                'augmentTags' => ['unusedTagsToKeepWhitelist' => ['fancy']]
+            ]
+        );
+
+        $this->assertCount(2, $analysis->openapi->tags, 'Expecting 3 unique tags');
+    }
 }

--- a/tests/Processors/AugmentTagsTest.php
+++ b/tests/Processors/AugmentTagsTest.php
@@ -50,7 +50,7 @@ class AugmentTagsTest extends OpenApiTestCase
             static::processors(),
             null,
             [
-                'augmentTags' => ['unusedTagsToKeepWhitelist' => ['fancy']]
+                'augmentTags' => ['unusedTagsToKeepWhitelist' => ['fancy']],
             ]
         );
 

--- a/tests/Processors/AugmentTagsTest.php
+++ b/tests/Processors/AugmentTagsTest.php
@@ -54,6 +54,6 @@ class AugmentTagsTest extends OpenApiTestCase
             ]
         );
 
-        $this->assertCount(2, $analysis->openapi->tags, 'Expecting 3 unique tags');
+        $this->assertCount(2, $analysis->openapi->tags, 'Expecting fancy tag to be preserved');
     }
 }

--- a/tests/Processors/AugmentTagsTest.php
+++ b/tests/Processors/AugmentTagsTest.php
@@ -50,10 +50,29 @@ class AugmentTagsTest extends OpenApiTestCase
             static::processors(),
             null,
             [
-                'augmentTags' => ['unusedTagsToKeepWhitelist' => ['fancy']],
+                'augmentTags' => ['whitelist' => ['fancy']],
             ]
         );
 
         $this->assertCount(2, $analysis->openapi->tags, 'Expecting fancy tag to be preserved');
+    }
+
+    /**
+     * @requires PHP 8.1
+     */
+    public function testAllowUnusedTagsWildcard(): void
+    {
+        $this->skipLegacy();
+
+        $analysis = $this->analysisFromFixtures(
+            ['UnusedTags.php'],
+            static::processors(),
+            null,
+            [
+                'augmentTags' => ['whitelist' => ['*']],
+            ]
+        );
+
+        $this->assertCount(3, $analysis->openapi->tags, 'Expecting all tags to be preserved');
     }
 }


### PR DESCRIPTION
The changes in https://github.com/zircote/swagger-php/pull/1625 mean that we cannot have descriptive tags that do not have a reference to them from an operation. It is nice to allow this so we can have pages dedicated to be informative only (and allow external links directly to that section in the page).

eg. tags like

* introduction
* setup
* how-to

