### PR TITLE
chore: add CLAUDE.md with project tooling and test conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,14 @@
+# Tools
+
+All tools are run via composer:
+
+- `composer lint` — check all code style issues (cs-fixer + rector)
+- `composer cs` / `composer rector` — fix code style issues
+- `composer analyse` — static analysis (phpstan)
+- `composer test` — lint + unit tests; use `./bin/phpunit` directly to run only tests (e.g. `./bin/phpunit --filter ClassName`)
+- `composer redocly` — validate spec fixtures (currently failing, fixtures not yet valid)
+
+# Tests
+
+- Prefer compact tests and data providers over repetition
+- Use shared traits from `tests/Concerns/` for common helpers (e.g. `AssemblesSpecification`)


### PR DESCRIPTION
 ## Summary

  - Adds CLAUDE.md documenting project tooling commands (lint, test, analyse) and test conventions

