### PR TITLE
Initialize Generator::$context

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -27,7 +27,7 @@ class Generator
     /**
      * Allows Annotation classes to know the context of the annotation that is being processed.
      */
-    public static ?Context $context;
+    public static ?Context $context = null;
 
     /** @var string Magic value to differentiate between null and undefined. */
     public const UNDEFINED = '@OA\Generator::UNDEFINED🙈';


### PR DESCRIPTION
Initialize `Generator::$context` to avoid a `Typed static property OpenApi\Generator::$context must not be accessed before initialization` error when `Generator::$context` is called from the `AbstractAnnotation` constructor (line 101).

Fixes #1693 