### PR TITLE
fix: resolve Schema ref from parameter type in AugmentRequestBody

### DIFF
--- a/src/Processors/AugmentRequestBody.php
+++ b/src/Processors/AugmentRequestBody.php
@@ -58,6 +58,17 @@ class AugmentRequestBody implements GeneratorAwareInterface
                     $requestBody->ref = $schema->ref;
                 }
 
+                // Fall back: resolve parameter type to a Schema ref
+                if (Generator::isDefault($requestBody->ref)) {
+                    $type = $context->reflector->getType();
+                    if ($type instanceof \ReflectionNamedType && !$type->isBuiltin()) {
+                        $className = $type->getName();
+                        if ($schemaAnnotation = $analysis->getAnnotationForSource($className, OA\Schema::class)) {
+                            $requestBody->ref = OA\Components::ref($schemaAnnotation);
+                        }
+                    }
+                }
+
                 if (Generator::isDefault($requestBody->required)) {
                     $requestBody->required = !$schema->isNullable();
                 }

--- a/tests/Fixtures/Scratch/RequestBody.php
+++ b/tests/Fixtures/Scratch/RequestBody.php
@@ -89,4 +89,17 @@ class RequestBodyController
     public function postRefFoo(#[OAT\RequestBody] RequestBodyRefFoo $body)
     {
     }
+
+    #[OAT\Post(
+        path: '/endpoint/schema-param',
+        responses: [
+            new OAT\Response(
+                response: 200,
+                description: 'All good'
+            ),
+        ]
+    )]
+    public function postSchemaParam(#[OAT\RequestBody] RequestBodySchema $body)
+    {
+    }
 }

--- a/tests/Fixtures/Scratch/RequestBody3.0.0-legacy.yaml
+++ b/tests/Fixtures/Scratch/RequestBody3.0.0-legacy.yaml
@@ -43,6 +43,14 @@ paths:
       responses:
         '200':
           description: 'All good'
+  /endpoint/schema-param:
+    post:
+      operationId: e9325a4f940b91d3babe398eeebd8426
+      requestBody:
+        $ref: '#/components/schemas/RequestBodySchema'
+      responses:
+        '200':
+          description: 'All good'
 components:
   schemas:
     RequestBodySchema: {  }

--- a/tests/Fixtures/Scratch/RequestBody3.0.0-type-info.yaml
+++ b/tests/Fixtures/Scratch/RequestBody3.0.0-type-info.yaml
@@ -43,6 +43,14 @@ paths:
       responses:
         '200':
           description: 'All good'
+  /endpoint/schema-param:
+    post:
+      operationId: e9325a4f940b91d3babe398eeebd8426
+      requestBody:
+        $ref: '#/components/schemas/RequestBodySchema'
+      responses:
+        '200':
+          description: 'All good'
 components:
   schemas:
     RequestBodySchema: {  }

--- a/tests/Fixtures/Scratch/RequestBody3.1.0-legacy.yaml
+++ b/tests/Fixtures/Scratch/RequestBody3.1.0-legacy.yaml
@@ -43,6 +43,14 @@ paths:
       responses:
         '200':
           description: 'All good'
+  /endpoint/schema-param:
+    post:
+      operationId: e9325a4f940b91d3babe398eeebd8426
+      requestBody:
+        $ref: '#/components/schemas/RequestBodySchema'
+      responses:
+        '200':
+          description: 'All good'
 components:
   schemas:
     RequestBodySchema: {  }

--- a/tests/Fixtures/Scratch/RequestBody3.1.0-type-info.yaml
+++ b/tests/Fixtures/Scratch/RequestBody3.1.0-type-info.yaml
@@ -43,6 +43,14 @@ paths:
       responses:
         '200':
           description: 'All good'
+  /endpoint/schema-param:
+    post:
+      operationId: e9325a4f940b91d3babe398eeebd8426
+      requestBody:
+        $ref: '#/components/schemas/RequestBodySchema'
+      responses:
+        '200':
+          description: 'All good'
 components:
   schemas:
     RequestBodySchema: {  }

--- a/tests/Fixtures/Scratch/RequestBody3.2.0-legacy.yaml
+++ b/tests/Fixtures/Scratch/RequestBody3.2.0-legacy.yaml
@@ -43,6 +43,14 @@ paths:
       responses:
         '200':
           description: 'All good'
+  /endpoint/schema-param:
+    post:
+      operationId: e9325a4f940b91d3babe398eeebd8426
+      requestBody:
+        $ref: '#/components/schemas/RequestBodySchema'
+      responses:
+        '200':
+          description: 'All good'
 components:
   schemas:
     RequestBodySchema: {  }

--- a/tests/Fixtures/Scratch/RequestBody3.2.0-type-info.yaml
+++ b/tests/Fixtures/Scratch/RequestBody3.2.0-type-info.yaml
@@ -43,6 +43,14 @@ paths:
       responses:
         '200':
           description: 'All good'
+  /endpoint/schema-param:
+    post:
+      operationId: e9325a4f940b91d3babe398eeebd8426
+      requestBody:
+        $ref: '#/components/schemas/RequestBodySchema'
+      responses:
+        '200':
+          description: 'All good'
 components:
   schemas:
     RequestBodySchema: {  }


### PR DESCRIPTION
## Summary
- When `#[OA\RequestBody]` is on a method parameter whose type has a `#[OA\Schema]` annotation, the existing `augmentSchemaType` + `type2ref` lookup fails because it searches for a `RequestBody` annotation on the class
- Adds a fallback that resolves the parameter type to a Schema `$ref` when ref remains UNDEFINED after the existing logic

## Details

**Problem:** `augmentSchemaType` calls `type2ref($schema, $analysis, $sourceClass)` where `$sourceClass = OA\RequestBody::class`. Inside `type2ref`, `getAnnotationForSource` looks for a `RequestBody` annotation on the class — but the class has a `Schema` annotation, so it returns null and the ref stays unresolved.

**Fix:** After the existing `augmentSchemaType` call, if `ref` is still UNDEFINED, use reflection to get the parameter type and look up a `Schema` annotation directly via `$analysis->getAnnotationForSource($className, OA\Schema::class)`.

**Backwards compatibility:**
- The existing `augmentSchemaType` + RequestBody lookup still runs first (unchanged)
- The new code only activates when ref is still UNDEFINED after the existing logic
- No existing behaviour is changed for classes annotated with `#[OA\RequestBody]`

## Test plan
- [x] Updated `Scratch/RequestBody` fixture with new `postSchemaParam` endpoint
- [x] All 1037 tests pass
- [x] PHP CS Fixer clean
- [x] Rector clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)