### PR TITLE
Fix CLI version override

### DIFF
--- a/src/Console/GenerateInput.php
+++ b/src/Console/GenerateInput.php
@@ -6,7 +6,6 @@
 
 namespace OpenApi\Console;
 
-use OpenApi\Annotations as OA;
 use Symfony\Component\Console\Attribute\Argument;
 use Symfony\Component\Console\Attribute\Option;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
@@ -44,7 +43,7 @@ class GenerateInput
     public array $removeProcessor = [];
 
     #[Option('The OpenAPI version')]
-    public string $version = OA\OpenApi::DEFAULT_VERSION;
+    public ?string $version = null;
 
     #[Option('Show additional error information', shortcut: 'd')]
     public bool $debug = false;

--- a/tests/CommandlineTest.php
+++ b/tests/CommandlineTest.php
@@ -89,9 +89,9 @@ final class CommandlineTest extends OpenApiTestCase
     public function testVersionDefault(string $args, string $expectedVersion): void
     {
         $fixture = $this->fixture('Explicit310.php');
-        $cmd = __DIR__ . '/../bin/openapi --bootstrap ' . $fixture . " $args " . escapeshellarg($fixture);
+        $cmd = __DIR__ . '/../bin/openapi --bootstrap ' . $fixture . " {$args} " . escapeshellarg((string) $fixture);
         exec($this->getCommandToExecute($cmd, '2>'), $output, $retval);
         $this->assertSame(0, $retval, $cmd . PHP_EOL . implode(PHP_EOL, $output));
-        $this->assertStringContainsString("openapi: $expectedVersion", implode(PHP_EOL, $output));
+        $this->assertStringContainsString("openapi: {$expectedVersion}", implode(PHP_EOL, $output));
     }
 }

--- a/tests/CommandlineTest.php
+++ b/tests/CommandlineTest.php
@@ -77,4 +77,13 @@ final class CommandlineTest extends OpenApiTestCase
         $output = implode(PHP_EOL, $output);
         $this->assertStringContainsString('The "--exclude" option requires a value.', $output);
     }
+
+    public function testVersionDefault(): void
+    {
+        $fixture = $this->fixture('Explicit310.php');
+        $cmd = __DIR__ . '/../bin/openapi --bootstrap ' . $fixture . ' ' . escapeshellarg($fixture);
+        exec($this->getCommandToExecute($cmd, '2>'), $output, $retval);
+        $this->assertSame(0, $retval, $cmd . PHP_EOL . implode(PHP_EOL, $output));
+        $this->assertStringContainsString('openapi: 3.1.0', implode(PHP_EOL, $output));
+    }
 }

--- a/tests/CommandlineTest.php
+++ b/tests/CommandlineTest.php
@@ -7,6 +7,7 @@
 namespace OpenApi\Tests;
 
 use OpenApi\Tests\Concerns\UsesExamples;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 final class CommandlineTest extends OpenApiTestCase
 {
@@ -78,12 +79,19 @@ final class CommandlineTest extends OpenApiTestCase
         $this->assertStringContainsString('The "--exclude" option requires a value.', $output);
     }
 
-    public function testVersionDefault(): void
+    public static function versionCases(): iterable
+    {
+        yield 'default' => ['', '3.1.0'];
+        yield 'override' => ['--version=3.0.3', '3.0.3'];
+    }
+
+    #[DataProvider('versionCases')]
+    public function testVersionDefault(string $args, string $expectedVersion): void
     {
         $fixture = $this->fixture('Explicit310.php');
-        $cmd = __DIR__ . '/../bin/openapi --bootstrap ' . $fixture . ' ' . escapeshellarg($fixture);
+        $cmd = __DIR__ . '/../bin/openapi --bootstrap ' . $fixture . " $args " . escapeshellarg($fixture);
         exec($this->getCommandToExecute($cmd, '2>'), $output, $retval);
         $this->assertSame(0, $retval, $cmd . PHP_EOL . implode(PHP_EOL, $output));
-        $this->assertStringContainsString('openapi: 3.1.0', implode(PHP_EOL, $output));
+        $this->assertStringContainsString("openapi: $expectedVersion", implode(PHP_EOL, $output));
     }
 }

--- a/tests/Fixtures/Explicit310.php
+++ b/tests/Fixtures/Explicit310.php
@@ -36,4 +36,6 @@ use OpenApi\Attributes as OAT;
         ),
     ],
 )]
-class Explicit310 { }
+class Explicit310
+{
+}

--- a/tests/Fixtures/Explicit310.php
+++ b/tests/Fixtures/Explicit310.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures;
+
+use OpenApi\Attributes as OAT;
+
+#[OAT\OpenApi(
+    openapi: OAT\OpenApi::VERSION_3_1_0,
+    info: new OAT\Info(
+        version: '0.0.1',
+        title: 'Foo API',
+    ),
+)]
+#[OAT\Get(
+    path: '/foo',
+    operationId: 'fooOperation',
+    description: 'Retrieve details for a foo',
+    summary: 'Foo Details',
+    tags: ['Foo'],
+    responses: [
+        new OAT\Response(
+            response: 200,
+            description: 'Successful Operation',
+            content: new OAT\JsonContent(
+                properties: [
+                    new OAT\Property(
+                        property: 'bar',
+                        type: 'string',
+                    ),
+                ],
+            ),
+        ),
+    ],
+)]
+class Explicit310 { }


### PR DESCRIPTION
## Summary

Stop overriding the OpenApi version on the CLI when not explicitly set.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Enhancement (improvement to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional changes)
- [ ] Chore (maintenance, dependencies, CI)

## Related Issues

Fixes #1991

## Test Plan

<!-- Describe the tests you ran or plan to run to verify the changes. -->

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass locally
- [ ] Any dependent changes have been merged and published
