### PR TITLE
refactor: remove version branching from type resolvers

### DIFF
--- a/src/Annotations/Schema.php
+++ b/src/Annotations/Schema.php
@@ -368,6 +368,9 @@ class Schema extends AbstractAnnotation
                 $data->enum = [$data->const];
                 unset($data->const);
             }
+            if (isset($data->not) && is_array($data->not) && array_key_exists('const', $data->not)) {
+                $data->not = ['enum' => [$data->not['const']]];
+            }
         }
 
         return $data;

--- a/src/Type/LegacyTypeResolver.php
+++ b/src/Type/LegacyTypeResolver.php
@@ -44,9 +44,7 @@ class LegacyTypeResolver extends AbstractTypeResolver
                     $schema->minimum = $details->explicitDetails['min'];
                     $schema->maximum = $details->explicitDetails['max'];
                 } elseif ('non-zero-int' === $details->explicitType) {
-                    $schema->not = $schema->_context->isVersion('3.0.x')
-                        ? ['enum' => [0]]
-                        : ['const' => 0];
+                    $schema->not = ['const' => 0];
                 }
             }
         }

--- a/src/Type/TypeInfoTypeResolver.php
+++ b/src/Type/TypeInfoTypeResolver.php
@@ -86,9 +86,7 @@ class TypeInfoTypeResolver extends AbstractTypeResolver
 
             if ($isNonZeroInt) {
                 $schema->type = 'int';
-                $schema->not = $schema->_context->isVersion('3.0.x')
-                    ? ['enum' => [0]]
-                    : ['const' => 0];
+                $schema->not = ['const' => 0];
             } else {
                 $allBuiltin = array_reduce($types, static fn ($carry, $t): bool => $carry && $t instanceof BuiltinType, true);
 


### PR DESCRIPTION
This is part of the overall plan to decouple annotations from a specific OpenApi version. Canonical version for future attribute sets is close (but not neccessary exact) the 3.1.x format.


Type resolvers now always produce the canonical 3.1+ form (not: {const: 0}) for non-zero-int. 

The version-specific downgrade (not: {enum: [0]}) is handled in Schema::jsonSerialize() alongside the existing const→enum conversion for 3.0.x output.
