### PR TITLE
Fix getRelativePath in SourceFinder

### DIFF
--- a/src/SourceFinder.php
+++ b/src/SourceFinder.php
@@ -49,8 +49,8 @@ class SourceFinder extends Finder
     private function getRelativePath(string $fullPath, array $directories): string
     {
         foreach ($directories as $directory) {
-            if (str_starts_with((string) $directory, $fullPath)) {
-                $relativePath = substr((string) $directory, strlen($fullPath));
+            if (str_starts_with($fullPath, (string) $directory)) {
+                $relativePath = substr($fullPath, strlen((string) $directory));
 
                 if ($relativePath !== '' && $relativePath !== '0') {
                     return trim($relativePath, '/');

--- a/tests/SourceFinderTest.php
+++ b/tests/SourceFinderTest.php
@@ -21,4 +21,16 @@ class SourceFinderTest extends OpenApiTestCase
         $this->assertCount(12, $sources, 'There should be at least a few files and a directory.');
         $this->assertArrayHasKey(static::examplePath('using-traits/annotations/Decoration/Whistles.php'), $sources);
     }
+
+    public function testExclude(): void
+    {
+        $finder = (new SourceFinder(
+            static::examplePath('using-traits/annotations'),
+            static::examplePath('using-traits/annotations/Decoration')
+        ));
+        $sources = iterator_to_array($finder);
+
+        $this->assertArrayNotHasKey(static::examplePath('using-traits/annotations/Decoration/Whistles.php'), $sources);
+        $this->assertArrayNotHasKey(static::examplePath('using-traits/annotations/Decoration/Bell.php'), $sources);
+    }
 }


### PR DESCRIPTION
`getRelativePath` method was implemented incorrectly causing `exclude` directories being not excluded.

Before change:
```bash
Runtime:       PHP 8.4.16
Configuration: /Users/darius/Sites/swagger-php/phpunit.xml.dist

Failed asserting that an array does not have the key '/Users/darius/Sites/swagger-php/docs/examples/specs/using-traits/annotations/Decoration/Whistles.php'.
/Users/darius/Sites/swagger-php/tests/SourceFinderTest.php:33

Time: 00:03.667, Memory: 10.00 MB

There was 1 failure:

1) OpenApi\Tests\SourceFinderTest::testExclude
Failed asserting that an array does not have the key '/Users/darius/Sites/swagger-php/docs/examples/specs/using-traits/annotations/Decoration/Whistles.php'.

/Users/darius/Sites/swagger-php/tests/SourceFinderTest.php:33

FAILURES!
Tests: 1, Assertions: 2, Failures: 1.
Process finished with exit code 1
```