### PR TITLE
Support `x-enumNames` for `BackedEnum`s

### DIFF
--- a/src/Processors/ExpandEnums.php
+++ b/src/Processors/ExpandEnums.php
@@ -56,6 +56,15 @@ class ExpandEnums
                     return ($useName || !($case instanceof \ReflectionEnumBackedCase)) ? $case->name : $case->getBackingValue();
                 }, $re->getCases());
 
+                if (!$useName) {
+                    $schemaX = Generator::isDefault($schema->x) ? [] : $schema->x;
+                    $schemaX['enumNames'] = array_map(function ($case) {
+                        return $case->name;
+                    }, $re->getCases());
+
+                    $schema->x = $schemaX;
+                }
+
                 $schema->type = $useName ? 'string' : $enumType;
 
                 $this->mapNativeType($schema, $schemaType);

--- a/src/Processors/ExpandEnums.php
+++ b/src/Processors/ExpandEnums.php
@@ -22,7 +22,7 @@ class ExpandEnums
 
     protected ?string $enumNames;
 
-    public function __construct(string $enumNames = null)
+    public function __construct(?string $enumNames = null)
     {
         $this->enumNames = $enumNames;
     }
@@ -41,7 +41,7 @@ class ExpandEnums
      * x-enumNames:
      *   - NAME1
      *   - NAME2
-     * ```
+     * ```.
      */
     public function setEnumNames(?string $enumNames = null): void
     {

--- a/src/Processors/ExpandEnums.php
+++ b/src/Processors/ExpandEnums.php
@@ -20,22 +20,32 @@ class ExpandEnums
 {
     use Concerns\TypesTrait;
 
-    /** @var bool Whether to add the extension `x-enumNames` to backed enums (default false). */
-    protected bool $addXEnumNames;
+    protected ?string $enumNames;
 
-    public function __construct(bool $addXEnumNames = false)
+    public function __construct(string $enumNames = null)
     {
-        $this->addXEnumNames = $addXEnumNames;
+        $this->enumNames = $enumNames;
     }
 
-    public function addXEnumNames(): bool
+    public function getEnumNames(): ?string
     {
-        return $this->addXEnumNames;
+        return $this->enumNames;
     }
 
-    public function setAddXEnumNames(bool $addXEnumNames): void
+    /**
+     * Specifies the name of the extension variable where backed enum names will be stored.
+     * Set to `NULL` to avoid writing backed enum names.
+     * Example:
+     * `setEnumNames('enumNames')` yields:
+     * ```
+     * x-enumNames:
+     *   - NAME1
+     *   - NAME2
+     * ```
+     */
+    public function setEnumNames(?string $enumNames = null): void
     {
-        $this->addXEnumNames = $addXEnumNames;
+        $this->enumNames = $enumNames;
     }
 
     public function __invoke(Analysis $analysis)
@@ -74,9 +84,9 @@ class ExpandEnums
                     return ($useName || !($case instanceof \ReflectionEnumBackedCase)) ? $case->name : $case->getBackingValue();
                 }, $re->getCases());
 
-                if ($this->addXEnumNames && !$useName) {
+                if ($this->enumNames !== null && !$useName) {
                     $schemaX = Generator::isDefault($schema->x) ? [] : $schema->x;
-                    $schemaX['enumNames'] = array_map(function ($case) {
+                    $schemaX[$this->enumNames] = array_map(function ($case) {
                         return $case->name;
                     }, $re->getCases());
 

--- a/src/Processors/ExpandEnums.php
+++ b/src/Processors/ExpandEnums.php
@@ -20,6 +20,24 @@ class ExpandEnums
 {
     use Concerns\TypesTrait;
 
+    /** @var bool Whether to add the extension `x-enumNames` to backed enums (default false). */
+    protected bool $addXEnumNames;
+
+    public function __construct(bool $addXEnumNames = false)
+    {
+        $this->addXEnumNames = $addXEnumNames;
+    }
+
+    public function addXEnumNames(): bool
+    {
+        return $this->addXEnumNames;
+    }
+
+    public function setAddXEnumNames(bool $addXEnumNames): void
+    {
+        $this->addXEnumNames = $addXEnumNames;
+    }
+
     public function __invoke(Analysis $analysis)
     {
         if (!class_exists('\\ReflectionEnum')) {
@@ -56,7 +74,7 @@ class ExpandEnums
                     return ($useName || !($case instanceof \ReflectionEnumBackedCase)) ? $case->name : $case->getBackingValue();
                 }, $re->getCases());
 
-                if (!$useName) {
+                if ($this->addXEnumNames && !$useName) {
                     $schemaX = Generator::isDefault($schema->x) ? [] : $schema->x;
                     $schemaX['enumNames'] = array_map(function ($case) {
                         return $case->name;

--- a/tests/Processors/ExpandEnumsTest.php
+++ b/tests/Processors/ExpandEnumsTest.php
@@ -64,7 +64,7 @@ class ExpandEnumsTest extends OpenApiTestCase
     public function testEnumNamesInBackedStringEnum(): void
     {
         $analysis = $this->analysisFromFixtures(['PHP/Enums/StatusEnumStringBacked.php']);
-        $analysis->process([new ExpandEnums(true)]);
+        $analysis->process([new ExpandEnums('enumNames')]);
         $schema = $analysis->getSchemaForSource(StatusEnumStringBacked::class);
 
         $this->assertEquals(['DRAFT', 'PUBLISHED', 'ARCHIVED'], $schema->x['enumNames']);

--- a/tests/Processors/ExpandEnumsTest.php
+++ b/tests/Processors/ExpandEnumsTest.php
@@ -61,6 +61,15 @@ class ExpandEnumsTest extends OpenApiTestCase
         $this->assertEquals('string', $schema->type);
     }
 
+    public function testEnumNamesInBackedStringEnum(): void
+    {
+        $analysis = $this->analysisFromFixtures(['PHP/Enums/StatusEnumStringBacked.php']);
+        $analysis->process([new ExpandEnums()]);
+        $schema = $analysis->getSchemaForSource(StatusEnumStringBacked::class);
+
+        $this->assertEquals(['DRAFT', 'PUBLISHED', 'ARCHIVED'], $schema->x['enumNames']);
+    }
+
     public static function expandEnumClassStringFixtures(): iterable
     {
         if (!class_exists('\\ReflectionEnum')) {

--- a/tests/Processors/ExpandEnumsTest.php
+++ b/tests/Processors/ExpandEnumsTest.php
@@ -64,7 +64,7 @@ class ExpandEnumsTest extends OpenApiTestCase
     public function testEnumNamesInBackedStringEnum(): void
     {
         $analysis = $this->analysisFromFixtures(['PHP/Enums/StatusEnumStringBacked.php']);
-        $analysis->process([new ExpandEnums()]);
+        $analysis->process([new ExpandEnums(true)]);
         $schema = $analysis->getSchemaForSource(StatusEnumStringBacked::class);
 
         $this->assertEquals(['DRAFT', 'PUBLISHED', 'ARCHIVED'], $schema->x['enumNames']);


### PR DESCRIPTION
Currently, in the OpenAPI spec, there's no standardized way to persist the name of enums when the value of the enum is stored in the `enum` value. There are competing implementations for providing this data in the form of extensions, but one with widespread support is `x-enumNames`, used by NSwag, `swagger-api-typescript`, and SwaggerUI via a plugin.

This PR specifically expands the enum processing to automatically generate the `x-enumNames` values in cases where the enum name isn't used as the value. This ensures that we're able to use this data in other libraries.

I figured I'd offer it as a PR since it may be of utility to more than just me, but I realize that it's using an extension and I can also implement it via directly modifying the pipeline myself. Either way, perhaps it's helpful for folks!