### PR TITLE
Handle parameter dockblocks

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -19,6 +19,8 @@ $finder = PhpCsFixer\Finder::create()
             && !strpos($file->getPathname(), 'tests/Fixtures/TypedProperties.php')
             // FQDN in docblock
             && !strpos($file->getPathname(), 'tests/Fixtures/PHP/DocblockAndTypehintTypes.php')
+            // parameter docblock for PHP 8.6
+            && !strpos($file->getPathname(), 'tests/Fixtures/Scratch/Docblocks.php')
         ;
     })
     ->in(__DIR__);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -31,18 +31,6 @@ parameters:
 			path: src/Annotations/Flow.php
 
 		-
-			message: '#^Strict comparison using \!\=\= between false and string will always evaluate to true\.$#'
-			identifier: notIdentical.alwaysTrue
-			count: 1
-			path: src/Processors/AugmentParameters.php
-
-		-
-			message: '#^Strict comparison using \!\=\= between false and string will always evaluate to true\.$#'
-			identifier: notIdentical.alwaysTrue
-			count: 1
-			path: src/Processors/AugmentProperties.php
-
-		-
 			message: '#^Parameter \#1 \$annotation of method OpenApi\\Processors\\DocBlockDescriptions\:\:description\(\) expects OpenApi\\Annotations\\Operation\|OpenApi\\Annotations\\Parameter\|OpenApi\\Annotations\\Schema, OpenApi\\Annotations\\AbstractAnnotation given\.$#'
 			identifier: argument.type
 			count: 1
@@ -51,12 +39,6 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$annotation of method OpenApi\\Processors\\DocBlockDescriptions\:\:summaryAndDescription\(\) expects OpenApi\\Annotations\\Operation\|OpenApi\\Annotations\\Parameter\|OpenApi\\Annotations\\Schema, OpenApi\\Annotations\\AbstractAnnotation given\.$#'
 			identifier: argument.type
-			count: 1
-			path: src/Processors/DocBlockDescriptions.php
-
-		-
-			message: '#^Strict comparison using \!\=\= between false and string will always evaluate to true\.$#'
-			identifier: notIdentical.alwaysTrue
 			count: 1
 			path: src/Processors/DocBlockDescriptions.php
 
@@ -83,21 +65,3 @@ parameters:
 			identifier: method.notFound
 			count: 1
 			path: tests/Annotations/AttributesSyncTest.php
-
-		-
-			message: '#^Strict comparison using \!\=\= between false and string will always evaluate to true\.$#'
-			identifier: notIdentical.alwaysTrue
-			count: 1
-			path: tests/Processors/AugmentParametersTest.php
-
-		-
-			message: '#^Strict comparison using \!\=\= between false and string will always evaluate to true\.$#'
-			identifier: notIdentical.alwaysTrue
-			count: 1
-			path: tests/Processors/AugmentRefsTest.php
-
-		-
-			message: '#^Strict comparison using \!\=\= between false and string will always evaluate to true\.$#'
-			identifier: notIdentical.alwaysTrue
-			count: 1
-			path: tests/Processors/DocBlockDescriptionsTest.php

--- a/src/Analysers/AttributeAnnotationFactory.php
+++ b/src/Analysers/AttributeAnnotationFactory.php
@@ -94,6 +94,10 @@ class AttributeAnnotationFactory implements AnnotationFactoryInterface
                                     }
                                 } else {
                                     $instance->_context->property = $rp->getName();
+                                    if (method_exists($rp, 'getDocComment')) {
+                                        $comment = $rp->getDocComment();
+                                        $instance->_context->comment = false !== $comment ? $comment : null;
+                                    }
                                 }
                             }
                             $annotations[] = $instance;

--- a/src/Analysers/AttributeAnnotationFactory.php
+++ b/src/Analysers/AttributeAnnotationFactory.php
@@ -94,12 +94,15 @@ class AttributeAnnotationFactory implements AnnotationFactoryInterface
                                     }
                                 } else {
                                     $instance->_context->property = $rp->getName();
-                                    if (method_exists($rp, 'getDocComment')) {
-                                        $comment = $rp->getDocComment();
-                                        $instance->_context->comment = false !== $comment ? $comment : null;
+                                }
+                            } elseif ($instance instanceof OAT\Parameter) {
+                                if (method_exists($rp, 'getDocComment')) {
+                                    if ($comment = $rp->getDocComment()) {
+                                        $instance->_context->comment = $comment;
                                     }
                                 }
                             }
+
                             $annotations[] = $instance;
                         }
                     }

--- a/src/Processors/AugmentParameters.php
+++ b/src/Processors/AugmentParameters.php
@@ -136,12 +136,12 @@ class AugmentParameters implements GeneratorAwareInterface
             if (!Generator::isDefault($operation->parameters)) {
                 $tags = [];
                 $this->parseDocblock($operation->_context->comment, $tags);
-                $docblockParams = $tags['param'] ?? [];
+                $operationDocblockParams = $tags['param'] ?? [];
 
                 foreach ($operation->parameters as $parameter) {
                     if (Generator::isDefault($parameter->description)) {
-                        if (array_key_exists($parameter->name, $docblockParams)) {
-                            $details = $docblockParams[$parameter->name];
+                        if (array_key_exists($parameter->name, $operationDocblockParams)) {
+                            $details = $operationDocblockParams[$parameter->name];
                             if ($details['description']) {
                                 $parameter->description = $details['description'];
                             }

--- a/src/Processors/AugmentParameters.php
+++ b/src/Processors/AugmentParameters.php
@@ -140,6 +140,13 @@ class AugmentParameters implements GeneratorAwareInterface
 
                 foreach ($operation->parameters as $parameter) {
                     if (Generator::isDefault($parameter->description)) {
+                        $typeAndDescription = $this->parseVarLine((string) $parameter->_context->comment);
+                        if ($typeAndDescription['description']) {
+                            $parameter->description = trim($typeAndDescription['description']);
+                        }
+                    }
+
+                    if (Generator::isDefault($parameter->description)) {
                         if (array_key_exists($parameter->name, $operationDocblockParams)) {
                             $details = $operationDocblockParams[$parameter->name];
                             if ($details['description']) {

--- a/src/Processors/Concerns/DocblockTrait.php
+++ b/src/Processors/Concerns/DocblockTrait.php
@@ -169,7 +169,7 @@ trait DocblockTrait
         }
 
         $description = '';
-        if (false !== ($substr = substr($content, strlen((string) $summary)))) {
+        if (!empty($substr = substr($content, strlen($summary)))) {
             $description = trim($substr);
         }
 

--- a/src/Processors/Concerns/DocblockTrait.php
+++ b/src/Processors/Concerns/DocblockTrait.php
@@ -184,9 +184,9 @@ trait DocblockTrait
     public function parseVarLine(?string $docblock): array
     {
         $comment = str_replace("\r\n", "\n", (string) $docblock);
-        $comment = preg_replace('/\*\/[ \t]*$/', '', $comment); // strip '*/'
+        $comment = preg_replace(['/[ \t]*\\/\*\*/', '/\*\/[ \t]*$/'], '', $comment); // '/**', '*/'
 
-        preg_match('/@var\s+(?<type>[^\s]+)([ \t])?(?<description>.+)?+$/im', (string) $comment, $matches);
+        preg_match('/@var[ \t]+(?<type>[^\s]+)(?:[ \t]+\$(?<name>\w+))?(?:[ \t]+(?<description>.+))?$/im', (string) $comment, $matches);
 
         $result = array_merge(
             ['type' => null, 'description' => null],

--- a/src/Processors/Concerns/DocblockTrait.php
+++ b/src/Processors/Concerns/DocblockTrait.php
@@ -9,6 +9,18 @@ namespace OpenApi\Processors\Concerns;
 use OpenApi\Annotations as OA;
 use OpenApi\Attributes as OAT;
 use OpenApi\Generator;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTextNode;
+use PHPStan\PhpDocParser\Ast\Type\IntersectionTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use PHPStan\PhpDocParser\Ast\Type\UnionTypeNode;
+use PHPStan\PhpDocParser\Lexer\Lexer;
+use PHPStan\PhpDocParser\Parser\ConstExprParser;
+use PHPStan\PhpDocParser\Parser\PhpDocParser;
+use PHPStan\PhpDocParser\Parser\TokenIterator;
+use PHPStan\PhpDocParser\Parser\TypeParser;
+use PHPStan\PhpDocParser\ParserConfig;
 
 trait DocblockTrait
 {
@@ -55,33 +67,54 @@ trait DocblockTrait
         return false;
     }
 
-    protected function handleTag(string $line, ?array &$tags = null): void
+    /**
+     * Parse a docblock string into a PhpDocNode.
+     */
+    protected function parsePhpDoc(?string $docblock): ?PhpDocNode
     {
-        if (null === $tags) {
-            return;
+        if (!$docblock || Generator::isDefault($docblock)) {
+            return null;
         }
 
-        // split of tag name
-        $token = preg_split("@[\s+　]@u", $line, 2);
-        if (2 == count($token)) {
-            $tag = substr($token[0], 1);
-            $tail = $token[1];
-            if (!array_key_exists($tag, $tags)) {
-                $tags[$tag] = [];
-            }
+        // Normalize single-star comments to PHPDoc format
+        $normalized = preg_replace('#^/\*(?!\*)#', '/**', $docblock);
 
-            if (false !== ($dpos = strpos($tail, '$'))) {
-                $type = trim(substr($tail, 0, $dpos));
-                $token = preg_split("@[\s+　]@u", substr($tail, $dpos), 2);
-                $name = trim(substr($token[0], 1));
-                $description = 2 == count($token) ? trim($token[1]) : null;
-
-                $tags[$tag][$name] = [
-                    'type' => $type,
-                    'description' => $description,
-                ];
-            }
+        // Ensure docblock has proper closing
+        if (!str_contains((string) $normalized, '*/')) {
+            $normalized = rtrim((string) $normalized) . '/';
         }
+
+        $config = new ParserConfig([]);
+        $lexer = new Lexer($config);
+        $phpDocParser = new PhpDocParser(
+            $config,
+            new TypeParser($config, $constExprParser = new ConstExprParser($config)),
+            $constExprParser,
+        );
+
+        try {
+            $tokens = new TokenIterator($lexer->tokenize($normalized));
+
+            return $phpDocParser->parse($tokens);
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * Format a type node as a compact string (without wrapping parentheses for union/intersection types).
+     */
+    protected function formatType(TypeNode $typeNode): string
+    {
+        if ($typeNode instanceof UnionTypeNode) {
+            return implode('|', array_map(strval(...), $typeNode->types));
+        }
+
+        if ($typeNode instanceof IntersectionTypeNode) {
+            return implode('&', array_map(strval(...), $typeNode->types));
+        }
+
+        return (string) $typeNode;
     }
 
     /**
@@ -89,36 +122,46 @@ trait DocblockTrait
      */
     public function parseDocblock(?string $docblock, ?array &$tags = null): string
     {
-        if (Generator::isDefault($docblock)) {
+        $docNode = $this->parsePhpDoc($docblock);
+        if (!$docNode) {
             return Generator::UNDEFINED;
         }
 
-        $comment = preg_split('/(\n|\r\n)/', (string) $docblock);
-        $comment[0] = preg_replace('/[ \t]*\\/\*\*/', '', $comment[0]); // strip '/**'
-        $ii = count($comment) - 1;
-        $comment[$ii] = preg_replace('/\*\/[ \t]*$/', '', (string) $comment[$ii]); // strip '*/'
+        // Extract @param tags if requested
+        if (null !== $tags) {
+            if (!array_key_exists('param', $tags)) {
+                $tags['param'] = [];
+            }
+            foreach ($docNode->getParamTagValues() as $param) {
+                $name = ltrim((string) $param->parameterName, '$');
+                $tags['param'][$name] = [
+                    'type' => (string) $param->type ?: null,
+                    'description' => $param->description !== '' ? $param->description : null,
+                ];
+            }
+            foreach ($docNode->getTypelessParamTagValues() as $param) {
+                $name = ltrim((string) $param->parameterName, '$');
+                $tags['param'][$name] = [
+                    'type' => null,
+                    'description' => $param->description !== '' ? $param->description : null,
+                ];
+            }
+        }
+
+        // Extract description from text nodes before first tag
         $lines = [];
-        $append = false;
-        $skip = false;
-        foreach ($comment as $line) {
-            $line = preg_replace('/^\s+\* ?/', '', (string) $line);
-            if (str_starts_with($tagline = trim((string) $line), '@')) {
-                $this->handleTag($tagline, $tags);
-                $skip = true;
+        foreach ($docNode->children as $child) {
+            if ($child instanceof PhpDocTagNode) {
+                break;
             }
-            if ($skip) {
-                continue;
+            if ($child instanceof PhpDocTextNode && $child->text !== '') {
+                $lines[] = $child->text;
             }
-            if ($append) {
-                $ii = count($lines) - 1;
-                $lines[$ii] = substr((string) $lines[$ii], 0, -1) . $line;
-            } else {
-                $lines[] = $line;
-            }
-            $append = (str_ends_with((string) $line, '\\'));
         }
 
         $description = trim(implode("\n", $lines));
+        // Handle line continuation with trailing backslash
+        $description = preg_replace('/\\\\\n/', '', $description);
 
         return $description === ''
             ? Generator::UNDEFINED
@@ -153,7 +196,7 @@ trait DocblockTrait
     }
 
     /**
-     * An optional longer piece of text providing more details on the associated element’s function.
+     * An optional longer piece of text providing more details on the associated element's function.
      *
      * @param string $content The full docblock content
      */
@@ -183,19 +226,23 @@ trait DocblockTrait
      */
     public function parseVarLine(?string $docblock): array
     {
-        $comment = str_replace("\r\n", "\n", (string) $docblock);
-        $comment = preg_replace(['/[ \t]*\\/\*\*/', '/\*\/[ \t]*$/'], '', $comment); // '/**', '*/'
+        $result = ['type' => null, 'description' => null];
 
-        if (!preg_match('/@var[ \t]+(?<type>[^\s<>]+(?:<[^>]*>)?(?:\|[^\s<>]+(?:<[^>]*>)?)*)(?:[ \t]+\$(?<name>\w+))?(?:[ \t]+(?<description>.+))?$/im', (string) $comment, $matches)) {
-            return ['type' => null, 'description' => null];
+        $docNode = $this->parsePhpDoc($docblock);
+        if (!$docNode) {
+            return $result;
         }
 
-        $result = array_merge(
-            ['type' => null, 'description' => null],
-            array_filter($matches, static fn ($key): bool => in_array($key, ['type', 'description']), ARRAY_FILTER_USE_KEY)
-        );
+        $varTags = $docNode->getVarTagValues();
+        if ($varTags) {
+            $varTag = reset($varTags);
+            $type = $this->formatType($varTag->type);
 
-        return array_map(static fn (?string $value): ?string => null !== $value ? trim($value) : null, $result);
+            $result['type'] = $type !== '' ? $type : null;
+            $result['description'] = $varTag->description !== '' ? trim((string) $varTag->description) : null;
+        }
+
+        return $result;
     }
 
     /**
@@ -203,24 +250,30 @@ trait DocblockTrait
      */
     public function extractExampleDescription(string $docblock): ?string
     {
-        if (!$docblock || Generator::isDefault($docblock)) {
+        $docNode = $this->parsePhpDoc($docblock);
+        if (!$docNode) {
             return null;
         }
 
-        preg_match('/@example\s+([ \t])?(?<example>.+)?$/im', $docblock, $matches);
+        foreach ($docNode->getTagsByName('@example') as $tag) {
+            $value = (string) $tag->value;
 
-        return $matches['example'] ?? null;
+            return $value !== '' ? trim($value) : null;
+        }
+
+        return null;
     }
 
     /**
-     * Returns true if the <code>\@deprecated</code> tag is present, false otherwise.
+     * Returns true if the <code>@deprecated</code> tag is present, false otherwise.
      */
     public function isDeprecated(?string $docblock): bool
     {
-        if (!$docblock || Generator::isDefault($docblock)) {
+        $docNode = $this->parsePhpDoc($docblock);
+        if (!$docNode) {
             return false;
         }
 
-        return 1 === preg_match('/@deprecated\s+([ \t])?(?<deprecated>.+)?$/im', $docblock);
+        return count($docNode->getDeprecatedTagValues()) > 0;
     }
 }

--- a/src/Processors/Concerns/DocblockTrait.php
+++ b/src/Processors/Concerns/DocblockTrait.php
@@ -169,7 +169,7 @@ trait DocblockTrait
         }
 
         $description = '';
-        if (!empty($substr = substr($content, strlen($summary)))) {
+        if (($substr = substr($content, strlen((string) $summary))) !== '') {
             $description = trim($substr);
         }
 

--- a/src/Processors/Concerns/DocblockTrait.php
+++ b/src/Processors/Concerns/DocblockTrait.php
@@ -186,7 +186,9 @@ trait DocblockTrait
         $comment = str_replace("\r\n", "\n", (string) $docblock);
         $comment = preg_replace(['/[ \t]*\\/\*\*/', '/\*\/[ \t]*$/'], '', $comment); // '/**', '*/'
 
-        preg_match('/@var[ \t]+(?<type>[^\s]+)(?:[ \t]+\$(?<name>\w+))?(?:[ \t]+(?<description>.+))?$/im', (string) $comment, $matches);
+        if (!preg_match('/@var[ \t]+(?<type>[^\s<>]+(?:<[^>]*>)?(?:\|[^\s<>]+(?:<[^>]*>)?)*)(?:[ \t]+\$(?<name>\w+))?(?:[ \t]+(?<description>.+))?$/im', (string) $comment, $matches)) {
+            return ['type' => null, 'description' => null];
+        }
 
         $result = array_merge(
             ['type' => null, 'description' => null],

--- a/tests/Fixtures/ComplexVarTypes.php
+++ b/tests/Fixtures/ComplexVarTypes.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures;
+
+use OpenApi\Attributes as OAT;
+
+#[OAT\Schema]
+class ComplexVarTypes
+{
+    /**
+     * An associative array with string values.
+     *
+     * @var array<string, string>
+     */
+    #[OAT\Property]
+    public array $map;
+
+    /**
+     * A map from int to user objects.
+     *
+     * @var array<int, User>
+     */
+    #[OAT\Property]
+    public array $userMap;
+
+    /** @var array<string, string> Inline generic with description */
+    #[OAT\Property]
+    public array $inlineGenericDesc;
+
+    /**
+     * A map using namespaced class.
+     *
+     * @var array<int, Customer>
+     */
+    #[OAT\Property]
+    public array $namespacedMap;
+
+    /**
+     * List of integer IDs.
+     *
+     * @var int[]
+     */
+    #[OAT\Property]
+    public array $intList;
+
+    /**
+     * Either an array or a string list.
+     *
+     * @var array|string[]
+     */
+    #[OAT\Property]
+    public $arrayOrStringList;
+
+    /**
+     * Nullable map of strings.
+     *
+     * @var array<string, string>|null
+     */
+    #[OAT\Property]
+    public ?array $nullableMap;
+
+    /**
+     * A collection of users or a single user array.
+     *
+     * @var array<int, User>|User[]
+     */
+    #[OAT\Property]
+    public array $mixedUserList;
+
+    /** @var array<string, string>|null Nullable inline with description */
+    #[OAT\Property]
+    public ?array $nullableInlineDesc;
+}

--- a/tests/Fixtures/PHP/DocblockAndTypehintTypes.php
+++ b/tests/Fixtures/PHP/DocblockAndTypehintTypes.php
@@ -210,6 +210,7 @@ class DocblockAndTypehintTypes
      * @param ?string[] $blah_values
      */
     public function blah(
+        /** @var string|null The blah */
         #[OAT\Property(example: 'My blah')]
         ?string $blah,
         #[OAT\Property(nullable: true, items: new OAT\Items(type: 'string', example: 'hello'))]

--- a/tests/Fixtures/Scratch/Docblocks.php
+++ b/tests/Fixtures/Scratch/Docblocks.php
@@ -101,9 +101,9 @@ class DocblocksEndpoint
     )]
     #[OAT\Response(response: 200, description: 'successful operation')]
     public function endpoint(
-        /* @var string|null $filter An optional filter */
+        /** @var string|null $filter An optional filter */
         #[OAT\QueryParameter(description: null)] ?string $filter,
-        /* @var string|null $limit An optional limit */
+        /** @var string|null $limit An optional limit */
         #[OAT\QueryParameter] ?int $limit,
     ) {
 

--- a/tests/Fixtures/Scratch/Docblocks.php
+++ b/tests/Fixtures/Scratch/Docblocks.php
@@ -101,7 +101,9 @@ class DocblocksEndpoint
     )]
     #[OAT\Response(response: 200, description: 'successful operation')]
     public function endpoint(
+        /* @var string|null $filter An optional filter */
         #[OAT\QueryParameter(description: null)] ?string $filter,
+        /* @var string|null $limit An optional limit */
         #[OAT\QueryParameter] ?int $limit,
     ) {
 

--- a/tests/Fixtures/Scratch/Docblocks3.0.0-8.6.yaml
+++ b/tests/Fixtures/Scratch/Docblocks3.0.0-8.6.yaml
@@ -1,0 +1,91 @@
+openapi: 3.0.0
+info:
+  title: Docblocks
+  version: '1.0'
+paths:
+  /api/endpoint:
+    get:
+      operationId: 4ca93475da117d3dea32e60d75f92fec
+      parameters:
+        -
+          name: filter
+          in: query
+          required: false
+          schema:
+            type: string
+        -
+          name: limit
+          in: query
+          description: 'An optional limit'
+          required: false
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: 'successful operation'
+components:
+  schemas:
+    DocblocksSchema:
+      properties:
+        name:
+          description: 'The name'
+          type: string
+        oldName:
+          description: 'The name (old)'
+          type: string
+          deprecated: true
+        rangeInt:
+          description: 'The range integer'
+          type: integer
+          maximum: 25
+          minimum: 5
+        minRangeInt:
+          description: 'The minimum range integer'
+          type: integer
+          maximum: 9223372036854775807
+          minimum: 2
+        maxRangeInt:
+          description: 'The maximum range integer'
+          type: integer
+          maximum: 10
+          minimum: -9223372036854775808
+        positiveInt:
+          description: 'The positive integer'
+          type: integer
+          maximum: 9223372036854775807
+          minimum: 1
+        negativeInt:
+          description: 'The negative integer'
+          type: integer
+          maximum: -1
+          minimum: -9223372036854775808
+        nonPositiveInt:
+          description: 'The non-positive integer'
+          type: integer
+          maximum: 0
+          minimum: -9223372036854775808
+        nonNegativeInt:
+          description: 'The non-negative integer'
+          type: integer
+          maximum: 9223372036854775807
+          minimum: 0
+        nonZeroInt:
+          description: 'The non-zero integer'
+          type: integer
+          not:
+            enum:
+              - 0
+      type: object
+    DocblockSchemaChild:
+      type: object
+      allOf:
+        -
+          $ref: '#/components/schemas/DocblocksSchema'
+        -
+          properties:
+            id:
+              description: 'The id'
+              type: integer
+            someOtherName:
+              type: string
+          type: object

--- a/tests/Fixtures/Scratch/Docblocks3.1.0-8.6.yaml
+++ b/tests/Fixtures/Scratch/Docblocks3.1.0-8.6.yaml
@@ -1,0 +1,90 @@
+openapi: 3.1.0
+info:
+  title: Docblocks
+  version: '1.0'
+paths:
+  /api/endpoint:
+    get:
+      operationId: 4ca93475da117d3dea32e60d75f92fec
+      parameters:
+        -
+          name: filter
+          in: query
+          required: false
+          schema:
+            type: string
+        -
+          name: limit
+          in: query
+          description: 'An optional limit'
+          required: false
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: 'successful operation'
+components:
+  schemas:
+    DocblocksSchema:
+      properties:
+        name:
+          description: 'The name'
+          type: string
+        oldName:
+          description: 'The name (old)'
+          type: string
+          deprecated: true
+        rangeInt:
+          description: 'The range integer'
+          type: integer
+          maximum: 25
+          minimum: 5
+        minRangeInt:
+          description: 'The minimum range integer'
+          type: integer
+          maximum: 9223372036854775807
+          minimum: 2
+        maxRangeInt:
+          description: 'The maximum range integer'
+          type: integer
+          maximum: 10
+          minimum: -9223372036854775808
+        positiveInt:
+          description: 'The positive integer'
+          type: integer
+          maximum: 9223372036854775807
+          minimum: 1
+        negativeInt:
+          description: 'The negative integer'
+          type: integer
+          maximum: -1
+          minimum: -9223372036854775808
+        nonPositiveInt:
+          description: 'The non-positive integer'
+          type: integer
+          maximum: 0
+          minimum: -9223372036854775808
+        nonNegativeInt:
+          description: 'The non-negative integer'
+          type: integer
+          maximum: 9223372036854775807
+          minimum: 0
+        nonZeroInt:
+          description: 'The non-zero integer'
+          type: integer
+          not:
+            const: 0
+      type: object
+    DocblockSchemaChild:
+      type: object
+      allOf:
+        -
+          $ref: '#/components/schemas/DocblocksSchema'
+        -
+          properties:
+            id:
+              description: 'The id'
+              type: integer
+            someOtherName:
+              type: string
+          type: object

--- a/tests/Fixtures/Scratch/Docblocks3.2.0-8.6.yaml
+++ b/tests/Fixtures/Scratch/Docblocks3.2.0-8.6.yaml
@@ -1,0 +1,90 @@
+openapi: 3.2.0
+info:
+  title: Docblocks
+  version: '1.0'
+paths:
+  /api/endpoint:
+    get:
+      operationId: 4ca93475da117d3dea32e60d75f92fec
+      parameters:
+        -
+          name: filter
+          in: query
+          required: false
+          schema:
+            type: string
+        -
+          name: limit
+          in: query
+          description: 'An optional limit'
+          required: false
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: 'successful operation'
+components:
+  schemas:
+    DocblocksSchema:
+      properties:
+        name:
+          description: 'The name'
+          type: string
+        oldName:
+          description: 'The name (old)'
+          type: string
+          deprecated: true
+        rangeInt:
+          description: 'The range integer'
+          type: integer
+          maximum: 25
+          minimum: 5
+        minRangeInt:
+          description: 'The minimum range integer'
+          type: integer
+          maximum: 9223372036854775807
+          minimum: 2
+        maxRangeInt:
+          description: 'The maximum range integer'
+          type: integer
+          maximum: 10
+          minimum: -9223372036854775808
+        positiveInt:
+          description: 'The positive integer'
+          type: integer
+          maximum: 9223372036854775807
+          minimum: 1
+        negativeInt:
+          description: 'The negative integer'
+          type: integer
+          maximum: -1
+          minimum: -9223372036854775808
+        nonPositiveInt:
+          description: 'The non-positive integer'
+          type: integer
+          maximum: 0
+          minimum: -9223372036854775808
+        nonNegativeInt:
+          description: 'The non-negative integer'
+          type: integer
+          maximum: 9223372036854775807
+          minimum: 0
+        nonZeroInt:
+          description: 'The non-zero integer'
+          type: integer
+          not:
+            const: 0
+      type: object
+    DocblockSchemaChild:
+      type: object
+      allOf:
+        -
+          $ref: '#/components/schemas/DocblocksSchema'
+        -
+          properties:
+            id:
+              description: 'The id'
+              type: integer
+            someOtherName:
+              type: string
+          type: object

--- a/tests/Fixtures/Scratch/PromotedProperty.php
+++ b/tests/Fixtures/Scratch/PromotedProperty.php
@@ -56,7 +56,7 @@ class PromotedPropertyDescription
         #[OAT\Property]
         public string $different = '',
 
-        /*
+        /**
          * Intentionally not promoted!
          */
         #[OAT\Property]

--- a/tests/Fixtures/Scratch/PromotedProperty.php
+++ b/tests/Fixtures/Scratch/PromotedProperty.php
@@ -56,7 +56,7 @@ class PromotedPropertyDescription
         #[OAT\Property]
         public string $different = '',
 
-        /**
+        /*
          * Intentionally not promoted!
          */
         #[OAT\Property]

--- a/tests/Processors/AugmentPropertiesTest.php
+++ b/tests/Processors/AugmentPropertiesTest.php
@@ -350,6 +350,41 @@ final class AugmentPropertiesTest extends OpenApiTestCase
         );
     }
 
+    public function testComplexVarTypeDescription(): void
+    {
+        $analysis = $this->analysisFromFixtures([
+            'ComplexVarTypes.php',
+        ], $this->processorPipeline([
+            new MergeIntoOpenApi(),
+            new MergeIntoComponents(),
+            new AugmentSchemas(),
+            new AugmentProperties(),
+        ]));
+
+        [
+            $map,
+            $userMap,
+            $inlineGenericDesc,
+            $namespacedMap,
+            $intList,
+            $arrayOrStringList,
+            $nullableMap,
+            $mixedUserList,
+            $nullableInlineDesc
+        ] = $analysis->openapi->components->schemas[0]->properties;
+
+        // Description should come from docblock text, not the generic type fragment
+        $this->assertSame('An associative array with string values.', $map->description);
+        $this->assertSame('A map from int to user objects.', $userMap->description);
+        $this->assertSame('Inline generic with description', $inlineGenericDesc->description);
+        $this->assertSame('A map using namespaced class.', $namespacedMap->description);
+        $this->assertSame('List of integer IDs.', $intList->description);
+        $this->assertSame('Either an array or a string list.', $arrayOrStringList->description);
+        $this->assertSame('Nullable map of strings.', $nullableMap->description);
+        $this->assertSame('A collection of users or a single user array.', $mixedUserList->description);
+        $this->assertSame('Nullable inline with description', $nullableInlineDesc->description);
+    }
+
     protected function assertName(OA\Property $property, array $expectedValues): void
     {
         foreach ($expectedValues as $key => $val) {

--- a/tests/Processors/DocBlockVarLineTest.php
+++ b/tests/Processors/DocBlockVarLineTest.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Processors;
+
+use OpenApi\Processors\Concerns\DocblockTrait;
+use OpenApi\Tests\OpenApiTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+final class DocBlockVarLineTest extends OpenApiTestCase
+{
+    use DocblockTrait;
+
+    public static function varLineCases(): iterable
+    {
+        yield 'multi-line' => [
+            <<<END
+/**
+ * @example Allan
+ * @var null|string the second name of the customer
+ */
+END,
+            [
+                'type' => 'null|string',
+                'description' => 'the second name of the customer',
+            ],
+        ];
+
+        yield 'split-description' => [
+            <<< END
+/**
+ * The unique identifier of a product in our catalog.
+ *
+ * @var int
+ *
+ * @OA\Property(format="int64", example=1)
+ */
+END,
+            [
+                'type' => 'int',
+                'description' => null,
+            ],
+        ];
+    }
+
+    #[DataProvider('varLineCases')]
+    public function testDocBlockVarLine(string $comment, array $expected): void
+    {
+        $this->assertSame($expected, $this->parseVarLine($comment));
+    }
+}

--- a/tests/Processors/DocBlockVarLineTest.php
+++ b/tests/Processors/DocBlockVarLineTest.php
@@ -44,6 +44,14 @@ END,
                 'description' => null,
             ],
         ];
+
+        yield 'single-full-line' => [
+            '/* @var string|null $limit An optional limit */',
+            [
+                'type' => 'string|null',
+                'description' => 'An optional limit',
+            ],
+        ];
     }
 
     #[DataProvider('varLineCases')]

--- a/tests/ScratchTest.php
+++ b/tests/ScratchTest.php
@@ -13,9 +13,10 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 final class ScratchTest extends OpenApiTestCase
 {
-    public static function scratchTestProvider(): iterable
+    public static function scratchTestCases(): iterable
     {
-        foreach (self::getTypeResolvers() as $resolverName => $typeResolver) {
+        // scratch (.php) iterator
+        $scratchIterator = function (): iterable {
             foreach (glob(self::fixture('Scratch/*.php')) as $fixture) {
                 $name = pathinfo($fixture, PATHINFO_FILENAME);
 
@@ -23,32 +24,49 @@ final class ScratchTest extends OpenApiTestCase
                     continue;
                 }
 
-                $scratch = self::fixture("Scratch/{$name}.php");
-                $specs = [
-                    self::fixture("Scratch/{$name}3.2.0.yaml") => OA\OpenApi::VERSION_3_2_0,
-                    self::fixture("Scratch/{$name}3.2.0-{$resolverName}.yaml") => OA\OpenApi::VERSION_3_2_0,
-                    self::fixture("Scratch/{$name}3.1.0.yaml") => OA\OpenApi::VERSION_3_1_0,
-                    self::fixture("Scratch/{$name}3.1.0-{$resolverName}.yaml") => OA\OpenApi::VERSION_3_1_0,
-                    self::fixture("Scratch/{$name}3.0.0.yaml") => OA\OpenApi::VERSION_3_0_0,
-                    self::fixture("Scratch/{$name}3.0.0-{$resolverName}.yaml") => OA\OpenApi::VERSION_3_0_0,
-                ];
+                yield $name => self::fixture("Scratch/{$name}.php");
+            }
+        };
 
-                $expectedLogs = [
-                    'Examples-3.0.0' => ['@OA\Schema() is only allowed as of 3.1.0'],
-                ];
-
-                foreach ($specs as $spec => $version) {
-                    if (file_exists($spec)) {
-                        $dataSet = "{$resolverName}-{$name}-{$version}";
-                        yield $dataSet => [
-                            $typeResolver,
-                            $scratch,
-                            $spec,
-                            $version,
-                            array_key_exists($dataSet, $expectedLogs) ? $expectedLogs[$dataSet] : [],
-                        ];
+        // spec iterator (most specific) for a given scratch name
+        $specIterator = function (string $scratchName): iterable {
+            foreach ([OA\OpenApi::VERSION_3_2_0, OA\OpenApi::VERSION_3_1_0, OA\OpenApi::VERSION_3_0_0] as $version) {
+                foreach (self::getTypeResolvers() as $resolverName => $typeResolver) {
+                    $phpVersion = PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION;
+                    $caseName = "{$resolverName}-{$scratchName}-{$version}-{$phpVersion}";
+                    $specs = [
+                        self::fixture("Scratch/{$scratchName}{$version}{$resolverName}-{$phpVersion}.yaml"),
+                        self::fixture("Scratch/{$scratchName}{$version}-{$phpVersion}.yaml"),
+                        self::fixture("Scratch/{$scratchName}{$version}{$resolverName}.yaml"),
+                        self::fixture("Scratch/{$scratchName}{$version}.yaml"),
+                    ];
+                    foreach ($specs as $spec) {
+                        if (file_exists($spec)) {
+                            yield $caseName => [
+                                'spec' => $spec,
+                                'typeResolver' => $typeResolver,
+                                'version' => $version,
+                            ];
+                            break;
+                        }
                     }
                 }
+            }
+        };
+
+        $expectedLogs = [
+            'Examples-3.0.0' => ['@OA\Schema() is only allowed as of 3.1.0'],
+        ];
+
+        foreach ($scratchIterator() as $scratchName => $scratch) {
+            foreach ($specIterator($scratchName) as $caseName => $details) {
+                yield $caseName => [
+                    $details['typeResolver'],
+                    $scratch,
+                    $details['spec'],
+                    $details['version'],
+                    array_key_exists($caseName, $expectedLogs) ? $expectedLogs[$caseName] : [],
+                ];
             }
         }
     }
@@ -56,7 +74,7 @@ final class ScratchTest extends OpenApiTestCase
     /**
      * Test scratch fixtures.
      */
-    #[DataProvider('scratchTestProvider')]
+    #[DataProvider('scratchTestCases')]
     public function testScratch(TypeResolverInterface $typeResolver, string $scratch, string $spec, string $version, array $expectedLogs): void
     {
         foreach ($expectedLogs as $logLine) {


### PR DESCRIPTION
## Summary

Handle PHP 8.6 method parameter docblocks for operations.

Also refactors the `DocblockTrait` to using `phpstan/phpdoc-parser`

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Enhancement (improvement to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional changes)
- [ ] Chore (maintenance, dependencies, CI)

## Related Issues

Fixed #1987 

## Test Plan

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass locally
- [ ] Any dependent changes have been merged and published
