### PR TITLE
feat: add Builder as unified entry point

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -55,6 +55,7 @@ function getReferenceSidebar() {
     {
       text: 'Api',
       items: [
+        { text: 'Builder', link: '/reference/builder' },
         { text: 'Generator', link: '/reference/generator' },
         { text: 'Processors', link: '/reference/processors' },
       ]

--- a/docs/guide/generating-openapi-documents.md
+++ b/docs/guide/generating-openapi-documents.md
@@ -50,6 +50,7 @@ Options:
   --add-processor (-a)        Register an additional processor (allows multiple).
   --remove-processor (-r)     Remove an existing processor (allows multiple).
   --format (-f)               Force yaml or json.
+  --mode (-m)                 Processing mode; "classic" uses the annotation/attribute pipeline.
   --debug (-d)                Show additional error information.
   --version                   The OpenAPI version; defaults to 3.0.0.
   --help (-h)                 Display this help message.

--- a/docs/guide/generating-openapi-documents.md
+++ b/docs/guide/generating-openapi-documents.md
@@ -59,13 +59,60 @@ Options:
 
 Depending on your use case, PHP code can also be used to generate OpenAPI documents in a more dynamic way.
 
-In its simplest form this may look something like
+### Using the Builder
+
+The `Builder` class is the recommended entry point for generating OpenAPI documents from PHP code.
 
 ```php
 <?php
 require('vendor/autoload.php');
 
-$openapi = (new \OpenApi\Generator)->generate(['/path/to/project']);
+$result = (new \OpenApi\Builder())
+    ->addSource('/path/to/project')
+    ->build();
+
+header('Content-Type: application/x-yaml');
+echo $result->toYaml();
+```
+
+The result object provides access to the generated spec in multiple formats, the list of scanned
+files, and any validation warnings or errors collected during generation.
+
+```php
+$result->toYaml();      // YAML string
+$result->toJson();      // JSON string
+$result->toArray();     // PHP array
+$result->files();       // list of scanned files
+$result->warnings();    // validation warnings
+$result->errors();      // validation errors
+$result->isValid();     // true if spec was generated
+```
+
+For advanced Generator configuration (custom analysers, processors, aliases, etc.), use the
+`withGenerator()` hook:
+
+```php
+$result = (new \OpenApi\Builder())
+    ->addSource('/path/to/project')
+    ->setVersion('3.1.0')
+    ->withGenerator(function (\OpenApi\Generator $generator) {
+        $generator->setConfig(['operationId.hash' => false]);
+        $generator->withProcessorPipeline(function ($pipeline) {
+            $pipeline->add(new MyCustomProcessor());
+        });
+    })
+    ->build();
+```
+
+### Using the Generator directly
+
+The `Generator` class can also be used directly:
+
+```php
+<?php
+require('vendor/autoload.php');
+
+$openapi = (new \OpenApi\Generator())->generate(['/path/to/project']);
 
 header('Content-Type: application/x-yaml');
 echo $openapi->toYaml();

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -44,7 +44,7 @@ Sets the target OpenAPI version. If not set, defaults to the version declared in
 $builder->setLogger($psrLogger);
 ```
 
-Accepts any PSR-3 logger. Defaults to `DefaultLogger` (which writes warnings to PHP's error log).
+Accepts any PSR-3 logger. Defaults to `NullLogger` (silent). The CLI command sets its own console logger.
 
 ### Generator configuration
 

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -1,0 +1,80 @@
+# Using the `Builder`
+
+## Introduction
+
+The `Builder` class is the recommended entry point for generating OpenAPI documents from PHP code. It provides a clean, fluent API and returns a `Result` object with access to the generated spec, scanned files, and validation diagnostics.
+
+## Basic usage
+
+```php
+$result = (new \OpenApi\Builder())
+    ->addSource('src/Controllers')
+    ->addSource('src/Models')
+    ->build();
+
+echo $result->toYaml();
+```
+
+## API
+
+### Sources
+
+```php
+// Add sources one at a time
+$builder->addSource('src/Controllers');
+$builder->addSource(new \OpenApi\Utils\SourceFinder('src/', ['tests']));
+
+// Or set all at once
+$builder->setSources(['src/Controllers', 'src/Models']);
+```
+
+Sources can be directory paths, file paths, `\SplFileInfo`, `\Symfony\Component\Finder\Finder` instances, or nested iterables of these.
+
+### Version
+
+```php
+$builder->setVersion('3.1.0');
+```
+
+Sets the target OpenAPI version. If not set, defaults to the version declared in your `#[OA\OpenApi]` attribute.
+
+### Logger
+
+```php
+$builder->setLogger($psrLogger);
+```
+
+Accepts any PSR-3 logger. Defaults to `DefaultLogger` (which writes warnings to PHP's error log).
+
+### Generator configuration
+
+For advanced Generator configuration (custom analysers, processors, aliases, type resolvers), use `withGenerator()`:
+
+```php
+$builder->withGenerator(function (\OpenApi\Generator $generator) {
+    $generator->setAnalyser($customAnalyser);
+    $generator->setConfig(['operationId.hash' => false]);
+    $generator->withProcessorPipeline(function ($pipeline) {
+        $pipeline->remove(\OpenApi\Processors\CleanUnusedComponents::class);
+    });
+});
+```
+
+The callable receives a pre-configured `Generator` instance and may either modify it in-place or return a new instance.
+
+## Result
+
+The `build()` method returns a `\OpenApi\Builder\Result` instance:
+
+```php
+$result = $builder->build();
+
+$result->isValid();     // bool — true if a spec was generated
+$result->toArray();     // array — the spec as a PHP array
+$result->toJson();      // string — JSON output
+$result->toYaml();      // string — YAML output
+$result->files();       // string[] — scanned source files
+$result->log();         // array — all log entries [{level, message}, ...]
+$result->warnings();    // string[] — warning messages
+$result->errors();      // string[] — error messages
+```

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -17,6 +17,14 @@ echo $result->toYaml();
 
 ## API
 
+### Mode
+
+```php
+$builder->setMode('classic');
+```
+
+Sets the processing mode. Currently the only mode is `classic`, which scans source files for annotations/attributes and assembles the OpenAPI document via the Generator pipeline. This is the default.
+
 ### Sources
 
 ```php

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -12,9 +12,13 @@ However, `swagger-php` offers more.
 
   The 'traditional' way of documenting your API.  
 
+* The [`Builder`](builder.md)
+
+  The `\OpenApi\Builder` class is the recommended entry point for generating OpenAPI documents from PHP code.
+
 * The [`Generator`](generator.md)
 
-  The `\OpenAPI\Generator` class is the main entry point to programmatically generate OpenAPI documents from your code.
+  The `\OpenApi\Generator` class can be used directly for advanced use cases or via the Builder's `withGenerator()` method.
 
 * [Processors](processors.md)
 

--- a/src/Analysers/ComposerAutoloaderScanner.php
+++ b/src/Analysers/ComposerAutoloaderScanner.php
@@ -26,7 +26,7 @@ class ComposerAutoloaderScanner
     public function scan(array $namespaces): array
     {
         $units = [];
-        if ($autoloader = static::getComposerAutoloader()) {
+        if (($autoloader = static::getComposerAutoloader()) instanceof ClassLoader) {
             foreach (array_keys($autoloader->getClassMap()) as $unit) {
                 foreach ($namespaces as $namespace) {
                     if (str_starts_with($unit, $namespace)) {

--- a/src/Analysers/DocBlockAnnotationFactory.php
+++ b/src/Analysers/DocBlockAnnotationFactory.php
@@ -38,13 +38,13 @@ class DocBlockAnnotationFactory implements AnnotationFactoryInterface
 
     public function build(\Reflector $reflector, Context $context): array
     {
-        $aliases = $this->generator ? $this->generator->getAliases() : [];
+        $aliases = $this->generator instanceof Generator ? $this->generator->getAliases() : [];
 
         if (method_exists($reflector, 'getShortName') && method_exists($reflector, 'getName')) {
             $aliases[strtolower((string) $reflector->getShortName())] = $reflector->getName();
         }
 
-        if ($context->with('scanned')) {
+        if ($context->with('scanned') instanceof Context) {
             $details = $context->scanned;
             foreach ($details['uses'] as $alias => $name) {
                 $aliasKey = strtolower((string) $alias);

--- a/src/Annotations/AbstractAnnotation.php
+++ b/src/Annotations/AbstractAnnotation.php
@@ -97,7 +97,7 @@ abstract class AbstractAnnotation implements \JsonSerializable
         if (isset($properties['_context'])) {
             $this->_context = $properties['_context'];
             unset($properties['_context']);
-        } elseif (Generator::$context) {
+        } elseif (Generator::$context instanceof Context) {
             $this->_context = Generator::$context;
         } else {
             $this->_context = new Context(['generated' => true]);

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -13,12 +13,10 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
 /**
- * Unified entry point for generating OpenAPI specs.
+ * Unified entry point for generating OpenAPI documents.
  *
  * Mode:
  *   setMode('classic') — annotation/attribute pipeline via Generator (default)
- *
- * Subclasses may add additional modes (e.g. 'spec', 'hybrid').
  */
 class Builder
 {
@@ -53,6 +51,10 @@ class Builder
 
     /**
      * Select the processing mode.
+     *
+     * Available modes:
+     *   - 'classic': scans source files for annotations/attributes and assembles
+     *                the OpenAPI document via Generator (default)
      *
      * @param string $mode 'classic' (default)
      */

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -64,7 +64,7 @@ class Builder
      * The callable receives a default Generator and may either modify it in-place
      * or return a fully configured instance.
      *
-     * @param callable(Generator): ?Generator $hook
+     * @param callable(Generator): (Generator|void) $hook
      */
     public function withGenerator(callable $hook): static
     {

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -1,0 +1,115 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi;
+
+use OpenApi\Builder\CollectingLogger;
+use OpenApi\Builder\Result;
+use OpenApi\Loggers\DefaultLogger;
+use OpenApi\Utils\SourceScanner;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Unified entry point for generating OpenAPI specs.
+ */
+class Builder
+{
+    /** @var list<string|iterable> */
+    protected array $sources = [];
+
+    protected ?string $version = null;
+
+    protected ?LoggerInterface $logger = null;
+
+    /** @var callable|null */
+    protected $generatorConfigurator;
+
+    public function addSource(string|iterable $source): static
+    {
+        $this->sources[] = $source;
+
+        return $this;
+    }
+
+    /**
+     * @param list<string|iterable> $sources
+     */
+    public function setSources(array $sources): static
+    {
+        $this->sources = $sources;
+
+        return $this;
+    }
+
+    public function setVersion(string $version): static
+    {
+        $this->version = $version;
+
+        return $this;
+    }
+
+    public function setLogger(LoggerInterface $logger): static
+    {
+        $this->logger = $logger;
+
+        return $this;
+    }
+
+    /**
+     * Configure the underlying Generator for classic mode.
+     *
+     * The callable receives a default Generator and may either modify it in-place
+     * or return a fully configured instance.
+     *
+     * @param callable(Generator): ?Generator $configurator
+     */
+    public function withGenerator(callable $configurator): static
+    {
+        $this->generatorConfigurator = $configurator;
+
+        return $this;
+    }
+
+    public function build(): Result
+    {
+        return $this->buildClassic();
+    }
+
+    protected function getLogger(): LoggerInterface
+    {
+        $this->logger ??= new DefaultLogger();
+
+        return $this->logger;
+    }
+
+    protected function buildClassic(): Result
+    {
+        $collecting = new CollectingLogger($this->getLogger());
+        $generator = new Generator($collecting);
+
+        if ($this->version !== null) {
+            $generator->setVersion($this->version);
+        }
+
+        if ($this->generatorConfigurator !== null) {
+            $generator = ($this->generatorConfigurator)($generator) ?? $generator;
+        }
+
+        $openApi = $generator->generate($this->sources);
+
+        return new Result($this->resolveFiles(), $openApi, $collecting->entries());
+    }
+
+    /**
+     * @return list<string>
+     */
+    protected function resolveFiles(): array
+    {
+        $scanner = new SourceScanner($this->getLogger());
+
+        return $scanner->scan($this->sources);
+    }
+}

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -14,6 +14,11 @@ use Psr\Log\NullLogger;
 
 /**
  * Unified entry point for generating OpenAPI specs.
+ *
+ * Mode:
+ *   setMode('classic') — annotation/attribute pipeline via Generator (default)
+ *
+ * Subclasses may add additional modes (e.g. 'spec', 'hybrid').
  */
 class Builder
 {
@@ -49,7 +54,7 @@ class Builder
     /**
      * Select the processing mode.
      *
-     * @param string $mode 'classic' (default) or 'spec'
+     * @param string $mode 'classic' (default)
      */
     public function setMode(string $mode): static
     {
@@ -90,8 +95,7 @@ class Builder
     public function build(): Result
     {
         return match ($this->mode) {
-            'classic' => $this->doBuild(),
-            default => throw new OpenApiException("Unsupported mode '{$this->mode}'"),
+            default => $this->doBuild(),
         };
     }
 
@@ -117,7 +121,7 @@ class Builder
 
         $openApi = $generator->generate($this->sources);
 
-        return new Result($this->resolveFiles(), $openApi, $collecting->entries());
+        return Result::fromClassic($this->resolveFiles(), $openApi, $collecting->entries());
     }
 
     /**

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -8,9 +8,9 @@ namespace OpenApi;
 
 use OpenApi\Builder\CollectingLogger;
 use OpenApi\Builder\Result;
-use OpenApi\Loggers\DefaultLogger;
 use OpenApi\Utils\SourceScanner;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 /**
  * Unified entry point for generating OpenAPI specs.
@@ -80,7 +80,7 @@ class Builder
 
     protected function getLogger(): LoggerInterface
     {
-        $this->logger ??= new DefaultLogger();
+        $this->logger ??= new NullLogger();
 
         return $this->logger;
     }

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -25,7 +25,7 @@ class Builder
     protected ?LoggerInterface $logger = null;
 
     /** @var callable|null */
-    protected $generatorConfigurator;
+    protected $generatorHook;
 
     public function addSource(string|iterable $source): static
     {
@@ -59,23 +59,23 @@ class Builder
     }
 
     /**
-     * Configure the underlying Generator for classic mode.
+     * Hook to configure the underlying Generator.
      *
      * The callable receives a default Generator and may either modify it in-place
      * or return a fully configured instance.
      *
-     * @param callable(Generator): ?Generator $configurator
+     * @param callable(Generator): ?Generator $hook
      */
-    public function withGenerator(callable $configurator): static
+    public function withGenerator(callable $hook): static
     {
-        $this->generatorConfigurator = $configurator;
+        $this->generatorHook = $hook;
 
         return $this;
     }
 
     public function build(): Result
     {
-        return $this->buildClassic();
+        return $this->doBuild();
     }
 
     protected function getLogger(): LoggerInterface
@@ -85,7 +85,7 @@ class Builder
         return $this->logger;
     }
 
-    protected function buildClassic(): Result
+    protected function doBuild(): Result
     {
         $collecting = new CollectingLogger($this->getLogger());
         $generator = new Generator($collecting);
@@ -94,8 +94,8 @@ class Builder
             $generator->setVersion($this->version);
         }
 
-        if ($this->generatorConfigurator !== null) {
-            $generator = ($this->generatorConfigurator)($generator) ?? $generator;
+        if ($this->generatorHook !== null) {
+            $generator = ($this->generatorHook)($generator) ?? $generator;
         }
 
         $openApi = $generator->generate($this->sources);

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -20,6 +20,8 @@ class Builder
     /** @var list<string|iterable> */
     protected array $sources = [];
 
+    protected string $mode = 'classic';
+
     protected ?string $version = null;
 
     protected ?LoggerInterface $logger = null;
@@ -40,6 +42,18 @@ class Builder
     public function setSources(array $sources): static
     {
         $this->sources = $sources;
+
+        return $this;
+    }
+
+    /**
+     * Select the processing mode.
+     *
+     * @param string $mode 'classic' (default) or 'spec'
+     */
+    public function setMode(string $mode): static
+    {
+        $this->mode = $mode;
 
         return $this;
     }
@@ -75,7 +89,10 @@ class Builder
 
     public function build(): Result
     {
-        return $this->doBuild();
+        return match ($this->mode) {
+            'classic' => $this->doBuild(),
+            default => throw new OpenApiException("Unsupported mode '{$this->mode}'"),
+        };
     }
 
     protected function getLogger(): LoggerInterface

--- a/src/Builder/CollectingLogger.php
+++ b/src/Builder/CollectingLogger.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Builder;
+
+use Psr\Log\AbstractLogger;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Logger decorator that collects entries while forwarding to a wrapped logger.
+ */
+class CollectingLogger extends AbstractLogger
+{
+    /** @var list<array{level: string, message: string}> */
+    protected array $entries = [];
+
+    public function __construct(protected LoggerInterface $delegate)
+    {
+    }
+
+    public function log($level, $message, array $context = []): void
+    {
+        $this->entries[] = ['level' => (string) $level, 'message' => (string) $message];
+        $this->delegate->log($level, $message, $context);
+    }
+
+    /**
+     * @return list<array{level: string, message: string}>
+     */
+    public function entries(): array
+    {
+        return $this->entries;
+    }
+}

--- a/src/Builder/Result.php
+++ b/src/Builder/Result.php
@@ -18,11 +18,20 @@ class Result
      * @param list<string>                                $files
      * @param list<array{level: string, message: string}> $log
      */
-    public function __construct(
+    protected function __construct(
         protected array $files,
         protected ?OpenApi $openApi,
         protected array $log = [],
     ) {
+    }
+
+    /**
+     * @param list<string>                                $files
+     * @param list<array{level: string, message: string}> $log
+     */
+    public static function fromClassic(array $files, ?OpenApi $openApi, array $log = []): self
+    {
+        return new self($files, $openApi, $log);
     }
 
     /**
@@ -74,7 +83,7 @@ class Result
     }
 
     /**
-     * @return array<string, mixed>
+     * @return array<string,mixed>
      */
     public function toArray(): array
     {

--- a/src/Builder/Result.php
+++ b/src/Builder/Result.php
@@ -7,6 +7,7 @@
 namespace OpenApi\Builder;
 
 use OpenApi\Annotations\OpenApi;
+use OpenApi\OpenApiException;
 
 /**
  * Result container for a build operation.
@@ -95,5 +96,18 @@ class Result
         }
 
         return $this->openApi->toYaml();
+    }
+
+    public function saveAs(string $filename, string $format = 'auto'): void
+    {
+        if ($format === 'auto') {
+            $format = strtolower(substr($filename, -5)) === '.json' ? 'json' : 'yaml';
+        }
+
+        $content = strtolower($format) === 'json' ? $this->toJson() : $this->toYaml();
+
+        if (file_put_contents($filename, $content) === false) {
+            throw new OpenApiException('Failed to save to "' . $filename . '"');
+        }
     }
 }

--- a/src/Builder/Result.php
+++ b/src/Builder/Result.php
@@ -1,0 +1,99 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Builder;
+
+use OpenApi\Annotations\OpenApi;
+
+/**
+ * Result container for a build operation.
+ */
+class Result
+{
+    /**
+     * @param list<string>                                $files
+     * @param list<array{level: string, message: string}> $log
+     */
+    public function __construct(
+        protected array $files,
+        protected ?OpenApi $openApi,
+        protected array $log = [],
+    ) {
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function files(): array
+    {
+        return $this->files;
+    }
+
+    public function isValid(): bool
+    {
+        return $this->openApi instanceof OpenApi;
+    }
+
+    /**
+     * @return list<array{level: string, message: string}>
+     */
+    public function log(): array
+    {
+        return $this->log;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function warnings(): array
+    {
+        return array_column(
+            array_filter($this->log, fn (array $entry): bool => $entry['level'] === 'warning'),
+            'message'
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function errors(): array
+    {
+        return array_column(
+            array_filter($this->log, fn (array $entry): bool => $entry['level'] === 'error'),
+            'message'
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        if (!$this->openApi instanceof OpenApi) {
+            return [];
+        }
+
+        return json_decode($this->openApi->toJson(), true) ?? [];
+    }
+
+    public function toJson(int $flags = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE): string
+    {
+        if (!$this->openApi instanceof OpenApi) {
+            return '{}';
+        }
+
+        return $this->openApi->toJson();
+    }
+
+    public function toYaml(int $inline = 10, int $indent = 4): string
+    {
+        if (!$this->openApi instanceof OpenApi) {
+            return '';
+        }
+
+        return $this->openApi->toYaml();
+    }
+}

--- a/src/Builder/Result.php
+++ b/src/Builder/Result.php
@@ -33,6 +33,11 @@ class Result
         return $this->files;
     }
 
+    public function openApi(): ?OpenApi
+    {
+        return $this->openApi;
+    }
+
     public function isValid(): bool
     {
         return $this->openApi instanceof OpenApi;

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -6,7 +6,8 @@
 
 namespace OpenApi\Console;
 
-use OpenApi\Annotations as OA;
+use OpenApi\Builder;
+use OpenApi\Builder\Result;
 use OpenApi\Generator;
 use OpenApi\Utils\SourceFinder;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -45,13 +46,13 @@ class GenerateCommand
             return 0;
         }
 
-        $openapi = $this->generate($input);
+        $result = $this->generate($input);
 
         if (!$input->output) {
             if ($input->format->isJson()) {
-                echo $openapi->toJson();
+                echo $result->toJson();
             } else {
-                echo $openapi->toYaml();
+                echo $result->toYaml();
             }
             echo "\n";
         } else {
@@ -59,36 +60,47 @@ class GenerateCommand
             if (is_dir($outputPath)) {
                 $outputPath .= '/openapi.yaml';
             }
-            $openapi->saveAs($outputPath, $input->format->value);
+            $result->saveAs($outputPath, $input->format->value);
         }
 
         return $this->logger->hasErrored() ? 1 : 0;
     }
 
-    private function generate(GenerateInput $input): OA\OpenApi
+    protected function generate(GenerateInput $input): Result
     {
-        $generator = new Generator($this->logger);
+        $builder = (new Builder())
+            ->addSource(new SourceFinder($input->paths, $input->exclude, $input->pattern))
+            ->setLogger($this->logger);
 
-        foreach ($input->addProcessor as $processor) {
-            $class = '\OpenApi\Processors\\' . ucfirst((string) $processor);
-            if (class_exists($class)) {
-                $processor = new $class();
-            } elseif (class_exists($processor)) {
-                $processor = new $processor();
-            }
-            $generator->getProcessorPipeline()->add($processor);
+        if ($input->version !== null) {
+            $builder->setVersion($input->version);
         }
 
-        foreach ($input->removeProcessor as $processor) {
-            $class = class_exists($processor)
-                ? $processor
-                : '\OpenApi\Processors\\' . ucfirst((string) $processor);
-            $generator->getProcessorPipeline()->remove($class);
+        if ($input->config || $input->addProcessor || $input->removeProcessor) {
+            $builder->withGenerator(function (Generator $generator) use ($input): void {
+                if ($input->config) {
+                    $generator->setConfig($input->config);
+                }
+
+                foreach ($input->addProcessor as $processor) {
+                    $class = '\OpenApi\Processors\\' . ucfirst((string) $processor);
+                    if (class_exists($class)) {
+                        $processor = new $class();
+                    } elseif (class_exists($processor)) {
+                        $processor = new $processor();
+                    }
+                    $generator->getProcessorPipeline()->add($processor);
+                }
+
+                foreach ($input->removeProcessor as $processor) {
+                    $class = class_exists($processor)
+                        ? $processor
+                        : '\OpenApi\Processors\\' . ucfirst((string) $processor);
+                    $generator->getProcessorPipeline()->remove($class);
+                }
+            });
         }
 
-        return $generator
-            ->setVersion($input->version)
-            ->setConfig($input->config)
-            ->generate(new SourceFinder($input->paths, $input->exclude, $input->pattern));
+        return $builder->build();
     }
 }

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -70,6 +70,7 @@ class GenerateCommand
     {
         $builder = (new Builder())
             ->addSource(new SourceFinder($input->paths, $input->exclude, $input->pattern))
+            ->setMode($input->mode)
             ->setLogger($this->logger);
 
         if ($input->version !== null) {

--- a/src/Console/GenerateInput.php
+++ b/src/Console/GenerateInput.php
@@ -45,6 +45,9 @@ class GenerateInput
     #[Option('The OpenAPI version')]
     public ?string $version = null;
 
+    #[Option('Processing mode (classic, spec)', shortcut: 'm')]
+    public string $mode = 'classic';
+
     #[Option('Show additional error information', shortcut: 'd')]
     public bool $debug = false;
 

--- a/src/Console/GenerateInput.php
+++ b/src/Console/GenerateInput.php
@@ -45,7 +45,7 @@ class GenerateInput
     #[Option('The OpenAPI version')]
     public ?string $version = null;
 
-    #[Option('Processing mode (classic, spec)', shortcut: 'm')]
+    #[Option('Processing mode (classic)', shortcut: 'm')]
     public string $mode = 'classic';
 
     #[Option('Show additional error information', shortcut: 'd')]

--- a/src/Console/GenerateInput.php
+++ b/src/Console/GenerateInput.php
@@ -45,7 +45,7 @@ class GenerateInput
     #[Option('The OpenAPI version')]
     public ?string $version = null;
 
-    #[Option('Processing mode (classic)', shortcut: 'm')]
+    #[Option('Processing mode; "classic" uses the annotation/attribute pipeline', shortcut: 'm')]
     public string $mode = 'classic';
 
     #[Option('Show additional error information', shortcut: 'd')]

--- a/src/Context.php
+++ b/src/Context.php
@@ -68,7 +68,7 @@ class Context implements \Stringable
             return;
         }
 
-        if (!$this->parent) {
+        if (!$this->parent instanceof Context) {
             // use root fallback for these...
             foreach (['logger', 'version'] as $property) {
                 unset($this->{$property});

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -10,7 +10,7 @@ use OpenApi\Analysers\AnalyserInterface;
 use OpenApi\Analysers\AttributeAnnotationFactory;
 use OpenApi\Analysers\DocBlockAnnotationFactory;
 use OpenApi\Analysers\ReflectionAnalyser;
-use OpenApi\Annotations as OA;
+use OpenApi\Annotations\OpenApi;
 use OpenApi\Loggers\DefaultLogger;
 use OpenApi\Type\TypeInfoTypeResolver;
 use OpenApi\Utils\Pipeline;
@@ -297,7 +297,7 @@ class Generator
             }
         };
 
-        if ($this->processorPipeline) {
+        if ($this->processorPipeline instanceof Pipeline) {
             $this->processorPipeline->walk($walker);
         }
 
@@ -379,7 +379,7 @@ class Generator
      * @param null|Analysis $analysis custom analysis instance
      * @param bool          $validate flag to enable/disable validation of the returned spec
      */
-    public function generate(iterable $sources, ?Analysis $analysis = null, bool $validate = true): ?OA\OpenApi
+    public function generate(iterable $sources, ?Analysis $analysis = null, bool $validate = true): ?OpenApi
     {
         $rootContext = new Context([
             'version' => $this->getVersion(),
@@ -394,7 +394,7 @@ class Generator
         // post-processing
         $this->getProcessorPipeline()->process($analysis);
 
-        if ($analysis->openapi) {
+        if ($analysis->openapi instanceof OpenApi) {
             // overwrite default/annotated version
             $analysis->openapi->openapi = $this->getVersion() ?: $analysis->openapi->openapi;
             // update context to provide the same to validation/serialisation code

--- a/src/Processors/AugmentRefs.php
+++ b/src/Processors/AugmentRefs.php
@@ -7,6 +7,7 @@
 namespace OpenApi\Processors;
 
 use OpenApi\Analysis;
+use OpenApi\Annotations\AbstractAnnotation;
 use OpenApi\Annotations as OA;
 use OpenApi\Undefined;
 
@@ -42,7 +43,7 @@ class AugmentRefs
             }
         }
 
-        if ($updatedRefs) {
+        if ($updatedRefs !== []) {
             foreach ($analysis->annotations as $annotation) {
                 if (property_exists($annotation, 'ref') && !Undefined::isDefault($annotation->ref) && $annotation->ref !== null) {
                     foreach ($updatedRefs as $origRef => $updatedRef) {
@@ -64,7 +65,7 @@ class AugmentRefs
                 // check if we can resolve the ref to a component
                 $resolved = false;
                 foreach (OA\Components::componentTypes() as $type) {
-                    if ($refSchema = $analysis->getAnnotationForSource($annotation->ref, $type)) {
+                    if (($refSchema = $analysis->getAnnotationForSource($annotation->ref, $type)) instanceof AbstractAnnotation) {
                         $resolved = true;
                         $annotation->ref = OA\Components::ref($refSchema);
                     }
@@ -95,7 +96,7 @@ class AugmentRefs
                         $refs[] = $allOfSchema->ref;
                     }
                 }
-                if ($dupes) {
+                if ($dupes !== []) {
                     $schema->allOf = array_values($schema->allOf);
                 }
             }

--- a/src/Processors/AugmentTags.php
+++ b/src/Processors/AugmentTags.php
@@ -66,13 +66,13 @@ class AugmentTags
                 }
             }
         }
-        if ($declaredTags) {
+        if ($declaredTags !== []) {
             // last one wins
             $analysis->openapi->tags = array_values($declaredTags);
         }
 
         // Add a tag for each tag that is used in operations but not declared in the global tags
-        if ($usedTagNames) {
+        if ($usedTagNames !== []) {
             $declatedTagNames = array_keys($declaredTags);
             foreach ($usedTagNames as $tagName) {
                 if (!in_array($tagName, $declatedTagNames)) {

--- a/src/Processors/BuildPaths.php
+++ b/src/Processors/BuildPaths.php
@@ -50,7 +50,7 @@ class BuildPaths
                 }
             }
         }
-        if ($paths) {
+        if ($paths !== []) {
             $analysis->openapi->paths = array_values($paths);
         }
     }

--- a/src/Processors/ExpandClasses.php
+++ b/src/Processors/ExpandClasses.php
@@ -7,7 +7,7 @@
 namespace OpenApi\Processors;
 
 use OpenApi\Analysis;
-use OpenApi\Annotations as OA;
+use OpenApi\Annotations\Schema;
 use OpenApi\Undefined;
 
 /**
@@ -23,7 +23,7 @@ class ExpandClasses
 
     public function __invoke(Analysis $analysis): void
     {
-        $schemas = $analysis->getAnnotationsOfType(OA\Schema::class, true);
+        $schemas = $analysis->getAnnotationsOfType(Schema::class, true);
 
         foreach ($schemas as $schema) {
             if ($schema->_context->is('class')) {
@@ -31,7 +31,7 @@ class ExpandClasses
                 $existing = [];
                 foreach ($ancestors as $ancestor) {
                     $ancestorSchema = $analysis->getAnnotationForSource($ancestor['context']->fullyQualifiedName($ancestor['class']));
-                    if ($ancestorSchema) {
+                    if ($ancestorSchema instanceof Schema) {
                         $refPath = Undefined::isDefault($ancestorSchema->schema) ? $ancestor['class'] : $ancestorSchema->schema;
                         $this->inheritFrom($analysis, $schema, $ancestorSchema, $refPath, $ancestor['context']);
 

--- a/src/Processors/ExpandInterfaces.php
+++ b/src/Processors/ExpandInterfaces.php
@@ -7,7 +7,7 @@
 namespace OpenApi\Processors;
 
 use OpenApi\Analysis;
-use OpenApi\Annotations as OA;
+use OpenApi\Annotations\Schema;
 use OpenApi\Undefined;
 
 /**
@@ -21,7 +21,7 @@ class ExpandInterfaces
 
     public function __invoke(Analysis $analysis): void
     {
-        $schemas = $analysis->getAnnotationsOfType(OA\Schema::class, true);
+        $schemas = $analysis->getAnnotationsOfType(Schema::class, true);
 
         foreach ($schemas as $schema) {
             if ($schema->_context->is('class')) {
@@ -41,7 +41,7 @@ class ExpandInterfaces
                 foreach ($interfaces as $interface) {
                     $interfaceName = $interface['context']->fullyQualifiedName($interface['interface']);
                     $interfaceSchema = $analysis->getAnnotationForSource($interfaceName);
-                    if ($interfaceSchema) {
+                    if ($interfaceSchema instanceof Schema) {
                         $refPath = Undefined::isDefault($interfaceSchema->schema) ? $interface['interface'] : $interfaceSchema->schema;
                         $this->inheritFrom($analysis, $schema, $interfaceSchema, $refPath, $interface['context']);
                     } else {

--- a/src/Processors/ExpandTraits.php
+++ b/src/Processors/ExpandTraits.php
@@ -7,7 +7,7 @@
 namespace OpenApi\Processors;
 
 use OpenApi\Analysis;
-use OpenApi\Annotations as OA;
+use OpenApi\Annotations\Schema;
 use OpenApi\Undefined;
 
 /**
@@ -21,7 +21,7 @@ class ExpandTraits
 
     public function __invoke(Analysis $analysis): void
     {
-        $schemas = $analysis->getAnnotationsOfType(OA\Schema::class, true);
+        $schemas = $analysis->getAnnotationsOfType(Schema::class, true);
 
         // do regular trait inheritance / merge
         foreach ($schemas as $schema) {
@@ -30,7 +30,7 @@ class ExpandTraits
                 $existing = [];
                 foreach ($traits as $trait) {
                     $traitSchema = $analysis->getAnnotationForSource($trait['context']->fullyQualifiedName($trait['trait']));
-                    if ($traitSchema) {
+                    if ($traitSchema instanceof Schema) {
                         $refPath = Undefined::isDefault($traitSchema->schema) ? $trait['trait'] : $traitSchema->schema;
                         $this->inheritFrom($analysis, $schema, $traitSchema, $refPath, $trait['context']);
                     } else {
@@ -48,7 +48,7 @@ class ExpandTraits
                 $existing = [];
                 foreach ($traits as $trait) {
                     $traitSchema = $analysis->getAnnotationForSource($trait['context']->fullyQualifiedName($trait['trait']));
-                    if ($traitSchema) {
+                    if ($traitSchema instanceof Schema) {
                         $refPath = Undefined::isDefault($traitSchema->schema) ? $trait['trait'] : $traitSchema->schema;
                         $this->inheritFrom($analysis, $schema, $traitSchema, $refPath, $trait['context']);
                     } else {
@@ -62,7 +62,7 @@ class ExpandTraits
                 $existing = [];
                 foreach ($ancestors as $ancestor) {
                     $ancestorSchema = $analysis->getAnnotationForSource($ancestor['context']->fullyQualifiedName($ancestor['class']));
-                    if ($ancestorSchema) {
+                    if ($ancestorSchema instanceof Schema) {
                         // stop here as we inherit everything above
                         break;
                     } else {

--- a/src/Processors/MergeIntoOpenApi.php
+++ b/src/Processors/MergeIntoOpenApi.php
@@ -8,6 +8,7 @@ namespace OpenApi\Processors;
 
 use OpenApi\Analysis;
 use OpenApi\Annotations as OA;
+use OpenApi\Annotations\OpenApi;
 use OpenApi\Context;
 use OpenApi\Undefined;
 
@@ -41,9 +42,9 @@ class MergeIntoOpenApi
     public function __invoke(Analysis $analysis): void
     {
         // Auto-create the OpenApi annotation.
-        if (!$analysis->openapi) {
+        if (!$analysis->openapi instanceof OpenApi) {
             $context = new Context(['generated' => true], $analysis->context);
-            $analysis->addAnnotation(new OA\OpenApi(['_context' => $context]), $context);
+            $analysis->addAnnotation(new OpenApi(['_context' => $context]), $context);
         }
 
         $openapi = $analysis->openapi;
@@ -57,7 +58,7 @@ class MergeIntoOpenApi
                 continue;
             }
 
-            if ($annotation instanceof OA\OpenApi) {
+            if ($annotation instanceof OpenApi) {
                 $paths = $annotation->paths;
                 unset($annotation->paths);
                 $openapi->mergeProperties($annotation);
@@ -70,7 +71,7 @@ class MergeIntoOpenApi
                     }
                 }
             } elseif ($annotation instanceof OA\AbstractAnnotation
-                && in_array(OA\OpenApi::class, $annotation::$_parents)
+                && in_array(OpenApi::class, $annotation::$_parents)
                 && false === $annotation->_context->is('nested')) {
                 // A top-level annotation.
                 $merge[] = $annotation;

--- a/src/Type/AbstractTypeResolver.php
+++ b/src/Type/AbstractTypeResolver.php
@@ -7,6 +7,7 @@
 namespace OpenApi\Type;
 
 use OpenApi\Analysis;
+use OpenApi\Annotations\AbstractAnnotation;
 use OpenApi\Annotations as OA;
 use OpenApi\TypeResolverInterface;
 use OpenApi\Undefined;
@@ -24,7 +25,7 @@ abstract class AbstractTypeResolver implements TypeResolverInterface
     protected function type2ref(OA\Schema $schema, Analysis $analysis, string $sourceClass = OA\Schema::class): void
     {
         if (!Undefined::isDefault($schema->type) && !is_array($schema->type)) {
-            if ($typeSchema = $analysis->getAnnotationForSource($schema->type, $sourceClass)) {
+            if (($typeSchema = $analysis->getAnnotationForSource($schema->type, $sourceClass)) instanceof AbstractAnnotation) {
                 $schema->type = Undefined::UNDEFINED;
                 $schema->ref = OA\Components::ref($typeSchema);
             }

--- a/src/Type/LegacyTypeResolver.php
+++ b/src/Type/LegacyTypeResolver.php
@@ -110,7 +110,7 @@ class LegacyTypeResolver extends AbstractTypeResolver
     {
         $types = array_filter($types, static fn (string $t): bool => !in_array($t, ['null', ''], strict: true));
 
-        if ($context) {
+        if ($context instanceof Context) {
             foreach ($types as $ii => $type) {
                 if (!array_key_exists(strtolower((string) $type), TypeMapper::NATIVE_TYPE_MAP) && !class_exists($type)) {
                     if (($resolved = $context->fullyQualifiedName($type)) && class_exists($resolved)) {
@@ -125,7 +125,7 @@ class LegacyTypeResolver extends AbstractTypeResolver
             $types = array_values($types);
         }
 
-        $explicitType = $explicitType ?: ($types ? $types[0] : null);
+        $explicitType = $explicitType ?: ($types !== [] ? $types[0] : null);
 
         return (object) [
             'explicitType' => $explicitType,

--- a/src/Type/TypeInfoTypeResolver.php
+++ b/src/Type/TypeInfoTypeResolver.php
@@ -110,7 +110,7 @@ class TypeInfoTypeResolver extends AbstractTypeResolver
                         $schema->type = Undefined::UNDEFINED;
                         $schema->oneOf = [];
 
-                        if ($builtinTypes) {
+                        if ($builtinTypes !== []) {
                             $schema->oneOf[] = $builtinSchema = new OA\Schema([
                                 'type' => array_values(array_map(static fn (Type $t): string => (string) $t, $builtinTypes)),
                                 '_context' => new Context(['generated' => true], $schema->_context),

--- a/src/Utils/DocBlockParser.php
+++ b/src/Utils/DocBlockParser.php
@@ -67,7 +67,7 @@ class DocBlockParser
     public function parseDocblock(?string $docblock, ?array &$tags = null): string
     {
         $docNode = $this->parsePhpDoc($docblock);
-        if (!$docNode) {
+        if (!$docNode instanceof PhpDocNode) {
             return Undefined::UNDEFINED;
         }
 
@@ -158,12 +158,12 @@ class DocBlockParser
         $result = ['type' => null, 'description' => null];
 
         $docNode = $this->parsePhpDoc($docblock);
-        if (!$docNode) {
+        if (!$docNode instanceof PhpDocNode) {
             return $result;
         }
 
         $varTags = $docNode->getVarTagValues();
-        if ($varTags) {
+        if ($varTags !== []) {
             $varTag = reset($varTags);
             $type = $this->formatType($varTag->type);
 
@@ -177,7 +177,7 @@ class DocBlockParser
     public function extractExampleDescription(string $docblock): ?string
     {
         $docNode = $this->parsePhpDoc($docblock);
-        if (!$docNode) {
+        if (!$docNode instanceof PhpDocNode) {
             return null;
         }
 
@@ -193,7 +193,7 @@ class DocBlockParser
     public function isDeprecated(?string $docblock): bool
     {
         $docNode = $this->parsePhpDoc($docblock);
-        if (!$docNode) {
+        if (!$docNode instanceof PhpDocNode) {
             return false;
         }
 

--- a/src/Utils/TokenScanner.php
+++ b/src/Utils/TokenScanner.php
@@ -9,6 +9,7 @@ namespace OpenApi\Utils;
 use PhpParser\Error;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Enum_;
 use PhpParser\Node\Stmt\Interface_;
 use PhpParser\Node\Stmt\Namespace_;
@@ -139,7 +140,7 @@ class TokenScanner
         }
 
         // promoted properties
-        if ($ctor = $stmt->getMethod('__construct')) {
+        if (($ctor = $stmt->getMethod('__construct')) instanceof ClassMethod) {
             foreach ($ctor->getParams() as $param) {
                 if ($param->flags) {
                     $details['properties'][] = $param->var->name;

--- a/tests/Annotations/AttributesSyncTest.php
+++ b/tests/Annotations/AttributesSyncTest.php
@@ -91,11 +91,11 @@ final class AttributesSyncTest extends OpenApiTestCase
             }
         }
 
-        if ($missing) {
+        if ($missing !== []) {
             $this->fail('Missing parameters: ' . implode(', ', $missing));
         }
 
-        if ($typeMismatch) {
+        if ($typeMismatch !== []) {
             var_dump($typeMismatch);
             $this->fail('Type mismatch: ' . count($typeMismatch));
         }
@@ -206,7 +206,7 @@ final class AttributesSyncTest extends OpenApiTestCase
             }
         }
 
-        if ($stale) {
+        if ($stale !== []) {
             $this->fail('Stale parameters: ' . implode(', ', $stale));
         }
     }

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -1,0 +1,134 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests;
+
+use OpenApi\Builder;
+use OpenApi\Generator;
+use OpenApi\Tests\Concerns\UsesExamples;
+use OpenApi\Utils\SourceFinder;
+use Psr\Log\NullLogger;
+
+final class BuilderTest extends OpenApiTestCase
+{
+    use UsesExamples;
+
+    public function testBuild(): void
+    {
+        $this->registerExampleClassloader('petstore');
+
+        $result = (new Builder())
+            ->addSource(self::examplePath('petstore/annotations'))
+            ->setLogger($this->getTrackingLogger())
+            ->withGenerator(function (Generator $generator): void {
+                $generator->setAnalyser($this->getAnalyzer());
+                $generator->setTypeResolver($this->getTypeResolver());
+            })
+            ->build();
+
+        $this->assertTrue($result->isValid());
+        $this->assertNotEmpty($result->toArray());
+        $this->assertNotEmpty($result->toJson());
+        $this->assertNotEmpty($result->toYaml());
+    }
+
+    public function testBuildMatchesGenerator(): void
+    {
+        $this->registerExampleClassloader('petstore');
+        $sourceDir = self::examplePath('petstore/annotations');
+
+        $generatorOutput = (new Generator())
+            ->setAnalyser($this->getAnalyzer())
+            ->setTypeResolver($this->getTypeResolver())
+            ->generate([$sourceDir]);
+
+        $builderResult = (new Builder())
+            ->addSource($sourceDir)
+            ->withGenerator(function (Generator $generator): void {
+                $generator->setAnalyser($this->getAnalyzer());
+                $generator->setTypeResolver($this->getTypeResolver());
+            })
+            ->build();
+
+        $this->assertSpecEquals($generatorOutput, $builderResult->toYaml());
+    }
+
+    public function testBuildWithVersion(): void
+    {
+        $this->registerExampleClassloader('petstore');
+
+        $result = (new Builder())
+            ->addSource(self::examplePath('petstore/annotations'))
+            ->setVersion('3.1.0')
+            ->withGenerator(function (Generator $generator): void {
+                $generator->setAnalyser($this->getAnalyzer());
+                $generator->setTypeResolver($this->getTypeResolver());
+            })
+            ->build();
+
+        $this->assertTrue($result->isValid());
+        $spec = $result->toArray();
+        $this->assertSame('3.1.0', $spec['openapi']);
+    }
+
+    public function testBuildWithFinder(): void
+    {
+        $this->registerExampleClassloader('petstore');
+
+        $result = (new Builder())
+            ->addSource(new SourceFinder(self::examplePath('petstore/annotations')))
+            ->withGenerator(function (Generator $generator): void {
+                $generator->setAnalyser($this->getAnalyzer());
+                $generator->setTypeResolver($this->getTypeResolver());
+            })
+            ->build();
+
+        $this->assertTrue($result->isValid());
+    }
+
+    public function testBuildFiles(): void
+    {
+        $this->registerExampleClassloader('petstore');
+
+        $result = (new Builder())
+            ->addSource(self::examplePath('petstore/annotations'))
+            ->withGenerator(function (Generator $generator): void {
+                $generator->setAnalyser($this->getAnalyzer());
+                $generator->setTypeResolver($this->getTypeResolver());
+            })
+            ->build();
+
+        $this->assertNotEmpty($result->files());
+        foreach ($result->files() as $file) {
+            $this->assertFileExists($file);
+        }
+    }
+
+    public function testBuildEmptySources(): void
+    {
+        $this->assertOpenApiLogEntryContains('Required @OA\Info() not found');
+        $this->assertOpenApiLogEntryContains('Required @OA\PathItem() not found');
+
+        $result = (new Builder())
+            ->setSources([])
+            ->setLogger($this->getTrackingLogger())
+            ->build();
+
+        $this->assertEmpty($result->files());
+    }
+
+    public function testBuildCollectsWarnings(): void
+    {
+        $result = (new Builder())
+            ->setSources([])
+            ->setLogger(new NullLogger())
+            ->build();
+
+        $this->assertNotEmpty($result->warnings());
+        $this->assertContains('Required @OA\Info() not found', $result->warnings());
+        $this->assertContains('Required @OA\PathItem() not found', $result->warnings());
+    }
+}

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -7,6 +7,7 @@
 namespace OpenApi\Tests;
 
 use OpenApi\Annotations as OA;
+use OpenApi\Builder;
 use OpenApi\Context;
 use OpenApi\Generator;
 use OpenApi\Tests\Fixtures\Customer;
@@ -17,11 +18,14 @@ final class ContextTest extends OpenApiTestCase
     public function testFullyQualifiedName(): void
     {
         $this->assertOpenApiLogEntryContains('Required @OA\PathItem() not found');
-        $openapi = (new Generator($this->getTrackingLogger()))
-            ->setAnalyser($this->getAnalyzer())
-            ->setTypeResolver($this->getTypeResolver())
-            ->generate([$this->fixture('Customer.php')]);
-        $context = $openapi->components->schemas[0]->_context;
+        $result = (new Builder())
+            ->addSource($this->fixture('Customer.php'))
+            ->setLogger($this->getTrackingLogger())
+            ->withGenerator(fn (Generator $generator): Generator => $generator
+                ->setAnalyser($this->getAnalyzer())
+                ->setTypeResolver($this->getTypeResolver()))
+            ->build();
+        $context = $result->openApi()->components->schemas[0]->_context;
         // resolve with namespace
         $this->assertSame('\\FullyQualified', $context->fullyQualifiedName('\FullyQualified'));
         $this->assertSame('\\OpenApi\\Tests\\Fixtures\\Unqualified', $context->fullyQualifiedName('Unqualified'));
@@ -54,11 +58,13 @@ final class ContextTest extends OpenApiTestCase
     public function testDebugLocation(): void
     {
         $this->assertOpenApiLogEntryContains('Required @OA\PathItem() not found');
-        $openapi = (new Generator($this->getTrackingLogger()))
-            ->setTypeResolver($this->getTypeResolver())
-            ->generate([$this->fixture('Customer.php')]);
+        $result = (new Builder())
+            ->addSource($this->fixture('Customer.php'))
+            ->setLogger($this->getTrackingLogger())
+            ->withGenerator(fn (Generator $generator): Generator => $generator->setTypeResolver($this->getTypeResolver()))
+            ->build();
 
-        $customerSchema = $openapi->components->schemas[0];
+        $customerSchema = $result->openApi()->components->schemas[0];
         $this->assertStringContainsString(
             'Fixtures' . DIRECTORY_SEPARATOR . 'Customer.php on line ',
             $customerSchema->_context->getDebugLocation()

--- a/tests/DocSnippetsTest.php
+++ b/tests/DocSnippetsTest.php
@@ -57,7 +57,7 @@ final class DocSnippetsTest extends OpenApiTestCase
                 ->setTypeResolver($this->getTypeResolver())
                  ->withProcessorPipeline(fn (Pipeline $processorPipeline): Pipeline => $processorPipeline->remove(OperationId::class))
                 ->generate([$tmp], null, false);
-            if ($lastSpec) {
+            if ($lastSpec instanceof \OpenApi\Annotations\OpenApi) {
                 $this->assertSpecEquals(
                     $openapi,
                     $lastSpec,

--- a/tests/ExamplesTest.php
+++ b/tests/ExamplesTest.php
@@ -7,6 +7,7 @@
 namespace OpenApi\Tests;
 
 use OpenApi\Annotations as OA;
+use OpenApi\Builder;
 use OpenApi\Generator;
 use OpenApi\Serializer;
 use OpenApi\Tests\Concerns\UsesExamples;
@@ -73,13 +74,15 @@ final class ExamplesTest extends OpenApiTestCase
         $path = self::examplePath("{$name}/{$implementation}");
         $specFilename = self::getSpecFilename($name, $implementation, $version);
 
-        $openapi = (new Generator($this->getTrackingLogger()))
+        $result = (new Builder())
+            ->addSource($path)
             ->setVersion($version)
-            ->setTypeResolver($typeResolver)
-            ->generate([$path]);
-        // file_put_contents($specFilename, $openapi->toYaml());
+            ->setLogger($this->getTrackingLogger())
+            ->withGenerator(fn (Generator $generator): Generator => $generator->setTypeResolver($typeResolver))
+            ->build();
+        // file_put_contents($specFilename, $result->toYaml());
         $this->assertSpecEquals(
-            $openapi,
+            $result->toYaml(),
             file_get_contents($specFilename),
             "Example: {$name}/{$implementation}/" . basename($specFilename)
         );

--- a/tests/OpenApiTestCase.php
+++ b/tests/OpenApiTestCase.php
@@ -222,7 +222,7 @@ class OpenApiTestCase extends TestCase
     {
         $fixtures = static::fixtures([$file]);
 
-        return $fixtures ? $fixtures[0] : null;
+        return $fixtures !== [] ? $fixtures[0] : null;
     }
 
     /**

--- a/tests/Processors/AugmentParametersTest.php
+++ b/tests/Processors/AugmentParametersTest.php
@@ -9,6 +9,7 @@ namespace OpenApi\Tests\Processors;
 use OpenApi\Annotations\Operation;
 use OpenApi\Annotations\Parameter;
 use OpenApi\Annotations\PathItem;
+use OpenApi\Builder;
 use OpenApi\Generator;
 use OpenApi\Processors\AugmentParameters;
 use OpenApi\Processors\BuildPaths;
@@ -24,10 +25,13 @@ final class AugmentParametersTest extends OpenApiTestCase
 
     public function testAugmentParameter(): void
     {
-        $openapi = (new Generator())
-            ->setAnalyser($this->getAnalyzer())
-            ->setTypeResolver($this->getTypeResolver())
-            ->generate([$this->fixture('UsingRefs.php')]);
+        $result = (new Builder())
+            ->addSource($this->fixture('UsingRefs.php'))
+            ->withGenerator(fn (Generator $generator): Generator => $generator
+                ->setAnalyser($this->getAnalyzer())
+                ->setTypeResolver($this->getTypeResolver()))
+            ->build();
+        $openapi = $result->openApi();
         $this->assertCount(1, $openapi->components->parameters, 'OpenApi contains 1 reusable parameter specification');
         $this->assertEquals('ItemName', $openapi->components->parameters[0]->parameter, 'When no @OA\Parameter()->parameter is specified, use @OA\Parameter()->name');
     }

--- a/tests/Processors/CleanUnusedComponentsPerformanceTest.php
+++ b/tests/Processors/CleanUnusedComponentsPerformanceTest.php
@@ -6,6 +6,8 @@
 
 namespace OpenApi\Tests\Processors;
 
+use OpenApi\Builder;
+use OpenApi\Builder\Result;
 use OpenApi\Generator;
 use OpenApi\Tests\OpenApiTestCase;
 use OpenApi\Undefined;
@@ -58,10 +60,13 @@ final class CleanUnusedComponentsPerformanceTest extends OpenApiTestCase
         try {
             $usedCount = (int) round(self::SCHEMA_COUNT * (1 - self::UNUSED_RATIO));
 
-            $openapi = (new Generator())
-                ->setConfig(['cleanUnusedComponents' => ['enabled' => true]])
-                ->generate([$sourceDir]);
+            $result = (new Builder())
+                ->addSource($sourceDir)
+                ->withGenerator(fn (Generator $generator): Generator => $generator
+                    ->setConfig(['cleanUnusedComponents' => ['enabled' => true]]))
+                ->build();
 
+            $openapi = $result->openApi();
             $schemaCount = Undefined::isDefault($openapi->components->schemas)
                 ? 0
                 : count($openapi->components->schemas);
@@ -74,15 +79,17 @@ final class CleanUnusedComponentsPerformanceTest extends OpenApiTestCase
 
     private function measureGeneration(string $sourceDir, bool $cleanup): float
     {
+        $build = fn (): Result => (new Builder())
+            ->addSource($sourceDir)
+            ->withGenerator(fn (Generator $generator): Generator => $generator
+                ->setConfig(['cleanUnusedComponents' => ['enabled' => $cleanup]]))
+            ->build();
+
         // Warmup run to eliminate autoloading variance
-        (new Generator())
-            ->setConfig(['cleanUnusedComponents' => ['enabled' => $cleanup]])
-            ->generate([$sourceDir]);
+        $build();
 
         $start = microtime(true);
-        (new Generator())
-            ->setConfig(['cleanUnusedComponents' => ['enabled' => $cleanup]])
-            ->generate([$sourceDir]);
+        $build();
 
         return microtime(true) - $start;
     }

--- a/tests/ScratchTest.php
+++ b/tests/ScratchTest.php
@@ -7,6 +7,7 @@
 namespace OpenApi\Tests;
 
 use OpenApi\Annotations as OA;
+use OpenApi\Builder;
 use OpenApi\Generator;
 use OpenApi\TypeResolverInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -83,13 +84,16 @@ final class ScratchTest extends OpenApiTestCase
 
         require_once $scratch;
 
-        $openapi = (new Generator($this->getTrackingLogger()))
-            ->setTypeResolver($typeResolver)
+        $result = (new Builder())
+            ->addSource($scratch)
             ->setVersion($version)
-            ->setConfig(['mergeIntoOpenApi' => ['mergeComponents' => true]])
-            ->generate([$scratch]);
+            ->setLogger($this->getTrackingLogger())
+            ->withGenerator(fn (Generator $generator): Generator => $generator
+                ->setTypeResolver($typeResolver)
+                ->setConfig(['mergeIntoOpenApi' => ['mergeComponents' => true]]))
+            ->build();
 
-        // file_put_contents($spec, $openapi->toYaml());
-        $this->assertSpecEquals($openapi, file_get_contents($spec));
+        // file_put_contents($spec, $result->toYaml());
+        $this->assertSpecEquals($result->toYaml(), file_get_contents($spec));
     }
 }


### PR DESCRIPTION
## Introduction

With the planned introduction of a new, simpler set of attributes to replace the current `OpenApi\Attributes` classes it became clear that the current `Generator` class is not compatible with the new processing chain.
For this reason a new `Builder` class has been created that unifies access to both the current (`classic`) annotations and attributes and the future new set (`spec`) which will live in `OpenApi\Spec`.


## Timeline
- v6
  -  The new attributes are added and support added to the `Builder` to toggle between the two. 
  - The current/`classic` code is not changed at all and keeps working.
  - The new `spec` system evolves until it hits feature paritit with `classic` (or beyond), `classic` is the default in the `Builder` class.
  - There is also a new `hybrid` mode planned that will route all `classic` annotations/attributes through the new `spec` processing chain.
- v7
  - All `classic` code is marked deprecated.
  - The default in `Builder` is switched to 'spec'.
- v8:
  - All `classic` code is removed and `spec` becomes the sole set of attributes.
  - classic `@OA` docblock annotations are no longer supported at all.


## Summary

- Introduce `Builder` class as the recommended entry point for generating OpenAPI specs
- Migrate CLI `GenerateCommand` to use Builder internally
- Add docs: reference page, generating guide updated, sidebar entry
- Tests updated to use `Builder` where appropriate
- `mode` option added to the CLI to toggle between `classic` (the current system) and `spec` - the new attributes (once they are implemented)

Related to #1953 