### PR TITLE
Fix: Prevent duplicate webhook entries in OpenAPI specification

### DIFF
--- a/src/Processors/MergeIntoOpenApi.php
+++ b/src/Processors/MergeIntoOpenApi.php
@@ -71,7 +71,8 @@ class MergeIntoOpenApi
                 }
             } elseif ($annotation instanceof OA\AbstractAnnotation
                 && in_array(OA\OpenApi::class, $annotation::$_parents)
-                && false === $annotation->_context->is('nested')) {
+                && false === $annotation->_context->is('nested')
+                && false === $annotation instanceof OA\Webhook) {
                 // A top-level annotation.
                 $merge[] = $annotation;
             }


### PR DESCRIPTION
### Problem
Without the explicit exclusion of `Webhook` instances, webhooks were being processed twice:

1. **First pass `MergeIntoOpenApi` (line 76)**: `Webhook` annotations were added to the `$merge[]` array.

2. **Second pass `MergeIntoOpenApi` (line 111)**: When `$openapi->merge($merge, true)` is called, the `AbstractAnnotation::merge()` method detects that `Webhook` has an entry in `OpenApi::$_nested` (`Webhook::class => ['webhooks', 'webhook']`) and processes them again through the standard nesting mechanism.

This resulted in duplicate webhook entries in the final OpenAPI specification.

Related to #1917