### PR TITLE
Preserve docblock indentation

### DIFF
--- a/docs/reference/annotations.md
+++ b/docs/reference/annotations.md
@@ -247,7 +247,7 @@ This must be in the form of an url.</p><table class="table-plain"><tbody><tr><td
   <dd><p>The URL to be used for obtaining refresh tokens.<br />
 <br />
 This must be in the form of an url.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
-  <dt><strong>flow</strong> : <span style="font-family: monospace;">string</span></dt>
+  <dt><strong>flow</strong> : <span style="font-family: monospace;">&#039;authorizationCode&#039;|&#039;clientCredentials&#039;|&#039;implicit&#039;|&#039;password&#039;</span></dt>
   <dd><p>Flow name.<br />
 <br />
 One of ['implicit', 'password', 'authorizationCode', 'clientCredentials'].</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>yes</b></td></tr></tbody></table></dd>
@@ -411,7 +411,21 @@ The description of an item in a Schema with type `array`.
 
 Shorthand for a json response.
 
-Use as `@OA\Schema` inside a `Response` and `MediaType`->`'application/json'` will be generated.
+Example:
+```php
+@OA\JsonContent(
+    ref="#/components/schemas/user"
+)
+```
+vs.
+```php
+@OA\MediaType(
+    mediaType="application/json",
+    @OA\Schema(
+        ref="#/components/schemas/user"
+    )
+)
+```
 
 #### Nested elements
 ---
@@ -553,7 +567,7 @@ This is the root document object for the API specification.
 #### Properties
 ---
 <dl>
-  <dt><strong>openapi</strong> : <span style="font-family: monospace;">string</span></dt>
+  <dt><strong>openapi</strong> : <span style="font-family: monospace;">&#039;3.0.0&#039;|&#039;3.1.0&#039;</span></dt>
   <dd><p>The semantic version number of the OpenAPI Specification version that the OpenAPI document uses.<br />
 <br />
 The openapi field should be used by tooling specifications and clients to interpret the OpenAPI document.<br />

--- a/docs/reference/attributes.md
+++ b/docs/reference/attributes.md
@@ -294,7 +294,7 @@ For all other cases, the name corresponds to the parameter name used by the in p
 This could contain examples of use.<br />
 <br />
 CommonMark syntax may be used for rich text representation.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
-  <dt><strong>in</strong> : <span style="font-family: monospace;">string|null</span></dt>
+  <dt><strong>in</strong> : <span style="font-family: monospace;">&#039;query&#039;|&#039;header&#039;|&#039;path&#039;|&#039;cookie&#039;|null</span></dt>
   <dd><p>This takes 'cookie' as the default location.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>yes</b></td></tr></tbody></table></dd>
   <dt><strong>required</strong> : <span style="font-family: monospace;">bool|null</span></dt>
   <dd><p>Determines whether this parameter is mandatory.<br />
@@ -591,7 +591,7 @@ This must be in the form of an url.</p><table class="table-plain"><tbody><tr><td
   <dd><p>The URL to be used for obtaining refresh tokens.<br />
 <br />
 This must be in the form of an url.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
-  <dt><strong>flow</strong> : <span style="font-family: monospace;">string|null</span></dt>
+  <dt><strong>flow</strong> : <span style="font-family: monospace;">&#039;implicit&#039;|&#039;password&#039;|&#039;authorizationCode&#039;|&#039;clientCredentials&#039;|null</span></dt>
   <dd><p>Flow name.<br />
 <br />
 One of ['implicit', 'password', 'authorizationCode', 'clientCredentials'].</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>yes</b></td></tr></tbody></table></dd>
@@ -865,7 +865,7 @@ For all other cases, the name corresponds to the parameter name used by the in p
 This could contain examples of use.<br />
 <br />
 CommonMark syntax may be used for rich text representation.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
-  <dt><strong>in</strong> : <span style="font-family: monospace;">string|null</span></dt>
+  <dt><strong>in</strong> : <span style="font-family: monospace;">&#039;query&#039;|&#039;header&#039;|&#039;path&#039;|&#039;cookie&#039;|null</span></dt>
   <dd><p>This takes 'header' as the default location.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>yes</b></td></tr></tbody></table></dd>
   <dt><strong>required</strong> : <span style="font-family: monospace;">bool|null</span></dt>
   <dd><p>Determines whether this parameter is mandatory.<br />
@@ -1149,7 +1149,23 @@ These will be ignored but can be used for custom processing.</p><table class="ta
 
 ### [JsonContent](https://github.com/zircote/swagger-php/tree/master/src/Attributes/JsonContent.php)
 
+Shorthand for a json response.
 
+Example:
+```php
+#[OA\JsonContent(
+    ref: '#/components/schemas/user'
+)]
+```
+vs.
+```php
+#[OA\MediaType(
+    mediaType: 'application/json',
+    schema: new OA\Schema(
+        ref: '#/components/schemas/user'
+    )
+)
+```
 
 #### Nested elements
 ---
@@ -1464,7 +1480,7 @@ These will be ignored but can be used for custom processing.</p><table class="ta
 #### Parameters
 ---
 <dl>
-  <dt><strong>openapi</strong> : <span style="font-family: monospace;">string</span></dt>
+  <dt><strong>openapi</strong> : <span style="font-family: monospace;">&#039;3.0.0&#039;|&#039;3.1.0&#039;</span></dt>
   <dd><p>The semantic version number of the OpenAPI Specification version that the OpenAPI document uses.<br />
 <br />
 The openapi field should be used by tooling specifications and clients to interpret the OpenAPI document.<br />
@@ -1629,7 +1645,7 @@ For all other cases, the name corresponds to the parameter name used by the in p
 This could contain examples of use.<br />
 <br />
 CommonMark syntax may be used for rich text representation.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
-  <dt><strong>in</strong> : <span style="font-family: monospace;">string|null</span></dt>
+  <dt><strong>in</strong> : <span style="font-family: monospace;">&#039;query&#039;|&#039;header&#039;|&#039;path&#039;|&#039;cookie&#039;|null</span></dt>
   <dd><p>The location of the parameter.<br />
 <br />
 Possible values are "query", "header", "path" or "cookie".</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>yes</b></td></tr></tbody></table></dd>
@@ -1881,7 +1897,7 @@ For all other cases, the name corresponds to the parameter name used by the in p
 This could contain examples of use.<br />
 <br />
 CommonMark syntax may be used for rich text representation.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
-  <dt><strong>in</strong> : <span style="font-family: monospace;">string|null</span></dt>
+  <dt><strong>in</strong> : <span style="font-family: monospace;">&#039;query&#039;|&#039;header&#039;|&#039;path&#039;|&#039;cookie&#039;|null</span></dt>
   <dd><p>This takes 'path' as the default location.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>required</strong> : <span style="font-family: monospace;">bool|null</span></dt>
   <dd><p>No details available.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -2332,7 +2348,7 @@ For all other cases, the name corresponds to the parameter name used by the in p
 This could contain examples of use.<br />
 <br />
 CommonMark syntax may be used for rich text representation.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
-  <dt><strong>in</strong> : <span style="font-family: monospace;">string|null</span></dt>
+  <dt><strong>in</strong> : <span style="font-family: monospace;">&#039;query&#039;|&#039;header&#039;|&#039;path&#039;|&#039;cookie&#039;|null</span></dt>
   <dd><p>This takes 'query' as the default location.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>yes</b></td></tr></tbody></table></dd>
   <dt><strong>required</strong> : <span style="font-family: monospace;">bool|null</span></dt>
   <dd><p>Determines whether this parameter is mandatory.<br />

--- a/docs/reference/processors.md
+++ b/docs/reference/processors.md
@@ -52,9 +52,9 @@ Merge reusable annotation into @OA\Schemas.
 
 Iterate over the chain of ancestors of a schema and:
 - if the ancestor has a schema
-=> inherit from the ancestor if it has a schema (allOf) and stop.
+  => inherit from the ancestor if it has a schema (allOf) and stop.
 - else
-=> merge ancestor properties into the schema.
+  => merge ancestor properties into the schema.
 ### [ExpandInterfaces](https://github.com/zircote/swagger-php/tree/master/src/Processors/ExpandInterfaces.php)
 
 Look at all (direct) interfaces for a schema and:

--- a/src/Annotations/JsonContent.php
+++ b/src/Annotations/JsonContent.php
@@ -11,7 +11,22 @@ use OpenApi\Annotations as OA;
 /**
  * Shorthand for a json response.
  *
- * Use as `@OA\Schema` inside a `Response` and `MediaType`->`'application/json'` will be generated.
+ * Example:
+ * ```php
+ *
+ * @OA\JsonContent(
+ *     ref="#/components/schemas/user"
+ * )
+ * ```
+ * vs.
+ * ```php
+ * @OA\MediaType(
+ *     mediaType="application/json",
+ *     @OA\Schema(
+ *         ref="#/components/schemas/user"
+ *     )
+ * )
+ * ```
  *
  * @Annotation
  */

--- a/src/Attributes/JsonContent.php
+++ b/src/Attributes/JsonContent.php
@@ -9,6 +9,27 @@ namespace OpenApi\Attributes;
 use OpenApi\Generator;
 use OpenApi\Annotations as OA;
 
+/**
+ * Shorthand for a json response.
+ *
+ * Example:
+ * ```php
+ * #[OA\JsonContent(
+ *     ref: '#/components/schemas/user'
+ * )]
+ * ```
+ * vs.
+ * ```php
+ * #[OA\MediaType(
+ *     mediaType: 'application/json',
+ *     schema: new OA\Schema(
+ *         ref: '#/components/schemas/user'
+ *     )
+ * )
+ * ```
+ *
+ * @Annotation
+ */
 #[\Attribute(\Attribute::TARGET_CLASS)]
 class JsonContent extends OA\JsonContent
 {

--- a/src/Processors/Concerns/DocblockTrait.php
+++ b/src/Processors/Concerns/DocblockTrait.php
@@ -101,9 +101,9 @@ trait DocblockTrait
         $append = false;
         $skip = false;
         foreach ($comment as $line) {
-            $line = ltrim($line, "\t *");
-            if (substr($line, 0, 1) === '@') {
-                $this->handleTag($line, $tags);
+            $line = preg_replace('/^\s+\* ?/', '', $line);
+            if (substr($tagline = trim($line), 0, 1) === '@') {
+                $this->handleTag($tagline, $tags);
                 $skip = true;
             }
             if ($skip) {

--- a/tools/src/Docs/DocGenerator.php
+++ b/tools/src/Docs/DocGenerator.php
@@ -83,13 +83,15 @@ EOT;
         $contentLines = [];
         $append = false;
         foreach ($comment as $line) {
-            $line = ltrim($line, "\t *");
+            $line = preg_replace('/^\s+\* ?/', '', $line);
             if (substr($line, 0, 1) === '@') {
                 if (substr($line, 0, 5) === '@see ') {
                     $see[] = trim(substr($line, 5));
+                    continue;
                 }
                 if (substr($line, 0, 5) === '@var ') {
                     $var = trim(substr($line, 5));
+                    continue;
                 }
                 if (substr($line, 0, 7) === '@param ') {
                     preg_match('/^([^\$]+)\$([^\s]+)(.*)$/', trim(substr($line, 7)), $match);
@@ -98,9 +100,12 @@ EOT;
                             'type' => trim($match[1]),
                             'content' => 4 == count($match) ? $match[3] : null,
                         ];
+                        continue;
                     }
                 }
-                continue;
+                if (in_array(substr($line, 0), ['@Annotation', '@inheritdoc', '@since 3.1.0'])) {
+                    continue;
+                }
             }
 
             if ($append) {
@@ -111,6 +116,7 @@ EOT;
             }
             $append = (substr($line, -1) === '\\');
         }
+
         $content = trim(implode("\n", $contentLines));
 
         return ['content' => $content, 'see' => $see, 'var' => $var, 'params' => $params];


### PR DESCRIPTION
Also properly handle sample code in `src` docblocks when generating docs.

Adds documentation to `JsonContent` on how to use vs. `MediaType`

resolves #1638 