### PR TITLE
Expand on Response annotation warning message.

### DIFF
--- a/src/Annotations/Response.php
+++ b/src/Annotations/Response.php
@@ -121,7 +121,7 @@ class Response extends AbstractAnnotation
         $valid = parent::validate($stack, $skip, $ref, $context);
 
         if (Generator::isDefault($this->description) && Generator::isDefault($this->ref)) {
-            $this->_context->logger->warning($this->identity() . ' One of description or ref is required');
+            $this->_context->logger->warning($this->identity() . ' One of description or ref is required in ' . $this->_context->getDebugLocation());
             $valid = false;
         }
 


### PR DESCRIPTION
If a `description` or `ref` is missing in `Response` annotation, this improves the warning message, telling where exactly the missing attribute for the annotation is, saving up one's debugging time.