### PR TITLE
Fixing 'Using null as an array offset is deprecated, use an empty string instead' deprecation warning

### DIFF
--- a/src/Annotations/AbstractAnnotation.php
+++ b/src/Annotations/AbstractAnnotation.php
@@ -309,7 +309,7 @@ abstract class AbstractAnnotation implements \JsonSerializable
                     $object->{$key} = $item;
                 } else {
                     $key = $item->{$keyField};
-                    if (!Generator::isDefault($key) && empty($object->{$key})) {
+                    if (!Generator::isDefault($key) && $key !== null && empty($object->{$key})) {
                         $object->{$key} = $item instanceof \JsonSerializable ? $item->jsonSerialize() : $item;
                         unset($object->{$key}->{$keyField});
                     }
@@ -506,7 +506,7 @@ abstract class AbstractAnnotation implements \JsonSerializable
                 if (is_array($item) && !is_numeric($key)) {
                     $this->_context->logger->warning($this->identity() . '->' . $property . ' is an object literal, use nested ' . AbstractAnnotation::shorten($annotationClass) . '() annotation(s) in ' . $this->_context);
                     $keys[$key] = $item;
-                } elseif (Generator::isDefault($item->{$keyField})) {
+                } elseif (Generator::isDefault($item->{$keyField}) || $item->{$keyField} === null) {
                     $this->_context->logger->error($item->identity() . ' is missing key-field: "' . $keyField . '" in ' . $item->_context);
                 } elseif (isset($keys[$item->{$keyField}])) {
                     $this->_context->logger->error('Multiple ' . $item->identity([]) . ' with the same ' . $keyField . '="' . $item->{$keyField} . "\":\n  " . $item->_context . "\n  " . $keys[$item->{$keyField}]->_context);

--- a/src/Processors/AugmentParameters.php
+++ b/src/Processors/AugmentParameters.php
@@ -113,14 +113,14 @@ class AugmentParameters implements GeneratorAwareInterface
             $keys = [];
             $parametersWithoutKey = [];
             foreach ($analysis->openapi->components->parameters as $parameter) {
-                if (!Generator::isDefault($parameter->parameter)) {
+                if (!Generator::isDefault($parameter->parameter) && $parameter->parameter !== null) {
                     $keys[$parameter->parameter] = $parameter;
                 } else {
                     $parametersWithoutKey[] = $parameter;
                 }
             }
             foreach ($parametersWithoutKey as $parameter) {
-                if (!Generator::isDefault($parameter->name) && empty($keys[$parameter->name])) {
+                if (!Generator::isDefault($parameter->name) && $parameter->name !== null && empty($keys[$parameter->name])) {
                     $parameter->parameter = $parameter->name;
                     $keys[$parameter->parameter] = $parameter;
                 }

--- a/src/Processors/AugmentTags.php
+++ b/src/Processors/AugmentTags.php
@@ -61,7 +61,9 @@ class AugmentTags
         $declaredTags = [];
         if (!Generator::isDefault($analysis->openapi->tags)) {
             foreach ($analysis->openapi->tags as $tag) {
-                $declaredTags[$tag->name] = $tag;
+                if ($tag->name !== null) {
+                    $declaredTags[$tag->name] = $tag;
+                }
             }
         }
         if ($declaredTags) {


### PR DESCRIPTION
## Summary
Using nulls as array offset is deprecated in PHP 8.5 https://www.php.net/manual/en/migration85.deprecated.php#migration85.deprecated.core.using-null-as-an-array-offset

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
