### PR TITLE
Add return type to `GeneratorAwareInterface::setGenerator()` and align related code

### DIFF
--- a/src/Analysers/DocBlockAnnotationFactory.php
+++ b/src/Analysers/DocBlockAnnotationFactory.php
@@ -27,7 +27,7 @@ class DocBlockAnnotationFactory implements AnnotationFactoryInterface
         return DocBlockParser::isEnabled();
     }
 
-    public function setGenerator(Generator $generator): self
+    public function setGenerator(Generator $generator): static
     {
         $this->generator = $generator;
 

--- a/src/Analysers/ReflectionAnalyser.php
+++ b/src/Analysers/ReflectionAnalyser.php
@@ -43,13 +43,15 @@ class ReflectionAnalyser implements AnalyserInterface
         }
     }
 
-    public function setGenerator(Generator $generator): void
+    public function setGenerator(Generator $generator): static
     {
         $this->generator = $generator;
 
         foreach ($this->annotationFactories as $annotationFactory) {
             $annotationFactory->setGenerator($generator);
         }
+
+        return $this;
     }
 
     public function fromFile(string $filename, Context $context): Analysis

--- a/src/GeneratorAwareInterface.php
+++ b/src/GeneratorAwareInterface.php
@@ -8,5 +8,5 @@ namespace OpenApi;
 
 interface GeneratorAwareInterface
 {
-    public function setGenerator(Generator $generator);
+    public function setGenerator(Generator $generator): static;
 }

--- a/src/GeneratorAwareTrait.php
+++ b/src/GeneratorAwareTrait.php
@@ -10,7 +10,7 @@ trait GeneratorAwareTrait
 {
     protected ?Generator $generator = null;
 
-    public function setGenerator(Generator $generator)
+    public function setGenerator(Generator $generator): static
     {
         $this->generator = $generator;
 

--- a/tests/Analysers/ReflectionAnalyserTest.php
+++ b/tests/Analysers/ReflectionAnalyserTest.php
@@ -38,9 +38,10 @@ final class ReflectionAnalyserTest extends OpenApiTestCase
                 return true;
             }
 
-            public function setGenerator(Generator $generator): void
+            public function setGenerator(Generator $generator): static
             {
                 // noop
+                return $this;
             }
         };
     }


### PR DESCRIPTION
## Summary

Switch implied return type to explict `static` on `GeneratorAwareInterface::setGenerator()` and adjust all affected code accordingly.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Enhancement (improvement to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactor (no functional changes)
- [ ] Chore (maintenance, dependencies, CI)

## Related Issues

<!-- Link related issues: Fixes #123, Closes #456 -->

## Test Plan

<!-- Describe the tests you ran or plan to run to verify the changes. -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass locally
- [ ] Any dependent changes have been merged and published
