### PR TITLE
Introduce `Generator` settings

### DIFF
--- a/bin/openapi
+++ b/bin/openapi
@@ -218,6 +218,7 @@ foreach ($options["processor"] as $processor) {
 }
 
 $analyser = new ReflectionAnalyser([new DocBlockAnnotationFactory(), new AttributeAnnotationFactory()]);
+$analyser->setGenerator($generator);
 
 $openapi = $generator
     ->setVersion($options['version'])

--- a/src/Analysers/AnalyserInterface.php
+++ b/src/Analysers/AnalyserInterface.php
@@ -8,11 +8,8 @@ namespace OpenApi\Analysers;
 
 use OpenApi\Analysis;
 use OpenApi\Context;
-use OpenApi\Generator;
 
-interface AnalyserInterface
+interface AnalyserInterface extends GeneratorAwareInterface
 {
-    public function setGenerator(Generator $generator): void;
-
     public function fromFile(string $filename, Context $context): Analysis;
 }

--- a/src/Analysers/AnnotationFactoryInterface.php
+++ b/src/Analysers/AnnotationFactoryInterface.php
@@ -10,14 +10,14 @@ use OpenApi\Annotations as OA;
 use OpenApi\Context;
 use OpenApi\Generator;
 
-interface AnnotationFactoryInterface
+interface AnnotationFactoryInterface extends GeneratorAwareInterface
 {
     /**
      * Checks if this factory is supported by the current runtime.
      */
     public function isSupported(): bool;
 
-    public function setGenerator(Generator $generator): void;
+    public function setGenerator(Generator $generator);
 
     /**
      * @return array<OA\AbstractAnnotation> top level annotations

--- a/src/Analysers/AttributeAnnotationFactory.php
+++ b/src/Analysers/AttributeAnnotationFactory.php
@@ -36,7 +36,7 @@ class AttributeAnnotationFactory implements AnnotationFactoryInterface
         /** @var OA\AbstractAnnotation[] $annotations */
         $annotations = [];
         try {
-            $attributeArgs = $this->generator->getSetting('ignoreOtherAttributes')
+            $attributeArgs = $this->generator->isIgnoreOtherAttributes()
                 ? [OA\AbstractAnnotation::class, \ReflectionAttribute::IS_INSTANCEOF]
                 : [];
 

--- a/src/Analysers/AttributeAnnotationFactory.php
+++ b/src/Analysers/AttributeAnnotationFactory.php
@@ -36,13 +36,17 @@ class AttributeAnnotationFactory implements AnnotationFactoryInterface
         /** @var OA\AbstractAnnotation[] $annotations */
         $annotations = [];
         try {
-            foreach ($reflector->getAttributes() as $attribute) {
+            $attributeArgs = $this->generator->getSetting('ignoreOtherAttributes')
+                ? [OA\AbstractAnnotation::class, \ReflectionAttribute::IS_INSTANCEOF]
+                : [];
+
+            foreach ($reflector->getAttributes(...$attributeArgs) as $attribute) {
                 if (class_exists($attribute->getName())) {
                     $instance = $attribute->newInstance();
                     if ($instance instanceof OA\AbstractAnnotation) {
                         $annotations[] = $instance;
                     } else {
-                        if ($context->is('other') === false) {
+                        if (false === $context->is('other')) {
                             $context->other = [];
                         }
                         $context->other[] = $instance;

--- a/src/Analysers/DocBlockAnnotationFactory.php
+++ b/src/Analysers/DocBlockAnnotationFactory.php
@@ -26,11 +26,13 @@ class DocBlockAnnotationFactory implements AnnotationFactoryInterface
         return DocBlockParser::isEnabled();
     }
 
-    public function setGenerator(Generator $generator): void
+    public function setGenerator(Generator $generator)
     {
         $this->generator = $generator;
 
         $this->docBlockParser->setAliases($generator->getAliases());
+
+        return $this;
     }
 
     public function build(\Reflector $reflector, Context $context): array

--- a/src/Analysers/GeneratorAwareInterface.php
+++ b/src/Analysers/GeneratorAwareInterface.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Analysers;
+
+use OpenApi\Generator;
+
+interface GeneratorAwareInterface
+{
+    public function setGenerator(Generator $generator);
+}

--- a/src/Analysers/GeneratorAwareTrait.php
+++ b/src/Analysers/GeneratorAwareTrait.php
@@ -12,8 +12,10 @@ trait GeneratorAwareTrait
 {
     protected ?Generator $generator = null;
 
-    public function setGenerator(Generator $generator): void
+    public function setGenerator(Generator $generator)
     {
         $this->generator = $generator;
+
+        return $this;
     }
 }

--- a/src/Analysers/ReflectionAnalyser.php
+++ b/src/Analysers/ReflectionAnalyser.php
@@ -42,13 +42,15 @@ class ReflectionAnalyser implements AnalyserInterface
         }
     }
 
-    public function setGenerator(Generator $generator): void
+    public function setGenerator(Generator $generator)
     {
         $this->generator = $generator;
 
         foreach ($this->annotationFactories as $annotationFactory) {
             $annotationFactory->setGenerator($generator);
         }
+
+        return $this;
     }
 
     public function fromFile(string $filename, Context $context): Analysis

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -21,6 +21,15 @@ use Psr\Log\LoggerInterface;
  *
  * This is an object-oriented alternative to using the now deprecated <code>\OpenApi\scan()</code> function and
  * static class properties of the <code>Analyzer</code> and <code>Analysis</code> classes.
+ *
+ * Supported generator config:
+ * <code>
+ *     [
+ *         'generator' => [
+ *             'ignoreOtherAttributes' => true|false,
+ *         ]
+ *     ]
+ * </code>
  */
 class Generator
 {
@@ -156,12 +165,9 @@ class Generator
             ];
     }
 
-    /**
-     * Get the value of a `Generator` setting.
-     */
-    public function getSetting(string $name)
+    public function isIgnoreOtherAttributes(): bool
     {
-        return $this->getConfig()['generator'][$name] ?? null;
+        return $this->getConfig()['generator']['ignoreOtherAttributes'];
     }
 
     protected function normaliseConfig(array $config): array

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -135,6 +135,9 @@ class Generator
         return $this;
     }
 
+    /**
+     * @deprecated
+     */
     public function getDefaultConfig(): array
     {
         return [
@@ -146,7 +149,19 @@ class Generator
 
     public function getConfig(): array
     {
-        return $this->config + $this->getDefaultConfig();
+        return $this->config + $this->getDefaultConfig() + [
+                'generator' => [
+                    'ignoreOtherAttributes' => false,
+                ],
+            ];
+    }
+
+    /**
+     * Get the value of a `Generator` setting.
+     */
+    public function getSetting(string $name)
+    {
+        return $this->getConfig()['generator'][$name] ?? null;
     }
 
     protected function normaliseConfig(array $config): array

--- a/tests/Analysers/AttributeAnnotationFactoryTest.php
+++ b/tests/Analysers/AttributeAnnotationFactoryTest.php
@@ -7,6 +7,7 @@
 namespace OpenApi\Tests\Analysers;
 
 use OpenApi\Analysers\AttributeAnnotationFactory;
+use OpenApi\Generator;
 use OpenApi\Tests\Fixtures\UsingAttributes;
 use OpenApi\Tests\Fixtures\InvalidPropertyAttribute;
 use OpenApi\Tests\OpenApiTestCase;
@@ -16,11 +17,22 @@ use OpenApi\Tests\OpenApiTestCase;
  */
 class AttributeAnnotationFactoryTest extends OpenApiTestCase
 {
-    public function testReturnedAnnotationsCout(): void
+    protected function getFactory(?array $config = null): AttributeAnnotationFactory
+    {
+        $generator = new Generator();
+        if (null !== $config) {
+            $generator->setConfig($config);
+        }
+
+        return (new AttributeAnnotationFactory())
+            ->setGenerator($generator);
+    }
+
+    public function testReturnedAnnotationsCount(): void
     {
         $rc = new \ReflectionClass(UsingAttributes::class);
 
-        $annotations = (new AttributeAnnotationFactory())->build($rc, $this->getContext());
+        $annotations = $this->getFactory()->build($rc, $this->getContext());
         $this->assertCount(1, $annotations);
     }
 
@@ -32,6 +44,18 @@ class AttributeAnnotationFactoryTest extends OpenApiTestCase
         $this->expectException(\TypeError::class);
         $this->expectExceptionMessage('OpenApi\Attributes\Property::__construct(): Argument #8 ($required) must be of type ?array');
 
-        (new AttributeAnnotationFactory())->build($rm, $this->getContext());
+        $this->getFactory()->build($rm, $this->getContext());
+    }
+
+    public function testIgnoreOtherAttributes(): void
+    {
+        $rc = new \ReflectionClass(UsingAttributes::class);
+
+        $this->getFactory()->build($rc, $context = $this->getContext());
+        $this->assertIsArray($context->other);
+        $this->assertCount(1, $context->other);
+
+        $this->getFactory(['generator' => ['ignoreOtherAttributes' => true]])->build($rc, $context = $this->getContext());
+        $this->assertNull($context->other);
     }
 }

--- a/tests/Fixtures/PHP/Label.php
+++ b/tests/Fixtures/PHP/Label.php
@@ -6,12 +6,12 @@
 
 namespace OpenApi\Tests\Fixtures\PHP;
 
-#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_PROPERTY | \Attribute::IS_REPEATABLE)]
 class Label
 {
     protected $name;
 
-    public function __construct(string $name, array $numbers)
+    public function __construct(string $name, array $numbers = [])
     {
         $this->name = $name;
     }

--- a/tests/Fixtures/UsingAttributes.php
+++ b/tests/Fixtures/UsingAttributes.php
@@ -7,7 +7,9 @@
 namespace OpenApi\Tests\Fixtures;
 
 use OpenApi\Attributes as OAT;
+use OpenApi\Tests\Fixtures\PHP\Label;
 
+#[Label(name: 'custom')]
 #[OAT\Response()]
 #[OAT\Header(header: 'X-Rate-Limit', allowEmptyValue: true)]
 class UsingAttributes

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -121,4 +121,15 @@ class GeneratorTest extends OpenApiTestCase
         $generator->setConfig($config);
         $this->assertOperationIdHash($generator, $expected);
     }
+
+    public function testGetSetting(): void
+    {
+        $generator = new Generator();
+
+        // valid; default
+        $this->assertFalse($generator->getSetting('ignoreOtherAttributes'));
+
+        // invalid
+        $this->assertNull($generator->getSetting('invalid'));
+    }
 }

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -122,14 +122,13 @@ class GeneratorTest extends OpenApiTestCase
         $this->assertOperationIdHash($generator, $expected);
     }
 
-    public function testGetSetting(): void
+    public function testIsIgnoreOtherAttributes(): void
     {
         $generator = new Generator();
 
-        // valid; default
-        $this->assertFalse($generator->getSetting('ignoreOtherAttributes'));
+        $this->assertFalse($generator->isIgnoreOtherAttributes());
 
-        // invalid
-        $this->assertNull($generator->getSetting('invalid'));
+        $generator->setConfig(['generator' => ['ignoreOtherAttributes' => true]]);
+        $this->assertTrue($generator->isIgnoreOtherAttributes());
     }
 }


### PR DESCRIPTION
Generator settings are following the same pattern as processor config and are stored under the key `'generator'`.

`Generator::getSetting()` provides a shortcut to access generator settings.

Fixes #1747 by allowing to set `Generator::setConfig(['generator' => ['ignoreOtherAttributes' => true]]);`