### PR TITLE
refactor: extract SourceScanner from Generator

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -14,7 +14,7 @@ use OpenApi\Annotations as OA;
 use OpenApi\Loggers\DefaultLogger;
 use OpenApi\Type\TypeInfoTypeResolver;
 use OpenApi\Utils\Pipeline;
-use OpenApi\Utils\SourceFinder;
+use OpenApi\Utils\SourceScanner;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -410,23 +410,11 @@ class Generator
     protected function scanSources(iterable $sources, Analysis $analysis, Context $rootContext): void
     {
         $analyser = $this->getAnalyser();
+        $scanner = new SourceScanner($rootContext->logger);
 
-        foreach ($sources as $source) {
-            if (is_iterable($source)) {
-                $this->scanSources($source, $analysis, $rootContext);
-            } else {
-                $resolvedSource = $source instanceof \SplFileInfo ? $source->getPathname() : realpath($source);
-                if (!$resolvedSource) {
-                    $rootContext->logger->warning(sprintf('Skipping invalid source: %s', $source));
-                    continue;
-                }
-                if (is_dir($resolvedSource)) {
-                    $this->scanSources(new SourceFinder($resolvedSource), $analysis, $rootContext);
-                } else {
-                    $rootContext->logger->debug(sprintf('Analysing source: %s', $resolvedSource));
-                    $analysis->addAnalysis($analyser->fromFile($resolvedSource, $rootContext));
-                }
-            }
+        foreach ($scanner->scan($sources) as $file) {
+            $rootContext->logger->debug(sprintf('Analysing source: %s', $file));
+            $analysis->addAnalysis($analyser->fromFile($file, $rootContext));
         }
     }
 }

--- a/src/Utils/SourceScanner.php
+++ b/src/Utils/SourceScanner.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Utils;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * Resolves mixed source inputs into a flat list of resolved file paths.
+ */
+class SourceScanner
+{
+    public function __construct(protected LoggerInterface $logger)
+    {
+    }
+
+    /**
+     * Scan sources and return resolved file paths.
+     *
+     * @param iterable $sources file/directory paths, \SplFileInfo, \Symfony\Component\Finder\Finder instances, or nested iterables
+     *
+     * @return string[] resolved absolute file paths
+     */
+    public function scan(iterable $sources): array
+    {
+        $files = [];
+        $this->collect($sources, $files);
+
+        return $files;
+    }
+
+    protected function collect(iterable $sources, array &$files): void
+    {
+        foreach ($sources as $source) {
+            if (is_iterable($source)) {
+                $this->collect($source, $files);
+            } else {
+                $resolvedSource = $source instanceof \SplFileInfo ? $source->getPathname() : realpath($source);
+                if (!$resolvedSource) {
+                    $this->logger->warning(sprintf('Skipping invalid source: %s', $source));
+                    continue;
+                }
+                if (is_dir($resolvedSource)) {
+                    $this->collect(new SourceFinder($resolvedSource), $files);
+                } else {
+                    $files[] = $resolvedSource;
+                }
+            }
+        }
+    }
+}

--- a/tests/Utils/SourceScannerTest.php
+++ b/tests/Utils/SourceScannerTest.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Utils;
+
+use OpenApi\Tests\Concerns\UsesExamples;
+use OpenApi\Tests\OpenApiTestCase;
+use OpenApi\Utils\SourceFinder;
+use OpenApi\Utils\SourceScanner;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+final class SourceScannerTest extends OpenApiTestCase
+{
+    use UsesExamples;
+
+    public static function sourcesProvider(): iterable
+    {
+        $sourceDir = self::examplePath('petstore/annotations');
+
+        yield 'dir-string' => [[$sourceDir]];
+        yield 'finder' => [new SourceFinder($sourceDir)];
+        yield 'finder-list' => [[new SourceFinder($sourceDir)]];
+    }
+
+    #[DataProvider('sourcesProvider')]
+    public function testScan(iterable $sources): void
+    {
+        $scanner = new SourceScanner($this->getTrackingLogger());
+        $files = $scanner->scan($sources);
+
+        $this->assertNotEmpty($files);
+        foreach ($files as $file) {
+            $this->assertFileExists($file);
+            $this->assertStringEndsWith('.php', $file);
+        }
+    }
+
+    public function testScanInvalidSource(): void
+    {
+        $this->assertOpenApiLogEntryContains('Skipping invalid source: /tmp/__swagger_php_does_not_exist__');
+
+        $scanner = new SourceScanner($this->getTrackingLogger());
+        $files = $scanner->scan(['/tmp/__swagger_php_does_not_exist__']);
+
+        $this->assertEmpty($files);
+    }
+
+    public function testScanNestedIterables(): void
+    {
+        $sourceDir = self::examplePath('petstore/annotations');
+        $nested = [[new SourceFinder($sourceDir)]];
+
+        $scanner = new SourceScanner($this->getTrackingLogger());
+        $files = $scanner->scan($nested);
+
+        $this->assertNotEmpty($files);
+    }
+
+    public function testScanSplFileInfo(): void
+    {
+        $sourceDir = self::examplePath('petstore/annotations');
+        $finder = new SourceFinder($sourceDir);
+        $splFiles = iterator_to_array($finder);
+        $first = reset($splFiles);
+
+        $scanner = new SourceScanner($this->getTrackingLogger());
+        $files = $scanner->scan([$first]);
+
+        $this->assertCount(1, $files);
+        $this->assertFileExists($files[0]);
+    }
+}


### PR DESCRIPTION
## Summary

- Extract source input resolution logic from `Generator::scanSources()` into `Utils\SourceScanner`
- Resolves mixed inputs (file paths, directories, `SplFileInfo`, Symfony Finder, nested iterables) into a flat file list
- Generator now delegates to `SourceScanner`, keeping only the analysis step
- Reusable for any pipeline that needs to resolve source inputs to files

## Test plan

- [x] New `SourceScannerTest` covers: directory strings, Finder instances, nested iterables, SplFileInfo, invalid source warning
- [x] Existing Generator tests still pass (1105 total)
- [x] CS fixer and Rector clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)