### PR TITLE
feat: populate schema required from its properties

### DIFF
--- a/docs/reference/annotations.md
+++ b/docs/reference/annotations.md
@@ -853,6 +853,10 @@ A <code>@OA\Request</code> path parameter.
 <dl>
   <dt><strong>property</strong> : <span style="font-family: monospace;">string</span></dt>
   <dd><p>The key into Schema->properties array.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+  <dt><strong>required</strong> : <span style="font-family: monospace;">bool|list&lt;string&gt;</span></dt>
+  <dd><p>A boolean flags the property as required in its parent schema, or a list names the required members when it is an object.<br />
+<br />
+The <code>AugmentRequired</code> processor collects a boolean into the parent <code>Schema::$required</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
 </dl>
 
 ### [Put](https://github.com/zircote/swagger-php/tree/master/src/Annotations/Put.php)

--- a/docs/reference/attributes.md
+++ b/docs/reference/attributes.md
@@ -2238,9 +2238,10 @@ value of this attribute.</p><table class="table-plain"><tbody><tr><td><i>Require
   <dd><p>The minimum number of properties allowed in an object instance.<br />
 An object instance is valid against this property if its number of properties is greater than, or equal to, the<br />
 value of this attribute.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
-  <dt><strong>required</strong> : <span style="font-family: monospace;">list&lt;string&gt;</span></dt>
-  <dd><p>An object instance is valid against this property if its property set contains all elements in this property's<br />
-array value.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+  <dt><strong>required</strong> : <span style="font-family: monospace;">bool|list&lt;string&gt;</span></dt>
+  <dd><p>A boolean flags the property as required in its parent schema, or a list names the required members when it is an object.<br />
+<br />
+The <code>AugmentRequired</code> processor collects a boolean into the parent <code>Schema::$required</code>.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>properties</strong> : <span style="font-family: monospace;">list&lt;Property&gt;</span></dt>
   <dd><p>A collection of properties to define for an object.<br />
 <br />

--- a/docs/reference/processors.md
+++ b/docs/reference/processors.md
@@ -138,6 +138,27 @@ Use the property context to extract useful information and inject that into the 
 
 
 
+### [AugmentRequired](https://github.com/zircote/swagger-php/tree/master/src/Processors/AugmentRequired.php)
+
+Populate <code>Schema::$required</code> from its properties.
+
+A property with a boolean <code>required</code> value is always honoured; <code>true</code> adds it to the parent <code>Schema::$required</code> and <code>false</code> removes it.
+The boolean is consumed so it never serialises on the property itself.
+When the <code>augmentRequired.enabled</code> config flag is set, properties without an explicit boolean are inferred: a property backed by a PHP member (property, promoted parameter or method) becomes required when it has a known, non-nullable type.
+Nullable properties, and properties whose type cannot be determined, are left optional.
+Inference is skipped for a schema that already declares a <code>required</code> list, leaving that list as-is.
+
+Inference (the <code>augmentRequired.enabled</code> flag) is off by default; the boolean <code>required</code> handling always runs.
+#### Config settings
+**augmentRequired.enabled**
+: <span style="font-family: monospace;">bool</span>
+<br>**default**
+: <span style="font-family: monospace;">false</span>
+
+&nbsp;&nbsp;&nbsp;&nbsp;Enables/disables the <code>AugmentRequired</code> processor.<br>
+
+
+
 ### [AugmentDiscriminators](https://github.com/zircote/swagger-php/tree/master/src/Processors/AugmentDiscriminators.php)
 
 Use the property context to extract useful information and inject that into the annotation.

--- a/src/Annotations/Property.php
+++ b/src/Annotations/Property.php
@@ -21,6 +21,15 @@ class Property extends Schema
     public $property = Generator::UNDEFINED;
 
     /**
+     * A boolean flags the property as required in its parent schema, or a list names the required members when it is an object.
+     *
+     * The <code>AugmentRequired</code> processor collects a boolean into the parent <code>Schema::$required</code>.
+     *
+     * @var bool|list<string>
+     */
+    public $required = Generator::UNDEFINED; // @phpstan-ignore property.phpDocType
+
+    /**
      * @var Encoding
      */
     public $encoding = Generator::UNDEFINED;

--- a/src/Attributes/Property.php
+++ b/src/Attributes/Property.php
@@ -14,7 +14,7 @@ class Property extends OA\Property
 {
     /**
      * @param string|class-string|object|null                              $ref
-     * @param list<string>                                                 $required
+     * @param bool|list<string>                                            $required
      * @param list<Property>                                               $properties
      * @param string|non-empty-array<string>|null                          $type
      * @param array<Examples>                                              $examples
@@ -36,7 +36,7 @@ class Property extends OA\Property
         ?string $description = Generator::UNDEFINED,
         ?int $maxProperties = null,
         ?int $minProperties = null,
-        ?array $required = null,
+        bool|array|null $required = null,
         ?array $properties = null,
         string|array|null $type = null,
         ?string $format = null,

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -161,6 +161,9 @@ class Generator
             'augmentParameters' => [
                 'augmentOperationParameters' => true,
             ],
+            'augmentRequired' => [
+                'enabled' => false,
+            ],
             'pathFilter' => [
                 'tags' => [],
                 'paths' => [],
@@ -249,6 +252,7 @@ class Generator
                 new Processors\AugmentSchemas(),
                 new Processors\AugmentRequestBody(),
                 new Processors\AugmentProperties(),
+                new Processors\AugmentRequired(),
                 new Processors\AugmentDiscriminators(),
                 new Processors\BuildPaths(),
                 new Processors\AugmentParameters(),

--- a/src/Processors/AugmentRequired.php
+++ b/src/Processors/AugmentRequired.php
@@ -1,0 +1,148 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Processors;
+
+use OpenApi\Analysis;
+use OpenApi\Annotations as OA;
+use OpenApi\Generator;
+
+/**
+ * Populate <code>Schema::$required</code> from its properties.
+ *
+ * A property with a boolean <code>required</code> value is always honoured; <code>true</code> adds it to the parent <code>Schema::$required</code> and <code>false</code> removes it.
+ * The boolean is consumed so it never serialises on the property itself.
+ * When the <code>augmentRequired.enabled</code> config flag is set, properties without an explicit boolean are inferred: a property backed by a PHP member (property, promoted parameter or method) becomes required when it has a known, non-nullable type.
+ * Nullable properties, and properties whose type cannot be determined, are left optional.
+ * Inference is skipped for a schema that already declares a <code>required</code> list, leaving that list as-is.
+ *
+ * Inference (the <code>augmentRequired.enabled</code> flag) is off by default; the boolean <code>required</code> handling always runs.
+ */
+class AugmentRequired
+{
+    protected bool $enabled;
+
+    public function __construct(bool $enabled = false)
+    {
+        $this->enabled = $enabled;
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
+    }
+
+    /**
+     * Enables/disables the <code>AugmentRequired</code> processor.
+     */
+    public function setEnabled(bool $enabled): AugmentRequired
+    {
+        $this->enabled = $enabled;
+
+        return $this;
+    }
+
+    public function __invoke(Analysis $analysis): void
+    {
+        /** @var OA\Schema[] $schemas */
+        $schemas = $analysis->getAnnotationsOfType(OA\Schema::class);
+
+        foreach ($schemas as $schema) {
+            if (!is_array($schema->properties) || $schema->properties === []) {
+                continue;
+            }
+
+            $declared = !Generator::isDefault($schema->required);
+            $required = $declared ? $schema->required : [];
+            $changed = false;
+
+            foreach ($schema->properties as $property) {
+                // consume an explicit boolean regardless of the property name so it never serialises on the property
+                $explicit = is_bool($property->required) ? $property->required : null;
+                if (null !== $explicit) {
+                    /* @phpstan-ignore assign.propertyType */
+                    $property->required = Generator::UNDEFINED;
+                }
+
+                if (Generator::isDefault($property->property) || !is_string($property->property)) {
+                    continue;
+                }
+                $name = $property->property;
+
+                // an explicit boolean is always honoured: true adds the property, false removes it
+                if (null !== $explicit) {
+                    if (null !== $updated = $this->withRequired($required, $name, $explicit)) {
+                        $required = $updated;
+                        $changed = true;
+                    }
+
+                    continue;
+                }
+
+                // inference is opt-in and never touches an explicitly declared list
+                if (!$this->enabled || $declared) {
+                    continue;
+                }
+
+                if ($this->isInferredRequired($property) && null !== $updated = $this->withRequired($required, $name, true)) {
+                    $required = $updated;
+                    $changed = true;
+                }
+            }
+
+            if ($changed) {
+                $schema->required = $required === [] ? Generator::UNDEFINED : $required;
+            }
+        }
+    }
+
+    /**
+     * Whether an unflagged property should be inferred as required.
+     */
+    protected function isInferredRequired(OA\Property $property): bool
+    {
+        // only infer from properties backed by a PHP member
+        $reflector = $property->_context->reflector;
+        if (!$reflector instanceof \ReflectionProperty
+            && !$reflector instanceof \ReflectionParameter
+            && !$reflector instanceof \ReflectionMethod) {
+            return false;
+        }
+
+        if ($property->isNullable()) {
+            return false;
+        }
+
+        // only mark required when a non-nullable type is actually known
+        return !Generator::isDefault($property->type) || !Generator::isDefault($property->ref);
+    }
+
+    /**
+     * Add or remove a property name in the required list.
+     *
+     * @param list<string> $required
+     *
+     * @return list<string>|null the updated list, or null when nothing changed
+     */
+    protected function withRequired(array $required, string $name, bool $include): ?array
+    {
+        $pos = array_search($name, $required, true);
+
+        if ($include && false === $pos) {
+            $required[] = $name;
+
+            return $required;
+        }
+
+        if (!$include && false !== $pos) {
+            unset($required[$pos]);
+
+            return array_values($required);
+        }
+
+        return null;
+    }
+}

--- a/tests/Analysers/AttributeAnnotationFactoryTest.php
+++ b/tests/Analysers/AttributeAnnotationFactoryTest.php
@@ -28,7 +28,7 @@ final class AttributeAnnotationFactoryTest extends OpenApiTestCase
         $rm = new \ReflectionMethod($instance, 'post');
 
         $this->expectException(\TypeError::class);
-        $this->expectExceptionMessage(Property::class . '::__construct(): Argument #9 ($required) must be of type ?array');
+        $this->expectExceptionMessage(Property::class . '::__construct(): Argument #9 ($required) must be of type array|bool|null');
 
         (new AttributeAnnotationFactory())->build($rm, $this->getContext());
     }

--- a/tests/Fixtures/AllNullableProperties.php
+++ b/tests/Fixtures/AllNullableProperties.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures;
+
+use OpenApi\Attributes as OAT;
+
+#[OAT\Schema]
+class AllNullableProperties
+{
+    #[OAT\Property]
+    public ?string $a;
+
+    #[OAT\Property]
+    public ?int $b;
+}

--- a/tests/Fixtures/DeclaredRequiredEmptied.php
+++ b/tests/Fixtures/DeclaredRequiredEmptied.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures;
+
+use OpenApi\Attributes as OAT;
+
+#[OAT\Schema(schema: 'DeclaredRequiredEmptied', required: ['only'])]
+class DeclaredRequiredEmptied
+{
+    #[OAT\Property(required: false)]
+    public string $only;
+}

--- a/tests/Fixtures/DeclaredRequiredMerged.php
+++ b/tests/Fixtures/DeclaredRequiredMerged.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures;
+
+use OpenApi\Attributes as OAT;
+
+#[OAT\Schema(schema: 'DeclaredRequiredMerged', required: ['declared'])]
+class DeclaredRequiredMerged
+{
+    #[OAT\Property]
+    public string $declared;
+
+    #[OAT\Property(required: true)]
+    public string $flagged;
+}

--- a/tests/Fixtures/ExplicitRequired.php
+++ b/tests/Fixtures/ExplicitRequired.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures;
+
+use OpenApi\Attributes as OAT;
+
+#[OAT\Schema]
+class ExplicitRequired
+{
+    #[OAT\Property(required: true)]
+    public ?string $explicitlyRequired;
+
+    #[OAT\Property(required: false)]
+    public string $explicitlyOptional;
+
+    #[OAT\Property]
+    public ?string $untouched;
+}

--- a/tests/Fixtures/InlineProperties.php
+++ b/tests/Fixtures/InlineProperties.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures;
+
+use OpenApi\Attributes as OAT;
+
+#[OAT\Schema(
+    schema: 'InlineProperties',
+    properties: [
+        new OAT\Property(property: 'inlineTyped', type: 'string'),
+        new OAT\Property(property: 'inlineFlagged', type: 'string', required: true),
+    ]
+)]
+class InlineProperties
+{
+}

--- a/tests/Fixtures/InvalidPropertyAttribute.php
+++ b/tests/Fixtures/InvalidPropertyAttribute.php
@@ -10,7 +10,7 @@ use OpenApi\Attributes as OA;
 
 class InvalidPropertyAttribute
 {
-    #[OA\Property(required: true)] // required has to be array or null
+    #[OA\Property(required: 'yes')] // required has to be a bool, array or null
     public function post()
     {
     }

--- a/tests/Fixtures/ObjectPropertyWithRequired.php
+++ b/tests/Fixtures/ObjectPropertyWithRequired.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures;
+
+use OpenApi\Attributes as OAT;
+
+#[OAT\Schema]
+class ObjectPropertyWithRequired
+{
+    #[OAT\Property(
+        property: 'address',
+        properties: [
+            new OAT\Property(property: 'street', type: 'string'),
+        ],
+        required: ['street'],
+    )]
+    public $address;
+}

--- a/tests/Fixtures/PhpMemberProperties.php
+++ b/tests/Fixtures/PhpMemberProperties.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures;
+
+use OpenApi\Attributes as OAT;
+
+#[OAT\Schema]
+class PhpMemberProperties
+{
+    public function __construct(
+        #[OAT\Property]
+        public string $promoted,
+        #[OAT\Property]
+        public ?string $promotedNullable,
+    ) {
+    }
+
+    #[OAT\Property(property: 'computed')]
+    public function computed(): int
+    {
+        return 0;
+    }
+}

--- a/tests/Fixtures/Scratch/RequiredFromProperties.php
+++ b/tests/Fixtures/Scratch/RequiredFromProperties.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Scratch;
+
+use OpenApi\Attributes as OAT;
+
+#[OAT\Info(
+    title: 'Required From Properties Scratch',
+    version: '1.0'
+)]
+#[OAT\Schema]
+class RequiredFromProperties
+{
+    #[OAT\Property(required: true)]
+    public string $id;
+
+    #[OAT\Property(required: false)]
+    public string $nickname;
+
+    #[OAT\Property]
+    public string $note;
+}
+
+class RequiredFromPropertiesController
+{
+    #[OAT\Get(
+        path: '/items',
+        operationId: 'getItems',
+        responses: [
+            new OAT\Response(
+                response: 200,
+                description: 'OK',
+                content: new OAT\JsonContent(ref: RequiredFromProperties::class),
+            ),
+        ],
+    )]
+    public function getItems()
+    {
+    }
+}

--- a/tests/Fixtures/Scratch/RequiredFromProperties3.0.0.yaml
+++ b/tests/Fixtures/Scratch/RequiredFromProperties3.0.0.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.0
+info:
+  title: 'Required From Properties Scratch'
+  version: '1.0'
+paths:
+  /items:
+    get:
+      operationId: getItems
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequiredFromProperties'
+components:
+  schemas:
+    RequiredFromProperties:
+      required:
+        - id
+      properties:
+        id:
+          type: string
+        nickname:
+          type: string
+        note:
+          type: string
+      type: object

--- a/tests/Fixtures/Scratch/RequiredFromProperties3.1.0.yaml
+++ b/tests/Fixtures/Scratch/RequiredFromProperties3.1.0.yaml
@@ -1,0 +1,28 @@
+openapi: 3.1.0
+info:
+  title: 'Required From Properties Scratch'
+  version: '1.0'
+paths:
+  /items:
+    get:
+      operationId: getItems
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequiredFromProperties'
+components:
+  schemas:
+    RequiredFromProperties:
+      required:
+        - id
+      properties:
+        id:
+          type: string
+        nickname:
+          type: string
+        note:
+          type: string
+      type: object

--- a/tests/Fixtures/Scratch/RequiredFromProperties3.2.0.yaml
+++ b/tests/Fixtures/Scratch/RequiredFromProperties3.2.0.yaml
@@ -1,0 +1,28 @@
+openapi: 3.2.0
+info:
+  title: 'Required From Properties Scratch'
+  version: '1.0'
+paths:
+  /items:
+    get:
+      operationId: getItems
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequiredFromProperties'
+components:
+  schemas:
+    RequiredFromProperties:
+      required:
+        - id
+      properties:
+        id:
+          type: string
+        nickname:
+          type: string
+        note:
+          type: string
+      type: object

--- a/tests/Fixtures/UnnamedBooleanRequired.php
+++ b/tests/Fixtures/UnnamedBooleanRequired.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures;
+
+use OpenApi\Attributes as OAT;
+
+#[OAT\Schema(
+    schema: 'UnnamedBooleanRequired',
+    properties: [
+        new OAT\Property(required: true),
+    ]
+)]
+class UnnamedBooleanRequired
+{
+}

--- a/tests/Processors/AugmentRequiredTest.php
+++ b/tests/Processors/AugmentRequiredTest.php
@@ -1,0 +1,159 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Processors;
+
+use OpenApi\Annotations as OA;
+use OpenApi\Generator;
+use OpenApi\Tests\OpenApiTestCase;
+use PHPUnit\Framework\Attributes\Group;
+
+#[Group('Properties')]
+final class AugmentRequiredTest extends OpenApiTestCase
+{
+    private function schema(string $fixture, bool $enabled): OA\Schema
+    {
+        $analysis = $this->analysisFromFixtures(
+            [$fixture],
+            $this->processorPipeline(),
+            null,
+            $enabled ? ['augmentRequired' => ['enabled' => true]] : []
+        );
+
+        return $analysis->openapi->components->schemas[0];
+    }
+
+    public function testDisabledByDefault(): void
+    {
+        $this->assertSame(Generator::UNDEFINED, $this->schema('TypedProperties.php', false)->required);
+    }
+
+    public function testMarksNonNullableTypedPropertiesRequired(): void
+    {
+        $required = $this->schema('TypedProperties.php', true)->required;
+
+        // typed, non-nullable properties (incl. $ref properties) are required
+        $this->assertContains('stringType', $required);
+        $this->assertContains('intType', $required);
+        $this->assertContains('arrayType', $required);
+        $this->assertContains('namespaced', $required);
+    }
+
+    public function testLeavesNullablePropertiesOptional(): void
+    {
+        $required = $this->schema('TypedProperties.php', true)->required;
+
+        $this->assertNotContains('nullableString', $required);
+        $this->assertNotContains('staticNullableString', $required);
+        $this->assertNotContains('mixedValue', $required);
+    }
+
+    public function testLeavesUntypedPropertiesOptional(): void
+    {
+        $required = $this->schema('TypedProperties.php', true)->required;
+
+        // without a resolvable type there is nothing to assert as required
+        $this->assertNotContains('undefined', $required);
+        $this->assertNotContains('staticUndefined', $required);
+    }
+
+    public function testRespectsExplicitNullable(): void
+    {
+        $required = $this->schema('Customer.php', true)->required;
+
+        // nullable: false makes the ?string property required
+        $this->assertContains('iq', $required);
+        // a nullable docblock type stays optional
+        $this->assertNotContains('secondname', $required);
+    }
+
+    public function testDoesNotOverrideDeclaredRequired(): void
+    {
+        // the declared list is kept; the non-nullable createdAt is not appended
+        $this->assertSame(['name'], $this->schema('UsingVar.php', true)->required);
+    }
+
+    public function testExplicitBooleanIsHonouredWithInferenceDisabled(): void
+    {
+        $schema = $this->schema('ExplicitRequired.php', false);
+
+        // required: true is collected even though inference is off; required: false and the unflagged property are not
+        $this->assertSame(['explicitlyRequired'], $schema->required);
+    }
+
+    public function testExplicitBooleanOverridesInference(): void
+    {
+        $schema = $this->schema('ExplicitRequired.php', true);
+
+        // required: true wins over the nullable type; required: false wins over the non-nullable type
+        $this->assertContains('explicitlyRequired', $schema->required);
+        $this->assertNotContains('explicitlyOptional', $schema->required);
+    }
+
+    public function testBooleanRequiredIsConsumedOnTheProperty(): void
+    {
+        $schema = $this->schema('ExplicitRequired.php', false);
+
+        // the boolean is consumed back to UNDEFINED, so it never serialises on the property where required has to be an array
+        foreach ($schema->properties as $property) {
+            $this->assertSame(Generator::UNDEFINED, $property->required);
+        }
+    }
+
+    public function testInferenceIgnoresPropertiesWithoutAPhpMember(): void
+    {
+        $required = $this->schema('InlineProperties.php', true)->required;
+
+        // a typed inline property is not backed by a PHP member, so inference leaves it out
+        $this->assertNotContains('inlineTyped', $required);
+        // an explicit boolean still applies to an inline property
+        $this->assertContains('inlineFlagged', $required);
+    }
+
+    public function testInfersFromPromotedParametersAndMethods(): void
+    {
+        $required = $this->schema('PhpMemberProperties.php', true)->required;
+
+        $this->assertContains('promoted', $required);
+        $this->assertContains('computed', $required);
+        $this->assertNotContains('promotedNullable', $required);
+    }
+
+    public function testAllNullablePropertiesLeaveRequiredUndefined(): void
+    {
+        $this->assertSame(Generator::UNDEFINED, $this->schema('AllNullableProperties.php', true)->required);
+    }
+
+    public function testRequiredFalseClearsAnEmptiedDeclaredList(): void
+    {
+        // required: false on the only declared entry must remove it, leaving no required list
+        $this->assertSame(Generator::UNDEFINED, $this->schema('DeclaredRequiredEmptied.php', false)->required);
+    }
+
+    public function testBooleanRequiredIsConsumedOnAnUnnamedProperty(): void
+    {
+        $property = $this->schema('UnnamedBooleanRequired.php', false)->properties[0];
+
+        // an unnamed property still has its boolean consumed back to UNDEFINED, never serialising as required: true
+        $this->assertSame(Generator::UNDEFINED, $property->required);
+    }
+
+    public function testExplicitTrueAddsToADeclaredList(): void
+    {
+        // a declared list is kept and a property flagged required: true is appended to it
+        $this->assertSame(['declared', 'flagged'], $this->schema('DeclaredRequiredMerged.php', false)->required);
+    }
+
+    public function testArrayRequiredOnAnObjectPropertyIsLeftUntouched(): void
+    {
+        $schema = $this->schema('ObjectPropertyWithRequired.php', false);
+
+        // an array required is the object's own member list, not a boolean flag, so it is not consumed
+        $this->assertSame(['street'], $schema->properties[0]->required);
+        // and with no boolean and inference off, the parent gains no required list
+        $this->assertSame(Generator::UNDEFINED, $schema->required);
+    }
+}


### PR DESCRIPTION
Adds an AugmentRequired processor: explicit `required: true`/`false` always applies, and nullability inference is opt-in via `augmentRequired.enabled`.

Closes #2017

## Summary

Today `Schema::required` (the array of required property names) has to be maintained separately from the properties it refers to. This adds a new `AugmentRequired` processor that derives it from the properties themselves, in two layers:

**Explicit per-property flag (always on).** A property can declare `required: true` or `required: false`. `true` adds its name to the parent `Schema::required`, `false` removes it. The boolean is consumed during processing so it never serialises on the property, where `required` must be an array.

```php
#[OA\Property(property: 'name', type: 'string', required: true)]
```

**Nullability inference (opt-in).** With the `augmentRequired.enabled` config flag (off by default, same shape as `cleanUnusedComponents.enabled`), a property backed by a PHP member becomes required when it has a known, non-nullable type:

```php
#[OA\Property] public string $name;       // required
#[OA\Property] public ?string $nickname;  // optional
```

### Design notes

- **Explicit wins, inference fills the gaps.** An explicit `required`/`nullable` value always takes precedence over inference, and an explicitly declared `required` list on a schema is never modified by inference.
- **Inference only marks a positively-known he `!isNullable()` rule used for parametersand request bodies, property scanning also hits untyped/`mixed`/unresolvable properties; those have no determinable nullability, so they are left optional rather than assumed required.
- **Inference is scoped to PHP-backed memberomoted parameter, method), so hand-authoredinline schema properties are untouched.
- **Off by default** because inference changes output for existing projects that use typed properties; the explicit flag is new syntax and therefore safe to always run.

### API change (non-breaking)

The `Property` attribute's `required` parameter widens from `?array` to `bool|array|null`. Arrays and `null` behave exactly as before; only the boolean form is new.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Enhancement (improvement to existing functionality)
- [ ] Breaking change (fix or feature that wlity to change)
- [x] Documentation update
- [ ] Refactor (no functional changes)
- [ ] Chore (maintenance, dependencies, CI)

## Related Issues

Closes #2017

## Test Plan

**Unit / processor tests** — `AugmentRequiredTest` (16 cases) plus fixtures cover: the opt-in flag, non-nullable typed properties (incl. `$ref`), nullable/untyped/`mixed` left optional, explicit `nullable` override, promoted-parameter and
method-backed properties, the reflector gate, explicit `true`/`false` adding to andremoving from both empty and declared lists, the boolean being consumed (named and unnamed properties), and an array `required` on an object property left untouched. The `InvalidPropertyAttribute` test now passes a string to still
assert the constructor's type error.

**Integration test** — a `ScratchTest` fixture (`RequiredFromProperties`) generates a full spec for a schema with explicit `required: true`/`false` properties referenced from a `GET` endpoint, and compares the serialized YAML across OpenAPI 3.0/3.1/3.2 and both type resolvers. This verifies end-to-end that `required: true` emits `required: [id]` on the component and that no `required: true` leaks onto a property in the output.

Ran locally: full suite (1081 tests), PHPStan, php-cs-fixer, and `rector --dry-run` all pass.

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally
- [x] Any dependent changes have been merged and published