### PR TITLE
Fix duplicate attachables

### DIFF
--- a/src/Attributes/AdditionalProperties.php
+++ b/src/Attributes/AdditionalProperties.php
@@ -103,7 +103,7 @@ class AdditionalProperties extends OA\AdditionalProperties
             'oneOf' => $oneOf ?? Generator::UNDEFINED,
             'x' => $x ?? Generator::UNDEFINED,
             'attachables' => $attachables ?? Generator::UNDEFINED,
-            'value' => $this->combine($items, $discriminator, $externalDocs, $additionalProperties, $attachables),
+            'value' => $this->combine($items, $discriminator, $externalDocs, $additionalProperties),
         ]);
     }
 }

--- a/src/Attributes/Components.php
+++ b/src/Attributes/Components.php
@@ -42,7 +42,7 @@ class Components extends OA\Components
             'callbacks' => $callbacks ?? Generator::UNDEFINED,
             'x' => $x ?? Generator::UNDEFINED,
             'attachables' => $attachables ?? Generator::UNDEFINED,
-            'value' => $this->combine($schemas, $responses, $parameters, $examples, $requestBodies, $headers, $securitySchemes, $links, $attachables),
+            'value' => $this->combine($schemas, $responses, $parameters, $examples, $requestBodies, $headers, $securitySchemes, $links),
         ]);
     }
 }

--- a/src/Attributes/Contact.php
+++ b/src/Attributes/Contact.php
@@ -29,7 +29,7 @@ class Contact extends OA\Contact
             'url' => $url ?? Generator::UNDEFINED,
             'email' => $email ?? Generator::UNDEFINED,
             'x' => $x ?? Generator::UNDEFINED,
-            'value' => $this->combine($attachables),
+            'attachables' => $attachables ?? Generator::UNDEFINED,
         ]);
     }
 }

--- a/src/Attributes/Discriminator.php
+++ b/src/Attributes/Discriminator.php
@@ -28,7 +28,7 @@ class Discriminator extends OA\Discriminator
             'propertyName' => $propertyName ?? Generator::UNDEFINED,
             'mapping' => $mapping ?? Generator::UNDEFINED,
             'x' => $x ?? Generator::UNDEFINED,
-            'value' => $this->combine($attachables),
+            'attachables' => $attachables ?? Generator::UNDEFINED,
         ]);
     }
 }

--- a/src/Attributes/Examples.php
+++ b/src/Attributes/Examples.php
@@ -36,9 +36,7 @@ class Examples extends OA\Examples
             'externalValue' => $externalValue ?? Generator::UNDEFINED,
             'ref' => $ref ?? Generator::UNDEFINED,
             'x' => $x ?? Generator::UNDEFINED,
+            'attachables' => $attachables ?? Generator::UNDEFINED,
         ]);
-        if ($attachables) {
-            $this->merge($attachables);
-        }
     }
 }

--- a/src/Attributes/ExternalDocumentation.php
+++ b/src/Attributes/ExternalDocumentation.php
@@ -27,7 +27,7 @@ class ExternalDocumentation extends OA\ExternalDocumentation
                 'description' => $description ?? Generator::UNDEFINED,
                 'url' => $url ?? Generator::UNDEFINED,
                 'x' => $x ?? Generator::UNDEFINED,
-                'value' => $this->combine($attachables),
+                'attachables' => $attachables ?? Generator::UNDEFINED,
             ]);
     }
 }

--- a/src/Attributes/Flow.php
+++ b/src/Attributes/Flow.php
@@ -34,7 +34,7 @@ class Flow extends OA\Flow
                 'flow' => $flow ?? Generator::UNDEFINED,
                 'scopes' => $scopes ?? Generator::UNDEFINED,
                 'x' => $x ?? Generator::UNDEFINED,
-                'value' => $this->combine($attachables),
+                'attachables' => $attachables ?? Generator::UNDEFINED,
             ]);
     }
 }

--- a/src/Attributes/Header.php
+++ b/src/Attributes/Header.php
@@ -36,7 +36,8 @@ class Header extends OA\Header
             'deprecated' => $deprecated ?? Generator::UNDEFINED,
             'allowEmptyValue' => $allowEmptyValue ?? Generator::UNDEFINED,
             'x' => $x ?? Generator::UNDEFINED,
-            'value' => $this->combine($attachables, $schema),
+            'attachables' => $attachables ?? Generator::UNDEFINED,
+            'value' => $this->combine($schema),
         ]);
     }
 }

--- a/src/Attributes/Info.php
+++ b/src/Attributes/Info.php
@@ -33,7 +33,8 @@ class Info extends OA\Info
                 'title' => $title ?? Generator::UNDEFINED,
                 'termsOfService' => $termsOfService ?? Generator::UNDEFINED,
                 'x' => $x ?? Generator::UNDEFINED,
-                'value' => $this->combine($contact, $license, $attachables),
+                'attachables' => $attachables ?? Generator::UNDEFINED,
+                'value' => $this->combine($contact, $license),
             ]);
     }
 }

--- a/src/Attributes/Items.php
+++ b/src/Attributes/Items.php
@@ -106,7 +106,7 @@ class Items extends OA\Items
             // annotation
             'x' => $x ?? Generator::UNDEFINED,
             'attachables' => $attachables ?? Generator::UNDEFINED,
-            'value' => $this->combine($items, $discriminator, $externalDocs, $attachables),
+            'value' => $this->combine($items, $discriminator, $externalDocs),
         ]);
     }
 }

--- a/src/Attributes/JsonContent.php
+++ b/src/Attributes/JsonContent.php
@@ -130,7 +130,7 @@ class JsonContent extends OA\JsonContent
             // annotation
             'x' => $x ?? Generator::UNDEFINED,
             'attachables' => $attachables ?? Generator::UNDEFINED,
-            'value' => $this->combine($items, $discriminator, $externalDocs, $attachables),
+            'value' => $this->combine($items, $discriminator, $externalDocs),
         ]);
     }
 }

--- a/src/Attributes/License.php
+++ b/src/Attributes/License.php
@@ -29,7 +29,7 @@ class License extends OA\License
             'identifier' => $identifier ?? Generator::UNDEFINED,
             'url' => $url ?? Generator::UNDEFINED,
             'x' => $x ?? Generator::UNDEFINED,
-            'value' => $this->combine($attachables),
+            'attachables' => $attachables ?? Generator::UNDEFINED,
         ]);
     }
 }

--- a/src/Attributes/Link.php
+++ b/src/Attributes/Link.php
@@ -40,7 +40,8 @@ class Link extends OA\Link
                 'requestBody' => $requestBody ?? Generator::UNDEFINED,
                 'description' => $description ?? Generator::UNDEFINED,
                 'x' => $x ?? Generator::UNDEFINED,
-                'value' => $this->combine($server, $attachables),
+                'attachables' => $attachables ?? Generator::UNDEFINED,
+                'value' => $this->combine($server),
             ]);
     }
 }

--- a/src/Attributes/MediaType.php
+++ b/src/Attributes/MediaType.php
@@ -33,7 +33,8 @@ class MediaType extends OA\MediaType
                 'example' => $example,
                 'encoding' => $encoding ?? Generator::UNDEFINED,
                 'x' => $x ?? Generator::UNDEFINED,
-                'value' => $this->combine($schema, $examples, $attachables),
+                'attachables' => $attachables ?? Generator::UNDEFINED,
+                'value' => $this->combine($schema, $examples),
             ]);
     }
 }

--- a/src/Attributes/OpenApi.php
+++ b/src/Attributes/OpenApi.php
@@ -39,7 +39,8 @@ class OpenApi extends OA\OpenApi
                 'openapi' => $openapi,
                 'security' => $security ?? Generator::UNDEFINED,
                 'x' => $x ?? Generator::UNDEFINED,
-                'value' => $this->combine($info, $servers, $tags, $externalDocs, $paths, $components, $webhooks, $attachables),
+                'attachables' => $attachables ?? Generator::UNDEFINED,
+                'value' => $this->combine($info, $servers, $tags, $externalDocs, $paths, $components, $webhooks),
             ]);
     }
 }

--- a/src/Attributes/OperationTrait.php
+++ b/src/Attributes/OperationTrait.php
@@ -47,7 +47,8 @@ trait OperationTrait
                 'callbacks' => $callbacks ?? Generator::UNDEFINED,
                 'deprecated' => $deprecated ?? Generator::UNDEFINED,
                 'x' => $x ?? Generator::UNDEFINED,
-                'value' => $this->combine($requestBody, $responses, $parameters, $externalDocs, $attachables),
+                'attachables' => $attachables ?? Generator::UNDEFINED,
+                'value' => $this->combine($requestBody, $responses, $parameters, $externalDocs),
             ]);
     }
 }

--- a/src/Attributes/ParameterTrait.php
+++ b/src/Attributes/ParameterTrait.php
@@ -56,7 +56,8 @@ trait ParameterTrait
                 'spaceDelimited' => $spaceDelimited ?? Generator::UNDEFINED,
                 'pipeDelimited' => $pipeDelimited ?? Generator::UNDEFINED,
                 'x' => $x ?? Generator::UNDEFINED,
-                'value' => $this->combine($schema, $examples, $content, $attachables),
+                'attachables' => $attachables ?? Generator::UNDEFINED,
+                'value' => $this->combine($schema, $examples, $content),
             ]);
     }
 }

--- a/src/Attributes/PathItem.php
+++ b/src/Attributes/PathItem.php
@@ -44,7 +44,8 @@ class PathItem extends OA\PathItem
             'summary' => $summary ?? Generator::UNDEFINED,
             'description' => $description ?? Generator::UNDEFINED,
             'x' => $x ?? Generator::UNDEFINED,
-            'value' => $this->combine($get, $put, $post, $delete, $options, $head, $patch, $trace, $servers, $parameters, $attachables),
+            'attachables' => $attachables ?? Generator::UNDEFINED,
+            'value' => $this->combine($get, $put, $post, $delete, $options, $head, $patch, $trace, $servers, $parameters),
         ]);
     }
 }

--- a/src/Attributes/Property.php
+++ b/src/Attributes/Property.php
@@ -108,7 +108,7 @@ class Property extends OA\Property
             // annotation
             'x' => $x ?? Generator::UNDEFINED,
             'attachables' => $attachables ?? Generator::UNDEFINED,
-            'value' => $this->combine($items, $discriminator, $externalDocs, $attachables),
+            'value' => $this->combine($items, $discriminator, $externalDocs),
         ]);
     }
 }

--- a/src/Attributes/RequestBody.php
+++ b/src/Attributes/RequestBody.php
@@ -34,7 +34,8 @@ class RequestBody extends OA\RequestBody
             'description' => $description ?? Generator::UNDEFINED,
             'required' => $required ?? Generator::UNDEFINED,
             'x' => $x ?? Generator::UNDEFINED,
-            'value' => $this->combine($content, $attachables),
+            'attachables' => $attachables ?? Generator::UNDEFINED,
+            'value' => $this->combine($content),
         ]);
     }
 }

--- a/src/Attributes/Response.php
+++ b/src/Attributes/Response.php
@@ -36,7 +36,8 @@ class Response extends OA\Response
             'response' => $response ?? Generator::UNDEFINED,
             'description' => $description ?? Generator::UNDEFINED,
             'x' => $x ?? Generator::UNDEFINED,
-            'value' => $this->combine($headers, $content, $links, $attachables),
+            'attachables' => $attachables ?? Generator::UNDEFINED,
+            'value' => $this->combine($headers, $content, $links),
         ]);
     }
 }

--- a/src/Attributes/Schema.php
+++ b/src/Attributes/Schema.php
@@ -108,7 +108,7 @@ class Schema extends OA\Schema
             'const' => $const,
             'x' => $x ?? Generator::UNDEFINED,
             'attachables' => $attachables ?? Generator::UNDEFINED,
-            'value' => $this->combine($items, $discriminator, $externalDocs, $examples, $attachables),
+            'value' => $this->combine($items, $discriminator, $externalDocs, $examples),
         ]);
     }
 }

--- a/src/Attributes/SecurityScheme.php
+++ b/src/Attributes/SecurityScheme.php
@@ -45,7 +45,8 @@ class SecurityScheme extends OA\SecurityScheme
                 'scheme' => $scheme ?? Generator::UNDEFINED,
                 'openIdConnectUrl' => $openIdConnectUrl ?? Generator::UNDEFINED,
                 'x' => $x ?? Generator::UNDEFINED,
-                'value' => $this->combine($flows, $attachables),
+                'attachables' => $attachables ?? Generator::UNDEFINED,
+                'value' => $this->combine($flows),
             ]);
     }
 }

--- a/src/Attributes/Server.php
+++ b/src/Attributes/Server.php
@@ -29,7 +29,8 @@ class Server extends OA\Server
                 'url' => $url ?? Generator::UNDEFINED,
                 'description' => $description ?? Generator::UNDEFINED,
                 'x' => $x ?? Generator::UNDEFINED,
-                'value' => $this->combine($variables, $attachables),
+                'attachables' => $attachables ?? Generator::UNDEFINED,
+                'value' => $this->combine($variables),
             ]);
     }
 }

--- a/src/Attributes/ServerVariable.php
+++ b/src/Attributes/ServerVariable.php
@@ -34,7 +34,7 @@ class ServerVariable extends OA\ServerVariable
                 'enum' => $enum ?? Generator::UNDEFINED,
                 'variables' => $variables ?? Generator::UNDEFINED,
                 'x' => $x ?? Generator::UNDEFINED,
-                'value' => $this->combine($attachables),
+                'attachables' => $attachables ?? Generator::UNDEFINED,
             ]);
     }
 }

--- a/src/Attributes/Tag.php
+++ b/src/Attributes/Tag.php
@@ -28,7 +28,8 @@ class Tag extends OA\Tag
                 'name' => $name ?? Generator::UNDEFINED,
                 'description' => $description ?? Generator::UNDEFINED,
                 'x' => $x ?? Generator::UNDEFINED,
-                'value' => $this->combine($externalDocs, $attachables),
+                'attachables' => $attachables ?? Generator::UNDEFINED,
+                'value' => $this->combine($externalDocs),
             ]);
     }
 }

--- a/src/Attributes/Webhook.php
+++ b/src/Attributes/Webhook.php
@@ -46,7 +46,8 @@ class Webhook extends OA\Webhook
             'summary' => $summary ?? Generator::UNDEFINED,
             'description' => $description ?? Generator::UNDEFINED,
             'x' => $x ?? Generator::UNDEFINED,
-            'value' => $this->combine($get, $put, $post, $delete, $options, $head, $patch, $trace, $servers, $parameters, $attachables),
+            'attachables' => $attachables ?? Generator::UNDEFINED,
+            'value' => $this->combine($get, $put, $post, $delete, $options, $head, $patch, $trace, $servers, $parameters),
         ]);
     }
 }

--- a/src/Attributes/Xml.php
+++ b/src/Attributes/Xml.php
@@ -33,7 +33,7 @@ class Xml extends OA\Xml
                 'attribute' => $attribute ?? Generator::UNDEFINED,
                 'wrapped' => $wrapped ?? Generator::UNDEFINED,
                 'x' => $x ?? Generator::UNDEFINED,
-                'value' => $this->combine($attachables),
+                'attachables' => $attachables ?? Generator::UNDEFINED,
             ]);
     }
 }

--- a/src/Attributes/XmlContent.php
+++ b/src/Attributes/XmlContent.php
@@ -109,7 +109,7 @@ class XmlContent extends OA\XmlContent
             // annotation
             'x' => $x ?? Generator::UNDEFINED,
             'attachables' => $attachables ?? Generator::UNDEFINED,
-            'value' => $this->combine($items, $discriminator, $externalDocs, $attachables),
+            'value' => $this->combine($items, $discriminator, $externalDocs),
         ]);
     }
 }


### PR DESCRIPTION
Fix duplicate `attachables` and format `attachables` assignment.

Bug display:
https://github.com/zircote/swagger-php/blob/18457fa71f753cfd4a2b21916baf329864fdfaa6/src/Attributes/Schema.php#L110-L111