### PR TITLE
fix: PHP 8.5 deprecation for null as array offset

### DIFF
--- a/src/Annotations/AbstractAnnotation.php
+++ b/src/Annotations/AbstractAnnotation.php
@@ -308,7 +308,7 @@ abstract class AbstractAnnotation implements \JsonSerializable
                 if (is_numeric($key) === false && is_array($item)) {
                     $object->{$key} = $item;
                 } else {
-                    $key = $item->{$keyField};
+                    $key = $item->{$keyField} ?? Generator::UNDEFINED;
                     if (!Generator::isDefault($key) && empty($object->{$key})) {
                         $object->{$key} = $item instanceof \JsonSerializable ? $item->jsonSerialize() : $item;
                         unset($object->{$key}->{$keyField});
@@ -506,7 +506,7 @@ abstract class AbstractAnnotation implements \JsonSerializable
                 if (is_array($item) && !is_numeric($key)) {
                     $this->_context->logger->warning($this->identity() . '->' . $property . ' is an object literal, use nested ' . AbstractAnnotation::shorten($annotationClass) . '() annotation(s) in ' . $this->_context);
                     $keys[$key] = $item;
-                } elseif (Generator::isDefault($item->{$keyField})) {
+                } elseif (Generator::isDefault($item->{$keyField} ?? Generator::UNDEFINED)) {
                     $this->_context->logger->error($item->identity() . ' is missing key-field: "' . $keyField . '" in ' . $item->_context);
                 } elseif (isset($keys[$item->{$keyField}])) {
                     $this->_context->logger->error('Multiple ' . $item->identity([]) . ' with the same ' . $keyField . '="' . $item->{$keyField} . "\":\n  " . $item->_context . "\n  " . $keys[$item->{$keyField}]->_context);

--- a/src/Processors/AugmentParameters.php
+++ b/src/Processors/AugmentParameters.php
@@ -113,14 +113,14 @@ class AugmentParameters implements GeneratorAwareInterface
             $keys = [];
             $parametersWithoutKey = [];
             foreach ($analysis->openapi->components->parameters as $parameter) {
-                if (!Generator::isDefault($parameter->parameter)) {
+                if (!Generator::isDefault($parameter->parameter) && $parameter->parameter !== null) {
                     $keys[$parameter->parameter] = $parameter;
                 } else {
                     $parametersWithoutKey[] = $parameter;
                 }
             }
             foreach ($parametersWithoutKey as $parameter) {
-                if (!Generator::isDefault($parameter->name) && empty($keys[$parameter->name])) {
+                if (!Generator::isDefault($parameter->name) && $parameter->name !== null && empty($keys[$parameter->name])) {
                     $parameter->parameter = $parameter->name;
                     $keys[$parameter->parameter] = $parameter;
                 }

--- a/src/Processors/AugmentTags.php
+++ b/src/Processors/AugmentTags.php
@@ -61,7 +61,9 @@ class AugmentTags
         $declaredTags = [];
         if (!Generator::isDefault($analysis->openapi->tags)) {
             foreach ($analysis->openapi->tags as $tag) {
-                $declaredTags[$tag->name] = $tag;
+                if (!empty($tag->name)) {
+                    $declaredTags[$tag->name] = $tag;
+                }
             }
         }
         if ($declaredTags) {

--- a/tests/Annotations/AbstractAnnotationTest.php
+++ b/tests/Annotations/AbstractAnnotationTest.php
@@ -156,6 +156,38 @@ END;
     {
         $this->assertSame($expected, $annotation->identity($identityArgs));
     }
+
+    public function testNullKeyFieldSerialize(): void
+    {
+        $response = new OA\Response([
+            'response' => 200,
+            'description' => 'Success',
+            'headers' => [
+                new OA\Header(['header' => null, '_context' => $this->getContext()]),
+                new OA\Header(['header' => 'X-Token', '_context' => $this->getContext()]),
+            ],
+            '_context' => $this->getContext(),
+        ]);
+
+        $json = $response->jsonSerialize();
+        $this->assertObjectHasProperty('headers', $json);
+        $this->assertObjectHasProperty('X-Token', $json->headers);
+    }
+
+    public function testNullKeyFieldValidate(): void
+    {
+        $response = new OA\Response([
+            'response' => 200,
+            'description' => 'Success',
+            'headers' => [
+                new OA\Header(['header' => null, '_context' => $this->getContext()]),
+            ],
+            '_context' => $this->getContext(),
+        ]);
+
+        $this->assertOpenApiLogEntryContains('is missing key-field: "header"');
+        $response->validate();
+    }
 }
 
 class SubSchema extends OA\Schema


### PR DESCRIPTION

  ## Summary

  - Fix PHP 8.5 "Using null as an array offset" deprecation warnings
  - Use `?? Generator::UNDEFINED` pattern for null-safe key-field checks in AbstractAnnotation
  - Guard against null `parameter`/`name` in AugmentParameters
  - Skip tags with empty name in AugmentTags
  - Add tests that reproduce the deprecation on unpatched code

  Improves and supersedes #2004 from @hotrush

  ## Test plan

  - [x] New tests trigger deprecation on old code, pass on fixed code
  - [x] All 1043 tests pass

