### PR TITLE
Support use x-* in ref

### DIFF
--- a/tests/RefTest.php
+++ b/tests/RefTest.php
@@ -19,9 +19,23 @@ class RefTest extends OpenApiTestCase
         $this->assertInstanceOf(OA\Info::class, $info);
 
         $comment = <<<END
-@OA\Get(
+@OA\Post(
     path="/api/~/endpoint",
-    @OA\Response(response="default", description="A response")
+    @OA\Response(
+        response="default",
+        description="A response",
+        @OA\JsonContent(ref="#/components/schemas/String/x-custom-key")
+    )
+)
+
+@OA\Schema(
+     schema="String",
+     @OA\Property(property="value", type="string"),
+     x={
+        "custom-key": @OA\Schema(
+            @OA\Property(property="value", type="string"),
+        )
+    }
 )
 END;
         $openapi->merge($this->annotationsFromDocBlockParser($comment));
@@ -32,8 +46,17 @@ END;
         $analysis->validate();
         // escape / as ~1
         // escape ~ as ~0
-        $response = $openapi->ref('#/paths/~1api~1~0~1endpoint/get/responses/default');
+        $response = $openapi->ref('#/paths/~1api~1~0~1endpoint/post/responses/default');
         $this->assertInstanceOf(OA\Response::class, $response);
         $this->assertSame('A response', $response->description);
+
+        // ref x value
+        $schema = $openapi->ref('#/components/schemas/String/x-custom-key');
+        $this->assertInstanceOf(OA\Schema::class, $schema);
+
+        // ref x with deep
+        $property = $openapi->ref('#/components/schemas/String/x-custom-key/properties/value');
+        $this->assertInstanceOf(OA\Property::class, $property);
+        $this->assertSame('string', $property->type);
     }
 }


### PR DESCRIPTION
```php
@OA\Schema(
     schema="String",
     @OA\Property(property="value", type="string"),
     x={
        "custom-key": @OA\Schema(
            @OA\Property(property="value", type="string"),
        )
    }
)
```

The above annotation will generate `x-custom-key` in the OpenAPI document.

However, we need to get ref of `x-custom-key` with `$openapi->ref('#/components/schemas/String/x/custom-key')` (note that here we use `x/custom-key` instead of `x-custom-key`).

This is not conducive to writing ref in the code ourselves. For example,

```php
@OA\Post(
    path="/api/~/endpoint",
    @OA\Response(
        response="default",
        description="A response",
        @OA\JsonContent(ref="#/components/schemas/String/x/custom-key")
    )
)
```

This will generate the following incorrect documentation when using `$openapi->toYaml()`(use `x/custom-key`)

```yaml
...
            application/json:
              schema:
                $ref: '#/components/schemas/String/x/custom-key'
...
```

Therefore, we have to write it in the following way (use `x-custom-key`)

```php
@OA\Post(
    path="/api/~/endpoint",
    @OA\Response(
        response="default",
        description="A response",
        @OA\JsonContent(ref="#/components/schemas/String/x-custom-key")
    )
)
```

However, if it is written directly in the above way, the validation will fail.

This PR is to fix this issue to support the use of ref `x-*`.