### PR TITLE
Integrate api, petstore examples into docs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -118,7 +118,8 @@
         ],
         "docs:gen": [
             "@php tools/refgen.php",
-            "@php tools/procgen.php"
+            "@php tools/procgen.php",
+            "@php tools/examplegen.php"
         ],
         "docs:dev": "cd docs && npm run dev",
         "docs:build": [

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -29,6 +29,7 @@ function getGuideSidebar() {
       text: 'Other',
       children: [
         { text: 'Cookbook', link: '/guide/cookbook' },
+        { text: 'Examples', link: '/guide/examples' },
         { text: 'FAQ', link: '/guide/faq' },
         { text: 'Under the hood', link: '/guide/under-the-hood' },
         { text: 'Related Projects', link: '/related-projects' },

--- a/docs/guide/examples.md
+++ b/docs/guide/examples.md
@@ -1,0 +1,295 @@
+# Example Reference
+
+This page is generated automatically from the `swagger-php` sources.
+
+For improvements head over to [GitHub](https://github.com/zircote/swagger-php) and create a PR ;)
+
+
+## api
+### Server.php
+
+<codeblock id="api-Server">
+  <template v-slot:at>
+
+<<< @/../examples/specs/api/attributes/Server.php
+
+  </template>
+  <template v-slot:an>
+
+<<< @/../examples/specs/api/annotations/Server.php
+
+  </template>
+</codeblock>
+
+### Product.php
+
+<codeblock id="api-Product">
+  <template v-slot:at>
+
+<<< @/../examples/specs/api/attributes/Product.php
+
+  </template>
+  <template v-slot:an>
+
+<<< @/../examples/specs/api/annotations/Product.php
+
+  </template>
+</codeblock>
+
+### NameTrait.php
+
+<codeblock id="api-NameTrait">
+  <template v-slot:at>
+
+<<< @/../examples/specs/api/attributes/NameTrait.php
+
+  </template>
+  <template v-slot:an>
+
+<<< @/../examples/specs/api/annotations/NameTrait.php
+
+  </template>
+</codeblock>
+
+### Colour.php
+
+<codeblock id="api-Colour">
+  <template v-slot:at>
+
+<<< @/../examples/specs/api/attributes/Colour.php
+
+  </template>
+  <template v-slot:an>
+
+<<< @/../examples/specs/api/annotations/Colour.php
+
+  </template>
+</codeblock>
+
+### OpenApiSpec.php
+
+<codeblock id="api-OpenApiSpec">
+  <template v-slot:at>
+
+<<< @/../examples/specs/api/attributes/OpenApiSpec.php
+
+  </template>
+  <template v-slot:an>
+
+<<< @/../examples/specs/api/annotations/OpenApiSpec.php
+
+  </template>
+</codeblock>
+
+### ProductController.php
+
+<codeblock id="api-ProductController">
+  <template v-slot:at>
+
+<<< @/../examples/specs/api/attributes/ProductController.php
+
+  </template>
+  <template v-slot:an>
+
+<<< @/../examples/specs/api/annotations/ProductController.php
+
+  </template>
+</codeblock>
+
+
+## petstore
+### Models/Category.php
+
+<codeblock id="petstore-Category">
+  <template v-slot:at>
+
+<<< @/../examples/specs/petstore/attributes/Models/Category.php
+
+  </template>
+  <template v-slot:an>
+
+<<< @/../examples/specs/petstore/annotations/Models/Category.php
+
+  </template>
+</codeblock>
+
+### Models/Order.php
+
+<codeblock id="petstore-Order">
+  <template v-slot:at>
+
+<<< @/../examples/specs/petstore/attributes/Models/Order.php
+
+  </template>
+  <template v-slot:an>
+
+<<< @/../examples/specs/petstore/annotations/Models/Order.php
+
+  </template>
+</codeblock>
+
+### Models/PetRequestBody.php
+
+<codeblock id="petstore-PetRequestBody">
+  <template v-slot:at>
+
+<<< @/../examples/specs/petstore/attributes/Models/PetRequestBody.php
+
+  </template>
+  <template v-slot:an>
+
+<<< @/../examples/specs/petstore/annotations/Models/PetRequestBody.php
+
+  </template>
+</codeblock>
+
+### Models/Tag.php
+
+<codeblock id="petstore-Tag">
+  <template v-slot:at>
+
+<<< @/../examples/specs/petstore/attributes/Models/Tag.php
+
+  </template>
+  <template v-slot:an>
+
+<<< @/../examples/specs/petstore/annotations/Models/Tag.php
+
+  </template>
+</codeblock>
+
+### Models/User.php
+
+<codeblock id="petstore-User">
+  <template v-slot:at>
+
+<<< @/../examples/specs/petstore/attributes/Models/User.php
+
+  </template>
+  <template v-slot:an>
+
+<<< @/../examples/specs/petstore/annotations/Models/User.php
+
+  </template>
+</codeblock>
+
+### Models/ApiResponse.php
+
+<codeblock id="petstore-ApiResponse">
+  <template v-slot:at>
+
+<<< @/../examples/specs/petstore/attributes/Models/ApiResponse.php
+
+  </template>
+  <template v-slot:an>
+
+<<< @/../examples/specs/petstore/annotations/Models/ApiResponse.php
+
+  </template>
+</codeblock>
+
+### Models/UserArrayRequestBody.php
+
+<codeblock id="petstore-UserArrayRequestBody">
+  <template v-slot:at>
+
+<<< @/../examples/specs/petstore/attributes/Models/UserArrayRequestBody.php
+
+  </template>
+  <template v-slot:an>
+
+<<< @/../examples/specs/petstore/annotations/Models/UserArrayRequestBody.php
+
+  </template>
+</codeblock>
+
+### Models/Pet.php
+
+<codeblock id="petstore-Pet">
+  <template v-slot:at>
+
+<<< @/../examples/specs/petstore/attributes/Models/Pet.php
+
+  </template>
+  <template v-slot:an>
+
+<<< @/../examples/specs/petstore/annotations/Models/Pet.php
+
+  </template>
+</codeblock>
+
+### Security.php
+
+<codeblock id="petstore-Security">
+  <template v-slot:at>
+
+<<< @/../examples/specs/petstore/attributes/Security.php
+
+  </template>
+  <template v-slot:an>
+
+<<< @/../examples/specs/petstore/annotations/Security.php
+
+  </template>
+</codeblock>
+
+### Controllers/UserController.php
+
+<codeblock id="petstore-UserController">
+  <template v-slot:at>
+
+<<< @/../examples/specs/petstore/attributes/Controllers/UserController.php
+
+  </template>
+  <template v-slot:an>
+
+<<< @/../examples/specs/petstore/annotations/Controllers/UserController.php
+
+  </template>
+</codeblock>
+
+### Controllers/StoreController.php
+
+<codeblock id="petstore-StoreController">
+  <template v-slot:at>
+
+<<< @/../examples/specs/petstore/attributes/Controllers/StoreController.php
+
+  </template>
+  <template v-slot:an>
+
+<<< @/../examples/specs/petstore/annotations/Controllers/StoreController.php
+
+  </template>
+</codeblock>
+
+### Controllers/PetController.php
+
+<codeblock id="petstore-PetController">
+  <template v-slot:at>
+
+<<< @/../examples/specs/petstore/attributes/Controllers/PetController.php
+
+  </template>
+  <template v-slot:an>
+
+<<< @/../examples/specs/petstore/annotations/Controllers/PetController.php
+
+  </template>
+</codeblock>
+
+### Petstore.php
+
+<codeblock id="petstore-Petstore">
+  <template v-slot:at>
+
+<<< @/../examples/specs/petstore/attributes/Petstore.php
+
+  </template>
+  <template v-slot:an>
+
+<<< @/../examples/specs/petstore/annotations/Petstore.php
+
+  </template>
+</codeblock>
+

--- a/docs/guide/examples.md
+++ b/docs/guide/examples.md
@@ -5,7 +5,10 @@ This page is generated automatically from the `swagger-php` sources.
 For improvements head over to [GitHub](https://github.com/zircote/swagger-php) and create a PR ;)
 
 
-## api
+## Api
+
+A simple API example uing `enums`, `traits` and `callbacks`.
+
 ### Server.php
 
 <codeblock id="api-Server">
@@ -97,7 +100,10 @@ For improvements head over to [GitHub](https://github.com/zircote/swagger-php) a
 </codeblock>
 
 
-## petstore
+## Petstore
+
+Classic petstore sample app. Uses `OAuth`
+
 ### Models/Category.php
 
 <codeblock id="petstore-Category">

--- a/docs/reference/generator.md
+++ b/docs/reference/generator.md
@@ -162,3 +162,4 @@ $openapi = \OpenApi\Generator::scan(\OpenApi\Util::finder(__DIR__, $exclude, $pa
 // same as
 
 $openapi = \OpenApi\scan(__DIR__, ['exclude' => $exclude, 'pattern' => $pattern]);
+```

--- a/examples/specs/api/Readme.md
+++ b/examples/specs/api/Readme.md
@@ -1,0 +1,3 @@
+## Api
+
+A simple API example uing `enums`, `traits` and `callbacks`.

--- a/examples/specs/petstore/Readme.md
+++ b/examples/specs/petstore/Readme.md
@@ -1,0 +1,3 @@
+## Petstore
+
+Classic petstore sample app. Uses `OAuth`

--- a/tools/examplegen.php
+++ b/tools/examplegen.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+use OpenApi\Tools\Docs\ExampleGenerator;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+$gen = new ExampleGenerator(__DIR__ . '/../');
+
+ob_start();
+echo $gen->preamble('Example');
+
+foreach (['api', 'petstore'] as $name) {
+    echo PHP_EOL;
+    echo '## ' . $name . PHP_EOL;
+
+    $typeFiles = [];
+    foreach (['annotations', 'attributes'] as $type) {
+        $typeFolder = $gen->examplePath("specs/$name/$type");
+        $typeFiles[$type] = $gen->collectFiles($typeFolder, '*.php');
+    }
+
+    // use annotations as reference... might flip eventually...
+    foreach ($typeFiles['annotations'] as $relFilename => $filename) {
+        echo '### ' . $relFilename . PHP_EOL . PHP_EOL;
+
+        if (array_key_exists($relFilename, $typeFiles['attributes'])) {
+            echo <<< EOB
+<codeblock id="$name-$filename">
+  <template v-slot:at>
+
+<<< @/../examples/specs/$name/attributes/$relFilename
+
+  </template>
+  <template v-slot:an>
+
+<<< @/../examples/specs/$name/annotations/$relFilename
+
+  </template>
+</codeblock>
+
+
+EOB;
+        }
+    }
+}
+
+file_put_contents($gen->docPath('guide/examples.md'), ob_get_clean());

--- a/tools/examplegen.php
+++ b/tools/examplegen.php
@@ -9,9 +9,17 @@ $gen = new ExampleGenerator(__DIR__ . '/../');
 ob_start();
 echo $gen->preamble('Example');
 
+
+
 foreach (['api', 'petstore'] as $name) {
+    $exampleFolder = $gen->examplePath("specs/$name");
+
     echo PHP_EOL;
-    echo '## ' . $name . PHP_EOL;
+    if (file_exists("$exampleFolder/Readme.md")) {
+        echo file_get_contents("$exampleFolder/Readme.md") . PHP_EOL;
+    } else {
+        echo '## ' . $name . PHP_EOL;
+    }
 
     $typeFiles = [];
     foreach (['annotations', 'attributes'] as $type) {

--- a/tools/examplegen.php
+++ b/tools/examplegen.php
@@ -9,8 +9,6 @@ $gen = new ExampleGenerator(__DIR__ . '/../');
 ob_start();
 echo $gen->preamble('Example');
 
-
-
 foreach (['api', 'petstore'] as $name) {
     $exampleFolder = $gen->examplePath("specs/$name");
 

--- a/tools/procgen.php
+++ b/tools/procgen.php
@@ -4,11 +4,11 @@ require_once __DIR__ . '/../vendor/autoload.php';
 
 use OpenApi\Tools\Docs\ProcGenerator;
 
-$procgen = new ProcGenerator(__DIR__ . '/../');
+$gen = new ProcGenerator(__DIR__ . '/../');
 
 ob_start();
 
-echo $procgen->preamble('Processors');
+echo $gen->preamble('Processors');
 
 echo PHP_EOL . '## Processor Configuration' . PHP_EOL;
 
@@ -47,9 +47,9 @@ as on the command line or be broken down into nested arrays.
 EOT;
 
 echo PHP_EOL . '## Default Processors' . PHP_EOL;
-foreach ($procgen->getProcessorsDetails() as $ii => $details) {
+foreach ($gen->getProcessorsDetails() as $ii => $details) {
     $off = $ii + 1;
-    echo $procgen->formatClassHeader($details['name'], 'Processors');
+    echo $gen->formatClassHeader($details['name'], 'Processors');
     echo $details['phpdoc']['content'] . PHP_EOL;
 
     if ($details['options']) {
@@ -84,4 +84,4 @@ foreach ($procgen->getProcessorsDetails() as $ii => $details) {
     }
 }
 
-file_put_contents($procgen->docPath('reference/processors.md'), ob_get_clean());
+file_put_contents($gen->docPath('reference/processors.md'), ob_get_clean());

--- a/tools/refgen.php
+++ b/tools/refgen.php
@@ -4,19 +4,19 @@ require_once __DIR__ . '/../vendor/autoload.php';
 
 use OpenApi\Tools\Docs\RefGenerator;
 
-$refgen = new RefGenerator(__DIR__ . '/../');
+$gen = new RefGenerator(__DIR__ . '/../');
 
-foreach ($refgen->types() as $type) {
+foreach ($gen->types() as $type) {
     ob_start();
 
-    echo $refgen->preamble($type);
+    echo $gen->preamble($type);
     echo PHP_EOL . "## $type" . PHP_EOL;
 
-    foreach ($refgen->classesForType($type) as $name => $details) {
-        echo $refgen->formatClassHeader($name, $type);
+    foreach ($gen->classesForType($type) as $name => $details) {
+        echo $gen->formatClassHeader($name, $type);
         $method = "format{$type}Details";
-        echo $refgen->$method($name, $details['fqdn'], $details['filename']);
+        echo $gen->$method($name, $details['fqdn'], $details['filename']);
     }
 
-    file_put_contents($refgen->docPath('reference/' . strtolower($type) . '.md'), ob_get_clean());
+    file_put_contents($gen->docPath('reference/' . strtolower($type) . '.md'), ob_get_clean());
 }

--- a/tools/src/Docs/ExampleGenerator.php
+++ b/tools/src/Docs/ExampleGenerator.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tools\Docs;
+
+use OpenApi\Analysers\TokenScanner;
+use OpenApi\Annotations\AbstractAnnotation;
+use Symfony\Component\Finder\Finder;
+
+class ExampleGenerator extends DocGenerator
+{
+    public function __construct($projectRoot)
+    {
+        parent::__construct($projectRoot);
+    }
+
+    public function examplePath(string $relativeName): string
+    {
+        return $this->projectRoot . '/examples/' . $relativeName;
+    }
+
+    public function collectFiles(string $folder, string $name): array
+    {
+        if (!file_exists($folder)) {
+            return [];
+        }
+
+        $finder = (new Finder())
+            ->in($folder)
+            ->name($name);
+
+        $files = [];
+        foreach ($finder as $file) {
+            $relativeName = $file->getRelativePathname();
+            $files[$file->getRelativePathname()] = $file->getBasename('.php');
+        }
+
+        return $files;
+    }
+}

--- a/tools/src/Docs/ExampleGenerator.php
+++ b/tools/src/Docs/ExampleGenerator.php
@@ -6,8 +6,6 @@
 
 namespace OpenApi\Tools\Docs;
 
-use OpenApi\Analysers\TokenScanner;
-use OpenApi\Annotations\AbstractAnnotation;
 use Symfony\Component\Finder\Finder;
 
 class ExampleGenerator extends DocGenerator


### PR DESCRIPTION
- [x] Add new page in guide
- [x] Generate page from existing example code
- [x] Add individual example `Readme.md` which then can be included

Edit: Reducing scope to get things out. Tweaking the actual example files can be done in separate PRs.

<img width="1569" alt="image" src="https://github.com/user-attachments/assets/82edee72-b038-4d28-a32f-344ff39f4f44" />
