### PR TITLE
feat: add Assembler and AttributeFactory for spec attribute collection

### DIFF
--- a/src/Assembler.php
+++ b/src/Assembler.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi;
+
+use OpenApi\Utils\AttributeFactory;
+
+/**
+ * Collects OpenAPI spec attributes from PHP reflectors and assembles them into a Specification.
+ *
+ * The assembler operates in two passes:
+ *
+ * 1. Stack-resolve (resolveNesting): On each reflector, sibling attributes are merged
+ *    using merge() — e.g., a Schema adjacent to a Property on the same parameter
+ *    fills the Property's $schema slot.
+ *
+ * 2. Hierarchical absorb (resolveHierarchy): Attributes from inner reflectors (properties,
+ *    parameters, constants) flow up into enclosing-level containers using contains() —
+ *    e.g., Property instances from class members are absorbed into the class-level Schema.
+ *
+ * After both passes, only root attributes (isRoot() = true) should remain.
+ */
+class Assembler
+{
+    public function __construct(
+        protected Specification $specification = new Specification(),
+        protected AttributeFactory $factory = new AttributeFactory(),
+    ) {
+    }
+
+    public function getSpecification(): Specification
+    {
+        return $this->specification;
+    }
+
+    public function getFactory(): AttributeFactory
+    {
+        return $this->factory;
+    }
+
+    /**
+     * Collect all OpenAPI attributes from the given reflectors into the specification.
+     */
+    public function collect(\ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant ...$reflectors): static
+    {
+        foreach ($reflectors as $reflector) {
+            $this->collectFromReflector($reflector);
+        }
+
+        return $this;
+    }
+
+    protected function collectFromReflector(\ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector): void
+    {
+        if ($reflector instanceof \ReflectionClass) {
+            $this->collectFromClass($reflector);
+
+            return;
+        }
+
+        foreach ($this->factory->fromReflector($reflector) as $root) {
+            $this->specification->add($root);
+        }
+    }
+
+    /**
+     * Collect attributes from a class: stack-resolve at each structural level,
+     * then hierarchically absorb inner attributes into class-level containers.
+     */
+    protected function collectFromClass(\ReflectionClass $class): void
+    {
+        $outer = $this->factory->fromReflector($class);
+
+        if ($outer !== []) {
+            // Only collect own members when the class has a root attribute (e.g. Schema).
+            // Classes without root attributes (plain parents/traits) are handled later
+            // by ExpandHierarchy which merges their members into the child schema.
+            $inner = $this->factory->membersOf($class);
+            $roots = $this->factory->resolveHierarchy($outer, $inner);
+
+            foreach ($roots as $root) {
+                $this->specification->add($root);
+            }
+        }
+
+        // Methods are always processed — a controller may have operations without
+        // any class-level schema attribute. Properties on methods are handled via
+        // membersOf() (absorbed into class schema) or ExpandHierarchy (non-schema interfaces).
+        foreach ($class->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
+            if ($method->isConstructor() || $method->getDeclaringClass()->getName() !== $class->getName()) {
+                continue;
+            }
+            if ($this->factory->hasOnlyProperties($method)) {
+                continue;
+            }
+            foreach ($this->factory->fromReflector($method) as $root) {
+                $this->specification->add($root);
+            }
+        }
+    }
+}

--- a/src/Spec/ExternalDocumentation.php
+++ b/src/Spec/ExternalDocumentation.php
@@ -31,4 +31,12 @@ class ExternalDocumentation extends AbstractAttribute
     {
         return true;
     }
+
+    public function merge(): array
+    {
+        return [
+            Operation::class => 'externalDocs',
+            Schema::class => 'externalDocs',
+        ];
+    }
 }

--- a/src/Utils/AttributeFactory.php
+++ b/src/Utils/AttributeFactory.php
@@ -1,0 +1,291 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Utils;
+
+use OpenApi\AttributeInterface;
+use OpenApi\OpenApiException;
+use OpenApi\Spec as OA;
+
+/**
+ * Creates spec attribute instances from PHP reflectors.
+ *
+ * Encapsulates: reading PHP attributes, stack-resolving siblings (merge),
+ * and hierarchical absorb (contains). Shared between the Assembler (initial
+ * collection) and augmenter pipes that need to manufacture spec objects
+ * from reflection (e.g. ExpandHierarchy for non-schema ancestor members).
+ */
+class AttributeFactory
+{
+    /**
+     * Read and resolve attributes from a single member reflector.
+     *
+     * For methods, also resolves parameter-level attributes into the method-level ones.
+     *
+     * @return list<AttributeInterface>
+     */
+    public function fromReflector(\ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector): array
+    {
+        if ($reflector instanceof \ReflectionMethod) {
+            $outer = $this->resolveNesting($this->readAttributes($reflector));
+            $inner = [];
+            foreach ($reflector->getParameters() as $parameter) {
+                array_push($inner, ...$this->resolveNesting($this->readAttributes($parameter)));
+            }
+
+            return $this->resolveHierarchy($outer, $inner);
+        }
+
+        return $this->resolveNesting($this->readAttributes($reflector));
+    }
+
+    /**
+     * Read and resolve attributes from a class's own members (properties, constructor params, constants).
+     *
+     * Does NOT include the class-level attributes themselves or methods.
+     * Returns inner attributes suitable for hierarchical absorption into a class-level container.
+     *
+     * @return list<AttributeInterface>
+     */
+    public function membersOf(\ReflectionClass $class): array
+    {
+        $inner = [];
+
+        foreach ($class->getProperties() as $property) {
+            if ($property->isPromoted() || $property->getDeclaringClass()->getName() !== $class->getName()) {
+                continue;
+            }
+            array_push($inner, ...$this->resolveNesting($this->readAttributes($property)));
+        }
+
+        $constructor = $class->getConstructor();
+        if ($constructor) {
+            foreach ($constructor->getParameters() as $parameter) {
+                array_push($inner, ...$this->resolveNesting($this->readAttributes($parameter)));
+            }
+        }
+
+        foreach ($class->getReflectionConstants() as $constant) {
+            if ($constant->getDeclaringClass()->getName() !== $class->getName()) {
+                continue;
+            }
+            array_push($inner, ...$this->resolveNesting($this->readAttributes($constant)));
+        }
+
+        foreach ($class->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
+            if ($method->isConstructor() || $method->getDeclaringClass()->getName() !== $class->getName()) {
+                continue;
+            }
+            $resolved = $this->resolveNesting($this->readAttributes($method));
+            foreach ($resolved as $attribute) {
+                if ($attribute instanceof OA\Property) {
+                    $inner[] = $attribute;
+                }
+            }
+        }
+
+        return $inner;
+    }
+
+    /**
+     * Check whether a reflector has any OpenAPI attributes.
+     */
+    public function hasAttributes(\ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector): bool
+    {
+        return $reflector->getAttributes(AttributeInterface::class, \ReflectionAttribute::IS_INSTANCEOF) !== [];
+    }
+
+    /**
+     * Check whether a method only produces Property attributes (no operations).
+     */
+    public function hasOnlyProperties(\ReflectionMethod $method): bool
+    {
+        $reflectionAttributes = $method->getAttributes(AttributeInterface::class, \ReflectionAttribute::IS_INSTANCEOF);
+        if ($reflectionAttributes === []) {
+            return false;
+        }
+
+        foreach ($reflectionAttributes as $reflectionAttribute) {
+            $name = $reflectionAttribute->getName();
+            if (!is_a($name, OA\Property::class, true) && !is_a($name, OA\Schema::class, true)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Stack-resolve: merge sibling attributes on the same reflector using merge().
+     *
+     * @param  list<AttributeInterface> $attributes
+     * @return list<AttributeInterface>
+     */
+    protected function resolveNesting(array $attributes): array
+    {
+        if (count($attributes) <= 1) {
+            return $attributes;
+        }
+
+        $merged = [];
+
+        foreach ($attributes as $index => $attribute) {
+            $mergeTargets = $attribute->merge();
+
+            if ($mergeTargets === []) {
+                continue;
+            }
+
+            $matchingTarget = null;
+            $matchingSlot = null;
+            foreach ($attributes as $candidateIndex => $candidate) {
+                if ($candidateIndex === $index || isset($merged[$candidateIndex])) {
+                    continue;
+                }
+
+                foreach ($mergeTargets as $targetClass => $slot) {
+                    if ($candidate instanceof $targetClass) {
+                        if ($matchingTarget instanceof AttributeInterface) {
+                            throw OpenApiException::fromSource(
+                                sprintf('Ambiguous merge: %s matches multiple siblings on the same target', $attribute::class),
+                                $attribute->getSourceLocation(),
+                            );
+                        }
+                        $matchingTarget = $candidate;
+                        $matchingSlot = $slot;
+                    }
+                }
+            }
+
+            if ($matchingTarget instanceof AttributeInterface) {
+                $this->nestChild($matchingTarget, $attribute, $matchingSlot);
+                $merged[$index] = true;
+            }
+        }
+
+        $roots = [];
+        foreach ($attributes as $index => $attribute) {
+            if (!isset($merged[$index])) {
+                $roots[] = $attribute;
+            }
+        }
+
+        return $roots;
+    }
+
+    /**
+     * Hierarchical absorb: outer-level attributes absorb inner-level attributes using contains().
+     *
+     * @param  list<AttributeInterface> $outer
+     * @param  list<AttributeInterface> $inner
+     * @return list<AttributeInterface>
+     */
+    public function resolveHierarchy(array $outer, array $inner): array
+    {
+        foreach ($inner as $innerAttribute) {
+            $matchingContainer = null;
+            $matchingSlot = null;
+
+            foreach ($outer as $outerAttribute) {
+                $containsTypes = $outerAttribute->contains();
+                if ($containsTypes === []) {
+                    continue;
+                }
+
+                foreach ($containsTypes as $childClass => $slot) {
+                    if ($innerAttribute instanceof $childClass) {
+                        if ($matchingContainer instanceof AttributeInterface) {
+                            throw OpenApiException::fromSource(
+                                sprintf(
+                                    'Ambiguous hierarchy: %s matches multiple containers (%s and %s)',
+                                    $innerAttribute::class,
+                                    $matchingContainer::class,
+                                    $outerAttribute::class,
+                                ),
+                                $innerAttribute->getSourceLocation(),
+                            );
+                        }
+                        $matchingContainer = $outerAttribute;
+                        $matchingSlot = $slot;
+                        break;
+                    }
+                }
+            }
+
+            if ($matchingContainer === null) {
+                throw OpenApiException::fromSource(
+                    sprintf('Orphan attribute: %s has no valid container at enclosing level', $innerAttribute::class),
+                    $innerAttribute->getSourceLocation(),
+                );
+            }
+
+            $this->nestChild($matchingContainer, $innerAttribute, $matchingSlot);
+        }
+
+        foreach ($outer as $attribute) {
+            if (!$attribute->isRoot()) {
+                throw OpenApiException::fromSource(
+                    sprintf('Non-root attribute %s remains after resolution — it should have been absorbed by a container', $attribute::class),
+                    $attribute->getSourceLocation(),
+                );
+            }
+        }
+
+        return $outer;
+    }
+
+    protected function nestChild(AttributeInterface $parent, AttributeInterface $child, string $slot): void
+    {
+        if (str_ends_with($slot, '[]')) {
+            $property = substr($slot, 0, -2);
+            $current = $parent->{$property} ?? [];
+            $current[] = $child;
+            $parent->{$property} = $current;
+        } else {
+            if ($parent->{$slot} instanceof AttributeInterface) {
+                throw OpenApiException::fromSource(
+                    sprintf('Duplicate merge: %s already has a %s in slot "%s"', $parent::class, $parent->{$slot}::class, $slot),
+                    $child->getSourceLocation(),
+                );
+            }
+            $parent->{$slot} = $child;
+        }
+    }
+
+    /**
+     * @return list<AttributeInterface>
+     */
+    protected function readAttributes(\ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector): array
+    {
+        $attributes = $reflector->getAttributes(
+            AttributeInterface::class,
+            \ReflectionAttribute::IS_INSTANCEOF,
+        );
+
+        $result = [];
+        foreach ($attributes as $attribute) {
+            if (!class_exists($attribute->getName())) {
+                continue;
+            }
+
+            try {
+                $instance = $attribute->newInstance();
+            } catch (\Error $e) {
+                throw OpenApiException::fromSource(
+                    sprintf('Failed to instantiate attribute "%s": %s', $attribute->getName(), $e->getMessage()),
+                    SourceLocation::fromReflector($reflector),
+                    $e,
+                );
+            }
+
+            $instance->setReflector($reflector);
+
+            $result[] = $instance;
+        }
+
+        return $result;
+    }
+}

--- a/src/Utils/SpecificationWalker.php
+++ b/src/Utils/SpecificationWalker.php
@@ -243,6 +243,8 @@ class SpecificationWalker
             foreach ($schema->properties as $property) {
                 if ($property instanceof OA\Property && $property->schema instanceof OA\Schema) {
                     $this->walkSchemaTree($property->schema, $schemaVisitor, $refVisitor);
+                } elseif ($property instanceof OA\Schema) {
+                    $this->walkSchemaTree($property, $schemaVisitor, $refVisitor);
                 }
             }
         }

--- a/tests/AssemblerTest.php
+++ b/tests/AssemblerTest.php
@@ -1,0 +1,93 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests;
+
+use OpenApi\Assembler;
+use OpenApi\OpenApiException;
+use PHPUnit\Framework\TestCase;
+
+final class AssemblerTest extends TestCase
+{
+    public function testHierarchyPropertyAbsorbedBySchema(): void
+    {
+        $assembler = new Assembler();
+        $assembler->collect(new \ReflectionClass(Fixtures\Assembler\SimpleProduct::class));
+
+        $spec = $assembler->getSpecification();
+        $this->assertCount(1, $spec->schemas);
+        $this->assertEquals('SimpleProduct', $spec->schemas[0]->schema);
+        $this->assertNotNull($spec->schemas[0]->properties);
+        $this->assertCount(2, $spec->schemas[0]->properties);
+    }
+
+    public function testHierarchyPromotedPropertyAbsorbedBySchema(): void
+    {
+        $assembler = new Assembler();
+        $assembler->collect(new \ReflectionClass(Fixtures\Assembler\PromotedProduct::class));
+
+        $spec = $assembler->getSpecification();
+        $this->assertCount(1, $spec->schemas);
+        $this->assertNotNull($spec->schemas[0]->properties);
+        $this->assertCount(2, $spec->schemas[0]->properties);
+
+        $names = array_map(fn ($p) => $p->property, $spec->schemas[0]->properties);
+        $this->assertContains('quantity', $names);
+        $this->assertContains('brand', $names);
+    }
+
+    public function testHierarchyMethodParametersAbsorbedByOperation(): void
+    {
+        $assembler = new Assembler();
+        $assembler->collect(new \ReflectionClass(Fixtures\Assembler\SimpleController::class));
+
+        $spec = $assembler->getSpecification();
+        $this->assertCount(1, $spec->operations);
+        $this->assertEquals('/products/{product_id}', $spec->operations[0]->path);
+        $this->assertNotNull($spec->operations[0]->parameters);
+        $this->assertCount(1, $spec->operations[0]->parameters);
+        $this->assertEquals('product_id', $spec->operations[0]->parameters[0]->name);
+    }
+
+    public function testClassWithoutRootAttributeSkipped(): void
+    {
+        $assembler = new Assembler();
+        $assembler->collect(new \ReflectionClass(Fixtures\Assembler\OrphanProperty::class));
+
+        $spec = $assembler->getSpecification();
+        $this->assertCount(0, $spec->schemas);
+    }
+
+    public function testClassConstantAbsorbedBySchema(): void
+    {
+        $assembler = new Assembler();
+        $assembler->collect(new \ReflectionClass(Fixtures\Assembler\WithConstant::class));
+
+        $spec = $assembler->getSpecification();
+        $this->assertCount(1, $spec->schemas);
+        $this->assertNotNull($spec->schemas[0]->properties);
+        $this->assertCount(1, $spec->schemas[0]->properties);
+        $this->assertEquals('kind', $spec->schemas[0]->properties[0]->property);
+    }
+
+    public function testParameterOnClassWithoutPathItemThrows(): void
+    {
+        $this->expectException(OpenApiException::class);
+        $this->expectExceptionMessageMatches('/Non-root attribute.*Parameter.*remains after resolution/');
+
+        $assembler = new Assembler();
+        $assembler->collect(new \ReflectionClass(Fixtures\Assembler\OrphanParameter::class));
+    }
+
+    public function testSecurityRequirementOnClassWithoutPathItemThrows(): void
+    {
+        $this->expectException(OpenApiException::class);
+        $this->expectExceptionMessageMatches('/Non-root attribute.*Requirement.*remains after resolution/');
+
+        $assembler = new Assembler();
+        $assembler->collect(new \ReflectionClass(Fixtures\Assembler\OrphanSecurity::class));
+    }
+}

--- a/tests/Fixtures/Assembler/AmbiguousMerge.php
+++ b/tests/Fixtures/Assembler/AmbiguousMerge.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Assembler;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema(schema: 'AmbiguousMerge')]
+class AmbiguousMerge
+{
+    #[OA\Schema(description: 'ambiguous')]
+    #[OA\Property(property: 'first')]
+    #[OA\Property(property: 'second')]
+    public string $value;
+}

--- a/tests/Fixtures/Assembler/OrphanParameter.php
+++ b/tests/Fixtures/Assembler/OrphanParameter.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Assembler;
+
+use OpenApi\Spec as OA;
+
+#[OA\Parameter\Path(name: 'id', schema: new OA\Schema(type: 'integer'))]
+class OrphanParameter
+{
+    #[OA\Operation\Get(path: '/orphan')]
+    #[OA\Response(response: 200, description: 'OK')]
+    public function index()
+    {
+    }
+}

--- a/tests/Fixtures/Assembler/OrphanProperty.php
+++ b/tests/Fixtures/Assembler/OrphanProperty.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Assembler;
+
+use OpenApi\Spec as OA;
+
+class OrphanProperty
+{
+    #[OA\Property(property: 'orphan')]
+    public string $orphan;
+}

--- a/tests/Fixtures/Assembler/OrphanSecurity.php
+++ b/tests/Fixtures/Assembler/OrphanSecurity.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Assembler;
+
+use OpenApi\Spec as OA;
+
+#[OA\Security\Requirement(scheme: 'bearerAuth')]
+class OrphanSecurity
+{
+    #[OA\Operation\Get(path: '/orphan')]
+    #[OA\Response(response: 200, description: 'OK')]
+    public function index()
+    {
+    }
+}

--- a/tests/Fixtures/Assembler/PromotedProduct.php
+++ b/tests/Fixtures/Assembler/PromotedProduct.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Assembler;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema(schema: 'PromotedProduct')]
+class PromotedProduct
+{
+    public function __construct(
+        #[OA\Property(property: 'quantity')]
+        public int $quantity,
+        #[OA\Property(property: 'brand')]
+        #[OA\Schema(example: 'Acme')]
+        public ?string $brand,
+    ) {
+    }
+}

--- a/tests/Fixtures/Assembler/SimpleController.php
+++ b/tests/Fixtures/Assembler/SimpleController.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Assembler;
+
+use OpenApi\Spec as OA;
+
+class SimpleController
+{
+    #[OA\Operation(path: '/products/{product_id}', method: 'get')]
+    #[OA\Response(response: 200, description: 'OK')]
+    public function getProduct(
+        #[OA\Parameter(name: 'product_id', in: 'path', required: true)]
+        #[OA\Schema(format: 'int64')]
+        ?int $product_id,
+    ) {
+    }
+}

--- a/tests/Fixtures/Assembler/SimpleProduct.php
+++ b/tests/Fixtures/Assembler/SimpleProduct.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Assembler;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema(schema: 'SimpleProduct')]
+class SimpleProduct
+{
+    #[OA\Property(property: 'name')]
+    #[OA\Schema(description: 'The name.')]
+    public string $name;
+
+    #[OA\Property(property: 'price')]
+    #[OA\Schema(type: 'number', format: 'float')]
+    public float $price;
+}

--- a/tests/Fixtures/Assembler/WithConstant.php
+++ b/tests/Fixtures/Assembler/WithConstant.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Assembler;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema(schema: 'WithConstant')]
+class WithConstant
+{
+    #[OA\Property(property: 'kind')]
+    public const KIND = 'Virtual';
+}

--- a/tests/Utils/AttributeFactoryTest.php
+++ b/tests/Utils/AttributeFactoryTest.php
@@ -1,0 +1,96 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Utils;
+
+use OpenApi\AttributeInterface;
+use OpenApi\OpenApiException;
+use OpenApi\Spec as OA;
+use OpenApi\Tests\Fixtures\Assembler\AmbiguousMerge;
+use OpenApi\Tests\Fixtures\Assembler\SimpleController;
+use OpenApi\Tests\Fixtures\Assembler\SimpleProduct;
+use OpenApi\Utils\AttributeFactory;
+use PHPUnit\Framework\TestCase;
+
+final class AttributeFactoryTest extends TestCase
+{
+    public function testFromReflectorProperty(): void
+    {
+        $factory = new AttributeFactory();
+        $result = $factory->fromReflector(new \ReflectionProperty(SimpleProduct::class, 'name'));
+
+        $this->assertCount(1, $result);
+        $this->assertInstanceOf(OA\Property::class, $result[0]);
+        $this->assertSame('name', $result[0]->property);
+        $this->assertInstanceOf(OA\Schema::class, $result[0]->schema);
+        $this->assertSame('The name.', $result[0]->schema->description);
+    }
+
+    public function testFromReflectorParameter(): void
+    {
+        $factory = new AttributeFactory();
+        $result = $factory->fromReflector(new \ReflectionParameter(
+            [SimpleController::class, 'getProduct'],
+            'product_id',
+        ));
+
+        $this->assertCount(1, $result);
+        $this->assertInstanceOf(OA\Parameter::class, $result[0]);
+        $this->assertSame('product_id', $result[0]->name);
+        $this->assertInstanceOf(OA\Schema::class, $result[0]->schema);
+        $this->assertSame('int64', $result[0]->schema->format);
+    }
+
+    public function testFromReflectorAmbiguousMergeThrows(): void
+    {
+        $this->expectException(OpenApiException::class);
+        $this->expectExceptionMessageMatches('/Ambiguous merge/');
+
+        $factory = new AttributeFactory();
+        $factory->fromReflector(new \ReflectionProperty(AmbiguousMerge::class, 'value'));
+    }
+
+    public function testMembersOfCollectsOwnProperties(): void
+    {
+        $factory = new AttributeFactory();
+        $members = $factory->membersOf(new \ReflectionClass(SimpleProduct::class));
+
+        $propertyNames = array_map(
+            fn (AttributeInterface $attr): ?string => $attr instanceof OA\Property ? $attr->property : null,
+            $members,
+        );
+
+        $this->assertContains('name', $propertyNames);
+    }
+
+    public function testHasAttributesTrue(): void
+    {
+        $factory = new AttributeFactory();
+
+        $this->assertTrue($factory->hasAttributes(new \ReflectionClass(SimpleProduct::class)));
+    }
+
+    public function testHasAttributesFalse(): void
+    {
+        $factory = new AttributeFactory();
+
+        $this->assertFalse($factory->hasAttributes(new \ReflectionClass(\stdClass::class)));
+    }
+
+    public function testResolveHierarchyAbsorbsChildren(): void
+    {
+        $factory = new AttributeFactory();
+
+        $outer = $factory->fromReflector(new \ReflectionClass(SimpleProduct::class));
+        $inner = $factory->membersOf(new \ReflectionClass(SimpleProduct::class));
+
+        $roots = $factory->resolveHierarchy($outer, $inner);
+
+        $this->assertCount(1, $roots);
+        $this->assertInstanceOf(OA\Schema::class, $roots[0]);
+        $this->assertNotEmpty($roots[0]->properties);
+    }
+}


### PR DESCRIPTION
## Summary

Introduces the assembly stage of the spec pipeline — the step that scans PHP classes and collects spec attributes into a `Specification` container.

```
Source files → ReflectionClass → Assembler → Specification
```

Builds on #2054 (merged).

## Design

### Two-pass assembly

The Assembler runs two distinct passes per class:

1. **Sibling merge** — attributes on the same reflector compose via `merge()` maps. E.g., `Schema` merges into `Property` filling its `$schema` slot.
2. **Hierarchy resolution** — attributes from inner reflectors (properties, methods, parameters, constants) flow up into enclosing-level attributes via `contains()` maps. E.g., `Operation` on a method absorbs `Parameter` from its parameters; `Schema` on a class absorbs `Property` from its members.

After both passes, only root attributes remain and are added to the `Specification`. Non-root attributes that survive resolution trigger an error (orphan detection).

### AttributeFactory

Extracted helper that encapsulates:
- Reading PHP 8.1+ attributes from reflectors
- Sibling composition via `merge()` slot maps (same-reflector nesting)
- Hierarchical absorption via `contains()` slot maps (inner → outer)

Shared between the Assembler and future augmenter pipes that need to manufacture spec objects from reflection (e.g. `ExpandHierarchy` for non-schema ancestor members).

### Slot semantics

The `merge()` and `contains()` maps return `[TargetClass => 'slotName']`:
- `'parameters[]'` — collection append
- `'requestBody'` — scalar assignment

This eliminates the implicit `$_nested` arrays and reflection-heavy nesting logic from the classic pipeline.

### Orphan detection

After hierarchy resolution, any remaining non-root attribute is an error — e.g. a `Parameter` on a class without a `PathItem` or `Operation` to absorb it. The Assembler throws `OpenApiException` with source location context.