### PR TITLE
feat: add Pipeline grouping and PipeInterface

### DIFF
--- a/src/Specification.php
+++ b/src/Specification.php
@@ -99,15 +99,12 @@ class Specification
 
     private function addComponentsChildren(OA\Components $components): void
     {
-        array_push($this->schemas, ...$components->schemas);
-        array_push($this->parameters, ...$components->parameters);
-        array_push($this->responses, ...$components->responses);
-        array_push($this->requestBodies, ...$components->requestBodies);
-        array_push($this->headers, ...$components->headers);
-        array_push($this->securitySchemes, ...$components->securitySchemes);
-        array_push($this->links, ...$components->links);
-        array_push($this->examples, ...$components->examples);
-        array_push($this->pathItems, ...$components->pathItems);
+        foreach ($components->contains() as $slot) {
+            $property = rtrim($slot, '[]');
+            if (property_exists($this, $property) && property_exists($components, $property)) {
+                array_push($this->{$property}, ...$components->{$property});
+            }
+        }
     }
 
     public function getWalker(): SpecificationWalker

--- a/src/Utils/PipeInterface.php
+++ b/src/Utils/PipeInterface.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Utils;
+
+/**
+ * Optional interface for pipeline pipes that support grouping.
+ *
+ * Pipes without this interface are placed in the pipeline's default group.
+ *
+ * @template T
+ */
+interface PipeInterface
+{
+    /**
+     * The group this pipe belongs to.
+     */
+    public function group(): string|\BackedEnum;
+
+    /**
+     * @param T $payload
+     *
+     * @return T|null
+     */
+    public function __invoke(mixed $payload): mixed;
+}

--- a/src/Utils/Pipeline.php
+++ b/src/Utils/Pipeline.php
@@ -7,17 +7,53 @@
 namespace OpenApi\Utils;
 
 use OpenApi\OpenApiException;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
+/**
+ * @template T
+ */
 class Pipeline
 {
     /**
-     * @var array<callable>
+     * @var array<callable(T): (T|null)>
      */
     protected $pipes = [];
 
-    public function __construct(array $pipes = [])
+    /**
+     * @var list<string>|null ordered group keys; null means no grouping (insertion order only)
+     */
+    protected ?array $groups = null;
+
+    protected ?string $defaultGroup = null;
+
+    protected LoggerInterface $logger;
+
+    /**
+     * @param list<string|\BackedEnum>|null $groups       Ordered group names/enums. When set, process() executes pipes in group order.
+     * @param string|\BackedEnum|null       $defaultGroup Group for pipes without PipeInterface. Must be in $groups if groups are set.
+     */
+    public function __construct(array $pipes = [], ?array $groups = null, string|\BackedEnum|null $defaultGroup = null, ?LoggerInterface $logger = null)
     {
         $this->pipes = $pipes;
+        $this->logger = $logger ?? new NullLogger();
+
+        if ($groups !== null) {
+            if ($groups === []) {
+                throw new OpenApiException('Groups must not be empty when provided');
+            }
+
+            $this->groups = array_map(self::groupKey(...), $groups);
+            $defaultKey = $defaultGroup !== null
+                ? self::groupKey($defaultGroup)
+                : null;
+
+            if ($defaultKey !== null && !in_array($defaultKey, $this->groups, true)) {
+                throw new OpenApiException("Default group '{$defaultKey}' must be listed in groups");
+            }
+            $this->defaultGroup = $defaultKey ?? $this->groups[array_key_last($this->groups)];
+        }
     }
 
     public function add(callable $pipe): Pipeline
@@ -25,6 +61,24 @@ class Pipeline
         $this->pipes[] = $pipe;
 
         return $this;
+    }
+
+    /**
+     * @template P
+     *
+     * @param class-string<P> $class
+     *
+     * @return P|null
+     */
+    public function get(string $class): mixed
+    {
+        foreach ($this->pipes as $pipe) {
+            if ($pipe instanceof $class) {
+                return $pipe;
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -96,7 +150,7 @@ class Pipeline
 
     public function walk(callable $walker): Pipeline
     {
-        foreach ($this->pipes as $pipe) {
+        foreach ($this->ordered() as $pipe) {
             $walker($pipe);
         }
 
@@ -104,14 +158,54 @@ class Pipeline
     }
 
     /**
-     * @return mixed
+     * @param T $payload
+     *
+     * @return T
      */
     public function process(mixed $payload)
     {
-        foreach ($this->pipes as $pipe) {
-            $payload = $pipe($payload) ?: $payload;
+        foreach ($this->ordered() as $pipe) {
+            if ($pipe instanceof LoggerAwareInterface) {
+                $pipe->setLogger($this->logger);
+            }
+            $payload = $pipe($payload) ?? $payload;
         }
 
         return $payload;
+    }
+
+    /**
+     * Return pipes in execution order: grouped if groups are configured, otherwise insertion order.
+     *
+     * @return list<callable>
+     */
+    protected function ordered(): array
+    {
+        if ($this->groups === null) {
+            return $this->pipes;
+        }
+
+        $buckets = array_fill_keys($this->groups, []);
+
+        foreach ($this->pipes as $pipe) {
+            $group = $pipe instanceof PipeInterface
+                ? self::groupKey($pipe->group())
+                : $this->defaultGroup;
+
+            if (!isset($buckets[$group])) {
+                throw new OpenApiException("Pipe declares unknown group '{$group}'; valid groups: " . implode(', ', $this->groups));
+            }
+
+            $buckets[$group][] = $pipe;
+        }
+
+        return array_merge(...array_values($buckets));
+    }
+
+    protected static function groupKey(string|\BackedEnum $group): string
+    {
+        return $group instanceof \BackedEnum
+            ? (string) $group->value
+            : $group;
     }
 }

--- a/src/Utils/SpecificationWalker.php
+++ b/src/Utils/SpecificationWalker.php
@@ -243,6 +243,8 @@ class SpecificationWalker
             foreach ($schema->properties as $property) {
                 if ($property instanceof OA\Property && $property->schema instanceof OA\Schema) {
                     $this->walkSchemaTree($property->schema, $schemaVisitor, $refVisitor);
+                } elseif ($property instanceof OA\Schema) {
+                    $this->walkSchemaTree($property, $schemaVisitor, $refVisitor);
                 }
             }
         }

--- a/tests/Utils/PipelineTest.php
+++ b/tests/Utils/PipelineTest.php
@@ -6,29 +6,50 @@
 
 namespace OpenApi\Tests\Utils;
 
-use OpenApi\Tests\OpenApiTestCase;
+use OpenApi\Utils\PipeInterface;
 use OpenApi\Utils\Pipeline;
+use PHPUnit\Framework\TestCase;
 
-final class PipelineTest extends OpenApiTestCase
+final class PipelineTest extends TestCase
 {
-    public function __invoke(string $payload): string
+    protected function pipe(string $add): callable
     {
-        return $payload . 'x';
+        return fn (string $payload): string => $payload . $add;
     }
 
-    protected function pipe(string $add): object
+    protected function namedPipe(string $name): object
     {
-        return new class ($add) {
-            protected string $add;
-
-            public function __construct(string $add)
+        return new class ($name) {
+            public function __construct(public readonly string $name)
             {
-                $this->add = $add;
             }
 
-            public function __invoke(string $payload): string
+            public function __invoke(mixed $payload): mixed
             {
-                return $payload . $this->add;
+                return null;
+            }
+        };
+    }
+
+    protected function groupedPipe(string $group, array &$log): PipeInterface
+    {
+        return new class ($group, $log) implements PipeInterface {
+            public function __construct(
+                protected string $group,
+                protected array &$log,
+            ) {
+            }
+
+            public function group(): string
+            {
+                return $this->group;
+            }
+
+            public function __invoke(mixed $payload): mixed
+            {
+                $this->log[] = $this->group;
+
+                return null;
             }
         };
     }
@@ -36,79 +57,179 @@ final class PipelineTest extends OpenApiTestCase
     public function testProcess(): void
     {
         $pipeline = new Pipeline([$this->pipe('x')]);
-        $result = $pipeline->process('');
 
-        $this->assertEquals('x', $result);
+        $this->assertSame('x', $pipeline->process(''));
     }
 
     public function testAdd(): void
     {
         $pipeline = new Pipeline();
-
         $pipeline->add($this->pipe('a'));
-        $this->assertEquals('a', $pipeline->process(''));
-
         $pipeline->add($this->pipe('b'));
-        $this->assertEquals('ab', $pipeline->process(''));
+
+        $this->assertSame('ab', $pipeline->process(''));
     }
 
-    public function testRemoveStrict(): void
+    public function testRemoveByInstance(): void
     {
-        $pipeline = new Pipeline();
+        $a = $this->pipe('a');
+        $b = $this->pipe('b');
+        $pipeline = new Pipeline([$a, $b]);
 
-        $pipeline->add($pipec = $this->pipe('c'));
-        $pipeline->add($this->pipe('d'));
-        $this->assertEquals('cd', $pipeline->process(''));
+        $pipeline->remove($a);
 
-        $pipeline->remove($pipec);
-        $this->assertEquals('d', $pipeline->process(''));
+        $this->assertSame('b', $pipeline->process(''));
     }
 
-    public function testRemoveMatcher(): void
+    public function testRemoveByMatcher(): void
     {
-        $pipeline = new Pipeline();
+        $keep = $this->namedPipe('keep');
+        $remove = $this->namedPipe('remove');
+        $pipeline = new Pipeline([$keep, $remove]);
 
-        $pipeline->add($pipec = $this->pipe('c'));
-        $pipeline->add($this->pipe('d'));
-        $this->assertEquals('cd', $pipeline->process(''));
+        $pipeline->remove(null, fn ($pipe): bool => $pipe->name !== 'remove');
 
-        $pipeline->remove(null, fn ($pipe): bool => $pipe !== $pipec);
-        $this->assertEquals('d', $pipeline->process(''));
+        $found = [];
+        $pipeline->walk(function ($pipe) use (&$found): void {
+            $found[] = $pipe->name;
+        });
+        $this->assertSame(['keep'], $found);
     }
 
-    public function testRemoveClassString(): void
+    public function testRemoveByClassString(): void
     {
-        $pipeline = new Pipeline();
+        $a = $this->pipe('a');
+        $b = new PipelineTestMarkerPipe('b');
+        $pipeline = new Pipeline([$a, $b]);
 
-        $pipeline->add($this->pipe('c'));
-        $pipeline->add($this);
-        $this->assertEquals('cx', $pipeline->process(''));
+        $pipeline->remove(PipelineTestMarkerPipe::class);
 
-        $pipeline->remove(self::class);
-        $this->assertEquals('c', $pipeline->process(''));
+        $this->assertSame('a', $pipeline->process(''));
     }
 
-    public function testInsertMatcher(): void
+    public function testInsertByClassString(): void
     {
-        $pipeline = new Pipeline();
+        $a = $this->pipe('a');
+        $b = new PipelineTestMarkerPipe('b');
+        $pipeline = new Pipeline([$a, $b]);
 
-        $pipeline->add($this->pipe('x'));
-        $pipeline->add($this->pipe('z'));
-        $this->assertEquals('xz', $pipeline->process(''));
+        $c = $this->pipe('c');
+        $pipeline->insert($c, PipelineTestMarkerPipe::class);
 
-        $pipeline->insert($this->pipe('y'), fn ($pipes): int => 1);
-        $this->assertEquals('xyz', $pipeline->process(''));
+        $this->assertSame('acb', $pipeline->process(''));
     }
 
-    public function testInsertClassString(): void
+    public function testInsertByMatcher(): void
     {
-        $pipeline = new Pipeline();
+        $pipeline = new Pipeline([$this->pipe('a'), $this->pipe('c')]);
 
-        $pipeline->add($this);
-        $pipeline->add($this->pipe('y'));
-        $this->assertEquals('xy', $pipeline->process(''));
+        $pipeline->insert($this->pipe('b'), fn ($pipes): int => 1);
 
-        $pipeline->insert($this->pipe('a'), self::class);
-        $this->assertEquals('axy', $pipeline->process(''));
+        $this->assertSame('abc', $pipeline->process(''));
+    }
+
+    public function testWalk(): void
+    {
+        $a = $this->namedPipe('a');
+        $b = $this->namedPipe('b');
+        $pipeline = new Pipeline([$a, $b]);
+
+        $names = [];
+        $pipeline->walk(function ($pipe) use (&$names): void {
+            $names[] = $pipe->name;
+        });
+
+        $this->assertSame(['a', 'b'], $names);
+    }
+
+    // --- Grouping ---
+
+    public function testGroupOrderOverridesInsertionOrder(): void
+    {
+        $log = [];
+
+        $resolve = $this->groupedPipe('resolve', $log);
+        $augment = $this->groupedPipe('augment', $log);
+
+        $pipeline = new Pipeline(
+            [$augment, $resolve],
+            groups: ['resolve', 'reduce', 'augment'],
+            defaultGroup: 'augment',
+        );
+
+        $pipeline->process('ignored');
+
+        $this->assertSame(['resolve', 'augment'], $log);
+    }
+
+    public function testDefaultGroupForPlainCallables(): void
+    {
+        $log = [];
+
+        $pipeline = new Pipeline(
+            [function ($p) use (&$log): void {
+                $log[] = 'plain';
+            }],
+            groups: ['first', 'default'],
+            defaultGroup: 'default',
+        );
+
+        $pipeline->process('x');
+
+        $this->assertSame(['plain'], $log);
+    }
+
+    public function testEnumGroupsWork(): void
+    {
+        $log = [];
+
+        $pipeline = new Pipeline(
+            [$this->groupedPipe('resolve', $log), $this->groupedPipe('augment', $log)],
+            groups: ['resolve', 'reduce', 'augment'],
+            defaultGroup: 'augment',
+        );
+
+        $result = $pipeline->process('payload');
+
+        $this->assertSame('payload', $result);
+        $this->assertSame(['resolve', 'augment'], $log);
+    }
+
+    // --- get() ---
+
+    public function testGetReturnsMatchingPipe(): void
+    {
+        $a = $this->namedPipe('a');
+        $pipeline = new Pipeline([$a]);
+
+        $this->assertSame($a, $pipeline->get($a::class));
+    }
+
+    public function testGetReturnsNullForMissing(): void
+    {
+        $pipeline = new Pipeline([$this->pipe('x')]);
+
+        $this->assertNotInstanceOf(\stdClass::class, $pipeline->get(\stdClass::class));
+    }
+
+    // --- No groups (BC) ---
+
+    public function testNoGroupsUsesInsertionOrder(): void
+    {
+        $pipeline = new Pipeline([$this->pipe('a'), $this->pipe('b'), $this->pipe('c')]);
+
+        $this->assertSame('abc', $pipeline->process(''));
+    }
+}
+
+class PipelineTestMarkerPipe
+{
+    public function __construct(private readonly string $add)
+    {
+    }
+
+    public function __invoke(string $payload): string
+    {
+        return $payload . $this->add;
     }
 }


### PR DESCRIPTION
## Summary

Enhances the existing `Pipeline` utility with ordered group execution, enabling staged processing pipelines (e.g. resolve → reduce → augment). Adds `PipeInterface` as an optional contract for pipes that declare their group.

Builds on #2054 (merged).

## Design

### Grouped execution

When constructed with a `groups` array, the pipeline executes pipes in group order rather than insertion order. This enables multi-stage processing where pipes from different groups can be registered in any order but always execute in the correct sequence.

```php
$pipeline = new Pipeline(
    [$augmentPipe, $resolvePipe],
    groups: ['resolve', 'reduce', 'augment'],
    defaultGroup: 'augment',
);
// resolvePipe runs first, augmentPipe second — regardless of insertion order
```

### PipeInterface

Optional interface for pipes that declare their group:

```php
interface PipeInterface
{
    public function group(): string|\BackedEnum;
    public function __invoke(mixed $payload): mixed;
}
```

Pipes without `PipeInterface` are placed in the pipeline's default group. Both string and BackedEnum group keys are supported.

### Other additions

- `get(class-string): ?T` — retrieve a pipe by class for typed configuration access
- `LoggerAwareInterface` support — logger injected into pipes during `process()`
- `walk()` now reflects grouped execution order (not insertion order)
- `process()` uses `??` (not `?:`) to preserve falsy return values from pipes

### Backwards compatible

Without groups configured, insertion order is preserved — existing behavior unchanged.