### PR TITLE
Fix parameter name matching in method docblocks for `LegacyTypeResolver`

### DIFF
--- a/src/Type/LegacyTypeResolver.php
+++ b/src/Type/LegacyTypeResolver.php
@@ -188,7 +188,7 @@ class LegacyTypeResolver extends AbstractTypeResolver
         $pattern = "/$tagName\s+(?<type>[^\s]+)([ \t])?/im";
         if ('@param' === $tagName) {
             // need to match on $name too
-            $pattern = "/$tagName\s+(?<type>[^\s]+)([ \t])?\\$$name/im";
+            $pattern = "/$tagName\s+(?<type>[^\s]+)([ \t])?\\$$name([\s\r\n])/im";
         }
 
         $docComment = str_replace("\r\n", "\n", $docComment);

--- a/tests/Fixtures/PHP/DocblockAndTypehintTypes.php
+++ b/tests/Fixtures/PHP/DocblockAndTypehintTypes.php
@@ -168,4 +168,15 @@ class DocblockAndTypehintTypes
     ): void
         {
         }
+
+    /**
+     * @param ?string[] $blah_values
+     */
+    public function blah(
+        #[OAT\Property(example: 'My blah')]
+        ?string $blah,
+        #[OAT\Property(nullable: true, items: new OAT\Items(type: 'string', example: 'hello'))]
+        ?array $blah_values,
+    ) {
+    }
 }

--- a/tests/Type/TypeResolverTest.php
+++ b/tests/Type/TypeResolverTest.php
@@ -55,6 +55,8 @@ class TypeResolverTest extends OpenApiTestCase
             'getstring' => '{ "type": "string", "property": "getString" }',
             'paramdatetimelist' => '{ "type": "array", "items": { "type": "string", "format": "date-time" }, "property": "paramDateTimeList" }',
             'paramstringlist' => '{ "type": "array", "items": { "type": "string" }, "property": "paramStringList" }',
+            'blah' => '{ "type": "string", "example": "My blah", "nullable": true, "property": "blah" }',
+            'blah_values' => '{ "type": "array", "items": { "type": "string", "example": "hello" }, "nullable": true, "property": "blah_values" }',
         ];
 
         $rc = new \ReflectionClass(DocblockAndTypehintTypes::class);


### PR DESCRIPTION
Fixes #1839 