### PR TITLE
`procgen` changes to support code blocks

### DIFF
--- a/docs/reference/annotations.md
+++ b/docs/reference/annotations.md
@@ -85,7 +85,7 @@ Contact information for the exposed API.
 
 ### [CookieParameter](https://github.com/zircote/swagger-php/tree/master/src/Annotations/CookieParameter.php)
 
-A `@OA\Request` cookie parameter.
+A <code>@OA\Request</code> cookie parameter.
 
 #### Allowed in
 ---
@@ -169,7 +169,7 @@ On top of this subset, there are extensions provided by this specification to al
   <dt><strong>ref</strong> : <span style="font-family: monospace;">string|class-string|object</span></dt>
   <dd><p>The relative or absolute path to an example.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr><tr><td style="padding-left: 0;"><i>See</i>:</td><td style="padding-left: 0;"><a href="https://spec.openapis.org/oas/v3.1.1.html#reference-object">Reference Object</a></td></tr></tbody></table></dd>
   <dt><strong>example</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd><p>The key into `#/components/examples`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+  <dd><p>The key into <code>#/components/examples</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>summary</strong> : <span style="font-family: monospace;">string</span></dt>
   <dd><p>Short description for the example.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>yes</b></td></tr></tbody></table></dd>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string</span></dt>
@@ -343,7 +343,7 @@ If style is used, and if behavior is n/a (cannot be serialized), the value of al
 
 ### [HeaderParameter](https://github.com/zircote/swagger-php/tree/master/src/Annotations/HeaderParameter.php)
 
-A `@OA\Request` header parameter.
+A <code>@OA\Request</code> header parameter.
 
 #### Allowed in
 ---
@@ -397,7 +397,7 @@ Must be in the format of an url.</p><table class="table-plain"><tbody><tr><td><i
 
 ### [Items](https://github.com/zircote/swagger-php/tree/master/src/Annotations/Items.php)
 
-The description of an item in a Schema with type `array`.
+The description of an item in a Schema with type <code>array</code>.
 
 #### Allowed in
 ---
@@ -449,11 +449,11 @@ License information for the exposed API.
   <dt><strong>name</strong> : <span style="font-family: monospace;">string</span></dt>
   <dd><p>The license name used for the API.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>yes</b></td></tr></tbody></table></dd>
   <dt><strong>identifier</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd><p>An SPDX license expression for the API. The `identifier` field is mutually exclusive of the `url` field.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+  <dd><p>An SPDX license expression for the API. The <code>identifier</code> field is mutually exclusive of the <code>url</code> field.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>url</strong> : <span style="font-family: monospace;">string</span></dt>
-  <dd><p>An URL to the license used for the API. This MUST be in the form of a URL.<br />
+  <dd><p>A URL to the license used for the API. This MUST be in the form of a URL.<br />
 <br />
-The `url` field is mutually exclusive of the `identifier` field.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The <code>url</code> field is mutually exclusive of the <code>identifier</code> field.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
 </dl>
 
 #### Reference
@@ -572,7 +572,7 @@ This is the root document object for the API specification.
 <br />
 The openapi field should be used by tooling specifications and clients to interpret the OpenAPI document.<br />
 <br />
-A version specified via `Generator::setVersion()` will overwrite this value.<br />
+A version specified via <code>Generator::setVersion()</code> will overwrite this value.<br />
 <br />
 This is not related to the API info::version string.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>yes</b></td></tr></tbody></table></dd>
   <dt><strong>security</strong> : <span style="font-family: monospace;">array</span></dt>
@@ -581,7 +581,7 @@ This is not related to the API info::version string.</p><table class="table-plai
 The list of values includes alternative security requirement objects that can be used.<br />
 Only one of the security requirement objects need to be satisfied to authorize a request.<br />
 Individual operations can override this definition.<br />
-To make security optional, an empty security requirement `({})` can be included in the array.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+To make security optional, an empty security requirement (<code>{}</code>) can be included in the array.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
 </dl>
 
 #### Reference
@@ -770,7 +770,7 @@ The path itself is still exposed to the documentation viewer, but they will not 
 
 ### [PathParameter](https://github.com/zircote/swagger-php/tree/master/src/Annotations/PathParameter.php)
 
-A `@OA\Request` path parameter.
+A <code>@OA\Request</code> path parameter.
 
 #### Allowed in
 ---
@@ -848,7 +848,7 @@ A `@OA\Request` path parameter.
 
 ### [QueryParameter](https://github.com/zircote/swagger-php/tree/master/src/Annotations/QueryParameter.php)
 
-A `@OA\Request` query parameter.
+A <code>@OA\Request</code> query parameter.
 
 #### Allowed in
 ---
@@ -1257,7 +1257,7 @@ CommonMark syntax MAY be used for rich text representation.</p><table class="tab
 
 ### [Webhook](https://github.com/zircote/swagger-php/tree/master/src/Annotations/Webhook.php)
 
-Acts like a `PathItem` with the main difference being that it requires `webhook` instead of `path`.
+Acts like a <code>PathItem</code> with the main difference being that it requires <code>webhook</code> instead of <code>path</code>.
 
 #### Allowed in
 ---
@@ -1322,7 +1322,7 @@ Default value is false. The definition takes effect only when defined alongside 
 
 Shorthand for a xml response.
 
-Use as `@OA\Schema` inside a `Response` and `MediaType`->`'application/xml'` will be generated.
+Use as <code>@OA\Schema</code> inside a <code>Response</code> and <code>MediaType</code>-><code>'application/xml'</code> will be generated.
 
 #### Nested elements
 ---

--- a/docs/reference/attributes.md
+++ b/docs/reference/attributes.md
@@ -171,7 +171,7 @@ defined by this property's value.</p><table class="table-plain"><tbody><tr><td><
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -228,7 +228,7 @@ These will be ignored but can be used for custom processing.</p><table class="ta
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -258,7 +258,7 @@ These will be ignored but can be used for custom processing.</p><table class="ta
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -361,7 +361,7 @@ This option replaces collectionFormat equal to pipes from OpenAPI 2.0.</p><table
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -451,7 +451,7 @@ Default value is false.</p><table class="table-plain"><tbody><tr><td><i>Required
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -479,7 +479,7 @@ These will be ignored but can be used for custom processing.</p><table class="ta
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -501,7 +501,7 @@ These will be ignored but can be used for custom processing.</p><table class="ta
 ---
 <dl>
   <dt><strong>example</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd><p>The key into `#/components/examples`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+  <dd><p>The key into <code>#/components/examples</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>summary</strong> : <span style="font-family: monospace;">string|null</span></dt>
   <dd><p>Short description for the example.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>yes</b></td></tr></tbody></table></dd>
   <dt><strong>description</strong> : <span style="font-family: monospace;">string|null</span></dt>
@@ -530,7 +530,7 @@ The value field and externalValue field are mutually exclusive.</p><table class=
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -558,7 +558,7 @@ These will be ignored but can be used for custom processing.</p><table class="ta
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -602,7 +602,7 @@ A map between the scope name and a short description for it.</p><table class="ta
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -692,7 +692,7 @@ Default value is false.</p><table class="table-plain"><tbody><tr><td><i>Required
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -782,7 +782,7 @@ Default value is false.</p><table class="table-plain"><tbody><tr><td><i>Required
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -829,7 +829,7 @@ If style is used, and if behavior is n/a (cannot be serialized), the value of al
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -932,7 +932,7 @@ This option replaces collectionFormat equal to pipes from OpenAPI 2.0.</p><table
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -972,7 +972,7 @@ Must be in the format of an url.</p><table class="table-plain"><tbody><tr><td><i
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -1141,7 +1141,7 @@ defined by this property's value.</p><table class="table-plain"><tbody><tr><td><
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -1328,7 +1328,7 @@ defined by this property's value.</p><table class="table-plain"><tbody><tr><td><
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -1352,15 +1352,15 @@ These will be ignored but can be used for custom processing.</p><table class="ta
   <dt><strong>name</strong> : <span style="font-family: monospace;">string|null</span></dt>
   <dd><p>The license name used for the API.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>yes</b></td></tr></tbody></table></dd>
   <dt><strong>identifier</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd><p>An SPDX license expression for the API. The `identifier` field is mutually exclusive of the `url` field.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+  <dd><p>An SPDX license expression for the API. The <code>identifier</code> field is mutually exclusive of the <code>url</code> field.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>url</strong> : <span style="font-family: monospace;">string|null</span></dt>
-  <dd><p>An URL to the license used for the API. This MUST be in the form of a URL.<br />
+  <dd><p>A URL to the license used for the API. This MUST be in the form of a URL.<br />
 <br />
-The `url` field is mutually exclusive of the `identifier` field.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The <code>url</code> field is mutually exclusive of the <code>identifier</code> field.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -1414,7 +1414,7 @@ CommonMark syntax may be used for rich text representation.</p><table class="tab
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -1463,7 +1463,7 @@ application/x-www-form-urlencoded.</p><table class="table-plain"><tbody><tr><td>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -1485,7 +1485,7 @@ These will be ignored but can be used for custom processing.</p><table class="ta
 <br />
 The openapi field should be used by tooling specifications and clients to interpret the OpenAPI document.<br />
 <br />
-A version specified via `Generator::setVersion()` will overwrite this value.<br />
+A version specified via <code>Generator::setVersion()</code> will overwrite this value.<br />
 <br />
 This is not related to the API info::version string.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>yes</b></td></tr></tbody></table></dd>
   <dt><strong>info</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Info|null</span></dt>
@@ -1500,7 +1500,7 @@ If not provided, or is an empty array, the default value would be a Server Objec
 The list of values includes alternative security requirement objects that can be used.<br />
 Only one of the security requirement objects need to be satisfied to authorize a request.<br />
 Individual operations can override this definition.<br />
-To make security optional, an empty security requirement `({})` can be included in the array.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+To make security optional, an empty security requirement (<code>{}</code>) can be included in the array.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>tags</strong> : <span style="font-family: monospace;">Tag[]|null</span></dt>
   <dd><p>A list of tags used by the specification with additional metadata.<br />
 <br />
@@ -1519,7 +1519,7 @@ Each tag name in the list must be unique.</p><table class="table-plain"><tbody><
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -1609,7 +1609,7 @@ Default value is false.</p><table class="table-plain"><tbody><tr><td><i>Required
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -1714,7 +1714,7 @@ This option replaces collectionFormat equal to pipes from OpenAPI 2.0.</p><table
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -1804,7 +1804,7 @@ Default value is false.</p><table class="table-plain"><tbody><tr><td><i>Required
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -1861,7 +1861,7 @@ The list can use the Reference Object to link to parameters that are defined at 
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -1961,7 +1961,7 @@ This option replaces collectionFormat equal to pipes from OpenAPI 2.0.</p><table
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -2051,7 +2051,7 @@ Default value is false.</p><table class="table-plain"><tbody><tr><td><i>Required
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -2222,7 +2222,7 @@ defined by this property's value.</p><table class="table-plain"><tbody><tr><td><
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -2312,7 +2312,7 @@ Default value is false.</p><table class="table-plain"><tbody><tr><td><i>Required
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -2415,7 +2415,7 @@ This option replaces collectionFormat equal to pipes from OpenAPI 2.0.</p><table
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -2459,7 +2459,7 @@ only the most specific key is applicable. e.g. text/plain overrides text/*.</p><
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -2511,7 +2511,7 @@ Objects.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td s
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -2688,7 +2688,7 @@ defined by this property's value.</p><table class="table-plain"><tbody><tr><td><
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -2734,7 +2734,7 @@ Bearer tokens are usually generated by an authorization server, so this informat
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -2772,7 +2772,7 @@ The value is used for substitution in the server's URL template.</p><table class
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -2812,7 +2812,7 @@ The value is used for substitution in the server's URL template.</p><table class
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -2842,7 +2842,7 @@ These will be ignored but can be used for custom processing.</p><table class="ta
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -2932,7 +2932,7 @@ Default value is false.</p><table class="table-plain"><tbody><tr><td><i>Required
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -2991,7 +2991,7 @@ The list can use the Reference Object to link to parameters that are defined at 
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -3038,7 +3038,7 @@ Default value is false. The definition takes effect only when defined alongside 
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
@@ -3209,7 +3209,7 @@ defined by this property's value.</p><table class="table-plain"><tbody><tr><td><
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
-The keys inside the array will be prefixed with `x-`.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+The keys inside the array will be prefixed with <code>x-</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>attachables</strong> : <span style="font-family: monospace;">Attachable[]|null</span></dt>
   <dd><p>Arbitrary attachables for this annotation.<br />
 These will be ignored but can be used for custom processing.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>

--- a/docs/reference/processors.md
+++ b/docs/reference/processors.md
@@ -41,13 +41,13 @@ as on the command line or be broken down into nested arrays.
 Checks if the annotation has a summary and/or description property
 and uses the text in the comment block (above the annotations) as summary and/or description.
 
-Use `null`, for example: `@Annotation(description=null)`, if you don't want the annotation to have a description.
+Use <code>null</code>, for example: <code>@Annotation(description=null)</code>, if you don't want the annotation to have a description.
 ### [MergeIntoOpenApi](https://github.com/zircote/swagger-php/tree/master/src/Processors/MergeIntoOpenApi.php)
 
-Merge all @OA\OpenApi annotations into one.
+Merge all <code>@OA\OpenApi</code> annotations into one.
 ### [MergeIntoComponents](https://github.com/zircote/swagger-php/tree/master/src/Processors/MergeIntoComponents.php)
 
-Merge reusable annotation into @OA\Schemas.
+Merge reusable annotation into <code>@OA\Schemas</code>.
 ### [ExpandClasses](https://github.com/zircote/swagger-php/tree/master/src/Processors/ExpandClasses.php)
 
 Iterate over the chain of ancestors of a schema and:
@@ -69,7 +69,26 @@ Look at all (direct) traits for a schema and:
 
 Expands PHP enums.
 
-Determines `schema`, `enum` and `type`.
+Determines <code>schema</code>, <code>enum</code> and <code>type</code>.
+#### Config settings
+**expandEnums.enumNames**
+: <span style="font-family: monospace;">string</span>
+<br>**default**
+: <span style="font-family: monospace;">null</span>
+
+&nbsp;&nbsp;&nbsp;&nbsp;Specifies the name of the extension variable where backed enum names will be stored.<br>
+&nbsp;&nbsp;&nbsp;&nbsp;Set to <code>null</code> to avoid writing backed enum names.<br>
+&nbsp;&nbsp;&nbsp;&nbsp;<br>
+&nbsp;&nbsp;&nbsp;&nbsp;Example:<br>
+&nbsp;&nbsp;&nbsp;&nbsp;<code>->setEnumNames('enumNames')</code> yields:<br>
+```yaml
+  x-enumNames:
+    - NAME1
+    - NAME2
+```
+
+
+
 ### [AugmentSchemas](https://github.com/zircote/swagger-php/tree/master/src/Processors/AugmentSchemas.php)
 
 Use the Schema context to extract useful information and inject that into the annotation.
@@ -81,18 +100,23 @@ Use the RequestBody context to extract useful information and inject that into t
 ### [AugmentProperties](https://github.com/zircote/swagger-php/tree/master/src/Processors/AugmentProperties.php)
 
 Use the property context to extract useful information and inject that into the annotation.
+### [AugmentDiscriminators](https://github.com/zircote/swagger-php/tree/master/src/Processors/AugmentDiscriminators.php)
+
+Use the property context to extract useful information and inject that into the annotation.
 ### [BuildPaths](https://github.com/zircote/swagger-php/tree/master/src/Processors/BuildPaths.php)
 
-Build the openapi->paths using the detected `@OA\PathItem` and `@OA\Operation` (`@OA\Get`, `@OA\Post`, etc).
+Build the openapi->paths using the detected <code>@OA\PathItem</code> and <code>@OA\Operation</code> (<code>@OA\Get</code>, etc).
 ### [AugmentParameters](https://github.com/zircote/swagger-php/tree/master/src/Processors/AugmentParameters.php)
 
 Augments shared and operations parameters from docblock comments.
 #### Config settings
-<dl>
-  <dt><strong>augmentParameters.augmentOperationParameters</strong> : <span style="font-family: monospace;">bool</span></dt>
-  <dt><strong>default</strong> : <span style="font-family: monospace;">true</span></dt>
-  <dd><p>If set to <code>true</code> try to find operation parameter descriptions in the operation docblock.</p>  </dd>
-</dl>
+**augmentParameters.augmentOperationParameters**
+: <span style="font-family: monospace;">bool</span>
+<br>**default**
+: <span style="font-family: monospace;">true</span>
+
+&nbsp;&nbsp;&nbsp;&nbsp;If set to <code>true</code> try to find operation parameter descriptions in the operation docblock.<br>
+
 
 
 ### [AugmentRefs](https://github.com/zircote/swagger-php/tree/master/src/Processors/AugmentRefs.php)
@@ -108,11 +132,13 @@ Split XmlContent into Schema and MediaType.
 
 Generate the OperationId based on the context of the OpenApi annotation.
 #### Config settings
-<dl>
-  <dt><strong>operationId.hash</strong> : <span style="font-family: monospace;">bool</span></dt>
-  <dt><strong>default</strong> : <span style="font-family: monospace;">true</span></dt>
-  <dd><p>If set to <code>true</code> generate ids (md5) instead of clear text operation ids.</p>  </dd>
-</dl>
+**operationId.hash**
+: <span style="font-family: monospace;">bool</span>
+<br>**default**
+: <span style="font-family: monospace;">true</span>
+
+&nbsp;&nbsp;&nbsp;&nbsp;If set to <code>true</code> generate ids (md5) instead of clear text operation ids.<br>
+
 
 
 ### [CleanUnmerged](https://github.com/zircote/swagger-php/tree/master/src/Processors/CleanUnmerged.php)
@@ -122,46 +148,56 @@ Generate the OperationId based on the context of the OpenApi annotation.
 
 Allows to filter endpoints based on tags and/or path.
 
-If no `tags` or `paths` filters are set, no filtering is performed.
+If no <code>tags</code> or <code>paths</code> filters are set, no filtering is performed.
 
 All filter (regular) expressions must be enclosed within delimiter characters as they are used as-is.
 #### Config settings
-<dl>
-  <dt><strong>pathFilter.tags</strong> : <span style="font-family: monospace;">array</span></dt>
-  <dt><strong>default</strong> : <span style="font-family: monospace;">[]</span></dt>
-  <dd><p>A list of regular expressions to match <code>tags</code> to include.</p>  </dd>
-</dl>
-<dl>
-  <dt><strong>pathFilter.paths</strong> : <span style="font-family: monospace;">array</span></dt>
-  <dt><strong>default</strong> : <span style="font-family: monospace;">[]</span></dt>
-  <dd><p>A list of regular expressions to match <code>paths</code> to include.</p>  </dd>
-</dl>
-<dl>
-  <dt><strong>pathFilter.recurseCleanup</strong> : <span style="font-family: monospace;">bool</span></dt>
-  <dt><strong>default</strong> : <span style="font-family: monospace;">false</span></dt>
-  <dd><p>Flag to do a recursive cleanup of unused paths and their nested annotations.</p>  </dd>
-</dl>
+**pathFilter.tags**
+: <span style="font-family: monospace;">array</span>
+<br>**default**
+: <span style="font-family: monospace;">[]</span>
+
+&nbsp;&nbsp;&nbsp;&nbsp;A list of regular expressions to match <code>tags</code> to include.<br>
+
+**pathFilter.paths**
+: <span style="font-family: monospace;">array</span>
+<br>**default**
+: <span style="font-family: monospace;">[]</span>
+
+&nbsp;&nbsp;&nbsp;&nbsp;A list of regular expressions to match <code>paths</code> to include.<br>
+
+**pathFilter.recurseCleanup**
+: <span style="font-family: monospace;">bool</span>
+<br>**default**
+: <span style="font-family: monospace;">false</span>
+
+&nbsp;&nbsp;&nbsp;&nbsp;Flag to do a recursive cleanup of unused paths and their nested annotations.<br>
+
 
 
 ### [CleanUnusedComponents](https://github.com/zircote/swagger-php/tree/master/src/Processors/CleanUnusedComponents.php)
 
 Tracks the use of all <code>Components</code> and removed unused schemas.
 #### Config settings
-<dl>
-  <dt><strong>cleanUnusedComponents.enabled</strong> : <span style="font-family: monospace;">bool</span></dt>
-  <dt><strong>default</strong> : <span style="font-family: monospace;">false</span></dt>
-  <dd><p>Enables/disables the <code>CleanUnusedComponents</code> processor.</p>  </dd>
-</dl>
+**cleanUnusedComponents.enabled**
+: <span style="font-family: monospace;">bool</span>
+<br>**default**
+: <span style="font-family: monospace;">false</span>
+
+&nbsp;&nbsp;&nbsp;&nbsp;Enables/disables the <code>CleanUnusedComponents</code> processor.<br>
+
 
 
 ### [AugmentTags](https://github.com/zircote/swagger-php/tree/master/src/Processors/AugmentTags.php)
 
 Ensures that all tags used on operations also exist in the global <code>tags</code> list.
 #### Config settings
-<dl>
-  <dt><strong>augmentTags.whitelist</strong> : <span style="font-family: monospace;">array</span></dt>
-  <dt><strong>default</strong> : <span style="font-family: monospace;">[]</span></dt>
-  <dd><p>Whitelist tags to keep even if not used. <code>*</code> may be used to keep all unused.</p>  </dd>
-</dl>
+**augmentTags.whitelist**
+: <span style="font-family: monospace;">array</span>
+<br>**default**
+: <span style="font-family: monospace;">[]</span>
+
+&nbsp;&nbsp;&nbsp;&nbsp;Whitelist tags to keep even if not used. <code>*</code> may be used to keep all unused.<br>
+
 
 

--- a/src/Analysers/ComposerAutoloaderScanner.php
+++ b/src/Analysers/ComposerAutoloaderScanner.php
@@ -11,7 +11,7 @@ use Composer\Autoload\ClassLoader;
 /**
  * Scans for classes/interfaces/traits.
  *
- * Relies on a `composer --optimized` run in order to utilize
+ * Relies on a <code>composer --optimized</code> run in order to utilize
  * the generated class map.
  */
 class ComposerAutoloaderScanner

--- a/src/Analysers/ReflectionAnalyser.php
+++ b/src/Analysers/ReflectionAnalyser.php
@@ -15,7 +15,7 @@ use OpenApi\OpenApiException;
 /**
  * OpenApi analyser using reflection.
  *
- * Can read either PHP `DocBlock`s or `Attribute`s.
+ * Can read either PHP <code>DocBlock</code>s or <code>Attribute</code>s.
  *
  * Due to the nature of reflection this requires all related classes
  * to be auto-loadable.

--- a/src/Annotations/AbstractAnnotation.php
+++ b/src/Annotations/AbstractAnnotation.php
@@ -21,7 +21,7 @@ abstract class AbstractAnnotation implements \JsonSerializable
     /**
      * While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.
      * For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions
-     * The keys inside the array will be prefixed with `x-`.
+     * The keys inside the array will be prefixed with <code>x-</code>.
      *
      * @var array<string,mixed>
      */
@@ -623,11 +623,11 @@ abstract class AbstractAnnotation implements \JsonSerializable
     }
 
     /**
-     * Check if `$other` can be nested and if so return details about where/how.
+     * Check if <code>$other</code> can be nested and if so return details about where/how.
      *
      * @param AbstractAnnotation $other the other annotation
      *
-     * @return null|object key/value object or `null`
+     * @return null|object key/value object or <code>null</code>
      */
     public function matchNested($other)
     {
@@ -644,7 +644,7 @@ abstract class AbstractAnnotation implements \JsonSerializable
      * This is used for resolving type equality and nesting rules to allow those rules to also work for custom,
      * derived annotation classes.
      *
-     * @return class-string the root annotation class in the `OpenApi\\Annotations` namespace
+     * @return class-string the root annotation class in the <code>OpenApi\\Annotations</code> namespace
      */
     public function getRoot(): string
     {

--- a/src/Annotations/Attachable.php
+++ b/src/Annotations/Attachable.php
@@ -65,7 +65,7 @@ class Attachable extends AbstractAnnotation
      * Container to allow custom annotations that are limited to a subset of potential parent
      * annotation classes.
      *
-     * @return array<class-string>|null List of valid parent annotation classes. If `null`, the default nesting rules apply.
+     * @return array<class-string>|null List of valid parent annotation classes. If <code>null</code>, the default nesting rules apply.
      */
     public function allowedParents(): ?array
     {

--- a/src/Annotations/Components.php
+++ b/src/Annotations/Components.php
@@ -127,9 +127,9 @@ class Components extends AbstractAnnotation
     }
 
     /**
-     * Generate a `#/components/...` reference for the given annotation.
+     * Generate a <code>#/components/...</code> reference for the given annotation.
      *
-     * A `string` component value always assumes type `Schema`.
+     * A <code>string</code> component value always assumes type <code>Schema</code>.
      *
      * @param AbstractAnnotation|string $component
      */

--- a/src/Annotations/CookieParameter.php
+++ b/src/Annotations/CookieParameter.php
@@ -7,7 +7,7 @@
 namespace OpenApi\Annotations;
 
 /**
- * A `@OA\Request` cookie parameter.
+ * A <code>@OA\Request</code> cookie parameter.
  *
  * @Annotation
  */

--- a/src/Annotations/Examples.php
+++ b/src/Annotations/Examples.php
@@ -23,7 +23,7 @@ class Examples extends AbstractAnnotation
     public $ref = Generator::UNDEFINED;
 
     /**
-     * The key into `#/components/examples`.
+     * The key into <code>#/components/examples</code>.
      *
      * @var string
      */

--- a/src/Annotations/HeaderParameter.php
+++ b/src/Annotations/HeaderParameter.php
@@ -9,7 +9,7 @@ namespace OpenApi\Annotations;
 use OpenApi\Annotations as OA;
 
 /**
- * A `@OA\Request` header parameter.
+ * A <code>@OA\Request</code> header parameter.
  *
  * @Annotation
  */

--- a/src/Annotations/Items.php
+++ b/src/Annotations/Items.php
@@ -7,7 +7,7 @@
 namespace OpenApi\Annotations;
 
 /**
- * The description of an item in a Schema with type `array`.
+ * The description of an item in a Schema with type <code>array</code>.
  *
  * @Annotation
  */

--- a/src/Annotations/License.php
+++ b/src/Annotations/License.php
@@ -25,16 +25,16 @@ class License extends AbstractAnnotation
     public $name = Generator::UNDEFINED;
 
     /**
-     * An SPDX license expression for the API. The `identifier` field is mutually exclusive of the `url` field.
+     * An SPDX license expression for the API. The <code>identifier</code> field is mutually exclusive of the <code>url</code> field.
      *
      * @var string
      */
     public $identifier = Generator::UNDEFINED;
 
     /**
-     * An URL to the license used for the API. This MUST be in the form of a URL.
+     * A URL to the license used for the API. This MUST be in the form of a URL.
      *
-     * The `url` field is mutually exclusive of the `identifier` field.
+     * The <code>url</code> field is mutually exclusive of the <code>identifier</code> field.
      *
      * @var string
      */

--- a/src/Annotations/OpenApi.php
+++ b/src/Annotations/OpenApi.php
@@ -30,7 +30,7 @@ class OpenApi extends AbstractAnnotation
      *
      * The openapi field should be used by tooling specifications and clients to interpret the OpenAPI document.
      *
-     * A version specified via `Generator::setVersion()` will overwrite this value.
+     * A version specified via <code>Generator::setVersion()</code> will overwrite this value.
      *
      * This is not related to the API info::version string.
      *
@@ -74,7 +74,7 @@ class OpenApi extends AbstractAnnotation
      * The list of values includes alternative security requirement objects that can be used.
      * Only one of the security requirement objects need to be satisfied to authorize a request.
      * Individual operations can override this definition.
-     * To make security optional, an empty security requirement `({})` can be included in the array.
+     * To make security optional, an empty security requirement (<code>{}</code>) can be included in the array.
      *
      * @var array
      */

--- a/src/Annotations/Operation.php
+++ b/src/Annotations/Operation.php
@@ -10,7 +10,7 @@ use OpenApi\Generator;
 use OpenApi\Annotations as OA;
 
 /**
- * Base class for `@OA\Get`,  `@OA\Post`,  `@OA\Put`,  etc.
+ * Base class for <code>@OA\Get</code>,  <code>@OA\Post</code>,  <code>@OA\Put</code>,  etc.
  *
  * Describes a single API operation on a path.
  *

--- a/src/Annotations/PathParameter.php
+++ b/src/Annotations/PathParameter.php
@@ -9,7 +9,7 @@ namespace OpenApi\Annotations;
 use OpenApi\Annotations as OA;
 
 /**
- * A `@OA\Request` path parameter.
+ * A <code>@OA\Request</code> path parameter.
  *
  * @Annotation
  */

--- a/src/Annotations/QueryParameter.php
+++ b/src/Annotations/QueryParameter.php
@@ -9,7 +9,7 @@ namespace OpenApi\Annotations;
 use OpenApi\Annotations as OA;
 
 /**
- * A `@OA\Request` query parameter.
+ * A <code>@OA\Request</code> query parameter.
  *
  * @Annotation
  */

--- a/src/Annotations/Webhook.php
+++ b/src/Annotations/Webhook.php
@@ -9,7 +9,7 @@ namespace OpenApi\Annotations;
 use OpenApi\Generator;
 
 /**
- * Acts like a `PathItem` with the main difference being that it requires `webhook` instead of `path`.
+ * Acts like a <code>PathItem</code> with the main difference being that it requires <code>webhook</code> instead of <code>path</code>.
  *
  * @Annotation
  */

--- a/src/Annotations/XmlContent.php
+++ b/src/Annotations/XmlContent.php
@@ -11,7 +11,7 @@ use OpenApi\Annotations as OA;
 /**
  * Shorthand for a xml response.
  *
- * Use as `@OA\Schema` inside a `Response` and `MediaType`->`'application/xml'` will be generated.
+ * Use as <code>@OA\Schema</code> inside a <code>Response</code> and <code>MediaType</code>-><code>'application/xml'</code> will be generated.
  *
  * @Annotation
  */

--- a/src/Context.php
+++ b/src/Context.php
@@ -38,7 +38,7 @@ use Psr\Log\LoggerInterface;
  * @property OA\AbstractAnnotation|null   $nested
  * @property OA\AbstractAnnotation[]|null $annotations
  * @property OA\AbstractAnnotation[]|null $other       Annotations not related to OpenApi
- * @property LoggerInterface|null         $logger      Guaranteed to be set when using the `Generator`
+ * @property LoggerInterface|null         $logger      Guaranteed to be set when using the <code>Generator</code>
  * @property array|null                   $scanned     Details of file scanner when using ReflectionAnalyser
  * @property string|null                  $version     The OpenAPI version in use
  */

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -19,8 +19,8 @@ use Psr\Log\LoggerInterface;
  *
  * Scans PHP source code and generates OpenApi specifications from the found OpenApi annotations.
  *
- * This is an object-oriented alternative to using the now deprecated `\OpenApi\scan()` function and
- * static class properties of the `Analyzer` and `Analysis` classes.
+ * This is an object-oriented alternative to using the now deprecated <code>\OpenApi\scan()</code> function and
+ * static class properties of the <code>Analyzer</code> and <code>Analysis</code> classes.
  */
 class Generator
 {
@@ -55,9 +55,9 @@ class Generator
     /**
      * OpenApi version override.
      *
-     * If set, it will override the version set in the `OpenApi` annotation.
+     * If set, it will override the version set in the <code>OpenApi</code> annotation.
      *
-     * Due to the order of processing any conditional code using this (via `Context::$version`)
+     * Due to the order of processing any conditional code using this (via <code>Context::$version</code>)
      * must come only after the analysis is finished.
      */
     protected ?string $version = null;
@@ -317,9 +317,9 @@ class Generator
      * Run code in the context of this generator.
      *
      * @param callable $callable Callable in the form of
-     *                           `function(Generator $generator, Analysis $analysis, Context $context): mixed`
+     *                           <code>function(Generator $generator, Analysis $analysis, Context $context): mixed</code>
      *
-     * @return mixed the result of the `callable`
+     * @return mixed the result of the <code>callable</code>
      */
     public function withContext(callable $callable)
     {

--- a/src/Loggers/ConsoleLogger.php
+++ b/src/Loggers/ConsoleLogger.php
@@ -40,7 +40,7 @@ class ConsoleLogger extends AbstractLogger implements LoggerInterface
     /**
      * @param string            $level
      * @param string|\Exception $message
-     * @param array             $context additional details; supports custom `prefix` and `exception`
+     * @param array             $context additional details; supports custom <code>prefix</code> and <code>exception</code>
      */
     public function log($level, $message, array $context = []): void
     {

--- a/src/Pipeline.php
+++ b/src/Pipeline.php
@@ -66,8 +66,8 @@ class Pipeline
 
     /**
      * @param callable|class-string $matcher used to determine the position to insert
-     *                                       either an `int` from a callable or, in the case of `$matcher` being
-     *                                       a `class-string`, the position before the first pipe of that class
+     *                                       either an <code>int</code> from a callable or, in the case of <code>$matcher</code> being
+     *                                       a <code>class-string</code>, the position before the first pipe of that class
      */
     public function insert(callable $pipe, $matcher): Pipeline
     {

--- a/src/Processors/AugmentRefs.php
+++ b/src/Processors/AugmentRefs.php
@@ -22,7 +22,7 @@ class AugmentRefs
     }
 
     /**
-     * Update refs broken due to `allOf` augmenting.
+     * Update refs broken due to <code>allOf</code> augmenting.
      */
     protected function resolveAllOfRefs(Analysis $analysis): void
     {

--- a/src/Processors/AugmentSchemas.php
+++ b/src/Processors/AugmentSchemas.php
@@ -114,7 +114,7 @@ class AugmentSchemas
     }
 
     /**
-     * Merge schema properties into `allOf` if both exist.
+     * Merge schema properties into <code>allOf</code> if both exist.
      *
      * @param array<OA\Schema> $schemas
      */

--- a/src/Processors/BuildPaths.php
+++ b/src/Processors/BuildPaths.php
@@ -12,7 +12,7 @@ use OpenApi\Context;
 use OpenApi\Generator;
 
 /**
- * Build the openapi->paths using the detected `@OA\PathItem` and `@OA\Operation` (`@OA\Get`, `@OA\Post`, etc).
+ * Build the openapi->paths using the detected <code>@OA\PathItem</code> and <code>@OA\Operation</code> (<code>@OA\Get</code>, etc).
  */
 class BuildPaths
 {

--- a/src/Processors/Concerns/AnnotationTrait.php
+++ b/src/Processors/Concerns/AnnotationTrait.php
@@ -29,7 +29,7 @@ trait AnnotationTrait
     }
 
     /**
-     * Remove all annotations that are part of the `$annotation` tree.
+     * Remove all annotations that are part of the <code>$annotation</code> tree.
      */
     public function removeAnnotation(iterable $root, OA\AbstractAnnotation $annotation, bool $recurse = true): void
     {

--- a/src/Processors/Concerns/DocblockTrait.php
+++ b/src/Processors/Concerns/DocblockTrait.php
@@ -170,9 +170,9 @@ trait DocblockTrait
     }
 
     /**
-     * Extract property type and description from a `@var` dockblock line.
+     * Extract property type and description from a <code>@var</code> dockblock line.
      *
-     * @return array<string, ?string> extracted `type` and `description`; values default to `null`
+     * @return array<string, ?string> extracted <code>type</code> and <code>description</code>; values default to <code>null</code>
      */
     public function extractVarTypeAndDescription(?string $docblock): array
     {
@@ -187,7 +187,7 @@ trait DocblockTrait
     }
 
     /**
-     * Extract example text from a `@example` dockblock line.
+     * Extract example text from a <code>@example</code> dockblock line.
      */
     public function extractExampleDescription(?string $docblock): ?string
     {
@@ -197,7 +197,7 @@ trait DocblockTrait
     }
 
     /**
-     * Returns true if the `\@deprecated` tag is present, false otherwise.
+     * Returns true if the <code>\@deprecated</code> tag is present, false otherwise.
      */
     public function isDeprecated(?string $docblock): bool
     {

--- a/src/Processors/DocBlockDescriptions.php
+++ b/src/Processors/DocBlockDescriptions.php
@@ -14,7 +14,7 @@ use OpenApi\Generator;
  * Checks if the annotation has a summary and/or description property
  * and uses the text in the comment block (above the annotations) as summary and/or description.
  *
- * Use `null`, for example: `@Annotation(description=null)`, if you don't want the annotation to have a description.
+ * Use <code>null</code>, for example: <code>@Annotation(description=null)</code>, if you don't want the annotation to have a description.
  */
 class DocBlockDescriptions
 {

--- a/src/Processors/ExpandEnums.php
+++ b/src/Processors/ExpandEnums.php
@@ -14,7 +14,7 @@ use OpenApi\OpenApiException;
 /**
  * Expands PHP enums.
  *
- * Determines `schema`, `enum` and `type`.
+ * Determines <code>schema</code>, <code>enum</code> and <code>type</code>.
  */
 class ExpandEnums
 {
@@ -34,14 +34,15 @@ class ExpandEnums
 
     /**
      * Specifies the name of the extension variable where backed enum names will be stored.
-     * Set to `NULL` to avoid writing backed enum names.
+     * Set to <code>null</code> to avoid writing backed enum names.
+     *
      * Example:
-     * `setEnumNames('enumNames')` yields:
+     * <code>->setEnumNames('enumNames')</code> yields:
+     * ```yaml
+     *   x-enumNames:
+     *     - NAME1
+     *     - NAME2
      * ```
-     * x-enumNames:
-     *   - NAME1
-     *   - NAME2
-     * ```.
      */
     public function setEnumNames(?string $enumNames = null): void
     {
@@ -126,6 +127,7 @@ class ExpandEnums
                 // transform each Enum cases into UnitEnum
                 foreach ($schema->enum as $enum) {
                     if (is_string($enum) && function_exists('enum_exists') && enum_exists($enum)) {
+                        /** @var \UnitEnum $enum */
                         foreach ($enum::cases() as $case) {
                             $cases[] = $case;
                         }

--- a/src/Processors/ExpandEnums.php
+++ b/src/Processors/ExpandEnums.php
@@ -124,10 +124,10 @@ class ExpandEnums
 
                 $cases = [];
 
-                // transform each Enum cases into UnitEnum
+                // transform \UnitEnum into individual cases
+                /** @var string|class-string<\UnitEnum> $enum */
                 foreach ($schema->enum as $enum) {
                     if (is_string($enum) && function_exists('enum_exists') && enum_exists($enum)) {
-                        /** @var \UnitEnum $enum */
                         foreach ($enum::cases() as $case) {
                             $cases[] = $case;
                         }

--- a/src/Processors/MergeIntoComponents.php
+++ b/src/Processors/MergeIntoComponents.php
@@ -12,7 +12,7 @@ use OpenApi\Context;
 use OpenApi\Generator;
 
 /**
- * Merge reusable annotation into @OA\Schemas.
+ * Merge reusable annotation into <code>@OA\Schemas</code>.
  */
 class MergeIntoComponents
 {

--- a/src/Processors/MergeIntoOpenApi.php
+++ b/src/Processors/MergeIntoOpenApi.php
@@ -12,7 +12,7 @@ use OpenApi\Context;
 use OpenApi\Generator;
 
 /**
- * Merge all @OA\OpenApi annotations into one.
+ * Merge all <code>@OA\OpenApi</code> annotations into one.
  */
 class MergeIntoOpenApi
 {

--- a/src/Processors/PathFilter.php
+++ b/src/Processors/PathFilter.php
@@ -13,7 +13,7 @@ use OpenApi\Processors\Concerns\AnnotationTrait;
 /**
  * Allows to filter endpoints based on tags and/or path.
  *
- * If no `tags` or `paths` filters are set, no filtering is performed.
+ * If no <code>tags</code> or <code>paths</code> filters are set, no filtering is performed.
  *
  * All filter (regular) expressions must be enclosed within delimiter characters as they are used as-is.
  */

--- a/src/Util.php
+++ b/src/Util.php
@@ -21,7 +21,7 @@ class Util
      * is always a chance it was a valid relative path to begin with.
      *
      * It should be noted that these are "relative paths" primarily in Finder's sense of them,
-     * and conform specifically to what is expected by functions like `exclude()` and `notPath()`.
+     * and conform specifically to what is expected by functions like <code>exclude()</code> and <code>notPath()</code>.
      * In particular, leading and trailing slashes are removed.
      *
      * @param array|string $basePaths

--- a/tools/procgen.php
+++ b/tools/procgen.php
@@ -46,6 +46,36 @@ as on the command line or be broken down into nested arrays.
 
 EOT;
 
+$mono = function (string $s): string {
+    return '<span style="font-family: monospace;">' . $s . '</span>';
+};
+
+$nl2br = function (string $s, bool $indent = false): string {
+    $lines = explode("\n", $s);
+
+    $processed  = [];
+    $inBlock = false;
+    foreach ($lines as $line) {
+        $blockStart = !$inBlock && str_contains($line, '```');
+        if ($blockStart) {
+            $inBlock = true;
+        }
+        if (!$inBlock) {
+            if ($indent) {
+                $line = '&nbsp;&nbsp;&nbsp;&nbsp;' . $line;
+            }
+            $processed[] = $line . '<br>';
+        } else {
+            $processed[] = $line;
+            if ('```' == $line) {
+                $inBlock = false;
+            }
+        }
+    }
+
+    return implode("\n", $processed);
+};
+
 echo PHP_EOL . '## Default Processors' . PHP_EOL;
 foreach ($gen->getProcessorsDetails() as $ii => $details) {
     $off = $ii + 1;
@@ -57,16 +87,9 @@ foreach ($gen->getProcessorsDetails() as $ii => $details) {
         echo '#### Config settings' . PHP_EOL;
         foreach ($details['options'] as $name => $odetails) {
             if ($odetails) {
-                $var = ' : <span style="font-family: monospace;">' . $odetails['type'] . '</span>';
-                $default = ' : <span style="font-family: monospace;">' . $odetails['default'] . '</span>';
-
-                echo '<dl>' . PHP_EOL;
-                echo '  <dt><strong>' . $configPrefix . $name . '</strong>' . $var . '</dt>' . PHP_EOL;
-                echo '  <dt><strong>default</strong>' . $default . '</dt>' . PHP_EOL;
-                echo '  <dd>';
-                echo '<p>' . nl2br($odetails['phpdoc'] ? $odetails['phpdoc']['content'] : ProcGenerator::NO_DETAILS_AVAILABLE) . '</p>';
-                echo '  </dd>' . PHP_EOL;
-                echo '</dl>' . PHP_EOL;
+                echo "**{$configPrefix}{$name}**\n: " . $mono($odetails['type']) . "\n<br>";
+                echo "**default**\n: " . $mono($odetails['default']) . "\n\n";
+                echo $nl2br($odetails['phpdoc'] ? $odetails['phpdoc']['content'] : ProcGenerator::NO_DETAILS_AVAILABLE, true) . "\n\n";
             }
         }
         echo PHP_EOL;

--- a/tools/src/Docs/ProcGenerator.php
+++ b/tools/src/Docs/ProcGenerator.php
@@ -49,6 +49,7 @@ class ProcGenerator extends DocGenerator
                 if ($rp) {
                     $dv = $rp->getDefaultValue();
                     $default = match (gettype($dv)) {
+                        'NULL' => 'null',
                         'boolean' => $dv ? 'true' : 'false',
                         'array' => '[' . implode(', ', $dv) . ']',
                     };


### PR DESCRIPTION
Also switch to using `<code>` everywhere in `src` to make it easier to parse and modify.

The whole doc generation system needs a bit of an overhaul IMO. Too much similar code yet subtly different...