### PR TITLE
Update vitepress, closes #1720

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -2,7 +2,7 @@ function getGuideSidebar() {
   return [
     {
       text: 'Introduction',
-      children: [
+      items: [
         { text: 'What is Swagger-PHP?', link: '/guide/' },
         { text: 'Installation', link: '/guide/installation' },
         { text: 'Generating OpenAPI documents', link: '/guide/generating-openapi-documents' },
@@ -10,7 +10,7 @@ function getGuideSidebar() {
     },
     {
       text: 'Annotating your code',
-      children: [
+      items: [
         { text: 'Attributes', link: '/guide/attributes' },
         { text: 'Annotations', link: '/guide/annotations' },
         { text: 'Required elements', link: '/guide/required-elements' },
@@ -19,7 +19,7 @@ function getGuideSidebar() {
     },
     {
       text: 'Upgrading',
-      children: [
+      items: [
         { text: 'Migration from 4.x to 5.x', link: '/guide/migrating-to-v5' },
         { text: 'Migration from 3.x to 4.x', link: '/guide/migrating-to-v4' },
         { text: 'Migration from 2.x to 3.x', link: '/guide/migrating-to-v3' },
@@ -27,7 +27,7 @@ function getGuideSidebar() {
     },
     {
       text: 'Other',
-      children: [
+      items: [
         { text: 'Cookbook', link: '/guide/cookbook' },
         { text: 'Examples', link: '/guide/examples' },
         { text: 'FAQ', link: '/guide/faq' },
@@ -42,14 +42,14 @@ function getReferenceSidebar() {
   return [
     {
       text: 'Reference',
-      children: [
+      items: [
         { text: 'Attributes', link: '/reference/attributes' },
         { text: 'Annotations', link: '/reference/annotations' },
       ]
     },
     {
       text: 'Api',
-      children: [
+      items: [
         { text: 'Generator', link: '/reference/generator' },
         { text: 'Processors', link: '/reference/processors' },
       ]
@@ -64,8 +64,10 @@ module.exports = {
   srcExclude: [
       'examples/Readme.md'
   ],
-  themeConfig: {
-    repo: 'zircote/swagger-php',
+  themeConfig: {    
+    socialLinks: [
+      { icon: 'github', link: 'https://github.com/zircote/swagger-php' },
+    ],
     docsDir: 'docs',
     docsBranch: 'master',
     editLinks: false,
@@ -81,6 +83,10 @@ module.exports = {
     sidebar: {
       '/guide/': getGuideSidebar(),
       '/reference/': getReferenceSidebar()
+    },
+
+    outline: {
+      level: [2, 3]
     }
   }
 };

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,8 +1,9 @@
 /* https://github.com/vuejs/vitepress/blob/main/src/client/theme-default/styles/vars.css */
 :root {
-    --c-brand: #74a535;
+    --vp-c-brand-1: #74a535;
+    --vp-button-brand-bg: var(--vp-c-brand-1);
+    --vp-home-hero-name-color: #2c3e50;
     --c-brand-light: #94c73d;
-
     --c-bg: #fefefe;
 }
 
@@ -17,16 +18,22 @@
 
 .tabs-component-tab-a {
     padding: 0.5em;
+    color: inherit !important;
 }
 
 .tabs-component-tab {
     transform: none;
+    margin-top: 0 !important;
 }
 
 @media (min-width: 700px) {
     .tabs-component-tab.is-active {
         border-bottom: solid 1px #ddd;
     }
+}
+
+.vp-doc a {
+    text-decoration: none;
 }
 
 .table-plain, table.table-plain tr, table.table-plain th, table.table-plain td  {

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,12 @@
 ---
-home: true
-actionText: User Guide →
-actionLink: /guide/
+layout: home
+hero: 
+  name: Swagger-PHP
+  tagline: Generate OpenAPI documentation for your RESTful API.
+  actions:
+      - theme: brand
+        text:  User Guide →
+        link: /guide/
 features:
   - title: OpenAPI conformant
     details: Generate OpenAPI documents in version 3.0 or 3.1.
@@ -46,7 +51,7 @@ possible attributes should be used.
 
 ### 4. Explore and interact with your API
 
-Use an OpenAPI tool like [Swagger UI ](https://swagger.io/tools/swagger-ui/) to explore and interact with your API.
+Use an OpenAPI tool like [Swagger UI](https://swagger.io/tools/swagger-ui/) to explore and interact with your API.
 
 ## Links
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,7 +8,7 @@
     "deploy": "npm run build && git-directory-deploy --branch gh-pages --directory .vitepress/dist/"
   },
   "devDependencies": {
-    "vitepress": "^0.22",
-    "vue3-tabs-component": "^1.0.8"
+    "vitepress": "^1.6",
+    "vue3-tabs-component": "^1.3.7"
   }
 }


### PR DESCRIPTION
There are some slight differences between the versions. Since there is now an official dark mode I decided to leave the codeblocks in the light style if darkmode isn't enabled. But I can change it if requested.