### PR TITLE
Update generator.md

### DIFF
--- a/docs/reference/generator.md
+++ b/docs/reference/generator.md
@@ -56,13 +56,15 @@ $logger = new \Psr\Log\NullLogger();
 $processors = [/* my processors */];
 $finder = \Symfony\Component\Finder\Finder::create()->files()->name('*.php')->in(__DIR__);
 
+$context = new OpenApi\Context();
+
 $openapi = (new \OpenApi\Generator($logger))
             ->setProcessorPipeline(new \OpenApi\Pipeline($processors))
             ->setAliases(['MY' => 'My\Annotations'])
             ->setNamespaces(['My\\Annotations\\'])
-            ->setAnalyser(new \OpenApi\Analysers\TokenAnalyser())
+            ->setAnalyser(new \OpenApi\Analysers\ReflectionAnalyser([new OpenApi\Analysers\DocBlockAnnotationFactory(), new OpenApi\Analysers\AttributeAnnotationFactory()]))
             ->setVersion(\OpenApi\Annotations\OpenApi::VERSION_3_0_0)
-            ->generate(['/path1/to/project', $finder], new \OpenApi\Analysis(), $validate);
+            ->generate(['/path1/to/project', $finder], new \OpenApi\Analysis([], $context)), $validate);
 ```
 
 `Aliases` and `namespaces` are additional options that allow to customize the parsing of docblocks.


### PR DESCRIPTION
I just spend way too long to figure out why the example throws errors. Since you can't call new Analysis without a context and TokenAnalyser is the old way of doing things, I updated it so the  example works.


Maybe the signature for 

```php 
public function __construct(array $annotations = [], ?Context $context = null)
```
in Analysis.php should get updated since it calls addAnnotations, which doesn't allow context to be null, so I don't quite see why it allows it in the constructor since it will just crash anyway?