### PR TITLE
Allow to ignore non `OpenApi` attributes

### DIFF
--- a/src/Analysers/AttributeAnnotationFactory.php
+++ b/src/Analysers/AttributeAnnotationFactory.php
@@ -15,6 +15,13 @@ class AttributeAnnotationFactory implements AnnotationFactoryInterface
 {
     use GeneratorAwareTrait;
 
+    protected bool $ignoreOtherAttributes = false;
+
+    public function __construct(bool $ignoreOtherAttributes = false)
+    {
+        $this->ignoreOtherAttributes = $ignoreOtherAttributes;
+    }
+
     public function isSupported(): bool
     {
         return \PHP_VERSION_ID >= 80100;
@@ -37,7 +44,11 @@ class AttributeAnnotationFactory implements AnnotationFactoryInterface
         /** @var OA\AbstractAnnotation[] $annotations */
         $annotations = [];
         try {
-            foreach ($reflector->getAttributes() as $attribute) {
+            $attributeName = $this->ignoreOtherAttributes
+                ? [OA\AbstractAnnotation::class, \ReflectionAttribute::IS_INSTANCEOF]
+                : [];
+
+            foreach ($reflector->getAttributes(...$attributeName) as $attribute) {
                 if (class_exists($attribute->getName())) {
                     $instance = $attribute->newInstance();
                     if ($instance instanceof OA\AbstractAnnotation) {

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -57,7 +57,7 @@ class Generator
      *
      * If set, it will override the version set in the <code>OpenApi</code> annotation.
      *
-     * Due to the order of processing any conditional code using this (via <code>Context::$version</code>)
+     * Due to the order of processing, any conditional code using this (via <code>Context::$version</code>)
      * must come only after the analysis is finished.
      */
     protected ?string $version = null;
@@ -122,7 +122,11 @@ class Generator
 
     public function getAnalyser(): AnalyserInterface
     {
-        $this->analyser = $this->analyser ?: new ReflectionAnalyser([new AttributeAnnotationFactory(), new DocBlockAnnotationFactory()]);
+        $generatorConfig = $this->getConfig()['generator'];
+        $this->analyser = $this->analyser ?: new ReflectionAnalyser([
+            new AttributeAnnotationFactory($generatorConfig['ignoreOtherAttributes']),
+            new DocBlockAnnotationFactory(),
+        ]);
         $this->analyser->setGenerator($this);
 
         return $this->analyser;
@@ -138,6 +142,9 @@ class Generator
     public function getDefaultConfig(): array
     {
         return [
+            'generator' => [
+                'ignoreOtherAttributes' => false,
+            ],
             'operationId' => [
                 'hash' => true,
             ],

--- a/tests/Analysers/AttributeAnnotationFactoryTest.php
+++ b/tests/Analysers/AttributeAnnotationFactoryTest.php
@@ -16,7 +16,7 @@ use OpenApi\Tests\OpenApiTestCase;
  */
 class AttributeAnnotationFactoryTest extends OpenApiTestCase
 {
-    public function testReturnedAnnotationsCout(): void
+    public function testReturnedAnnotationsCount(): void
     {
         $rc = new \ReflectionClass(UsingAttributes::class);
 
@@ -33,5 +33,17 @@ class AttributeAnnotationFactoryTest extends OpenApiTestCase
         $this->expectExceptionMessage('OpenApi\Attributes\Property::__construct(): Argument #8 ($required) must be of type ?array');
 
         (new AttributeAnnotationFactory())->build($rm, $this->getContext());
+    }
+
+    public function testIgnoreOtherAttributes(): void
+    {
+        $rc = new \ReflectionClass(UsingAttributes::class);
+
+        (new AttributeAnnotationFactory())->build($rc, $context = $this->getContext());
+        $this->assertIsArray($context->other);
+        $this->assertCount(1, $context->other);
+
+        (new AttributeAnnotationFactory(true))->build($rc, $context = $this->getContext());
+        $this->assertNull($context->other);
     }
 }

--- a/tests/Fixtures/PHP/Label.php
+++ b/tests/Fixtures/PHP/Label.php
@@ -6,12 +6,12 @@
 
 namespace OpenApi\Tests\Fixtures\PHP;
 
-#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_PROPERTY | \Attribute::IS_REPEATABLE)]
 class Label
 {
     protected $name;
 
-    public function __construct(string $name, array $numbers)
+    public function __construct(string $name, array $numbers = [])
     {
         $this->name = $name;
     }

--- a/tests/Fixtures/UsingAttributes.php
+++ b/tests/Fixtures/UsingAttributes.php
@@ -7,7 +7,9 @@
 namespace OpenApi\Tests\Fixtures;
 
 use OpenApi\Attributes as OAT;
+use OpenApi\Tests\Fixtures\PHP\Label;
 
+#[Label(name: 'custom')]
 #[OAT\Response()]
 #[OAT\Header(header: 'X-Rate-Limit', allowEmptyValue: true)]
 class UsingAttributes


### PR DESCRIPTION
Adds an option to `AttributeAnnotationFactory` to ignore non `OpenApi` annotations and not instantiate them.

This can be done by either instantiating the `AttributeAnnotationFactory` yourself or by configuring this in the `Generator`.

```php
(new Generator())
    ->setConfig([
        'generator' => [
            'ignoreOtherAttributes' => true,
        ],
    ]);
```

Fixes #1747 