### PR TITLE
Add CS phpdoc_line_span rule for class/method docblocks

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -98,6 +98,7 @@ return (new PhpCsFixer\Config())
         'phpdoc_no_alias_tag' => true,
         'phpdoc_param_order' => true,
         'multiline_comment_opening_closing' => true,
+        'phpdoc_line_span' => ['class' => 'multi', 'method' => 'multi', 'property' => null, 'const' => null, 'case' => null, 'function' => null],
 
         'php_unit_attributes' => true,
     ])

--- a/docs/snippets/guide/cookbook/enums_an.php
+++ b/docs/snippets/guide/cookbook/enums_an.php
@@ -4,7 +4,9 @@ namespace Openapi\Snippets\Cookbook\Enums;
 
 use OpenApi\Annotations as OA;
 
-/** @OA\Schema() */
+/**
+ * @OA\Schema()
+ */
 enum State
 {
     case OPEN;
@@ -12,7 +14,9 @@ enum State
     case DECLINED;
 }
 
-/** @OA\Schema */
+/**
+ * @OA\Schema
+ */
 class PullRequest
 {
     /** @OA\Property */

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -73,7 +73,9 @@ class Generator
         $this->setNamespaces(self::DEFAULT_NAMESPACES);
     }
 
-    /** @deprecated Use {@see Undefined::isDefault()} instead. */
+    /**
+     * @deprecated use {@see Undefined::isDefault()} instead
+     */
     public static function isDefault(...$value): bool
     {
         return Undefined::isDefault(...$value);

--- a/src/Type/LegacyTypeResolver.php
+++ b/src/Type/LegacyTypeResolver.php
@@ -17,7 +17,9 @@ use OpenApi\Utils\TypeMapper;
  */
 class LegacyTypeResolver extends AbstractTypeResolver
 {
-    /** @inheritdoc */
+    /**
+     * @inheritdoc
+     */
     protected function doAugment(Analysis $analysis, OA\Schema $schema, \Reflector $reflector, string $sourceClass = OA\Schema::class): void
     {
         $docblockDetails = $this->getDocblockTypeDetails($reflector, $schema->_context);

--- a/src/Type/TypeInfoTypeResolver.php
+++ b/src/Type/TypeInfoTypeResolver.php
@@ -37,7 +37,9 @@ use Symfony\Component\TypeInfo\TypeResolver\ReflectionTypeResolver;
 
 class TypeInfoTypeResolver extends AbstractTypeResolver
 {
-    /** @inheritdoc */
+    /**
+     * @inheritdoc
+     */
     protected function doAugment(Analysis $analysis, OA\Schema $schema, \Reflector $reflector, string $sourceClass = OA\Schema::class): void
     {
         $docblockType = $this->getDocblockType($reflector);

--- a/tests/Fixtures/Scratch/ComplexCustomAttributes.php
+++ b/tests/Fixtures/Scratch/ComplexCustomAttributes.php
@@ -66,7 +66,9 @@ class Schema extends OAT\Schema
 )]
 class Collection extends OAT\Property
 {
-    /** @param class-string $of */
+    /**
+     * @param class-string $of
+     */
     public function __construct(
         string $of,
         ?string $description = null
@@ -90,7 +92,9 @@ class Collection extends OAT\Property
 )]
 class Item extends OAT\Property
 {
-    /** @param class-string $of */
+    /**
+     * @param class-string $of
+     */
     public function __construct(
         string $of,
         ?string $description = null
@@ -128,7 +132,9 @@ class Raw extends OAT\Property
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class Successful extends OAT\Response
 {
-    /** @param ?class-string $of */
+    /**
+     * @param ?class-string $of
+     */
     public function __construct(
         ?string $of = null,
     ) {

--- a/tests/Fixtures/Scratch/CustomAttributes.php
+++ b/tests/Fixtures/Scratch/CustomAttributes.php
@@ -28,7 +28,9 @@ class CustomProperty extends OAT\Property
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY | \Attribute::TARGET_PARAMETER | \Attribute::TARGET_CLASS_CONSTANT | \Attribute::IS_REPEATABLE)]
 class CustomItem extends OAT\Property
 {
-    /** @param class-string $of */
+    /**
+     * @param class-string $of
+     */
     public function __construct(
         string $of,
         ?string $description = null
@@ -44,7 +46,9 @@ class CustomItem extends OAT\Property
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY | \Attribute::TARGET_PARAMETER | \Attribute::TARGET_CLASS_CONSTANT | \Attribute::IS_REPEATABLE)]
 class CustomList extends OAT\Property
 {
-    /** @param class-string $of */
+    /**
+     * @param class-string $of
+     */
     public function __construct(string $of, ?string $description = null)
     {
         parent::__construct(


### PR DESCRIPTION
## Summary
- Adds `phpdoc_line_span` CS Fixer rule enforcing multi-line docblocks on class/interface/trait/enum and method declarations
- Explicitly preserves existing style (single or multi) for properties, constants, and other code elements
- Fixes 6 existing violations

## Test plan
- [x] `composer cs` passes cleanly
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)