### PR TITLE
Replace Spectral with Redocly for spec validation

### DIFF
--- a/.github/workflows/spec-validation.yml
+++ b/.github/workflows/spec-validation.yml
@@ -1,0 +1,39 @@
+name: spec-validation
+
+on:
+  push:
+    branches:
+      - master
+      - 5.x
+  pull_request:
+    branches:
+      - master
+      - 5.x
+
+jobs:
+  spec-validation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        name: Checkout repository
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+
+      - uses: ramsey/composer-install@v4
+        with:
+          dependency-versions: 'highest'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Validate specs
+        run: composer redocly

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ docs/.vitepress/dist/
 docs/node_modules/
 docs/package-lock.json
 node_modules/
-package-lock.json
 scratch/
 vendor/
 .idea/

--- a/.redocly.lint-ignore.yaml
+++ b/.redocly.lint-ignore.yaml
@@ -1,0 +1,697 @@
+# This file instructs Redocly's linter to ignore the rules contained for specific parts of your API.
+# See https://redocly.com/docs/cli/ for more information.
+docs/examples/specs/webhooks/webhooks-3.2.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+docs/examples/specs/webhooks/webhooks-3.1.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+docs/examples/specs/using-traits/using-traits-3.2.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  spec-components-invalid-map-name:
+    - '#/components/schemas/CustomName~1Blink'
+docs/examples/specs/using-traits/using-traits-3.1.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  spec-components-invalid-map-name:
+    - '#/components/schemas/CustomName~1Blink'
+docs/examples/specs/using-traits/using-traits-3.0.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  spec-components-invalid-map-name:
+    - '#/components/schemas/CustomName~1Blink'
+docs/examples/specs/using-links/using-links-3.2.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-ambiguous-paths:
+    - '#/paths/~12.0~1repositories~1{username}~1{slug}~1pullrequests~1{pid}'
+docs/examples/specs/using-links/using-links-3.1.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-ambiguous-paths:
+    - '#/paths/~12.0~1repositories~1{username}~1{slug}~1pullrequests~1{pid}'
+docs/examples/specs/using-links/using-links-3.0.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-ambiguous-paths:
+    - '#/paths/~12.0~1repositories~1{username}~1{slug}~1pullrequests~1{pid}'
+docs/examples/specs/using-refs/using-refs-3.2.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  struct:
+    - '#/components/schemas/Product/allOf/1/properties/id'
+    - '#/components/schemas/Product/allOf/1/properties/id/type'
+    - '#/components/schemas/Product/allOf/1/properties/id/format'
+  path-parameters-defined:
+    - '#/paths/~1products~1{product_id}~1do-other-stuff/get/parameters'
+docs/examples/specs/using-refs/using-refs-3.1.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  struct:
+    - '#/components/schemas/Product/allOf/1/properties/id'
+    - '#/components/schemas/Product/allOf/1/properties/id/type'
+    - '#/components/schemas/Product/allOf/1/properties/id/format'
+  path-parameters-defined:
+    - '#/paths/~1products~1{product_id}~1do-other-stuff/get/parameters'
+docs/examples/specs/using-refs/using-refs-3.0.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  struct:
+    - '#/components/schemas/Product/allOf/1/properties/id'
+    - '#/components/schemas/Product/allOf/1/properties/id/type'
+    - '#/components/schemas/Product/allOf/1/properties/id/format'
+  path-parameters-defined:
+    - '#/paths/~1products~1{product_id}~1do-other-stuff/get/parameters'
+docs/examples/specs/using-interfaces/using-interfaces-3.2.0.yaml:
+  no-server-example.com:
+    - '#/servers/0/url'
+docs/examples/specs/using-interfaces/using-interfaces-3.1.0.yaml:
+  no-server-example.com:
+    - '#/servers/0/url'
+docs/examples/specs/using-interfaces/using-interfaces-3.0.0.yaml:
+  no-server-example.com:
+    - '#/servers/0/url'
+docs/examples/specs/polymorphism/polymorphism-3.2.0.yaml:
+  no-server-example.com:
+    - '#/servers/0/url'
+docs/examples/specs/polymorphism/polymorphism-3.1.0.yaml:
+  no-server-example.com:
+    - '#/servers/0/url'
+docs/examples/specs/polymorphism/polymorphism-3.0.0.yaml:
+  no-server-example.com:
+    - '#/servers/0/url'
+docs/examples/specs/nesting/nesting-3.2.0.yaml:
+  no-server-example.com:
+    - '#/servers/0/url'
+docs/examples/specs/nesting/nesting-3.1.0.yaml:
+  no-server-example.com:
+    - '#/servers/0/url'
+docs/examples/specs/nesting/nesting-3.0.0.yaml:
+  no-server-example.com:
+    - '#/servers/0/url'
+docs/examples/specs/misc/misc-3.2.0.yaml:
+  tag-description:
+    - '#/tags/0/description'
+  no-invalid-media-type-examples:
+    - >-
+      #/paths/~1users/post/responses/200/content/application~1json/examples/result/value/success
+    - >-
+      #/paths/~1users/post/responses/200/content/application~1json/examples/result/value
+docs/examples/specs/misc/misc-3.1.0.yaml:
+  tag-description:
+    - '#/tags/0/description'
+  no-invalid-media-type-examples:
+    - >-
+      #/paths/~1users/post/responses/200/content/application~1json/examples/result/value/success
+    - >-
+      #/paths/~1users/post/responses/200/content/application~1json/examples/result/value
+docs/examples/specs/misc/misc-3.0.0.yaml:
+  tag-description:
+    - '#/tags/0/description'
+  no-invalid-media-type-examples:
+    - >-
+      #/paths/~1users/post/responses/200/content/application~1json/examples/result/value/success
+    - >-
+      #/paths/~1users/post/responses/200/content/application~1json/examples/result/value
+docs/examples/specs/api/api-3.2.0.yaml:
+  no-server-example.com:
+    - '#/servers/0/url'
+    - '#/servers/1/url'
+    - '#/servers/2/url'
+  struct:
+    - '#/paths/~1subscribe/post/parameters/0'
+    - >-
+      #/paths/~1subscribe/post/callbacks/onChange/{$request.query.callbackUrl}/responses
+docs/examples/specs/api/api-3.1.0.yaml:
+  no-server-example.com:
+    - '#/servers/0/url'
+    - '#/servers/1/url'
+    - '#/servers/2/url'
+  struct:
+    - '#/paths/~1subscribe/post/parameters/0'
+    - >-
+      #/paths/~1subscribe/post/callbacks/onChange/{$request.query.callbackUrl}/responses
+docs/examples/specs/api/api-3.0.0.yaml:
+  no-server-example.com:
+    - '#/servers/0/url'
+    - '#/servers/1/url'
+    - '#/servers/2/url'
+  struct:
+    - '#/paths/~1subscribe/post/parameters/0'
+    - >-
+      #/paths/~1subscribe/post/callbacks/onChange/{$request.query.callbackUrl}/responses
+    - >-
+      #/paths/~1subscribe/post/callbacks/onChange/{$request.query.callbackUrl}/post
+tests/Fixtures/Scratch/VendorExtensions3.2.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+tests/Fixtures/Scratch/VendorExtensions3.1.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+tests/Fixtures/Scratch/VendorExtensions3.0.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+tests/Fixtures/Scratch/UsingRefs3.2.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+tests/Fixtures/Scratch/UsingRefs3.1.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+tests/Fixtures/Scratch/UsingRefs3.0.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+tests/Fixtures/Scratch/Types3.2.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/Types'
+tests/Fixtures/Scratch/Types3.1.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/Types'
+tests/Fixtures/Scratch/ThirdPartyAnnotation3.2.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/Child'
+tests/Fixtures/Scratch/ThirdPartyAnnotation3.1.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/Child'
+tests/Fixtures/Scratch/ThirdPartyAnnotation3.0.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/Child'
+tests/Fixtures/Scratch/Tags3.2.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  tag-description:
+    - '#/tags/2/description'
+tests/Fixtures/Scratch/Tags3.1.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  tag-description:
+    - '#/tags/2/description'
+tests/Fixtures/Scratch/Tags3.0.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  tag-description:
+    - '#/tags/2/description'
+tests/Fixtures/Scratch/Security3.2.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  struct:
+    - '#/components/securitySchemes/store_auth/flows/password'
+    - '#/components/securitySchemes/store_auth/flows/password/authorizationUrl'
+  no-unused-components:
+    - '#/components/securitySchemes/api_key'
+    - '#/components/securitySchemes/store_auth'
+tests/Fixtures/Scratch/Security3.1.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  struct:
+    - '#/components/securitySchemes/store_auth/flows/password'
+    - '#/components/securitySchemes/store_auth/flows/password/authorizationUrl'
+  no-unused-components:
+    - '#/components/securitySchemes/api_key'
+    - '#/components/securitySchemes/store_auth'
+tests/Fixtures/Scratch/Security3.0.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  struct:
+    - '#/components/securitySchemes/store_auth/flows/password'
+    - '#/components/securitySchemes/store_auth/flows/password/authorizationUrl'
+  no-unused-components:
+    - '#/components/securitySchemes/api_key'
+    - '#/components/securitySchemes/store_auth'
+tests/Fixtures/Scratch/Response3.2.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+tests/Fixtures/Scratch/Response3.1.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+tests/Fixtures/Scratch/Response3.0.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+tests/Fixtures/Scratch/RequestBody3.2.0-type-info.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  struct:
+    - '#/components/requestBodies/RequestBodyRef'
+    - '#/components/requestBodies/foo'
+tests/Fixtures/Scratch/RequestBody3.2.0-legacy.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  struct:
+    - '#/components/requestBodies/RequestBodyRef'
+    - '#/paths/~1endpoint~1ref-foo/post/requestBody'
+    - '#/components/requestBodies/foo'
+  no-unused-components:
+    - '#/components/requestBodies/foo'
+tests/Fixtures/Scratch/RequestBody3.1.0-type-info.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  struct:
+    - '#/components/requestBodies/RequestBodyRef'
+    - '#/components/requestBodies/foo'
+tests/Fixtures/Scratch/RequestBody3.1.0-legacy.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  struct:
+    - '#/components/requestBodies/RequestBodyRef'
+    - '#/paths/~1endpoint~1ref-foo/post/requestBody'
+    - '#/components/requestBodies/foo'
+  no-unused-components:
+    - '#/components/requestBodies/foo'
+tests/Fixtures/Scratch/RequestBody3.0.0-type-info.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  struct:
+    - '#/components/requestBodies/RequestBodyRef'
+    - '#/components/requestBodies/foo'
+tests/Fixtures/Scratch/RequestBody3.0.0-legacy.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  struct:
+    - '#/components/requestBodies/RequestBodyRef'
+    - '#/paths/~1endpoint~1ref-foo/post/requestBody'
+    - '#/components/requestBodies/foo'
+  no-unused-components:
+    - '#/components/requestBodies/foo'
+tests/Fixtures/Scratch/PropertyItems3.2.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/PropertyItems'
+tests/Fixtures/Scratch/PropertyItems3.1.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/PropertyItems'
+tests/Fixtures/Scratch/PropertyItems3.0.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/PropertyItems'
+tests/Fixtures/Scratch/PropertyInheritance3.2.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+tests/Fixtures/Scratch/PropertyInheritance3.1.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+tests/Fixtures/Scratch/PropertyInheritance3.0.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+tests/Fixtures/Scratch/PromotedProperty3.2.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/PromotedPropertyDescription'
+tests/Fixtures/Scratch/PromotedProperty3.1.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/PromotedPropertyDescription'
+tests/Fixtures/Scratch/PromotedProperty3.0.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/PromotedPropertyDescription'
+tests/Fixtures/Scratch/PathParameter3.2.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  struct:
+    - '#/paths/~1items~1{item_name}/get/parameters/0'
+    - '#/paths/~1admin~1items~1{item_name}/get/parameters/0'
+tests/Fixtures/Scratch/PathParameter3.1.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  struct:
+    - '#/paths/~1items~1{item_name}/get/parameters/0'
+    - '#/paths/~1admin~1items~1{item_name}/get/parameters/0'
+tests/Fixtures/Scratch/PathParameter3.0.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  struct:
+    - '#/paths/~1items~1{item_name}/get/parameters/0'
+    - '#/paths/~1admin~1items~1{item_name}/get/parameters/0'
+tests/Fixtures/Scratch/ParameterContent3.2.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+tests/Fixtures/Scratch/ParameterContent3.1.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+tests/Fixtures/Scratch/ParameterContent3.0.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+tests/Fixtures/Scratch/Nullable3.2.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/Nullable'
+tests/Fixtures/Scratch/Nullable3.1.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/Nullable'
+tests/Fixtures/Scratch/Nullable3.0.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  nullable-type-sibling:
+    - '#/components/schemas/Nullable/properties/birthdate/nullable'
+    - '#/components/schemas/Nullable/properties/otherdate/nullable'
+    - '#/components/schemas/Nullable/properties/anotherdate/nullable'
+  no-unused-components:
+    - '#/components/schemas/Nullable'
+tests/Fixtures/Scratch/NullRef3.2.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+tests/Fixtures/Scratch/NullRef3.1.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+tests/Fixtures/Scratch/NullRef3.0.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  nullable-type-sibling:
+    - >-
+      #/paths/~1api~1refonly/get/responses/200/content/application~1json/schema/nullable
+    - >-
+      #/paths/~1api~1refplus/get/responses/200/content/application~1json/schema/nullable
+tests/Fixtures/Scratch/NestedSchema3.2.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/NestedSchema'
+tests/Fixtures/Scratch/NestedSchema3.1.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/NestedSchema'
+tests/Fixtures/Scratch/NestedSchema3.0.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/NestedSchema'
+tests/Fixtures/Scratch/NestedAdditionalProperties3.2.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/NestedAdditionalAttributes'
+tests/Fixtures/Scratch/NestedAdditionalProperties3.1.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/NestedAdditionalAttributes'
+tests/Fixtures/Scratch/NestedAdditionalProperties3.0.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/NestedAdditionalAttributes'
+tests/Fixtures/Scratch/MultiplePathsForEndpoint3.2.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+tests/Fixtures/Scratch/MultiplePathsForEndpoint3.1.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+tests/Fixtures/Scratch/MultiplePathsForEndpoint3.0.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+tests/Fixtures/Scratch/MultiTypeProperty3.2.0-type-info.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/MultiTypeProperty'
+tests/Fixtures/Scratch/MultiTypeProperty3.2.0-legacy.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/MultiTypeProperty'
+tests/Fixtures/Scratch/MultiTypeProperty3.1.0-type-info.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/MultiTypeProperty'
+tests/Fixtures/Scratch/MultiTypeProperty3.1.0-legacy.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/MultiTypeProperty'
+tests/Fixtures/Scratch/MultiTypeProperty3.0.0-type-info.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  nullable-type-sibling:
+    - '#/components/schemas/MultiTypeProperty/properties/value/nullable'
+  no-unused-components:
+    - '#/components/schemas/MultiTypeProperty'
+tests/Fixtures/Scratch/MultiTypeProperty3.0.0-legacy.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  nullable-type-sibling:
+    - '#/components/schemas/MultiTypeProperty/properties/value/nullable'
+  no-unused-components:
+    - '#/components/schemas/MultiTypeProperty'
+tests/Fixtures/Scratch/MergeTraitsExtended3.2.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+tests/Fixtures/Scratch/MergeTraitsExtended3.1.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+tests/Fixtures/Scratch/MergeTraitsExtended3.0.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+tests/Fixtures/Scratch/MergeTraits3.2.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+tests/Fixtures/Scratch/MergeTraits3.1.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+tests/Fixtures/Scratch/MergeTraits3.0.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+tests/Fixtures/Scratch/JsonContentEquiv3.2.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+tests/Fixtures/Scratch/JsonContentEquiv3.1.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+tests/Fixtures/Scratch/JsonContentEquiv3.0.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+tests/Fixtures/Scratch/ExclusiveMinMax3.2.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/minMaxClass'
+tests/Fixtures/Scratch/ExclusiveMinMax3.1.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/minMaxClass'
+tests/Fixtures/Scratch/ExclusiveMinMax3.0.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/minMaxClass'
+tests/Fixtures/Scratch/Examples3.2.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  struct:
+    - '#/components/schemas/YoYo/examples'
+tests/Fixtures/Scratch/Examples3.1.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  struct:
+    - '#/components/schemas/YoYo/examples'
+tests/Fixtures/Scratch/Encoding3.2.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+tests/Fixtures/Scratch/Encoding3.1.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+tests/Fixtures/Scratch/Encoding3.0.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+tests/Fixtures/Scratch/DynamicEnumCase3.2.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/DynamicEnumCase'
+tests/Fixtures/Scratch/DynamicEnumCase3.1.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/DynamicEnumCase'
+tests/Fixtures/Scratch/DynamicEnumCase3.0.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/DynamicEnumCase'
+tests/Fixtures/Scratch/DuplicateRef3.2.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/create-user'
+tests/Fixtures/Scratch/DuplicateRef3.1.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/create-user'
+tests/Fixtures/Scratch/DuplicateRef3.0.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/create-user'
+tests/Fixtures/Scratch/Docblocks3.2.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/DocblockSchemaChild'
+tests/Fixtures/Scratch/Docblocks3.2.0-8.6.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/DocblockSchemaChild'
+tests/Fixtures/Scratch/Docblocks3.1.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/DocblockSchemaChild'
+tests/Fixtures/Scratch/Docblocks3.1.0-8.6.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/DocblockSchemaChild'
+tests/Fixtures/Scratch/Docblocks3.0.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/DocblockSchemaChild'
+tests/Fixtures/Scratch/Docblocks3.0.0-8.6.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/DocblockSchemaChild'
+tests/Fixtures/Scratch/CustomPropertyAttribute3.2.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/CustomPropertyAttribute'
+tests/Fixtures/Scratch/CustomPropertyAttribute3.1.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/CustomPropertyAttribute'
+tests/Fixtures/Scratch/CustomPropertyAttribute3.0.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/CustomPropertyAttribute'
+tests/Fixtures/Scratch/CustomAttributes3.2.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/CAModel'
+tests/Fixtures/Scratch/CustomAttributes3.1.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/CAModel'
+tests/Fixtures/Scratch/CustomAttributes3.0.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/CAModel'
+tests/Fixtures/Scratch/CustomAttributeSchema3.2.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/MyClass'
+tests/Fixtures/Scratch/CustomAttributeSchema3.1.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/MyClass'
+tests/Fixtures/Scratch/CustomAttributeSchema3.0.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/MyClass'
+tests/Fixtures/Scratch/Components3.2.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  spec-components-invalid-map-name:
+    - '#/components/schemas/first schema'
+    - '#/components/schemas/second schema'
+    - '#/components/requestBodies/first request body'
+  struct:
+    - '#/components/requestBodies/first request body'
+  no-unused-components:
+    - '#/components/schemas/first schema'
+    - '#/components/schemas/second schema'
+    - '#/components/requestBodies/first request body'
+tests/Fixtures/Scratch/Components3.1.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  spec-components-invalid-map-name:
+    - '#/components/schemas/first schema'
+    - '#/components/schemas/second schema'
+    - '#/components/requestBodies/first request body'
+  struct:
+    - '#/components/requestBodies/first request body'
+  no-unused-components:
+    - '#/components/schemas/first schema'
+    - '#/components/schemas/second schema'
+    - '#/components/requestBodies/first request body'
+tests/Fixtures/Scratch/Components3.0.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  spec-components-invalid-map-name:
+    - '#/components/schemas/first schema'
+    - '#/components/schemas/second schema'
+    - '#/components/requestBodies/first request body'
+  struct:
+    - '#/components/requestBodies/first request body'
+  no-unused-components:
+    - '#/components/schemas/first schema'
+    - '#/components/schemas/second schema'
+    - '#/components/requestBodies/first request body'
+tests/Fixtures/Scratch/ComplexCustomAttributes3.2.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+tests/Fixtures/Scratch/ComplexCustomAttributes3.1.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+tests/Fixtures/Scratch/ComplexCustomAttributes3.0.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+tests/Fixtures/Scratch/ClassRef3.2.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+tests/Fixtures/Scratch/ClassRef3.1.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+tests/Fixtures/Scratch/ClassRef3.0.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+tests/Fixtures/Scratch/AttributeInheritance3.2.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/Child1'
+    - '#/components/schemas/Child2'
+tests/Fixtures/Scratch/AttributeInheritance3.1.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/Child1'
+    - '#/components/schemas/Child2'
+tests/Fixtures/Scratch/AttributeInheritance3.0.0.yaml:
+  no-empty-servers:
+    - '#/openapi'
+  no-unused-components:
+    - '#/components/schemas/Child1'
+    - '#/components/schemas/Child2'

--- a/.redocly.lint-ignore.yaml
+++ b/.redocly.lint-ignore.yaml
@@ -1,44 +1,15 @@
 # This file instructs Redocly's linter to ignore the rules contained for specific parts of your API.
 # See https://redocly.com/docs/cli/ for more information.
-docs/examples/specs/webhooks/webhooks-3.2.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
-docs/examples/specs/webhooks/webhooks-3.1.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
 docs/examples/specs/using-traits/using-traits-3.2.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   spec-components-invalid-map-name:
     - '#/components/schemas/CustomName~1Blink'
 docs/examples/specs/using-traits/using-traits-3.1.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   spec-components-invalid-map-name:
     - '#/components/schemas/CustomName~1Blink'
 docs/examples/specs/using-traits/using-traits-3.0.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   spec-components-invalid-map-name:
     - '#/components/schemas/CustomName~1Blink'
-docs/examples/specs/using-links/using-links-3.2.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
-  no-ambiguous-paths:
-    - '#/paths/~12.0~1repositories~1{username}~1{slug}~1pullrequests~1{pid}'
-docs/examples/specs/using-links/using-links-3.1.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
-  no-ambiguous-paths:
-    - '#/paths/~12.0~1repositories~1{username}~1{slug}~1pullrequests~1{pid}'
-docs/examples/specs/using-links/using-links-3.0.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
-  no-ambiguous-paths:
-    - '#/paths/~12.0~1repositories~1{username}~1{slug}~1pullrequests~1{pid}'
 docs/examples/specs/using-refs/using-refs-3.2.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   struct:
     - '#/components/schemas/Product/allOf/1/properties/id'
     - '#/components/schemas/Product/allOf/1/properties/id/type'
@@ -46,8 +17,6 @@ docs/examples/specs/using-refs/using-refs-3.2.0.yaml:
   path-parameters-defined:
     - '#/paths/~1products~1{product_id}~1do-other-stuff/get/parameters'
 docs/examples/specs/using-refs/using-refs-3.1.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   struct:
     - '#/components/schemas/Product/allOf/1/properties/id'
     - '#/components/schemas/Product/allOf/1/properties/id/type'
@@ -55,8 +24,6 @@ docs/examples/specs/using-refs/using-refs-3.1.0.yaml:
   path-parameters-defined:
     - '#/paths/~1products~1{product_id}~1do-other-stuff/get/parameters'
 docs/examples/specs/using-refs/using-refs-3.0.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   struct:
     - '#/components/schemas/Product/allOf/1/properties/id'
     - '#/components/schemas/Product/allOf/1/properties/id/type'
@@ -72,6 +39,15 @@ docs/examples/specs/using-interfaces/using-interfaces-3.1.0.yaml:
 docs/examples/specs/using-interfaces/using-interfaces-3.0.0.yaml:
   no-server-example.com:
     - '#/servers/0/url'
+docs/examples/specs/using-links/using-links-3.2.0.yaml:
+  no-ambiguous-paths:
+    - '#/paths/~12.0~1repositories~1{username}~1{slug}~1pullrequests~1{pid}'
+docs/examples/specs/using-links/using-links-3.1.0.yaml:
+  no-ambiguous-paths:
+    - '#/paths/~12.0~1repositories~1{username}~1{slug}~1pullrequests~1{pid}'
+docs/examples/specs/using-links/using-links-3.0.0.yaml:
+  no-ambiguous-paths:
+    - '#/paths/~12.0~1repositories~1{username}~1{slug}~1pullrequests~1{pid}'
 docs/examples/specs/polymorphism/polymorphism-3.2.0.yaml:
   no-server-example.com:
     - '#/servers/0/url'
@@ -143,67 +119,31 @@ docs/examples/specs/api/api-3.0.0.yaml:
       #/paths/~1subscribe/post/callbacks/onChange/{$request.query.callbackUrl}/responses
     - >-
       #/paths/~1subscribe/post/callbacks/onChange/{$request.query.callbackUrl}/post
-tests/Fixtures/Scratch/VendorExtensions3.2.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
-tests/Fixtures/Scratch/VendorExtensions3.1.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
-tests/Fixtures/Scratch/VendorExtensions3.0.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
-tests/Fixtures/Scratch/UsingRefs3.2.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
-tests/Fixtures/Scratch/UsingRefs3.1.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
-tests/Fixtures/Scratch/UsingRefs3.0.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
 tests/Fixtures/Scratch/Types3.2.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/Types'
 tests/Fixtures/Scratch/Types3.1.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/Types'
 tests/Fixtures/Scratch/ThirdPartyAnnotation3.2.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/Child'
 tests/Fixtures/Scratch/ThirdPartyAnnotation3.1.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/Child'
 tests/Fixtures/Scratch/ThirdPartyAnnotation3.0.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/Child'
 tests/Fixtures/Scratch/Tags3.2.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   tag-description:
     - '#/tags/2/description'
 tests/Fixtures/Scratch/Tags3.1.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   tag-description:
     - '#/tags/2/description'
 tests/Fixtures/Scratch/Tags3.0.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   tag-description:
     - '#/tags/2/description'
 tests/Fixtures/Scratch/Security3.2.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   struct:
     - '#/components/securitySchemes/store_auth/flows/password'
     - '#/components/securitySchemes/store_auth/flows/password/authorizationUrl'
@@ -211,8 +151,6 @@ tests/Fixtures/Scratch/Security3.2.0.yaml:
     - '#/components/securitySchemes/api_key'
     - '#/components/securitySchemes/store_auth'
 tests/Fixtures/Scratch/Security3.1.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   struct:
     - '#/components/securitySchemes/store_auth/flows/password'
     - '#/components/securitySchemes/store_auth/flows/password/authorizationUrl'
@@ -220,32 +158,17 @@ tests/Fixtures/Scratch/Security3.1.0.yaml:
     - '#/components/securitySchemes/api_key'
     - '#/components/securitySchemes/store_auth'
 tests/Fixtures/Scratch/Security3.0.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   struct:
     - '#/components/securitySchemes/store_auth/flows/password'
     - '#/components/securitySchemes/store_auth/flows/password/authorizationUrl'
   no-unused-components:
     - '#/components/securitySchemes/api_key'
     - '#/components/securitySchemes/store_auth'
-tests/Fixtures/Scratch/Response3.2.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
-tests/Fixtures/Scratch/Response3.1.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
-tests/Fixtures/Scratch/Response3.0.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
 tests/Fixtures/Scratch/RequestBody3.2.0-type-info.yaml:
-  no-empty-servers:
-    - '#/openapi'
   struct:
     - '#/components/requestBodies/RequestBodyRef'
     - '#/components/requestBodies/foo'
 tests/Fixtures/Scratch/RequestBody3.2.0-legacy.yaml:
-  no-empty-servers:
-    - '#/openapi'
   struct:
     - '#/components/requestBodies/RequestBodyRef'
     - '#/paths/~1endpoint~1ref-foo/post/requestBody'
@@ -253,14 +176,10 @@ tests/Fixtures/Scratch/RequestBody3.2.0-legacy.yaml:
   no-unused-components:
     - '#/components/requestBodies/foo'
 tests/Fixtures/Scratch/RequestBody3.1.0-type-info.yaml:
-  no-empty-servers:
-    - '#/openapi'
   struct:
     - '#/components/requestBodies/RequestBodyRef'
     - '#/components/requestBodies/foo'
 tests/Fixtures/Scratch/RequestBody3.1.0-legacy.yaml:
-  no-empty-servers:
-    - '#/openapi'
   struct:
     - '#/components/requestBodies/RequestBodyRef'
     - '#/paths/~1endpoint~1ref-foo/post/requestBody'
@@ -268,14 +187,10 @@ tests/Fixtures/Scratch/RequestBody3.1.0-legacy.yaml:
   no-unused-components:
     - '#/components/requestBodies/foo'
 tests/Fixtures/Scratch/RequestBody3.0.0-type-info.yaml:
-  no-empty-servers:
-    - '#/openapi'
   struct:
     - '#/components/requestBodies/RequestBodyRef'
     - '#/components/requestBodies/foo'
 tests/Fixtures/Scratch/RequestBody3.0.0-legacy.yaml:
-  no-empty-servers:
-    - '#/openapi'
   struct:
     - '#/components/requestBodies/RequestBodyRef'
     - '#/paths/~1endpoint~1ref-foo/post/requestBody'
@@ -283,346 +198,173 @@ tests/Fixtures/Scratch/RequestBody3.0.0-legacy.yaml:
   no-unused-components:
     - '#/components/requestBodies/foo'
 tests/Fixtures/Scratch/PropertyItems3.2.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/PropertyItems'
 tests/Fixtures/Scratch/PropertyItems3.1.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/PropertyItems'
 tests/Fixtures/Scratch/PropertyItems3.0.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/PropertyItems'
-tests/Fixtures/Scratch/PropertyInheritance3.2.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
-tests/Fixtures/Scratch/PropertyInheritance3.1.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
-tests/Fixtures/Scratch/PropertyInheritance3.0.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
 tests/Fixtures/Scratch/PromotedProperty3.2.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/PromotedPropertyDescription'
 tests/Fixtures/Scratch/PromotedProperty3.1.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/PromotedPropertyDescription'
 tests/Fixtures/Scratch/PromotedProperty3.0.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/PromotedPropertyDescription'
 tests/Fixtures/Scratch/PathParameter3.2.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   struct:
     - '#/paths/~1items~1{item_name}/get/parameters/0'
     - '#/paths/~1admin~1items~1{item_name}/get/parameters/0'
 tests/Fixtures/Scratch/PathParameter3.1.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   struct:
     - '#/paths/~1items~1{item_name}/get/parameters/0'
     - '#/paths/~1admin~1items~1{item_name}/get/parameters/0'
 tests/Fixtures/Scratch/PathParameter3.0.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   struct:
     - '#/paths/~1items~1{item_name}/get/parameters/0'
     - '#/paths/~1admin~1items~1{item_name}/get/parameters/0'
-tests/Fixtures/Scratch/ParameterContent3.2.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
-tests/Fixtures/Scratch/ParameterContent3.1.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
-tests/Fixtures/Scratch/ParameterContent3.0.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
 tests/Fixtures/Scratch/Nullable3.2.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/Nullable'
 tests/Fixtures/Scratch/Nullable3.1.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/Nullable'
 tests/Fixtures/Scratch/Nullable3.0.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   nullable-type-sibling:
     - '#/components/schemas/Nullable/properties/birthdate/nullable'
     - '#/components/schemas/Nullable/properties/otherdate/nullable'
     - '#/components/schemas/Nullable/properties/anotherdate/nullable'
   no-unused-components:
     - '#/components/schemas/Nullable'
-tests/Fixtures/Scratch/NullRef3.2.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
-tests/Fixtures/Scratch/NullRef3.1.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
 tests/Fixtures/Scratch/NullRef3.0.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   nullable-type-sibling:
     - >-
       #/paths/~1api~1refonly/get/responses/200/content/application~1json/schema/nullable
     - >-
       #/paths/~1api~1refplus/get/responses/200/content/application~1json/schema/nullable
 tests/Fixtures/Scratch/NestedSchema3.2.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/NestedSchema'
 tests/Fixtures/Scratch/NestedSchema3.1.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/NestedSchema'
 tests/Fixtures/Scratch/NestedSchema3.0.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/NestedSchema'
 tests/Fixtures/Scratch/NestedAdditionalProperties3.2.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/NestedAdditionalAttributes'
 tests/Fixtures/Scratch/NestedAdditionalProperties3.1.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/NestedAdditionalAttributes'
 tests/Fixtures/Scratch/NestedAdditionalProperties3.0.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/NestedAdditionalAttributes'
-tests/Fixtures/Scratch/MultiplePathsForEndpoint3.2.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
-tests/Fixtures/Scratch/MultiplePathsForEndpoint3.1.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
-tests/Fixtures/Scratch/MultiplePathsForEndpoint3.0.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
 tests/Fixtures/Scratch/MultiTypeProperty3.2.0-type-info.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/MultiTypeProperty'
 tests/Fixtures/Scratch/MultiTypeProperty3.2.0-legacy.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/MultiTypeProperty'
 tests/Fixtures/Scratch/MultiTypeProperty3.1.0-type-info.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/MultiTypeProperty'
 tests/Fixtures/Scratch/MultiTypeProperty3.1.0-legacy.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/MultiTypeProperty'
 tests/Fixtures/Scratch/MultiTypeProperty3.0.0-type-info.yaml:
-  no-empty-servers:
-    - '#/openapi'
   nullable-type-sibling:
     - '#/components/schemas/MultiTypeProperty/properties/value/nullable'
   no-unused-components:
     - '#/components/schemas/MultiTypeProperty'
 tests/Fixtures/Scratch/MultiTypeProperty3.0.0-legacy.yaml:
-  no-empty-servers:
-    - '#/openapi'
   nullable-type-sibling:
     - '#/components/schemas/MultiTypeProperty/properties/value/nullable'
   no-unused-components:
     - '#/components/schemas/MultiTypeProperty'
-tests/Fixtures/Scratch/MergeTraitsExtended3.2.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
-tests/Fixtures/Scratch/MergeTraitsExtended3.1.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
-tests/Fixtures/Scratch/MergeTraitsExtended3.0.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
-tests/Fixtures/Scratch/MergeTraits3.2.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
-tests/Fixtures/Scratch/MergeTraits3.1.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
-tests/Fixtures/Scratch/MergeTraits3.0.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
-tests/Fixtures/Scratch/JsonContentEquiv3.2.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
-tests/Fixtures/Scratch/JsonContentEquiv3.1.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
-tests/Fixtures/Scratch/JsonContentEquiv3.0.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
 tests/Fixtures/Scratch/ExclusiveMinMax3.2.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/minMaxClass'
 tests/Fixtures/Scratch/ExclusiveMinMax3.1.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/minMaxClass'
 tests/Fixtures/Scratch/ExclusiveMinMax3.0.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/minMaxClass'
 tests/Fixtures/Scratch/Examples3.2.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   struct:
     - '#/components/schemas/YoYo/examples'
 tests/Fixtures/Scratch/Examples3.1.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   struct:
     - '#/components/schemas/YoYo/examples'
-tests/Fixtures/Scratch/Encoding3.2.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
-tests/Fixtures/Scratch/Encoding3.1.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
-tests/Fixtures/Scratch/Encoding3.0.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
 tests/Fixtures/Scratch/DynamicEnumCase3.2.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/DynamicEnumCase'
 tests/Fixtures/Scratch/DynamicEnumCase3.1.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/DynamicEnumCase'
 tests/Fixtures/Scratch/DynamicEnumCase3.0.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/DynamicEnumCase'
 tests/Fixtures/Scratch/DuplicateRef3.2.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/create-user'
 tests/Fixtures/Scratch/DuplicateRef3.1.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/create-user'
 tests/Fixtures/Scratch/DuplicateRef3.0.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/create-user'
 tests/Fixtures/Scratch/Docblocks3.2.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/DocblockSchemaChild'
 tests/Fixtures/Scratch/Docblocks3.2.0-8.6.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/DocblockSchemaChild'
 tests/Fixtures/Scratch/Docblocks3.1.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/DocblockSchemaChild'
 tests/Fixtures/Scratch/Docblocks3.1.0-8.6.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/DocblockSchemaChild'
 tests/Fixtures/Scratch/Docblocks3.0.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/DocblockSchemaChild'
 tests/Fixtures/Scratch/Docblocks3.0.0-8.6.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/DocblockSchemaChild'
 tests/Fixtures/Scratch/CustomPropertyAttribute3.2.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/CustomPropertyAttribute'
 tests/Fixtures/Scratch/CustomPropertyAttribute3.1.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/CustomPropertyAttribute'
 tests/Fixtures/Scratch/CustomPropertyAttribute3.0.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/CustomPropertyAttribute'
 tests/Fixtures/Scratch/CustomAttributes3.2.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/CAModel'
 tests/Fixtures/Scratch/CustomAttributes3.1.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/CAModel'
 tests/Fixtures/Scratch/CustomAttributes3.0.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/CAModel'
 tests/Fixtures/Scratch/CustomAttributeSchema3.2.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/MyClass'
 tests/Fixtures/Scratch/CustomAttributeSchema3.1.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/MyClass'
 tests/Fixtures/Scratch/CustomAttributeSchema3.0.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/MyClass'
 tests/Fixtures/Scratch/Components3.2.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   spec-components-invalid-map-name:
     - '#/components/schemas/first schema'
     - '#/components/schemas/second schema'
@@ -634,8 +376,6 @@ tests/Fixtures/Scratch/Components3.2.0.yaml:
     - '#/components/schemas/second schema'
     - '#/components/requestBodies/first request body'
 tests/Fixtures/Scratch/Components3.1.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   spec-components-invalid-map-name:
     - '#/components/schemas/first schema'
     - '#/components/schemas/second schema'
@@ -647,8 +387,6 @@ tests/Fixtures/Scratch/Components3.1.0.yaml:
     - '#/components/schemas/second schema'
     - '#/components/requestBodies/first request body'
 tests/Fixtures/Scratch/Components3.0.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   spec-components-invalid-map-name:
     - '#/components/schemas/first schema'
     - '#/components/schemas/second schema'
@@ -659,39 +397,15 @@ tests/Fixtures/Scratch/Components3.0.0.yaml:
     - '#/components/schemas/first schema'
     - '#/components/schemas/second schema'
     - '#/components/requestBodies/first request body'
-tests/Fixtures/Scratch/ComplexCustomAttributes3.2.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
-tests/Fixtures/Scratch/ComplexCustomAttributes3.1.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
-tests/Fixtures/Scratch/ComplexCustomAttributes3.0.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
-tests/Fixtures/Scratch/ClassRef3.2.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
-tests/Fixtures/Scratch/ClassRef3.1.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
-tests/Fixtures/Scratch/ClassRef3.0.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
 tests/Fixtures/Scratch/AttributeInheritance3.2.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/Child1'
     - '#/components/schemas/Child2'
 tests/Fixtures/Scratch/AttributeInheritance3.1.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/Child1'
     - '#/components/schemas/Child2'
 tests/Fixtures/Scratch/AttributeInheritance3.0.0.yaml:
-  no-empty-servers:
-    - '#/openapi'
   no-unused-components:
     - '#/components/schemas/Child1'
     - '#/components/schemas/Child2'

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,2 +1,0 @@
-extends:
-    - spectral:oas

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,11 @@ composer lint
 composer cs
 ```
 
+### Validate generated specs with Redocly
+```shell
+composer redocly
+```
+
 ### Run dev server for local development of `gh-pages`
 ```shell
 composer docs:dev

--- a/composer.json
+++ b/composer.json
@@ -87,12 +87,7 @@
         "test": "Run all PHP, codestyle and rector tests",
         "performance": "Run performance regression tests",
         "analyse": "Run static analysis (phpstan)",
-        "spectral-examples": "Run spectral lint over all .yaml files in the docs/examples folder",
-        "spectral-scratch": "Run spectral lint over all .yaml files in the tests/Fixtures/Scratch folder",
-        "spectral": "Run all spectral tests",
-        "redocly-examples": "Run redocly lint over all .yaml files in the docs/examples folder",
-        "redocly-scratch": "Run redocly lint over all .yaml files in the tests/Fixtures/Scratch folder",
-        "redocly": "Run all redocly tests",
+        "redocly": "Validate generated specs with Redocly",
         "docs:gen": "Rebuild reference documentation",
         "docs:dev": "Run dev server for local development of gh-pages",
         "docs:build": "Re-build static gh-pages"
@@ -112,18 +107,7 @@
         "analyse": [
             "export XDEBUG_MODE=off && phpstan analyse --memory-limit=3G"
         ],
-        "spectral-examples": "for ff in `find docs/examples -name '*.yaml'`; do npm run spectral lint $ff; done",
-        "spectral-scratch": "for ff in `find tests/Fixtures/Scratch -name '*.yaml'`; do npm run spectral lint $ff; done",
-        "spectral": [
-            "@spectral-examples",
-            "@spectral-scratch"
-        ],
-        "redocly-examples": "for ff in `find docs/examples -name '*.yaml'`; do npm run redocly lint $ff; done",
-        "redocly-scratch": "for ff in `find tests/Fixtures/Scratch -name '*.yaml'`; do npm run redocly lint $ff; done",
-        "redocly": [
-            "@redocly-examples",
-            "@redocly-scratch"
-        ],
+        "redocly": "npm run redocly -- lint 'docs/examples/specs/**/*.yaml' 'tests/Fixtures/Scratch/*.yaml'",
         "docs:gen": [
             "@php tools/refgen.php",
             "@php tools/procgen.php",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,31 @@
+{
+  "name": "swagger-php-tools",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "swagger-php-tools",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@redocly/cli": "^2.37.0"
+      }
+    },
+    "node_modules/@redocly/cli": {
+      "version": "2.37.0",
+      "resolved": "https://registry.npmjs.org/@redocly/cli/-/cli-2.37.0.tgz",
+      "integrity": "sha512-2xKvVy2re6xiWfrWHJj633oEoVAYHisPsxEwoxtSxMqB+RhW2uqM98+JPjrLQPpj2m1bXrj08KXwpSFfojV0/g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "openapi": "bin/cli.js",
+        "redocly": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0 || >=20.19.0 <21.0.0",
+        "npm": ">=10"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,11 +3,9 @@
   "version": "1.0.0",
   "license": "Apache-2.0",
   "scripts": {
-    "spectral": "spectral",
     "redocly": "redocly"
   },
   "devDependencies": {
-    "@redocly/cli": "^2.5.1",
-    "@stoplight/spectral-cli": "^6.15.0"
+    "@redocly/cli": "^2.37.0"
   }
 }

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -4,6 +4,7 @@ extends:
 rules:
   no-unresolved-refs: error
   no-unused-components: warn
+  no-empty-servers: off
   spec-components-invalid-map-name: error
   security-defined: off
   operation-summary: off

--- a/redocly.yaml
+++ b/redocly.yaml
@@ -1,0 +1,11 @@
+extends:
+  - minimal
+
+rules:
+  no-unresolved-refs: error
+  no-unused-components: warn
+  spec-components-invalid-map-name: error
+  security-defined: off
+  operation-summary: off
+  operation-2xx-response: off
+  operation-4xx-response: off


### PR DESCRIPTION
## Summary
- Replace Spectral with Redocly CLI for OpenAPI spec validation (`minimal` ruleset with targeted overrides)
- Add baseline ignore file for existing violations (309 issues)
- Add `spec-validation` CI workflow
- Document `composer redocly` in CONTRIBUTING.md

## Test plan
- [x] Verify `composer redocly` runs cleanly locally
- [x] Confirm CI workflow passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)