### PR TITLE
Fix CleanUnusedComponents removing schemas referenced via JsonContent

### DIFF
--- a/src/Processors/CleanUnusedComponents.php
+++ b/src/Processors/CleanUnusedComponents.php
@@ -53,23 +53,49 @@ class CleanUnusedComponents
         }
     }
 
-    protected function cleanup(Analysis $analysis): bool
+    protected function collectAnnotationRefs(OA\AbstractAnnotation $annotation, array &$usedRefs, \SplObjectStorage $visited): void
     {
-        $usedRefs = [];
-        foreach ($analysis->annotations as $annotation) {
-            if (property_exists($annotation, 'ref') && !Undefined::isDefault($annotation->ref) && $annotation->ref !== null) {
-                $usedRefs[$annotation->ref] = true;
-            }
+        if ($visited->offsetExists($annotation)) {
+            return;
+        }
+        $visited->offsetSet($annotation);
 
-            foreach (['allOf', 'anyOf', 'oneOf'] as $sub) {
-                if (property_exists($annotation, $sub) && !Undefined::isDefault($annotation->{$sub})) {
-                    foreach ($annotation->{$sub} as $subElem) {
-                        if (is_object($subElem) && property_exists($subElem, 'ref') && !Undefined::isDefault($subElem->ref) && $subElem->ref !== null) {
-                            $usedRefs[$subElem->ref] = true;
-                        }
+        if (property_exists($annotation, 'ref') && !Undefined::isDefault($annotation->ref) && $annotation->ref !== null) {
+            $usedRefs[$annotation->ref] = true;
+        }
+
+        foreach (['allOf', 'anyOf', 'oneOf'] as $sub) {
+            if (property_exists($annotation, $sub) && !Undefined::isDefault($annotation->{$sub})) {
+                foreach ($annotation->{$sub} as $subElem) {
+                    if ($subElem instanceof OA\AbstractAnnotation) {
+                        $this->collectAnnotationRefs($subElem, $usedRefs, $visited);
                     }
                 }
             }
+        }
+
+        foreach (get_object_vars($annotation) as $property => $value) {
+            if (in_array($property, $annotation::$_blacklist)) {
+                continue;
+            }
+            if ($value instanceof OA\AbstractAnnotation) {
+                $this->collectAnnotationRefs($value, $usedRefs, $visited);
+            } elseif (is_array($value)) {
+                foreach ($value as $item) {
+                    if ($item instanceof OA\AbstractAnnotation) {
+                        $this->collectAnnotationRefs($item, $usedRefs, $visited);
+                    }
+                }
+            }
+        }
+    }
+
+    protected function cleanup(Analysis $analysis): bool
+    {
+        $usedRefs = [];
+        $visited = new \SplObjectStorage();
+        foreach ($analysis->annotations as $annotation) {
+            $this->collectAnnotationRefs($annotation, $usedRefs, $visited);
 
             if ($annotation instanceof OA\OpenApi || $annotation instanceof OA\Operation) {
                 if (!Undefined::isDefault($annotation->security)) {
@@ -83,9 +109,14 @@ class CleanUnusedComponents
         }
 
         $unusedComponents = [];
+        $seen = [];
         foreach (OA\Components::$_nested as $nested) {
             if (2 == count($nested)) {
-                [$componentType, $nameProperty] = $nested;
+                [$componentType] = $nested;
+                if (isset($seen[$componentType])) {
+                    continue;
+                }
+                $seen[$componentType] = true;
                 if (!Undefined::isDefault($analysis->openapi->components->{$componentType})) {
                     foreach ($analysis->openapi->components->{$componentType} as $ii => $component) {
                         $ref = OA\Components::ref($component);
@@ -99,10 +130,13 @@ class CleanUnusedComponents
 
         foreach ($unusedComponents as [$componentType, $ii, $component]) {
             $this->removeAnnotationRecursive($analysis, $component);
-            unset($analysis->openapi->components->{$componentType}[$ii]);
 
-            if (!$analysis->openapi->components->{$componentType}) {
-                $analysis->openapi->components->{$componentType} = Undefined::UNDEFINED;
+            if (is_array($analysis->openapi->components->{$componentType})) {
+                unset($analysis->openapi->components->{$componentType}[$ii]);
+
+                if (!$analysis->openapi->components->{$componentType}) {
+                    $analysis->openapi->components->{$componentType} = Undefined::UNDEFINED;
+                }
             }
         }
 

--- a/tests/Processors/CleanUnusedComponentsPerformanceTest.php
+++ b/tests/Processors/CleanUnusedComponentsPerformanceTest.php
@@ -124,16 +124,19 @@ class ApiInfo
 PHP);
 
         // Schema models
+        // Half of the used schemas are only referenced via JsonContent (no cross-ref Property),
+        // exercising the nested annotation traversal in CleanUnusedComponents.
+        $jsonContentOnlyCount = (int) floor($usedCount / 2);
         foreach ($allSchemas as $idx => $schemaName) {
             $properties = [
                 "        new OA\Property(property: 'id', type: 'integer'),",
                 "        new OA\Property(property: 'name', type: 'string'),",
             ];
 
-            // Used schemas cross-reference other used schemas
-            if ($idx < $usedCount) {
-                $refIdx = ($idx + 1) % $usedCount;
-                $refSchema = $usedSchemas[$refIdx];
+            // Only the second half of used schemas cross-reference each other
+            if ($idx >= $jsonContentOnlyCount && $idx < $usedCount) {
+                $refIdx = $jsonContentOnlyCount + (($idx - $jsonContentOnlyCount + 1) % ($usedCount - $jsonContentOnlyCount));
+                $refSchema = $allSchemas[$refIdx];
                 $properties[] = "        new OA\Property(property: 'related', ref: '#/components/schemas/{$refSchema}'),";
             }
 


### PR DESCRIPTION
## Summary
- Fix `CleanUnusedComponents` incorrectly removing schemas that are only referenced via `JsonContent(ref: ...)` or `XmlContent(ref: ...)`. The performance refactor in #2030 stopped traversing nested annotation properties, making those refs invisible since `MergeJsonContent` removes the `JsonContent` from `$analysis->annotations` (but keeps it as `MediaType->schema`).
- Guard against "Cannot unset string offsets" crash when the component type has already been set to `UNDEFINED`.
- Deduplicate `$_nested` componentType iteration (`Parameter`/`PathParameter` both map to `'parameters'`).
- Updated the performance test so that half the used schemas are only referenced via `JsonContent`, properly exercising the new traversal path.

Fixes #2046

🤖 Generated with [Claude Code](https://claude.com/claude-code)