### PR TITLE
Add CS `multiline_comment_opening_closing` rule

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -97,6 +97,7 @@ return (new PhpCsFixer\Config())
         'phpdoc_no_empty_return' => true,
         'phpdoc_no_alias_tag' => true,
         'phpdoc_param_order' => true,
+        'multiline_comment_opening_closing' => true,
 
         'php_unit_attributes' => true,
     ])

--- a/src/Type/TypeInfoTypeResolver.php
+++ b/src/Type/TypeInfoTypeResolver.php
@@ -268,7 +268,7 @@ class TypeInfoTypeResolver extends AbstractTypeResolver
         return $this->typeMapper->hasOpenApiType($native);
     }
 
-    /**645 1050272  02 1268 0026220 00
+    /**
      * @param \ReflectionParameter|\ReflectionProperty|\ReflectionMethod $reflector
      */
     protected function getReflectionType(\Reflector $reflector): ?Type


### PR DESCRIPTION
## Summary

Add `multiline_comment_opening_closing` rule to cs-fixer configuration and fix some stray comment.