### PR TITLE
Methods SplObjectStorage::attach(), detach & contains() are deprecated since PHP 8.5.

### DIFF
--- a/src/Analysis.php
+++ b/src/Analysis.php
@@ -55,7 +55,7 @@ class Analysis
 
     public function addAnnotation(object $annotation, Context $context): void
     {
-        if ($this->annotations->contains($annotation)) {
+        if ($this->annotations->offsetExists($annotation)) {
             return;
         }
 
@@ -72,7 +72,7 @@ class Analysis
                 $context->annotations[] = $annotation;
             }
         }
-        $this->annotations->attach($annotation, $context);
+        $this->annotations->offsetSet($annotation, $context);
         $blacklist = property_exists($annotation, '_blacklist') ? $annotation::$_blacklist : [];
         foreach ($annotation as $property => $value) {
             if (in_array($property, $blacklist)) {
@@ -297,8 +297,8 @@ class Analysis
         foreach ((array) $classes as $class) {
             /** @var OA\AbstractAnnotation $annotation */
             foreach ($this->annotations as $annotation) {
-                if ($annotation instanceof $class && (!$strict || ($annotation->isRoot($class) && !$unique->contains($annotation)))) {
-                    $unique->attach($annotation);
+                if ($annotation instanceof $class && (!$strict || ($annotation->isRoot($class) && !$unique->offsetExists($annotation)))) {
+                    $unique->offsetSet($annotation);
                     $annotations[] = $annotation;
                 }
             }
@@ -340,7 +340,7 @@ class Analysis
         if ($annotation instanceof OA\AbstractAnnotation) {
             return $annotation->_context;
         }
-        if ($this->annotations->contains($annotation) === false) {
+        if ($this->annotations->offsetExists($annotation) === false) {
             throw new OpenApiException('Annotation not found');
         }
         $context = $this->annotations[$annotation];
@@ -387,8 +387,8 @@ class Analysis
         $result->merged = $this->merged();
         $result->unmerged = new Analysis([], $this->context);
         foreach ($this->annotations as $annotation) {
-            if ($result->merged->annotations->contains($annotation) === false) {
-                $result->unmerged->annotations->attach($annotation, $this->annotations[$annotation]);
+            if ($result->merged->annotations->offsetExists($annotation) === false) {
+                $result->unmerged->annotations->offsetSet($annotation, $this->annotations[$annotation]);
             }
         }
 

--- a/src/Processors/AugmentRefs.php
+++ b/src/Processors/AugmentRefs.php
@@ -88,7 +88,7 @@ class AugmentRefs
                     if (!Generator::isDefault($allOfSchema->ref)) {
                         if (in_array($allOfSchema->ref, $refs)) {
                             $dupes[] = $allOfSchema->ref;
-                            $analysis->annotations->detach($allOfSchema);
+                            $analysis->annotations->offsetUnset($allOfSchema);
                             unset($schema->allOf[$ii]);
                             continue;
                         }

--- a/src/Processors/AugmentTags.php
+++ b/src/Processors/AugmentTags.php
@@ -97,7 +97,7 @@ class AugmentTags
         foreach ($declaredTags as $tag) {
             if (!in_array($tag->name, $tagsToKeep)) {
                 if (false !== $index = array_search($tag, $analysis->openapi->tags, true)) {
-                    $analysis->annotations->detach($tag);
+                    $analysis->annotations->offsetUnset($tag);
                     unset($analysis->openapi->tags[$index]);
                     $analysis->openapi->tags = array_values($analysis->openapi->tags);
                 }

--- a/src/Processors/BuildPaths.php
+++ b/src/Processors/BuildPaths.php
@@ -26,7 +26,7 @@ class BuildPaths
                     $annotation->_context->logger->warning($annotation->identity() . ' is missing required property "path" in ' . $annotation->_context);
                 } elseif (isset($paths[$annotation->path])) {
                     $paths[$annotation->path]->mergeProperties($annotation);
-                    $analysis->annotations->detach($annotation);
+                    $analysis->annotations->offsetUnset($annotation);
                 } else {
                     $paths[$annotation->path] = $annotation;
                 }

--- a/src/Processors/CleanUnmerged.php
+++ b/src/Processors/CleanUnmerged.php
@@ -21,7 +21,7 @@ class CleanUnmerged
         foreach ($analysis->annotations as $annotation) {
             if (property_exists($annotation, '_unmerged')) {
                 foreach ($annotation->_unmerged as $ii => $item) {
-                    if ($merged->contains($item)) {
+                    if ($merged->offsetExists($item)) {
                         unset($annotation->_unmerged[$ii]); // Property was merged
                     }
                 }

--- a/src/Processors/Concerns/AnnotationTrait.php
+++ b/src/Processors/Concerns/AnnotationTrait.php
@@ -20,8 +20,8 @@ trait AnnotationTrait
         $storage = new \SplObjectStorage();
 
         $this->traverseAnnotations($root, static function ($item) use (&$storage): void {
-            if ($item instanceof OA\AbstractAnnotation && !$storage->contains($item)) {
-                $storage->attach($item);
+            if ($item instanceof OA\AbstractAnnotation && !$storage->offsetExists($item)) {
+                $storage->offsetSet($item);
             }
         });
 
@@ -37,7 +37,7 @@ trait AnnotationTrait
         $this->traverseAnnotations($root, static function ($item) use ($remove): void {
             if ($item instanceof \SplObjectStorage) {
                 foreach ($remove as $annotation) {
-                    $item->detach($annotation);
+                    $item->offsetUnset($annotation);
                 }
             }
         }, $recurse);

--- a/src/Processors/MergeIntoOpenApi.php
+++ b/src/Processors/MergeIntoOpenApi.php
@@ -98,7 +98,7 @@ class MergeIntoOpenApi
                         }
                     }
 
-                    $analysis->annotations->detach($components);
+                    $analysis->annotations->offsetUnset($components);
                 }
 
                 $merge = array_filter($merge, static fn (OA\AbstractAnnotation $annotation): bool => !$annotation instanceof OA\Components);


### PR DESCRIPTION
Methods SplObjectStorage::[attach()](https://www.php.net/manual/en/splobjectstorage.attach.php), [detach()](https://www.php.net/manual/en/splobjectstorage.detach.php) & [contains()](https://www.php.net/manual/en/splobjectstorage.contains.php) are deprecated since PHP 8.5.
Use [offsetSet()](https://www.php.net/manual/en/splobjectstorage.offsetset.php), [offsetUnset()](https://www.php.net/manual/en/splobjectstorage.offsetunset.php) & [offsetExists()](https://www.php.net/manual/en/splobjectstorage.offsetexists.php) instead.

Those are present in PHP 5 >= 5.3.0, PHP 7 and PHP 8, so backward compatibility should be maintained.