### PR TITLE
Make `AbstractAnnotation::$_context` non-nullable

### DIFF
--- a/src/Annotations/AbstractAnnotation.php
+++ b/src/Annotations/AbstractAnnotation.php
@@ -35,7 +35,7 @@ abstract class AbstractAnnotation implements \JsonSerializable
      */
     public $attachables = Generator::UNDEFINED;
 
-    public ?Context $_context;
+    public Context $_context;
 
     /**
      * Annotations that couldn't be merged by mapping or postprocessing.

--- a/src/Processors/Concerns/DocblockTrait.php
+++ b/src/Processors/Concerns/DocblockTrait.php
@@ -17,10 +17,6 @@ trait DocblockTrait
      */
     public function isDocblockRoot(OA\AbstractAnnotation $annotation): bool
     {
-        if (!$annotation->_context) {
-            return true;
-        }
-
         if (1 == count($annotation->_context->annotations)) {
             return true;
         }


### PR DESCRIPTION
Closes #2007

## Summary

- Change `AbstractAnnotation::$_context` type from `?Context` to `Context`
- The constructor guarantees a non-null `Context` across all three initialization branches
- The nullable type was a leftover from the pre-native-type PHPDoc `@var Context|null`, converted in #1947

## Test plan

- [x] Full test suite passes (1037 tests)
- [ ] CI matrix