### PR TITLE
feat: MetaStorm Integration

### DIFF
--- a/.meta-storm.xml
+++ b/.meta-storm.xml
@@ -1,0 +1,39 @@
+<meta-storm xmlns="meta-storm">
+    <definitions>
+        <classConstructor class="\OpenApi\Attributes\Property" argument="0">
+            <collection name="zircote/swagger-php:types"/>
+        </classConstructor>
+        <classConstructor class="\OpenApi\Attributes\ParameterTrait" argument="3">
+            <collection name="zircote/swagger-php:path-in"/>
+        </classConstructor>
+        <classConstructor class="\OpenApi\Attributes\SecurityScheme" argument="1">
+            <collection name="zircote/swagger-php:path-in"/>
+        </classConstructor>
+        <classConstructor class="\OpenApi\Attributes\MediaType" argument="0">
+            <collection name="GLOBAL:media-types"/>
+        </classConstructor>
+        <classMethod class="\OpenApi\Annotations\AbstractAnnotation" method="__construct" argument="0" targetInArray="key">
+            <properties xpath="$containingClass" />
+        </classMethod>
+    </definitions>
+    <collections>
+        <strings name="zircote/swagger-php:types">
+            <value>string</value>
+            <value>number</value>
+            <value>integer</value>
+            <value>boolean</value>
+            <value>array</value>
+        </strings>
+        <strings name="zircote/swagger-php:path-in">
+            <value>path</value>
+            <value>header</value>
+            <value>query</value>
+            <value>cookie</value>
+        </strings>
+        <strings name="zircote/swagger-php:security-schema-in">
+            <value>header</value>
+            <value>query</value>
+            <value>cookie</value>
+        </strings>
+    </collections>
+</meta-storm>


### PR DESCRIPTION
Here is MetaStorm integration. Get more about MetaStorm:
- [Source](https://github.com/xepozz/meta-storm-idea-plugin)
- [Marketplace](https://plugins.jetbrains.com/plugin/26121-meta-storm/)

I'm not a big fan of writing open api manually, but sometimes I should do it. Last time I modified the attributes notation I've noticed that there are not suggestions for query/path/header/cookie in "in" parameter, no suggestions about media type.
I've added some to help other users do not a typo. 

One more thing is global collection `GLOBAL:media-types` will be available soon, currently it's absent it released versions.