### PR TITLE
Allow nesting of `Attachable` annotations

### DIFF
--- a/src/Analysers/AttributeAnnotationFactory.php
+++ b/src/Analysers/AttributeAnnotationFactory.php
@@ -139,9 +139,9 @@ class AttributeAnnotationFactory implements AnnotationFactoryInterface
                 }
             }
 
-            // Property can be nested...
-            return $annotation->getRoot() != $possibleParent->getRoot()
-                && ($explicitParent || ($isAttachable && $isParentAllowed));
+            // Attachables can always be nested (unless explicitly restricted)
+            return ($isAttachable && $isParentAllowed)
+                || ($annotation->getRoot() != $possibleParent->getRoot() && $explicitParent);
         };
 
         $annotationsWithoutParent = [];


### PR DESCRIPTION
This change somewhat loosens the restrictions about nesting of custom `Attachable` annotations to allow proper nesting of custom annotations.

TO avoid bad nesting it is strongly recommended to limit parent/child relationships by implementing the `Attachable::allowedParents()` method. (This will be enforced in v5).