### PR TITLE
FIX tests for windows

### DIFF
--- a/tests/CommandlineTest.php
+++ b/tests/CommandlineTest.php
@@ -12,7 +12,7 @@ class CommandlineTest extends OpenApiTestCase
 {
     use UsesExamples;
 
-    private function getCommandToExecute(string $cmd, bool $appendDevNull = true): string
+    private function getCommandToExecute(string $cmd, ?string $devNullRedir = null): string
     {
         if (PHP_OS_FAMILY === 'Windows') {
             $cmd = 'php ' . $cmd;
@@ -20,8 +20,8 @@ class CommandlineTest extends OpenApiTestCase
         } else {
             $devNull = '/dev/null';
         }
-        if ($appendDevNull) {
-            $cmd .= ' ' . $devNull;
+        if ($devNullRedir) {
+            $cmd .= " $devNullRedir $devNull";
         }
 
         return $cmd;
@@ -31,7 +31,7 @@ class CommandlineTest extends OpenApiTestCase
     {
         $basePath = $this->examplePath('petstore');
         $path = "$basePath/annotations";
-        exec($this->getCommandToExecute(__DIR__ . '/../bin/openapi --bootstrap ' . __DIR__ . '/cl_bootstrap.php --format yaml ' . escapeshellarg($path) . ' 2>'), $output, $retval);
+        exec($this->getCommandToExecute(__DIR__ . '/../bin/openapi --bootstrap ' . __DIR__ . '/cl_bootstrap.php --format yaml ' . escapeshellarg($path), '2>'), $output, $retval);
         $this->assertSame(0, $retval, implode(PHP_EOL, $output));
         $yaml = implode(PHP_EOL, $output);
         $this->assertSpecEquals(file_get_contents($this->getSpecFilename('petstore')), $yaml);
@@ -42,7 +42,7 @@ class CommandlineTest extends OpenApiTestCase
         $basePath = $this->examplePath('petstore');
         $path = "$basePath/annotations";
         $filename = sys_get_temp_dir() . '/swagger-php-clitest.yaml';
-        exec($this->getCommandToExecute(__DIR__ . '/../bin/openapi --bootstrap ' . __DIR__ . '/cl_bootstrap.php --format yaml -o ' . escapeshellarg($filename) . ' ' . escapeshellarg($path) . ' 2>'), $output, $retval);
+        exec($this->getCommandToExecute(__DIR__ . '/../bin/openapi --bootstrap ' . __DIR__ . '/cl_bootstrap.php --format yaml -o ' . escapeshellarg($filename) . ' ' . escapeshellarg($path), '2>'), $output, $retval);
         $this->assertSame(0, $retval, implode(PHP_EOL, $output));
         $this->assertCount(0, $output, 'No output to stdout');
         $yaml = file_get_contents($filename);
@@ -55,7 +55,7 @@ class CommandlineTest extends OpenApiTestCase
         $basePath = $this->examplePath('petstore');
         $path = "$basePath/annotations";
         $cmd = __DIR__ . '/../bin/openapi --bootstrap ' . __DIR__ . '/cl_bootstrap.php --processor OperationId --format yaml ' . escapeshellarg($path);
-        exec($this->getCommandToExecute($cmd . ' 2>'), $output, $retval);
+        exec($this->getCommandToExecute($cmd, '2>'), $output, $retval);
         $this->assertSame(0, $retval, $cmd . PHP_EOL . implode(PHP_EOL, $output));
     }
 
@@ -63,7 +63,7 @@ class CommandlineTest extends OpenApiTestCase
     {
         $basePath = $this->examplePath('petstore');
         $path = "$basePath/annotations";
-        exec($this->getCommandToExecute(__DIR__ . '/../bin/openapi -e foo,bar ' . escapeshellarg($path) . ' 2>&1', false), $output, $retval);
+        exec($this->getCommandToExecute(__DIR__ . '/../bin/openapi -e foo,bar ' . escapeshellarg($path) . ' 2>&1'), $output, $retval);
         $this->assertSame(1, $retval);
         $output = implode(PHP_EOL, $output);
         $this->assertStringContainsString('Comma-separated exclude paths are deprecated', $output);
@@ -73,7 +73,7 @@ class CommandlineTest extends OpenApiTestCase
     {
         $basePath = $this->examplePath('petstore');
         $path = "$basePath/annotations";
-        exec($this->getCommandToExecute(__DIR__ . '/../bin/openapi ' . escapeshellarg($path) . ' -e 2>&1', false), $output, $retval);
+        exec($this->getCommandToExecute(__DIR__ . '/../bin/openapi ' . escapeshellarg($path) . ' -e 2>&1'), $output, $retval);
         $this->assertSame(1, $retval);
         $output = implode(PHP_EOL, $output);
         $this->assertStringContainsString('Error: Missing argument for "-e"', $output);

--- a/tests/CommandlineTest.php
+++ b/tests/CommandlineTest.php
@@ -12,22 +12,37 @@ class CommandlineTest extends OpenApiTestCase
 {
     use UsesExamples;
 
+    private function getCommandToExecute(string $cmd, bool $appendDevNull = true): string
+    {
+        if (PHP_OS_FAMILY === 'Windows') {
+            $cmd = 'php ' . $cmd;
+            $devNull = 'NUL';
+        } else {
+            $devNull = '/dev/null';
+        }
+        if ($appendDevNull) {
+            $cmd .= ' ' . $devNull;
+        }
+
+        return $cmd;
+    }
+
     public function testStdout(): void
     {
         $basePath = $this->examplePath('petstore');
         $path = "$basePath/annotations";
-        exec(__DIR__ . '/../bin/openapi --bootstrap ' . __DIR__ . '/cl_bootstrap.php --format yaml ' . escapeshellarg($path) . ' 2> /dev/null', $output, $retval);
+        exec($this->getCommandToExecute(__DIR__ . '/../bin/openapi --bootstrap ' . __DIR__ . '/cl_bootstrap.php --format yaml ' . escapeshellarg($path) . ' 2>'), $output, $retval);
         $this->assertSame(0, $retval, implode(PHP_EOL, $output));
         $yaml = implode(PHP_EOL, $output);
         $this->assertSpecEquals(file_get_contents($this->getSpecFilename('petstore')), $yaml);
     }
 
-    public function testOutputTofile(): void
+    public function testOutputToFile(): void
     {
         $basePath = $this->examplePath('petstore');
         $path = "$basePath/annotations";
         $filename = sys_get_temp_dir() . '/swagger-php-clitest.yaml';
-        exec(__DIR__ . '/../bin/openapi --bootstrap ' . __DIR__ . '/cl_bootstrap.php --format yaml -o ' . escapeshellarg($filename) . ' ' . escapeshellarg($path) . ' 2> /dev/null', $output, $retval);
+        exec($this->getCommandToExecute(__DIR__ . '/../bin/openapi --bootstrap ' . __DIR__ . '/cl_bootstrap.php --format yaml -o ' . escapeshellarg($filename) . ' ' . escapeshellarg($path) . ' 2>'), $output, $retval);
         $this->assertSame(0, $retval, implode(PHP_EOL, $output));
         $this->assertCount(0, $output, 'No output to stdout');
         $yaml = file_get_contents($filename);
@@ -40,7 +55,7 @@ class CommandlineTest extends OpenApiTestCase
         $basePath = $this->examplePath('petstore');
         $path = "$basePath/annotations";
         $cmd = __DIR__ . '/../bin/openapi --bootstrap ' . __DIR__ . '/cl_bootstrap.php --processor OperationId --format yaml ' . escapeshellarg($path);
-        exec($cmd . ' 2> /dev/null', $output, $retval);
+        exec($this->getCommandToExecute($cmd . ' 2>'), $output, $retval);
         $this->assertSame(0, $retval, $cmd . PHP_EOL . implode(PHP_EOL, $output));
     }
 
@@ -48,7 +63,7 @@ class CommandlineTest extends OpenApiTestCase
     {
         $basePath = $this->examplePath('petstore');
         $path = "$basePath/annotations";
-        exec(__DIR__ . '/../bin/openapi -e foo,bar ' . escapeshellarg($path) . ' 2>&1', $output, $retval);
+        exec($this->getCommandToExecute(__DIR__ . '/../bin/openapi -e foo,bar ' . escapeshellarg($path) . ' 2>&1', false), $output, $retval);
         $this->assertSame(1, $retval);
         $output = implode(PHP_EOL, $output);
         $this->assertStringContainsString('Comma-separated exclude paths are deprecated', $output);
@@ -58,7 +73,7 @@ class CommandlineTest extends OpenApiTestCase
     {
         $basePath = $this->examplePath('petstore');
         $path = "$basePath/annotations";
-        exec(__DIR__ . '/../bin/openapi ' . escapeshellarg($path) . ' -e 2>&1', $output, $retval);
+        exec($this->getCommandToExecute(__DIR__ . '/../bin/openapi ' . escapeshellarg($path) . ' -e 2>&1', false), $output, $retval);
         $this->assertSame(1, $retval);
         $output = implode(PHP_EOL, $output);
         $this->assertStringContainsString('Error: Missing argument for "-e"', $output);

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -58,7 +58,7 @@ class ContextTest extends OpenApiTestCase
 
         $customerSchema = $openapi->components->schemas[0];
         $this->assertStringContainsString(
-            'Fixtures/Customer.php on line ',
+            'Fixtures' . DIRECTORY_SEPARATOR . 'Customer.php on line ',
             $customerSchema->_context->getDebugLocation()
         );
 

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -9,7 +9,6 @@ namespace OpenApi\Tests;
 use OpenApi\Annotations as OA;
 use OpenApi\Tests\Concerns\UsesExamples;
 use OpenApi\Util;
-use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\Finder;
 
 class UtilTest extends OpenApiTestCase
@@ -32,12 +31,15 @@ class UtilTest extends OpenApiTestCase
         $finder = (new Finder())->in($this->examplePath('using-traits/annotations'));
         $this->assertGreaterThan(0, iterator_count($finder), 'There should be at least a few files and a directory.');
         $finder_array = \iterator_to_array($finder);
-        $directory_path = Path::normalize($this->examplePath('using-traits/annotations/Decoration'));
-        $normalizePathKeys = function ($paths) {
+        $normalize = static function (string $path): string {
+            return str_replace('\\', '/', $path);
+        };
+        $directory_path = $normalize($this->examplePath('using-traits/annotations/Decoration'));
+        $normalizePathKeys = static function ($paths) use ($normalize) {
             return \array_combine(
                 \array_map(
-                    function ($path) {
-                        return Path::normalize($path);
+                    static function ($path) use ($normalize) {
+                        return $normalize($path);
                     },
                     \array_keys($paths)
                 ),

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -38,9 +38,7 @@ class UtilTest extends OpenApiTestCase
         $normalizePathKeys = static function ($paths) use ($normalize) {
             return \array_combine(
                 \array_map(
-                    static function ($path) use ($normalize) {
-                        return $normalize($path);
-                    },
+                    $normalize,
                     \array_keys($paths)
                 ),
                 \array_values($paths)

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -9,6 +9,7 @@ namespace OpenApi\Tests;
 use OpenApi\Annotations as OA;
 use OpenApi\Tests\Concerns\UsesExamples;
 use OpenApi\Util;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\Finder;
 
 class UtilTest extends OpenApiTestCase
@@ -31,13 +32,24 @@ class UtilTest extends OpenApiTestCase
         $finder = (new Finder())->in($this->examplePath('using-traits/annotations'));
         $this->assertGreaterThan(0, iterator_count($finder), 'There should be at least a few files and a directory.');
         $finder_array = \iterator_to_array($finder);
-        $directory_path = $this->examplePath('using-traits/annotations/Decoration');
-        $this->assertArrayHasKey($directory_path, $finder_array, 'The directory should be a path in the finder.');
+        $directory_path = Path::normalize($this->examplePath('using-traits/annotations/Decoration'));
+        $normalizePathKeys = function ($paths) {
+            return \array_combine(
+                \array_map(
+                    function ($path) {
+                        return Path::normalize($path);
+                    },
+                    \array_keys($paths)
+                ),
+                \array_values($paths)
+            );
+        };
+        $this->assertArrayHasKey($directory_path, $normalizePathKeys($finder_array), 'The directory should be a path in the finder.');
         // Use the Util method that should set the finder to only find files, since swagger-php only needs files.
         $finder_result = Util::finder($finder);
         $this->assertGreaterThan(0, iterator_count($finder_result), 'There should be at least a few file paths.');
         $finder_result_array = \iterator_to_array($finder_result);
-        $this->assertArrayNotHasKey($directory_path, $finder_result_array, 'The directory should not be a path in the finder.');
+        $this->assertArrayNotHasKey($directory_path, $normalizePathKeys($finder_result_array), 'The directory should not be a path in the finder.');
     }
 
     public static function shortenFixtures(): iterable


### PR DESCRIPTION
Summary of changes for tests to work in windows environments:

- normalized paths where possible for assertions
- use DIRECTORY_SEPARATOR inside paths where normalization is not possible
- prepend `php` to command line tests
- use `NUL` instead of `/dev/null` for error output in command line tests