### PR TITLE
fix: add native array|string type to Serializer::doDeserializeBaseProperty()

### DIFF
--- a/src/Serializer.php
+++ b/src/Serializer.php
@@ -189,7 +189,7 @@ class Serializer
      *
      * @return array|OA\AbstractAnnotation
      */
-    protected function doDeserializeBaseProperty($type, mixed $value, Context $context)
+    protected function doDeserializeBaseProperty(array|string $type, mixed $value, Context $context)
     {
         $isAnnotationClass = is_string($type) && is_subclass_of(trim($type, '[]'), OA\AbstractAnnotation::class);
 


### PR DESCRIPTION
Rector flagged the untyped $type parameter; adding the union type satisfies static analysis without breaking runtime (it receives both arrays and strings).
