### PR TITLE
fix: bracket correction in readme

### DIFF
--- a/docs/reference/generator.md
+++ b/docs/reference/generator.md
@@ -64,7 +64,7 @@ $openapi = (new \OpenApi\Generator($logger))
             ->setNamespaces(['My\\Annotations\\'])
             ->setAnalyser(new \OpenApi\Analysers\ReflectionAnalyser([new OpenApi\Analysers\DocBlockAnnotationFactory(), new OpenApi\Analysers\AttributeAnnotationFactory()]))
             ->setVersion(\OpenApi\Annotations\OpenApi::VERSION_3_0_0)
-            ->generate(['/path1/to/project', $finder], new \OpenApi\Analysis([], $context)), $validate);
+            ->generate(['/path1/to/project', $finder], new \OpenApi\Analysis([], $context), $validate);
 ```
 
 `Aliases` and `namespaces` are additional options that allow to customize the parsing of docblocks.


### PR DESCRIPTION
In this generator [document,](https://zircote.github.io/swagger-php/reference/generator.html#the-openapi-generator-class) the example for generator does not work, due to bracket placed incorrectly.

This change is to fix that example.