### PR TITLE
refactor: extract TypeMapper as pipeline-agnostic type mapping utility

### DIFF
--- a/src/Type/AbstractTypeResolver.php
+++ b/src/Type/AbstractTypeResolver.php
@@ -10,9 +10,17 @@ use OpenApi\Analysis;
 use OpenApi\Annotations as OA;
 use OpenApi\TypeResolverInterface;
 use OpenApi\Undefined;
+use OpenApi\Utils\TypeMapper;
 
 abstract class AbstractTypeResolver implements TypeResolverInterface
 {
+    protected TypeMapper $typeMapper;
+
+    public function __construct()
+    {
+        $this->typeMapper = new TypeMapper();
+    }
+
     protected function type2ref(OA\Schema $schema, Analysis $analysis, string $sourceClass = OA\Schema::class): void
     {
         if (!Undefined::isDefault($schema->type) && !is_array($schema->type)) {
@@ -29,46 +37,34 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
     public function mapNativeType(OA\Schema $schema, $type): bool
     {
         if (is_array($type)) {
-            $mapped = [];
-            foreach ($type as $t) {
-                $mapped[] = $this->native2spec(strtolower((string) $t));
-            }
-
-            $schema->type = $mapped;
+            $schema->type = $this->typeMapper->toSpecTypes(
+                array_map(static fn ($t): string => strtolower((string) $t), $type)
+            );
 
             return true;
         }
 
-        $type = strtolower($type);
-        if (!array_key_exists($type, TypeResolverInterface::NATIVE_TYPE_MAP)) {
+        $result = $this->typeMapper->map($type);
+        if (null === $result) {
             return false;
         }
 
-        $type = TypeResolverInterface::NATIVE_TYPE_MAP[$type];
-        if (is_array($type)) {
-            if (Undefined::isDefault($schema->format)) {
-                $schema->format = $type[1];
-            }
-            $type = $type[0];
-        }
-
-        // PHP `mixed` is not a valid OpenAPI type; represent as unconstrained (no type set)
-        if ('mixed' === $type) {
+        if ('mixed' === $result['type']) {
             return true;
         }
 
-        $schema->type = $type;
+        if (null !== $result['format'] && Undefined::isDefault($schema->format)) {
+            $schema->format = $result['format'];
+        }
+
+        $schema->type = $result['type'];
 
         return true;
     }
 
     public function native2spec(string $type): string
     {
-        $mapped = array_key_exists($type, TypeResolverInterface::NATIVE_TYPE_MAP)
-            ? TypeResolverInterface::NATIVE_TYPE_MAP[$type]
-            : $type;
-
-        return is_array($mapped) ? $mapped[0] : $mapped;
+        return $this->typeMapper->toSpecType($type);
     }
 
     public function augmentSchemaType(Analysis $analysis, OA\Schema $schema, string $sourceClass = OA\Schema::class): void

--- a/src/Type/LegacyTypeResolver.php
+++ b/src/Type/LegacyTypeResolver.php
@@ -9,8 +9,8 @@ namespace OpenApi\Type;
 use OpenApi\Analysis;
 use OpenApi\Annotations as OA;
 use OpenApi\Context;
-use OpenApi\TypeResolverInterface;
 use OpenApi\Undefined;
+use OpenApi\Utils\TypeMapper;
 
 /**
  * @deprecated use `TypeInfoTypeResolver` instead
@@ -110,7 +110,7 @@ class LegacyTypeResolver extends AbstractTypeResolver
 
         if ($context) {
             foreach ($types as $ii => $type) {
-                if (!array_key_exists(strtolower((string) $type), TypeResolverInterface::NATIVE_TYPE_MAP) && !class_exists($type)) {
+                if (!array_key_exists(strtolower((string) $type), TypeMapper::NATIVE_TYPE_MAP) && !class_exists($type)) {
                     if (($resolved = $context->fullyQualifiedName($type)) && class_exists($resolved)) {
                         $types[$ii] = ltrim($resolved, '\\');
                     } else {

--- a/src/Type/TypeInfoTypeResolver.php
+++ b/src/Type/TypeInfoTypeResolver.php
@@ -9,7 +9,6 @@ namespace OpenApi\Type;
 use OpenApi\Analysis;
 use OpenApi\Annotations as OA;
 use OpenApi\Context;
-use OpenApi\TypeResolverInterface;
 use OpenApi\Undefined;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ReturnTagValueNode;
@@ -264,21 +263,9 @@ class TypeInfoTypeResolver extends AbstractTypeResolver
         $this->mapNativeType($schema->items, $schema->items->type);
     }
 
-    /**
-     * Checks that the given type has an OpenAPI representation.
-     *
-     * Types such as mixed, callable, resource and iterable have none; callers leave the schema open for those instead of emitting an invalid type.
-     */
     protected function hasOpenApiType(string $native): bool
     {
-        $native = strtolower($native);
-
-        // NATIVE_TYPE_MAP maps "mixed" to "mixed", which is not a valid OpenAPI type, so mixed has no representation.
-        if ('mixed' === $native) {
-            return false;
-        }
-
-        return 'null' === $native || array_key_exists($native, TypeResolverInterface::NATIVE_TYPE_MAP);
+        return $this->typeMapper->hasOpenApiType($native);
     }
 
     /**645 1050272  02 1268 0026220 00

--- a/src/TypeResolverInterface.php
+++ b/src/TypeResolverInterface.php
@@ -7,31 +7,12 @@
 namespace OpenApi;
 
 use OpenApi\Annotations as OA;
+use OpenApi\Utils\TypeMapper;
 
 interface TypeResolverInterface
 {
-    public const NATIVE_TYPE_MAP = [
-        'mixed' => 'mixed',
-        'string' => 'string',
-        'array' => 'array',
-        'byte' => ['string', 'byte'],
-        'boolean' => 'boolean',
-        'bool' => 'boolean',
-        'int' => 'integer',
-        'integer' => 'integer',
-        'long' => ['integer', 'long'],
-        'float' => ['number', 'float'],
-        'double' => ['number', 'double'],
-        'date' => ['string', 'date'],
-        'datetime' => ['string', 'date-time'],
-        '\\datetime' => ['string', 'date-time'],
-        'datetimeimmutable' => ['string', 'date-time'],
-        '\\datetimeimmutable' => ['string', 'date-time'],
-        'datetimeinterface' => ['string', 'date-time'],
-        '\\datetimeinterface' => ['string', 'date-time'],
-        'number' => 'number',
-        'object' => 'object',
-    ];
+    /** @deprecated Use TypeMapper::NATIVE_TYPE_MAP instead */
+    public const NATIVE_TYPE_MAP = TypeMapper::NATIVE_TYPE_MAP;
 
     public function mapNativeType(OA\Schema $schema, $type): bool;
 

--- a/src/Utils/TypeMapper.php
+++ b/src/Utils/TypeMapper.php
@@ -1,0 +1,99 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Utils;
+
+class TypeMapper
+{
+    public const NATIVE_TYPE_MAP = [
+        'mixed' => 'mixed',
+        'string' => 'string',
+        'array' => 'array',
+        'byte' => ['string', 'byte'],
+        'boolean' => 'boolean',
+        'bool' => 'boolean',
+        'int' => 'integer',
+        'integer' => 'integer',
+        'long' => ['integer', 'long'],
+        'float' => ['number', 'float'],
+        'double' => ['number', 'double'],
+        'date' => ['string', 'date'],
+        'datetime' => ['string', 'date-time'],
+        '\\datetime' => ['string', 'date-time'],
+        'datetimeimmutable' => ['string', 'date-time'],
+        '\\datetimeimmutable' => ['string', 'date-time'],
+        'datetimeinterface' => ['string', 'date-time'],
+        '\\datetimeinterface' => ['string', 'date-time'],
+        'number' => 'number',
+        'object' => 'object',
+    ];
+
+    /**
+     * Map a native PHP type to its OpenAPI type and optional format.
+     *
+     * @return array{type: string, format: string|null}|null null if the type has no OpenAPI representation
+     */
+    public function map(string $type): ?array
+    {
+        $type = strtolower($type);
+
+        if (!array_key_exists($type, self::NATIVE_TYPE_MAP)) {
+            return null;
+        }
+
+        $mapped = self::NATIVE_TYPE_MAP[$type];
+
+        if (is_array($mapped)) {
+            return ['type' => $mapped[0], 'format' => $mapped[1]];
+        }
+
+        if ('mixed' === $mapped) {
+            return ['type' => 'mixed', 'format' => null];
+        }
+
+        return ['type' => $mapped, 'format' => null];
+    }
+
+    /**
+     * Map a native type to its OpenAPI spec type string only.
+     */
+    public function toSpecType(string $type): string
+    {
+        $mapped = array_key_exists(strtolower($type), self::NATIVE_TYPE_MAP)
+            ? self::NATIVE_TYPE_MAP[strtolower($type)]
+            : $type;
+
+        return is_array($mapped) ? $mapped[0] : $mapped;
+    }
+
+    /**
+     * Map an array of native types to their spec type strings.
+     *
+     * @param list<string> $types
+     *
+     * @return list<string>
+     */
+    public function toSpecTypes(array $types): array
+    {
+        return array_map($this->toSpecType(...), $types);
+    }
+
+    /**
+     * Check whether a native type has a valid OpenAPI representation.
+     *
+     * Types like mixed, callable, resource, iterable have none.
+     */
+    public function hasOpenApiType(string $type): bool
+    {
+        $type = strtolower($type);
+
+        if ('mixed' === $type) {
+            return false;
+        }
+
+        return 'null' === $type || array_key_exists($type, self::NATIVE_TYPE_MAP);
+    }
+}

--- a/tests/Utils/TypeMapperTest.php
+++ b/tests/Utils/TypeMapperTest.php
@@ -1,0 +1,98 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Utils;
+
+use OpenApi\Tests\OpenApiTestCase;
+use OpenApi\Utils\TypeMapper;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+final class TypeMapperTest extends OpenApiTestCase
+{
+    private TypeMapper $mapper;
+
+    protected function setUp(): void
+    {
+        $this->mapper = new TypeMapper();
+    }
+
+    public static function mapCases(): iterable
+    {
+        yield 'string' => ['string', ['type' => 'string', 'format' => null]];
+        yield 'int' => ['int', ['type' => 'integer', 'format' => null]];
+        yield 'integer' => ['integer', ['type' => 'integer', 'format' => null]];
+        yield 'bool' => ['bool', ['type' => 'boolean', 'format' => null]];
+        yield 'boolean' => ['boolean', ['type' => 'boolean', 'format' => null]];
+        yield 'float' => ['float', ['type' => 'number', 'format' => 'float']];
+        yield 'double' => ['double', ['type' => 'number', 'format' => 'double']];
+        yield 'number' => ['number', ['type' => 'number', 'format' => null]];
+        yield 'array' => ['array', ['type' => 'array', 'format' => null]];
+        yield 'object' => ['object', ['type' => 'object', 'format' => null]];
+        yield 'byte' => ['byte', ['type' => 'string', 'format' => 'byte']];
+        yield 'date' => ['date', ['type' => 'string', 'format' => 'date']];
+        yield 'datetime' => ['datetime', ['type' => 'string', 'format' => 'date-time']];
+        yield '\\datetime' => ['\\datetime', ['type' => 'string', 'format' => 'date-time']];
+        yield 'datetimeimmutable' => ['datetimeimmutable', ['type' => 'string', 'format' => 'date-time']];
+        yield '\\datetimeimmutable' => ['\\datetimeimmutable', ['type' => 'string', 'format' => 'date-time']];
+        yield 'datetimeinterface' => ['datetimeinterface', ['type' => 'string', 'format' => 'date-time']];
+        yield '\\datetimeinterface' => ['\\datetimeinterface', ['type' => 'string', 'format' => 'date-time']];
+        yield 'mixed' => ['mixed', ['type' => 'mixed', 'format' => null]];
+        yield 'long' => ['long', ['type' => 'integer', 'format' => 'long']];
+        yield 'case insensitive' => ['String', ['type' => 'string', 'format' => null]];
+        yield 'unknown' => ['callable', null];
+        yield 'resource' => ['resource', null];
+        yield 'iterable' => ['iterable', null];
+        yield 'class name' => ['App\\Model\\User', null];
+    }
+
+    #[DataProvider('mapCases')]
+    public function testMap(string $type, ?array $expected): void
+    {
+        $this->assertSame($expected, $this->mapper->map($type));
+    }
+
+    public static function toSpecTypeCases(): iterable
+    {
+        yield 'string' => ['string', 'string'];
+        yield 'int' => ['int', 'integer'];
+        yield 'float' => ['float', 'number'];
+        yield 'datetime' => ['datetime', 'string'];
+        yield 'unknown passthrough' => ['SomeClass', 'SomeClass'];
+    }
+
+    #[DataProvider('toSpecTypeCases')]
+    public function testToSpecType(string $type, string $expected): void
+    {
+        $this->assertSame($expected, $this->mapper->toSpecType($type));
+    }
+
+    public function testToSpecTypes(): void
+    {
+        $this->assertSame(
+            ['string', 'integer', 'number'],
+            $this->mapper->toSpecTypes(['string', 'int', 'float'])
+        );
+    }
+
+    public static function hasOpenApiTypeCases(): iterable
+    {
+        yield 'string' => ['string', true];
+        yield 'int' => ['int', true];
+        yield 'null' => ['null', true];
+        yield 'boolean' => ['boolean', true];
+        yield 'mixed' => ['mixed', false];
+        yield 'callable' => ['callable', false];
+        yield 'resource' => ['resource', false];
+        yield 'iterable' => ['iterable', false];
+        yield 'void' => ['void', false];
+    }
+
+    #[DataProvider('hasOpenApiTypeCases')]
+    public function testHasOpenApiType(string $type, bool $expected): void
+    {
+        $this->assertSame($expected, $this->mapper->hasOpenApiType($type));
+    }
+}


### PR DESCRIPTION
Moves `NATIVE_TYPE_MAP` and pure type-mapping logic out of the OA\Schema-coupled type resolvers into `OpenApi\Utils\TypeMapper`, enabling future code to reuse type mapping without depending on current annotation/attribute classes.
