### PR TITLE
docs: mention Scalar as an alternative to Swagger UI

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 layout: home
-hero: 
+hero:
   name: Swagger-PHP
   tagline: Generate OpenAPI documentation for your RESTful API.
   actions:
@@ -51,7 +51,7 @@ possible attributes should be used.
 
 ### 4. Explore and interact with your API
 
-Use an OpenAPI tool like [Swagger UI](https://swagger.io/tools/swagger-ui/) to explore and interact with your API.
+Use an OpenAPI tool like [Swagger UI](https://swagger.io/tools/swagger-ui/) or [Scalar](https://github.com/scalar/scalar) to explore and interact with your API.
 
 ## Links
 

--- a/docs/related-projects.md
+++ b/docs/related-projects.md
@@ -5,7 +5,7 @@ sidebar: false
 # Related projects
 
 | Project                       | Description                                               |
-|-------------------------------|-----------------------------------------------------------|
+| ----------------------------- | --------------------------------------------------------- |
 | [Swagger UI][1]               | The webinterface for reading the generated documentation  |
 | [Swagger Explained][2]        | Browse the spec by using an swagger.json.                 |
 | [silex2swagger][3]            | Generate swagger documentation from Silex Annotations     |
@@ -21,6 +21,7 @@ sidebar: false
 | [Laravel Swagger][13]         | OpenApi or Swagger integration to Laravel                 |
 | [openapi-extras][14]          | Extra annotations for swagger-php                         |
 | [openapi-serialize][15]       | Serialize an object using swagger-php                     |
+| [Scalar][16]                  | An alternative webinterface for generating documentation  |
 
 Is a related project missing? Create a pull request!
 
@@ -39,3 +40,4 @@ Is a related project missing? Create a pull request!
 [13]: https://github.com/DarkaOnLine/L5-Swagger
 [14]: https://github.com/DerManoMann/openapi-extras
 [15]: https://github.com/MattyRad/openapi-serialize
+[16]: https://github.com/scalar/scalar


### PR DESCRIPTION
big PHP fan here, I just discovered swagger-php. I spend the last years to build an alternative to Swagger UI that some people like, mostly for the more modern look and the fully featured API client that’s embedded. it’s called [Scalar](https://github.com/scalar/scalar).

I just thought it would be cool to offer it as an alternative to Swagger UI, what do you think?

I added it in two places. If you think that's too much, I can also just put it in one place, or whatever you think is good.