### PR TITLE
Fix handling of `processor` option in `Generator::scan()`

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -444,7 +444,7 @@ class Generator
             ];
 
         $processorPipeline = $config['processor'] ??
-            $config['processors'] ? new Pipeline($config['processors']) : null;
+            ($config['processors'] ? new Pipeline($config['processors']) : null);
 
         return (new Generator($config['logger']))
             ->setVersion($config['version'])

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -26,11 +26,25 @@ class GeneratorTest extends OpenApiTestCase
     /**
      * @dataProvider sourcesProvider
      */
-    public function testScan(string $sourceDir, iterable $sources): void
+    public function testGenerate(string $sourceDir, iterable $sources): void
     {
         $openapi = (new Generator())
             ->setAnalyser($this->getAnalyzer())
             ->generate($sources);
+
+        $this->assertSpecEquals(file_get_contents(sprintf('%s/%s.yaml', $sourceDir, basename($sourceDir))), $openapi);
+    }
+
+    /**
+     * @dataProvider sourcesProvider
+     */
+    public function testScan(string $sourceDir, iterable $sources): void
+    {
+        $analyzer = $this->getAnalyzer();
+        $processor = (new Generator())
+            ->getProcessorPipeline();
+
+        $openapi = Generator::scan($sources, ['processor' => $processor, 'analyser' => $analyzer]);
 
         $this->assertSpecEquals(file_get_contents(sprintf('%s/%s.yaml', $sourceDir, basename($sourceDir))), $openapi);
     }


### PR DESCRIPTION
Replaces #1646