### PR TITLE
feat: add version-specific OpenAPI compilers

### DIFF
--- a/src/Compiler/OpenApi30Compiler.php
+++ b/src/Compiler/OpenApi30Compiler.php
@@ -1,0 +1,267 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Compiler;
+
+use OpenApi\Spec as OA;
+use OpenApi\Specification;
+use OpenApi\Undefined;
+
+/**
+ * Compiles a Specification into an OpenAPI 3.0.x document array.
+ *
+ * Extends the 3.1 compiler and overrides version-specific methods:
+ * - JSON Schema draft-04 subset: type is always a string (not array)
+ * - nullable is a separate boolean keyword
+ * - exclusiveMinimum/Maximum are booleans (used alongside minimum/maximum)
+ * - No $ref siblings (summary/description stripped from $ref objects)
+ * - No webhooks
+ * - No const, no examples array on Schema (only singular example)
+ * - No prefixItems, unevaluatedItems, unevaluatedProperties
+ * - No if/then/else
+ * - No contentMediaType/contentEncoding on Schema
+ * - No dependentRequired/dependentSchemas
+ * - No propertyNames, contains, minContains, maxContains
+ * - License: no identifier field (only url)
+ */
+class OpenApi30Compiler extends OpenApi31Compiler
+{
+    protected const VERSIONS = ['3.0.0', '3.0.1', '3.0.2', '3.0.3', '3.0.4'];
+
+    public function getVersion(): string
+    {
+        return '3.0.0';
+    }
+
+    public function validate(Specification $specification): array
+    {
+        $diagnostics = parent::validate($specification);
+
+        $hasPaths = (bool) array_filter($specification->operations, fn (OA\Operation $op): bool => $op->path !== null);
+        if (!$hasPaths) {
+            $diagnostics[] = ['level' => 'warning', 'message' => 'paths is required in OpenAPI 3.0'];
+        }
+
+        $hasWebhooks = (bool) array_filter($specification->operations, fn (OA\Operation $op): bool => $op->webhook !== null);
+        if ($hasWebhooks) {
+            $diagnostics[] = ['level' => 'warning', 'message' => 'webhooks are not supported in OpenAPI 3.0 and will be omitted'];
+        }
+
+        if ($specification->info?->license instanceof OA\License) {
+            $license = $specification->info->license;
+            if ($license->identifier !== null) {
+                $diagnostics[] = ['level' => 'warning', 'message' => 'License identifier is not supported in OpenAPI 3.0, use url instead'];
+            }
+        }
+
+        $this->validateSchemas($specification, $diagnostics);
+
+        return $diagnostics;
+    }
+
+    protected function compileWebhooks(array $operations): array
+    {
+        return [];
+    }
+
+    protected function compileInfo(OA\Info $info): array
+    {
+        return $this->filter([
+            'title' => $info->title,
+            'description' => $info->description,
+            'termsOfService' => $info->termsOfService,
+            'contact' => $info->contact instanceof OA\Contact ? $this->compileContact($info->contact) : null,
+            'license' => $info->license instanceof OA\License ? $this->compileLicense($info->license) : null,
+            'version' => $info->version,
+        ], $info);
+    }
+
+    protected function compileLicense(OA\License $license): array
+    {
+        return $this->filter([
+            'name' => $license->name,
+            'url' => $license->url,
+        ], $license);
+    }
+
+    /**
+     * Compile schema using OAS 3.0 / JSON Schema draft-04 semantics.
+     */
+    protected function compileSchema(OA\Schema|string $schema): array
+    {
+        if (is_string($schema)) {
+            return ['$ref' => $schema];
+        }
+
+        if ($schema->ref !== null) {
+            return ['$ref' => $schema->ref];
+        }
+
+        $type = $schema->type;
+        if (is_array($type)) {
+            $type = array_values(array_filter($type, fn (string $t): bool => $t !== 'null'));
+            $type = count($type) === 1 ? $type[0] : ($type[0] ?? null);
+        }
+
+        $nullable = $schema->nullable;
+        if ($nullable === null && $schema->type !== null) {
+            $typeArray = (array) $schema->type;
+            if (in_array('null', $typeArray, true)) {
+                $nullable = true;
+            }
+        }
+
+        $exclusiveMinimum = null;
+        $exclusiveMaximum = null;
+        $minimum = $schema->minimum;
+        $maximum = $schema->maximum;
+
+        if ($schema->exclusiveMinimum !== null) {
+            if (is_bool($schema->exclusiveMinimum)) {
+                $exclusiveMinimum = $schema->exclusiveMinimum ?: null;
+            } else {
+                $minimum = $schema->exclusiveMinimum;
+                $exclusiveMinimum = true;
+            }
+        }
+
+        if ($schema->exclusiveMaximum !== null) {
+            if (is_bool($schema->exclusiveMaximum)) {
+                $exclusiveMaximum = $schema->exclusiveMaximum ?: null;
+            } else {
+                $maximum = $schema->exclusiveMaximum;
+                $exclusiveMaximum = true;
+            }
+        }
+
+        $result = $this->filter([
+            'type' => $type,
+            'format' => $schema->format,
+            'title' => $schema->title,
+            'description' => $schema->description,
+            'nullable' => $nullable,
+            'enum' => $schema->enum,
+
+            // String
+            'minLength' => $schema->minLength,
+            'maxLength' => $schema->maxLength,
+            'pattern' => $schema->pattern,
+
+            // Numeric
+            'minimum' => $minimum,
+            'maximum' => $maximum,
+            'exclusiveMinimum' => $exclusiveMinimum,
+            'exclusiveMaximum' => $exclusiveMaximum,
+            'multipleOf' => $schema->multipleOf,
+
+            // Array
+            'items' => $schema->items !== null ? $this->compileSchema($schema->items) : null,
+            'minItems' => $schema->minItems,
+            'maxItems' => $schema->maxItems,
+            'uniqueItems' => $schema->uniqueItems,
+
+            // Object
+            'properties' => $schema->properties !== null ? $this->compileProperties($schema->properties) : null,
+            'required' => $schema->required,
+            'additionalProperties' => $schema->additionalProperties !== null ? (is_bool($schema->additionalProperties) ? $schema->additionalProperties : $this->compileSchema($schema->additionalProperties)) : null,
+            'minProperties' => $schema->minProperties,
+            'maxProperties' => $schema->maxProperties,
+
+            // Composition
+            'allOf' => $schema->allOf !== null ? array_map($this->compileSchema(...), $schema->allOf) : null,
+            'anyOf' => $schema->anyOf !== null ? array_map($this->compileSchema(...), $schema->anyOf) : null,
+            'oneOf' => $schema->oneOf !== null ? array_map($this->compileSchema(...), $schema->oneOf) : null,
+            'not' => $schema->not instanceof OA\Schema ? $this->compileSchema($schema->not) : null,
+
+            // Meta
+            'deprecated' => $schema->deprecated,
+            'readOnly' => $schema->readOnly,
+            'writeOnly' => $schema->writeOnly,
+
+            // OpenAPI extensions on schema
+            'discriminator' => $schema->discriminator instanceof OA\Discriminator ? $this->compileDiscriminator($schema->discriminator) : null,
+            'externalDocs' => $schema->externalDocs instanceof OA\ExternalDocumentation ? $this->compileExternalDocs($schema->externalDocs) : null,
+            'xml' => $schema->xml instanceof OA\Xml ? $this->compileXml($schema->xml) : null,
+        ], $schema);
+
+        if ($schema->default !== Undefined::UNDEFINED) {
+            $result['default'] = $schema->default;
+        }
+        if ($schema->example !== Undefined::UNDEFINED) {
+            $result['example'] = $schema->example;
+        } elseif ($schema->examples !== null && $schema->examples !== []) {
+            $result['example'] = $schema->examples[0];
+        }
+        // const is not supported in 3.0 — fall back to enum
+        if ($schema->const !== Undefined::UNDEFINED && !isset($result['enum'])) {
+            $result['enum'] = [$schema->const];
+        }
+
+        return $result;
+    }
+
+    protected function validateSchemas(Specification $specification, array &$diagnostics): void
+    {
+        $allSchemas = $this->collectSchemas($specification);
+
+        foreach ($allSchemas as $schema) {
+            $type = $schema->type;
+            if (is_array($type)) {
+                $type = array_filter($type, fn (string $t): bool => $t !== 'null');
+                $type = reset($type) ?: null;
+            }
+
+            if ($type === 'array' && $schema->items === null) {
+                $diagnostics[] = [
+                    'level' => 'warning',
+                    'message' => 'Schema' . ($schema->schema ? " \"$schema->schema\"" : '') . ' has type "array" but no items',
+                ];
+            }
+
+            if ($schema->prefixItems !== null) {
+                $diagnostics[] = [
+                    'level' => 'warning',
+                    'message' => 'Schema' . ($schema->schema ? " \"$schema->schema\"" : '') . ': prefixItems is not supported in OpenAPI 3.0',
+                ];
+            }
+
+            if ($schema->unevaluatedProperties !== null) {
+                $diagnostics[] = [
+                    'level' => 'warning',
+                    'message' => 'Schema' . ($schema->schema ? " \"$schema->schema\"" : '') . ': unevaluatedProperties is not supported in OpenAPI 3.0',
+                ];
+            }
+
+            if ($schema->unevaluatedItems !== null) {
+                $diagnostics[] = [
+                    'level' => 'warning',
+                    'message' => 'Schema' . ($schema->schema ? " \"$schema->schema\"" : '') . ': unevaluatedItems is not supported in OpenAPI 3.0',
+                ];
+            }
+
+            if ($schema->if instanceof OA\Schema || $schema->then instanceof OA\Schema || $schema->else instanceof OA\Schema) {
+                $diagnostics[] = [
+                    'level' => 'warning',
+                    'message' => 'Schema' . ($schema->schema ? " \"$schema->schema\"" : '') . ': if/then/else is not supported in OpenAPI 3.0',
+                ];
+            }
+
+            if ($schema->const !== Undefined::UNDEFINED) {
+                $diagnostics[] = [
+                    'level' => 'warning',
+                    'message' => 'Schema' . ($schema->schema ? " \"$schema->schema\"" : '') . ': const is not supported in OpenAPI 3.0, using enum fallback',
+                ];
+            }
+
+            if ($schema->examples !== null) {
+                $diagnostics[] = [
+                    'level' => 'warning',
+                    'message' => 'Schema' . ($schema->schema ? " \"$schema->schema\"" : '') . ': examples array is not supported in OpenAPI 3.0, using first value as example',
+                ];
+            }
+        }
+    }
+}

--- a/src/Compiler/OpenApi31Compiler.php
+++ b/src/Compiler/OpenApi31Compiler.php
@@ -1,0 +1,843 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Compiler;
+
+use OpenApi\CompilerInterface;
+use OpenApi\Spec as OA;
+use OpenApi\Specification;
+use OpenApi\Undefined;
+
+/**
+ * Compiles a Specification into an OpenAPI 3.1.x document array.
+ */
+class OpenApi31Compiler implements CompilerInterface
+{
+    protected const VERSIONS = ['3.1.0', '3.1.1', '3.1.2'];
+
+    public function getVersion(): string
+    {
+        return '3.1.0';
+    }
+
+    public function supports(string $version): bool
+    {
+        return in_array($version, static::VERSIONS, true);
+    }
+
+    public function validate(Specification $specification): array
+    {
+        $diagnostics = [];
+
+        if (!$specification->info instanceof OA\Info) {
+            $diagnostics[] = ['level' => 'error', 'message' => 'info is required'];
+        } elseif ($specification->info->title === null) {
+            $diagnostics[] = ['level' => 'error', 'message' => 'info.title is required'];
+        }
+
+        $hasPaths = (bool) array_filter($specification->operations, fn (OA\Operation $op): bool => $op->path !== null);
+        $hasWebhooks = (bool) array_filter($specification->operations, fn (OA\Operation $op): bool => $op->webhook !== null);
+        $hasComponents = $specification->schemas || $specification->responses
+            || $specification->parameters || $specification->requestBodies
+            || $specification->headers || $specification->securitySchemes
+            || $specification->links || $specification->examples;
+
+        if (!$hasPaths && !$hasWebhooks && !$hasComponents) {
+            $diagnostics[] = ['level' => 'warning', 'message' => 'At least one of paths, webhooks, or components is required'];
+        }
+
+        if ($specification->info?->license instanceof OA\License) {
+            $license = $specification->info->license;
+            if ($license->url !== null && $license->identifier !== null) {
+                $diagnostics[] = ['level' => 'warning', 'message' => 'License url and identifier are mutually exclusive'];
+            }
+        }
+
+        $this->validateSchemas($specification, $diagnostics);
+
+        return $diagnostics;
+    }
+
+    public function compile(Specification $specification): array
+    {
+        $output = ['openapi' => $specification->openapi->version ?? $this->getVersion()];
+
+        if ($specification->info instanceof OA\Info) {
+            $output['info'] = $this->compileInfo($specification->info);
+        }
+
+        if ($specification->servers) {
+            $output['servers'] = array_map($this->compileServer(...), $specification->servers);
+        }
+
+        $paths = $this->compilePaths($specification->operations, $specification->pathItems);
+        if ($paths !== []) {
+            $output['paths'] = $paths;
+        }
+
+        $webhooks = $this->compileWebhooks($specification->operations);
+        if ($webhooks !== []) {
+            $output['webhooks'] = $webhooks;
+        }
+
+        if ($specification->tags) {
+            $output['tags'] = array_map($this->compileTag(...), $specification->tags);
+        }
+
+        if ($specification->openapi->security) {
+            $output['security'] = $this->compileSecurity($specification->openapi->security);
+        }
+
+        if ($specification->externalDocs) {
+            $output['externalDocs'] = $this->compileExternalDocs($specification->externalDocs[0]);
+        }
+
+        $components = $this->compileComponents($specification);
+        if ($components !== []) {
+            $output['components'] = $components;
+        }
+
+        return $output;
+    }
+
+    protected function compileInfo(OA\Info $info): array
+    {
+        return $this->filter([
+            'title' => $info->title,
+            'description' => $info->description,
+            'termsOfService' => $info->termsOfService,
+            'contact' => $info->contact instanceof OA\Contact ? $this->compileContact($info->contact) : null,
+            'license' => $info->license instanceof OA\License ? $this->compileLicense($info->license) : null,
+            'summary' => $info->summary,
+            'version' => $info->version,
+        ], $info);
+    }
+
+    protected function compileContact(OA\Contact $contact): array
+    {
+        return $this->filter([
+            'name' => $contact->name,
+            'url' => $contact->url,
+            'email' => $contact->email,
+        ], $contact);
+    }
+
+    protected function compileLicense(OA\License $license): array
+    {
+        return $this->filter([
+            'name' => $license->name,
+            'identifier' => $license->identifier,
+            'url' => $license->url,
+        ], $license);
+    }
+
+    protected function compileServer(OA\Server $server): array
+    {
+        $variables = null;
+        if ($server->variables) {
+            $variables = [];
+            foreach ($server->variables as $variable) {
+                if ($variable->serverVariable !== null) {
+                    $variables[$variable->serverVariable] = $this->compileServerVariable($variable);
+                }
+            }
+            $variables = $variables ?: null;
+        }
+
+        return $this->filter([
+            'url' => $server->url,
+            'description' => $server->description,
+            'variables' => $variables,
+        ], $server);
+    }
+
+    protected function compileServerVariable(OA\ServerVariable $variable): array
+    {
+        return $this->filter([
+            'default' => $variable->default,
+            'enum' => $variable->enum,
+            'description' => $variable->description,
+        ], $variable);
+    }
+
+    protected function compileTag(OA\Tag $tag): array
+    {
+        return $this->filter([
+            'name' => $tag->name,
+            'description' => $tag->description,
+            'externalDocs' => $tag->externalDocs instanceof OA\ExternalDocumentation ? $this->compileExternalDocs($tag->externalDocs) : null,
+        ], $tag);
+    }
+
+    protected function compileExternalDocs(OA\ExternalDocumentation $docs): array
+    {
+        return $this->filter([
+            'url' => $docs->url,
+            'description' => $docs->description,
+        ], $docs);
+    }
+
+    /**
+     * @param  list<OA\Operation>                $operations
+     * @param  list<OA\PathItem>                 $pathItems
+     * @return array<string,array<string,mixed>>
+     */
+    protected function compilePaths(array $operations, array $pathItems = []): array
+    {
+        $paths = [];
+
+        foreach ($operations as $operation) {
+            if ($operation->path === null || $operation->method === null) {
+                continue;
+            }
+
+            $paths[$operation->path] ??= [];
+            $paths[$operation->path][$operation->method] = $this->compileOperation($operation);
+        }
+
+        foreach ($pathItems as $pathItem) {
+            if ($pathItem->path === null) {
+                continue;
+            }
+
+            $paths[$pathItem->path] ??= [];
+            $this->mergePathItem($paths[$pathItem->path], $pathItem);
+        }
+
+        return $paths;
+    }
+
+    protected function mergePathItem(array &$pathEntry, OA\PathItem $pathItem): void
+    {
+        if ($pathItem->summary !== null) {
+            $pathEntry['summary'] = $pathItem->summary;
+        }
+
+        if ($pathItem->description !== null) {
+            $pathEntry['description'] = $pathItem->description;
+        }
+
+        if ($pathItem->parameters) {
+            $pathEntry['parameters'] = array_map($this->compileParameter(...), $pathItem->parameters);
+        }
+
+        if ($pathItem->servers) {
+            $pathEntry['servers'] = array_map($this->compileServer(...), $pathItem->servers);
+        }
+    }
+
+    /**
+     * @param  list<OA\Operation>                $operations
+     * @return array<string,array<string,mixed>>
+     */
+    protected function compileWebhooks(array $operations): array
+    {
+        $webhooks = [];
+
+        foreach ($operations as $operation) {
+            if ($operation->webhook === null || $operation->method === null) {
+                continue;
+            }
+
+            $webhooks[$operation->webhook] ??= [];
+            $webhooks[$operation->webhook][$operation->method] = $this->compileOperation($operation);
+        }
+
+        return $webhooks;
+    }
+
+    protected function compileOperation(OA\Operation $operation): array
+    {
+        return $this->filter([
+            'tags' => $operation->tags,
+            'summary' => $operation->summary,
+            'description' => $operation->description,
+            'externalDocs' => $operation->externalDocs instanceof OA\ExternalDocumentation ? $this->compileExternalDocs($operation->externalDocs) : null,
+            'operationId' => $operation->operationId,
+            'parameters' => $operation->parameters ? array_map($this->compileParameter(...), $operation->parameters) : null,
+            'requestBody' => $operation->requestBody instanceof OA\RequestBody ? $this->compileRequestBody($operation->requestBody) : null,
+            'responses' => $operation->responses ? $this->compileResponses($operation->responses) : null,
+            'callbacks' => $operation->callbacks !== null ? $this->compileCallbacks($operation->callbacks) : null,
+            'deprecated' => $operation->deprecated,
+            'security' => $operation->security ? $this->compileSecurity($operation->security) : null,
+            'servers' => $operation->servers ? array_map($this->compileServer(...), $operation->servers) : null,
+        ], $operation);
+    }
+
+    /**
+     * Recursively compile callback structures, resolving any DTO objects found within.
+     */
+    protected function compileCallbacks(array $callbacks): array
+    {
+        $result = [];
+
+        foreach ($callbacks as $key => $value) {
+            $result[$key] = $this->compileCallbackValue($value);
+        }
+
+        return $result;
+    }
+
+    protected function compileCallbackValue(mixed $value): mixed
+    {
+        if ($value instanceof OA\Operation) {
+            return $this->compileOperation($value);
+        }
+        if ($value instanceof OA\RequestBody) {
+            return $this->compileRequestBody($value);
+        }
+        if ($value instanceof OA\Response) {
+            return $this->compileResponse($value);
+        }
+        if ($value instanceof OA\Schema) {
+            return $this->compileSchema($value);
+        }
+        if (is_array($value)) {
+            $result = [];
+            foreach ($value as $k => $v) {
+                $result[$k] = $this->compileCallbackValue($v);
+            }
+
+            return $result;
+        }
+
+        return $value;
+    }
+
+    protected function compileParameter(OA\Parameter $parameter): array
+    {
+        if ($parameter->ref !== null) {
+            return ['$ref' => $parameter->ref];
+        }
+
+        return $this->filter([
+            'name' => $parameter->name,
+            'in' => $parameter->in,
+            'description' => $parameter->description,
+            'required' => $parameter->required,
+            'deprecated' => $parameter->deprecated,
+            'allowEmptyValue' => $parameter->allowEmptyValue,
+            'style' => $parameter->style,
+            'explode' => $parameter->explode,
+            'allowReserved' => $parameter->allowReserved,
+            'schema' => $parameter->schema instanceof OA\Schema ? $this->compileSchema($parameter->schema) : null,
+            'example' => $parameter->example,
+            'examples' => $parameter->examples !== null ? $this->compileExamples($parameter->examples) : null,
+            'content' => $parameter->content !== null ? $this->compileMediaTypes($parameter->content) : null,
+        ], $parameter);
+    }
+
+    protected function compileRequestBody(OA\RequestBody $body): array
+    {
+        if ($body->ref !== null) {
+            return ['$ref' => $body->ref];
+        }
+
+        return $this->filter([
+            'description' => $body->description,
+            'content' => $body->content ? $this->compileMediaTypes($body->content) : null,
+            'required' => $body->required,
+        ], $body);
+    }
+
+    /**
+     * @param  list<OA\Response>   $responses
+     * @return array<string,mixed>
+     */
+    protected function compileResponses(array $responses): array
+    {
+        $result = [];
+
+        foreach ($responses as $response) {
+            $key = (string) $response->response;
+            $result[$key] = $this->compileResponse($response);
+        }
+
+        return $result;
+    }
+
+    protected function compileResponse(OA\Response $response): array
+    {
+        if ($response->ref !== null) {
+            return ['$ref' => $response->ref];
+        }
+
+        $headers = null;
+        if ($response->headers) {
+            $headers = [];
+            foreach ($response->headers as $header) {
+                if ($header->header !== null) {
+                    $headers[$header->header] = $this->compileHeader($header);
+                }
+            }
+            $headers = $headers ?: null;
+        }
+
+        $links = null;
+        if ($response->links) {
+            $links = [];
+            foreach ($response->links as $link) {
+                $name = $link->link ?? $link->operationId ?? 'link';
+                $links[$name] = $this->compileLink($link);
+            }
+        }
+
+        return $this->filter([
+            'description' => $response->description,
+            'headers' => $headers,
+            'content' => $response->content ? $this->compileMediaTypes($response->content) : null,
+            'links' => $links,
+        ], $response);
+    }
+
+    protected function compileHeader(OA\Header $header): array
+    {
+        if ($header->ref !== null) {
+            return ['$ref' => $header->ref];
+        }
+
+        return $this->filter([
+            'description' => $header->description,
+            'required' => $header->required,
+            'deprecated' => $header->deprecated,
+            'style' => $header->style,
+            'explode' => $header->explode,
+            'schema' => $header->schema instanceof OA\Schema ? $this->compileSchema($header->schema) : null,
+            'example' => $header->example,
+            'examples' => $header->examples !== null ? $this->compileExamples($header->examples) : null,
+            'content' => $header->content !== null ? $this->compileMediaTypes($header->content) : null,
+        ], $header);
+    }
+
+    /**
+     * @param  list<OA\MediaType>  $mediaTypes
+     * @return array<string,mixed>
+     */
+    protected function compileMediaTypes(array $mediaTypes): array
+    {
+        $result = [];
+
+        foreach ($mediaTypes as $mediaType) {
+            $key = $mediaType->mediaType ?? 'application/json';
+            $result[$key] = $this->compileMediaType($mediaType);
+        }
+
+        return $result;
+    }
+
+    protected function compileMediaType(OA\MediaType $mediaType): array
+    {
+        $encoding = null;
+        if ($mediaType->encoding) {
+            $encoding = [];
+            foreach ($mediaType->encoding as $enc) {
+                $key = $enc->encoding ?? (string) count($encoding);
+                $encoding[$key] = $this->compileEncoding($enc);
+            }
+        }
+
+        return $this->filter([
+            'schema' => $mediaType->schema instanceof OA\Schema ? $this->compileSchema($mediaType->schema) : null,
+            'example' => $mediaType->example,
+            'examples' => $mediaType->examples !== null ? $this->compileExamples($mediaType->examples) : null,
+            'encoding' => $encoding,
+        ], $mediaType);
+    }
+
+    protected function compileEncoding(OA\Encoding $encoding): array
+    {
+        $headers = null;
+        if ($encoding->headers) {
+            $headers = [];
+            foreach ($encoding->headers as $header) {
+                if ($header->header !== null) {
+                    $headers[$header->header] = $this->compileHeader($header);
+                }
+            }
+            $headers = $headers ?: null;
+        }
+
+        return $this->filter([
+            'contentType' => $encoding->contentType,
+            'headers' => $headers,
+            'style' => $encoding->style,
+            'explode' => $encoding->explode,
+            'allowReserved' => $encoding->allowReserved,
+        ], $encoding);
+    }
+
+    protected function compileLink(OA\Link $link): array
+    {
+        if ($link->ref !== null) {
+            return ['$ref' => $link->ref];
+        }
+
+        return $this->filter([
+            'operationRef' => $link->operationRef,
+            'operationId' => $link->operationId,
+            'parameters' => $link->parameters,
+            'requestBody' => $link->requestBody,
+            'description' => $link->description,
+            'server' => $link->server instanceof OA\Server ? $this->compileServer($link->server) : null,
+        ], $link);
+    }
+
+    protected function compileSchema(OA\Schema|string $schema): array
+    {
+        if (is_string($schema)) {
+            return ['$ref' => $schema];
+        }
+
+        if ($schema->ref !== null) {
+            $ref = ['$ref' => $schema->ref];
+            if ($schema->description !== null) {
+                $ref['description'] = $schema->description;
+            }
+
+            return $ref;
+        }
+
+        $type = $schema->type;
+        if ($schema->nullable === true && $type !== null) {
+            $type = (array) $type;
+            if (!in_array('null', $type, true)) {
+                $type[] = 'null';
+            }
+        }
+
+        $result = $this->filter([
+            'type' => $type,
+            'format' => $schema->format,
+            'title' => $schema->title,
+            'description' => $schema->description,
+            'enum' => $schema->enum,
+
+            // String
+            'minLength' => $schema->minLength,
+            'maxLength' => $schema->maxLength,
+            'pattern' => $schema->pattern,
+            'contentMediaType' => $schema->contentMediaType,
+            'contentEncoding' => $schema->contentEncoding,
+
+            // Numeric
+            'minimum' => $schema->minimum,
+            'maximum' => $schema->maximum,
+            'exclusiveMinimum' => $schema->exclusiveMinimum,
+            'exclusiveMaximum' => $schema->exclusiveMaximum,
+            'multipleOf' => $schema->multipleOf,
+
+            // Array
+            'items' => $schema->items !== null ? $this->compileSchema($schema->items) : null,
+            'minItems' => $schema->minItems,
+            'maxItems' => $schema->maxItems,
+            'uniqueItems' => $schema->uniqueItems,
+            'prefixItems' => $schema->prefixItems !== null ? array_map($this->compileSchema(...), $schema->prefixItems) : null,
+            'contains' => $schema->contains !== null ? (is_bool($schema->contains) ? $schema->contains : $this->compileSchema($schema->contains)) : null,
+            'minContains' => $schema->minContains,
+            'maxContains' => $schema->maxContains,
+            'unevaluatedItems' => $schema->unevaluatedItems !== null ? (is_bool($schema->unevaluatedItems) ? $schema->unevaluatedItems : $this->compileSchema($schema->unevaluatedItems)) : null,
+
+            // Object
+            'properties' => $schema->properties !== null ? $this->compileProperties($schema->properties) : null,
+            'required' => $schema->required,
+            'additionalProperties' => $schema->additionalProperties !== null ? (is_bool($schema->additionalProperties) ? $schema->additionalProperties : $this->compileSchema($schema->additionalProperties)) : null,
+            'patternProperties' => $schema->patternProperties !== null ? array_map($this->compileSchema(...), $schema->patternProperties) : null,
+            'minProperties' => $schema->minProperties,
+            'maxProperties' => $schema->maxProperties,
+            'unevaluatedProperties' => $schema->unevaluatedProperties !== null ? (is_bool($schema->unevaluatedProperties) ? $schema->unevaluatedProperties : $this->compileSchema($schema->unevaluatedProperties)) : null,
+            'propertyNames' => $schema->propertyNames instanceof OA\Schema ? $this->compileSchema($schema->propertyNames) : null,
+            'dependentRequired' => $schema->dependentRequired,
+            'dependentSchemas' => $schema->dependentSchemas !== null ? array_map($this->compileSchema(...), $schema->dependentSchemas) : null,
+
+            // Composition
+            'allOf' => $schema->allOf !== null ? array_map($this->compileSchema(...), $schema->allOf) : null,
+            'anyOf' => $schema->anyOf !== null ? array_map($this->compileSchema(...), $schema->anyOf) : null,
+            'oneOf' => $schema->oneOf !== null ? array_map($this->compileSchema(...), $schema->oneOf) : null,
+            'not' => $schema->not instanceof OA\Schema ? $this->compileSchema($schema->not) : null,
+
+            // Conditional
+            'if' => $schema->if instanceof OA\Schema ? $this->compileSchema($schema->if) : null,
+            'then' => $schema->then instanceof OA\Schema ? $this->compileSchema($schema->then) : null,
+            'else' => $schema->else instanceof OA\Schema ? $this->compileSchema($schema->else) : null,
+
+            // Examples
+            'examples' => $schema->examples,
+
+            // Meta
+            'deprecated' => $schema->deprecated,
+            'readOnly' => $schema->readOnly,
+            'writeOnly' => $schema->writeOnly,
+
+            // OpenAPI extensions on schema
+            'discriminator' => $schema->discriminator instanceof OA\Discriminator ? $this->compileDiscriminator($schema->discriminator) : null,
+            'externalDocs' => $schema->externalDocs instanceof OA\ExternalDocumentation ? $this->compileExternalDocs($schema->externalDocs) : null,
+            'xml' => $schema->xml instanceof OA\Xml ? $this->compileXml($schema->xml) : null,
+        ], $schema);
+
+        if ($schema->default !== Undefined::UNDEFINED) {
+            $result['default'] = $schema->default;
+        }
+        if ($schema->const !== Undefined::UNDEFINED) {
+            $result['const'] = $schema->const;
+        }
+        if ($schema->example !== Undefined::UNDEFINED) {
+            $result['example'] = $schema->example;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param  list<OA\Property|OA\Schema> $properties
+     * @return array<string,mixed>
+     */
+    protected function compileProperties(array $properties): array
+    {
+        $result = [];
+
+        foreach ($properties as $property) {
+            if ($property instanceof OA\Property) {
+                $name = $property->property ?? 'unknown';
+                $result[$name] = $property->schema instanceof OA\Schema
+                    ? $this->compileSchema($property->schema)
+                    : new \stdClass();
+            } elseif ($property instanceof OA\Schema) {
+                $name = $property->schema ?? $property->title ?? 'unknown';
+                $result[$name] = $this->compileSchema($property);
+            }
+        }
+
+        return $result;
+    }
+
+    protected function compileDiscriminator(OA\Discriminator $discriminator): array
+    {
+        return $this->filter([
+            'propertyName' => $discriminator->propertyName,
+            'mapping' => $discriminator->mapping,
+        ], $discriminator);
+    }
+
+    protected function compileXml(OA\Xml $xml): array
+    {
+        return $this->filter([
+            'name' => $xml->name,
+            'namespace' => $xml->namespace,
+            'prefix' => $xml->prefix,
+            'attribute' => $xml->attribute,
+            'wrapped' => $xml->wrapped,
+        ], $xml);
+    }
+
+    protected function compileComponents(Specification $specification): array
+    {
+        $components = [];
+
+        if ($specification->schemas) {
+            $schemas = [];
+            foreach ($specification->schemas as $schema) {
+                $name = $schema->schema ?? $schema->title ?? 'Schema';
+                $schemas[$name] = $this->compileSchema($schema);
+            }
+            $components['schemas'] = $schemas;
+        }
+
+        if ($specification->responses) {
+            $responses = [];
+            foreach ($specification->responses as $response) {
+                $key = (string) $response->response;
+                $responses[$key] = $this->compileResponse($response);
+            }
+            $components['responses'] = $responses;
+        }
+
+        if ($specification->parameters) {
+            $parameters = [];
+            foreach ($specification->parameters as $parameter) {
+                $name = $parameter->parameter ?? $parameter->name ?? 'param';
+                $parameters[$name] = $this->compileParameter($parameter);
+            }
+            $components['parameters'] = $parameters;
+        }
+
+        if ($specification->requestBodies) {
+            $bodies = [];
+            foreach ($specification->requestBodies as $i => $body) {
+                $name = $body->request ?? 'body' . $i;
+                $bodies[$name] = $this->compileRequestBody($body);
+            }
+            $components['requestBodies'] = $bodies;
+        }
+
+        if ($specification->headers) {
+            $headers = [];
+            foreach ($specification->headers as $header) {
+                $name = $header->header ?? 'header';
+                $headers[$name] = $this->compileHeader($header);
+            }
+            $components['headers'] = $headers;
+        }
+
+        if ($specification->securitySchemes) {
+            $schemes = [];
+            foreach ($specification->securitySchemes as $scheme) {
+                $name = $scheme->securityScheme ?? 'scheme';
+                $schemes[$name] = $this->compileSecurityScheme($scheme);
+            }
+            $components['securitySchemes'] = $schemes;
+        }
+
+        if ($specification->links) {
+            $links = [];
+            foreach ($specification->links as $link) {
+                $name = $link->link ?? $link->operationId ?? 'link';
+                $links[$name] = $this->compileLink($link);
+            }
+            $components['links'] = $links;
+        }
+
+        if ($specification->examples) {
+            $examples = [];
+            foreach ($specification->examples as $example) {
+                $name = $example->example ?? 'example';
+                $examples[$name] = $this->compileExample($example);
+            }
+            $components['examples'] = $examples;
+        }
+
+        return $components;
+    }
+
+    /**
+     * Passing raw arrays is deprecated; use OA\Security\Requirement instances instead.
+     *
+     * @param list<OA\Security\Requirement|array<string,list<string>>> $security
+     */
+    protected function compileSecurity(array $security): array
+    {
+        return array_map(static function (OA\Security\Requirement|array $item): array {
+            if ($item instanceof OA\Security\Requirement) {
+                return $item->toArray();
+            }
+
+            return $item;
+        }, $security);
+    }
+
+    protected function compileSecurityScheme(OA\Security\Scheme $scheme): array
+    {
+        return $this->filter([
+            'type' => $scheme->type,
+            'description' => $scheme->description,
+            'name' => $scheme->name,
+            'in' => $scheme->in,
+            'scheme' => $scheme->scheme,
+            'bearerFormat' => $scheme->bearerFormat,
+            'openIdConnectUrl' => $scheme->openIdConnectUrl,
+            'flows' => $scheme->flows !== null ? $this->compileFlows($scheme->flows) : null,
+        ], $scheme);
+    }
+
+    /**
+     * @param list<OA\Flow> $flows
+     */
+    protected function compileFlows(array $flows): array
+    {
+        $result = [];
+
+        foreach ($flows as $flow) {
+            if ($flow->flow !== null) {
+                $result[$flow->flow] = $this->compileFlow($flow);
+            }
+        }
+
+        return $result;
+    }
+
+    protected function compileFlow(OA\Flow $flow): array
+    {
+        return $this->filter([
+            'authorizationUrl' => $flow->authorizationUrl,
+            'tokenUrl' => $flow->tokenUrl,
+            'refreshUrl' => $flow->refreshUrl,
+            'scopes' => $flow->scopes !== null ? (object) $flow->scopes : null,
+        ], $flow);
+    }
+
+    protected function compileExample(OA\Example $example): array
+    {
+        return $this->filter([
+            'summary' => $example->summary,
+            'description' => $example->description,
+            'value' => $example->value,
+            'externalValue' => $example->externalValue,
+        ], $example);
+    }
+
+    /**
+     * @param  list<OA\Example>    $examples
+     * @return array<string,mixed>
+     */
+    protected function compileExamples(array $examples): array
+    {
+        $result = [];
+
+        foreach ($examples as $example) {
+            $name = $example->example ?? 'example';
+            $result[$name] = $this->compileExample($example);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param list<array{level: string, message: string}> $diagnostics
+     */
+    protected function validateSchemas(Specification $specification, array &$diagnostics): void
+    {
+        $allSchemas = $this->collectSchemas($specification);
+
+        foreach ($allSchemas as $schema) {
+            if ($schema->type !== null && (is_array($schema->type) ? in_array('array', $schema->type, true) : $schema->type === 'array')) {
+                if ($schema->items === null) {
+                    $diagnostics[] = [
+                        'level' => 'warning',
+                        'message' => 'Schema' . ($schema->schema ? " \"$schema->schema\"" : '') . ' has type "array" but no items',
+                    ];
+                }
+            }
+        }
+    }
+
+    /**
+     * @return list<OA\Schema>
+     */
+    protected function collectSchemas(Specification $specification): array
+    {
+        $schemas = [];
+        $specification->getWalker()->eachSchema(function (OA\Schema $schema) use (&$schemas): void {
+            $schemas[] = $schema;
+        });
+
+        return $schemas;
+    }
+
+    /**
+     * Remove null entries and apply x- extensions.
+     */
+    protected function filter(array $result, OA\AbstractAttribute $attribute): array
+    {
+        $result = array_filter($result, fn ($value): bool => !in_array($value, [null, Undefined::UNDEFINED, []], true));
+
+        if ($attribute->x !== null) {
+            foreach ($attribute->x as $key => $value) {
+                $result['x-' . $key] = $value;
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Compiler/OpenApi32Compiler.php
+++ b/src/Compiler/OpenApi32Compiler.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Compiler;
+
+use OpenApi\Specification;
+
+/**
+ * Compiles a Specification into an OpenAPI 3.2.x document array.
+ *
+ * 3.2 is a superset of 3.1 — adds Tag summary/parent/kind and PathItem query.
+ */
+class OpenApi32Compiler extends OpenApi31Compiler
+{
+    protected const VERSIONS = ['3.2.0'];
+
+    public function getVersion(): string
+    {
+        return '3.2.0';
+    }
+
+    public function validate(Specification $specification): array
+    {
+        return parent::validate($specification);
+    }
+}

--- a/src/CompilerInterface.php
+++ b/src/CompilerInterface.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi;
+
+/**
+ * Compiles a Specification into a versioned OpenAPI document.
+ */
+interface CompilerInterface
+{
+    /**
+     * The primary OpenAPI version this compiler targets (e.g. '3.1.0').
+     */
+    public function getVersion(): string;
+
+    /**
+     * Whether this compiler handles the given version string.
+     */
+    public function supports(string $version): bool;
+
+    /**
+     * Compile a Specification into a structured OpenAPI document array.
+     *
+     * @return array<string,mixed>
+     */
+    public function compile(Specification $specification): array;
+
+    /**
+     * Validate a Specification for completeness and correctness.
+     *
+     * @return list<array{level: string, message: string}>
+     */
+    public function validate(Specification $specification): array;
+}

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -1,0 +1,572 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests;
+
+use OpenApi\Compiler\OpenApi30Compiler;
+use OpenApi\Compiler\OpenApi31Compiler;
+use OpenApi\Compiler\OpenApi32Compiler;
+use OpenApi\CompilerInterface;
+use OpenApi\Spec as OA;
+use OpenApi\Specification;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class CompilerTest extends TestCase
+{
+    protected function createSpecification(string $version = '3.1.0'): Specification
+    {
+        $spec = new Specification();
+        $spec->openapi = new OA\OpenApi(version: $version);
+        $spec->info = new OA\Info(title: 'Test API', version: '1.0.0');
+
+        return $spec;
+    }
+
+    protected function compileSchema(CompilerInterface $compiler, OA\Schema $schema): array
+    {
+        $spec = $this->createSpecification($compiler->getVersion());
+        $spec->schemas[] = $schema;
+
+        $output = $compiler->compile($spec);
+
+        return $output['components']['schemas'][$schema->schema];
+    }
+
+    // --- Version support ---
+
+    public function testSupportsVersions(): void
+    {
+        $c30 = new OpenApi30Compiler();
+        $c31 = new OpenApi31Compiler();
+        $c32 = new OpenApi32Compiler();
+
+        $this->assertTrue($c30->supports('3.0.0'));
+        $this->assertTrue($c30->supports('3.0.3'));
+        $this->assertTrue($c30->supports('3.0.4'));
+        $this->assertFalse($c30->supports('3.1.0'));
+
+        $this->assertTrue($c31->supports('3.1.0'));
+        $this->assertTrue($c31->supports('3.1.1'));
+        $this->assertFalse($c31->supports('3.0.0'));
+        $this->assertFalse($c31->supports('3.2.0'));
+
+        $this->assertTrue($c32->supports('3.2.0'));
+        $this->assertFalse($c32->supports('3.1.0'));
+    }
+
+    // --- Nullable handling ---
+
+    public static function nullableProvider(): iterable
+    {
+        yield '3.0 type array with null → string type + nullable keyword' => [
+            new OpenApi30Compiler(),
+            new OA\Schema(schema: 'N', type: ['string', 'null']),
+            ['type' => 'string', 'nullable' => true],
+        ];
+
+        yield '3.0 explicit nullable flag' => [
+            new OpenApi30Compiler(),
+            new OA\Schema(schema: 'N', type: 'integer', nullable: true),
+            ['type' => 'integer', 'nullable' => true],
+        ];
+
+        yield '3.0 non-nullable stays clean' => [
+            new OpenApi30Compiler(),
+            new OA\Schema(schema: 'N', type: 'string'),
+            ['type' => 'string'],
+        ];
+
+        yield '3.1 nullable flag → type array' => [
+            new OpenApi31Compiler(),
+            new OA\Schema(schema: 'N', type: 'string', nullable: true),
+            ['type' => ['string', 'null']],
+        ];
+
+        yield '3.1 type array passthrough' => [
+            new OpenApi31Compiler(),
+            new OA\Schema(schema: 'N', type: ['string', 'null']),
+            ['type' => ['string', 'null']],
+        ];
+
+        yield '3.1 non-nullable stays clean' => [
+            new OpenApi31Compiler(),
+            new OA\Schema(schema: 'N', type: 'string'),
+            ['type' => 'string'],
+        ];
+    }
+
+    #[DataProvider('nullableProvider')]
+    public function testNullableHandling(CompilerInterface $compiler, OA\Schema $schema, array $expected): void
+    {
+        $result = $this->compileSchema($compiler, $schema);
+
+        foreach ($expected as $key => $value) {
+            $this->assertArrayHasKey($key, $result);
+            $this->assertEquals($value, $result[$key]);
+        }
+
+        if (!isset($expected['nullable'])) {
+            $this->assertArrayNotHasKey('nullable', $result);
+        }
+    }
+
+    // --- ExclusiveMinimum/Maximum ---
+
+    public static function exclusiveBoundsProvider(): iterable
+    {
+        yield '3.0 numeric exclusiveMinimum → minimum + boolean' => [
+            new OpenApi30Compiler(),
+            new OA\Schema(schema: 'B', type: 'integer', exclusiveMinimum: 5),
+            ['minimum' => 5, 'exclusiveMinimum' => true],
+        ];
+
+        yield '3.0 numeric exclusiveMaximum → maximum + boolean' => [
+            new OpenApi30Compiler(),
+            new OA\Schema(schema: 'B', type: 'integer', exclusiveMaximum: 100),
+            ['maximum' => 100, 'exclusiveMaximum' => true],
+        ];
+
+        yield '3.0 boolean exclusiveMinimum passthrough' => [
+            new OpenApi30Compiler(),
+            new OA\Schema(schema: 'B', type: 'integer', minimum: 0, exclusiveMinimum: true),
+            ['minimum' => 0, 'exclusiveMinimum' => true],
+        ];
+
+        yield '3.0 minimum without exclusive stays plain' => [
+            new OpenApi30Compiler(),
+            new OA\Schema(schema: 'B', type: 'integer', minimum: 0),
+            ['minimum' => 0],
+            ['exclusiveMinimum'],
+        ];
+
+        yield '3.1 numeric exclusiveMinimum stays numeric' => [
+            new OpenApi31Compiler(),
+            new OA\Schema(schema: 'B', type: 'integer', exclusiveMinimum: 5),
+            ['exclusiveMinimum' => 5],
+            ['minimum'],
+        ];
+
+        yield '3.1 numeric exclusiveMaximum stays numeric' => [
+            new OpenApi31Compiler(),
+            new OA\Schema(schema: 'B', type: 'integer', exclusiveMaximum: 100),
+            ['exclusiveMaximum' => 100],
+            ['maximum'],
+        ];
+    }
+
+    /**
+     * @param list<string> $absent
+     */
+    #[DataProvider('exclusiveBoundsProvider')]
+    public function testExclusiveBounds(CompilerInterface $compiler, OA\Schema $schema, array $expected, array $absent = []): void
+    {
+        $result = $this->compileSchema($compiler, $schema);
+
+        foreach ($expected as $key => $value) {
+            $this->assertArrayHasKey($key, $result, "Expected key '{$key}' in output");
+            $this->assertEquals($value, $result[$key]);
+        }
+
+        foreach ($absent as $key) {
+            $this->assertArrayNotHasKey($key, $result, "Key '{$key}' should not be in output");
+        }
+    }
+
+    // --- $ref siblings ---
+
+    public function test30RefStripsDescription(): void
+    {
+        $result = $this->compileSchema(
+            new OpenApi30Compiler(),
+            new OA\Schema(schema: 'Alias', description: 'Stripped', ref: '#/components/schemas/Original'),
+        );
+
+        $this->assertEquals('#/components/schemas/Original', $result['$ref']);
+        $this->assertArrayNotHasKey('description', $result);
+    }
+
+    public function test31RefAllowsSiblings(): void
+    {
+        $result = $this->compileSchema(
+            new OpenApi31Compiler(),
+            new OA\Schema(schema: 'Alias', description: 'Kept', ref: '#/components/schemas/Original'),
+        );
+
+        $this->assertEquals('#/components/schemas/Original', $result['$ref']);
+        $this->assertEquals('Kept', $result['description']);
+    }
+
+    // --- Schema features: 3.0 omits, 3.1 includes ---
+
+    public static function schemaFeatureProvider(): iterable
+    {
+        yield 'const' => [
+            new OA\Schema(schema: 'F', type: 'string', const: 'only'),
+            'const',
+            'only',
+        ];
+
+        yield 'examples array' => [
+            new OA\Schema(schema: 'F', type: 'string', examples: ['foo', 'bar']),
+            'examples',
+            ['foo', 'bar'],
+        ];
+
+        yield 'unevaluatedProperties false' => [
+            new OA\Schema(schema: 'F', type: 'object', unevaluatedProperties: false),
+            'unevaluatedProperties',
+            false,
+        ];
+
+        yield 'unevaluatedProperties schema' => [
+            new OA\Schema(schema: 'F', type: 'object', unevaluatedProperties: new OA\Schema(type: 'string')),
+            'unevaluatedProperties',
+            ['type' => 'string'],
+        ];
+
+        yield 'prefixItems' => [
+            new OA\Schema(schema: 'F', type: 'array', items: new OA\Schema(type: 'integer'), prefixItems: [new OA\Schema(type: 'string')]),
+            'prefixItems',
+            [['type' => 'string']],
+        ];
+    }
+
+    #[DataProvider('schemaFeatureProvider')]
+    public function test30OmitsSchemaFeature(OA\Schema $schema, string $key, mixed $expectedIn31): void
+    {
+        $result = $this->compileSchema(new OpenApi30Compiler(), $schema);
+
+        $this->assertArrayNotHasKey($key, $result);
+    }
+
+    #[DataProvider('schemaFeatureProvider')]
+    public function test31IncludesSchemaFeature(OA\Schema $schema, string $key, mixed $expectedIn31): void
+    {
+        $result = $this->compileSchema(new OpenApi31Compiler(), $schema);
+
+        $this->assertArrayHasKey($key, $result);
+        $this->assertEquals($expectedIn31, $result[$key]);
+    }
+
+    public function test30OmitsIfThenElse(): void
+    {
+        $result = $this->compileSchema(
+            new OpenApi30Compiler(),
+            new OA\Schema(
+                schema: 'Cond',
+                if: new OA\Schema(properties: [new OA\Property(property: 'type')]),
+                then: new OA\Schema(required: ['value']),
+                else: new OA\Schema(required: ['other']),
+            ),
+        );
+
+        $this->assertArrayNotHasKey('if', $result);
+        $this->assertArrayNotHasKey('then', $result);
+        $this->assertArrayNotHasKey('else', $result);
+    }
+
+    public function test31IncludesIfThenElse(): void
+    {
+        $result = $this->compileSchema(
+            new OpenApi31Compiler(),
+            new OA\Schema(
+                schema: 'Cond',
+                if: new OA\Schema(properties: [new OA\Property(property: 'type')]),
+                then: new OA\Schema(required: ['value']),
+            ),
+        );
+
+        $this->assertArrayHasKey('if', $result);
+        $this->assertArrayHasKey('then', $result);
+    }
+
+    // --- Webhooks ---
+
+    public function test30OmitsWebhooks(): void
+    {
+        $spec = $this->createSpecification('3.0.0');
+        $spec->operations[] = new OA\Operation(webhook: 'onEvent', method: 'post', operationId: 'onEvent');
+
+        $output = (new OpenApi30Compiler())->compile($spec);
+
+        $this->assertArrayNotHasKey('webhooks', $output);
+    }
+
+    public function test31IncludesWebhooks(): void
+    {
+        $spec = $this->createSpecification('3.1.0');
+        $spec->operations[] = new OA\Operation(webhook: 'onEvent', method: 'post', operationId: 'onEvent');
+
+        $output = (new OpenApi31Compiler())->compile($spec);
+
+        $this->assertArrayHasKey('webhooks', $output);
+        $this->assertArrayHasKey('onEvent', $output['webhooks']);
+    }
+
+    // --- License ---
+
+    public function test30LicenseStripsIdentifier(): void
+    {
+        $spec = $this->createSpecification('3.0.0');
+        $spec->info = new OA\Info(
+            title: 'Test',
+            version: '1.0',
+            license: new OA\License(name: 'MIT', identifier: 'MIT', url: 'https://mit.edu'),
+        );
+
+        $output = (new OpenApi30Compiler())->compile($spec);
+
+        $this->assertEquals('MIT', $output['info']['license']['name']);
+        $this->assertEquals('https://mit.edu', $output['info']['license']['url']);
+        $this->assertArrayNotHasKey('identifier', $output['info']['license']);
+    }
+
+    public function test31LicenseIncludesIdentifier(): void
+    {
+        $spec = $this->createSpecification('3.1.0');
+        $spec->info = new OA\Info(
+            title: 'Test',
+            version: '1.0',
+            license: new OA\License(name: 'MIT', identifier: 'MIT'),
+        );
+
+        $output = (new OpenApi31Compiler())->compile($spec);
+
+        $this->assertEquals('MIT', $output['info']['license']['identifier']);
+    }
+
+    // --- Default and example values ---
+
+    public static function defaultAndExampleProvider(): iterable
+    {
+        yield 'string default emitted' => [
+            new OA\Schema(schema: 'D', type: 'string', default: 'hello'),
+            'default', 'hello',
+        ];
+
+        yield 'null default emitted' => [
+            new OA\Schema(schema: 'D', type: ['string', 'null'], default: null),
+            'default', null,
+        ];
+
+        yield 'false default emitted' => [
+            new OA\Schema(schema: 'D', type: 'boolean', default: false),
+            'default', false,
+        ];
+
+        yield 'example emitted' => [
+            new OA\Schema(schema: 'D', type: 'string', example: 'sample'),
+            'example', 'sample',
+        ];
+    }
+
+    #[DataProvider('defaultAndExampleProvider')]
+    public function testDefaultAndExampleEmitted(OA\Schema $schema, string $key, mixed $expected): void
+    {
+        $result = $this->compileSchema(new OpenApi31Compiler(), $schema);
+
+        $this->assertArrayHasKey($key, $result);
+        $this->assertSame($expected, $result[$key]);
+    }
+
+    public function testUndefinedDefaultNotEmitted(): void
+    {
+        $result = $this->compileSchema(new OpenApi31Compiler(), new OA\Schema(schema: 'X', type: 'string'));
+
+        $this->assertArrayNotHasKey('default', $result);
+        $this->assertArrayNotHasKey('example', $result);
+        $this->assertArrayNotHasKey('const', $result);
+    }
+
+    // --- Version output ---
+
+    public function test32SetsVersionInOutput(): void
+    {
+        $spec = $this->createSpecification('3.2.0');
+
+        $output = (new OpenApi32Compiler())->compile($spec);
+
+        $this->assertEquals('3.2.0', $output['openapi']);
+    }
+
+    // --- Operations and paths ---
+
+    public function testOperationsGroupedByPath(): void
+    {
+        $spec = $this->createSpecification('3.1.0');
+        $spec->operations[] = new OA\Operation(path: '/users', method: 'get', operationId: 'listUsers');
+        $spec->operations[] = new OA\Operation(path: '/users', method: 'post', operationId: 'createUser');
+        $spec->operations[] = new OA\Operation(path: '/users/{id}', method: 'get', operationId: 'getUser');
+
+        $output = (new OpenApi31Compiler())->compile($spec);
+
+        $this->assertCount(2, $output['paths']);
+        $this->assertArrayHasKey('get', $output['paths']['/users']);
+        $this->assertArrayHasKey('post', $output['paths']['/users']);
+        $this->assertArrayHasKey('get', $output['paths']['/users/{id}']);
+    }
+
+    // --- Components ---
+
+    public function testSecuritySchemeCompiled(): void
+    {
+        $spec = $this->createSpecification('3.1.0');
+        $spec->securitySchemes[] = new OA\Security\Scheme\Http(
+            securityScheme: 'bearer',
+            scheme: 'bearer',
+            bearerFormat: 'JWT',
+        );
+
+        $output = (new OpenApi31Compiler())->compile($spec);
+        $scheme = $output['components']['securitySchemes']['bearer'];
+
+        $this->assertEquals('http', $scheme['type']);
+        $this->assertEquals('bearer', $scheme['scheme']);
+        $this->assertEquals('JWT', $scheme['bearerFormat']);
+    }
+
+    // --- Validation ---
+
+    public static function validationProvider(): iterable
+    {
+        $specWithWebhook = new Specification();
+        $specWithWebhook->openapi = new OA\OpenApi(version: '3.0.0');
+        $specWithWebhook->info = new OA\Info(title: 'T', version: '1.0');
+        $specWithWebhook->operations[] = new OA\Operation(webhook: 'ev', method: 'post');
+
+        yield '3.0 webhooks unsupported' => [
+            new OpenApi30Compiler(),
+            $specWithWebhook,
+            'webhooks are not supported in OpenAPI 3.0 and will be omitted',
+        ];
+
+        $specWithIdentifier = new Specification();
+        $specWithIdentifier->openapi = new OA\OpenApi(version: '3.0.0');
+        $specWithIdentifier->info = new OA\Info(title: 'T', version: '1.0', license: new OA\License(name: 'MIT', identifier: 'MIT'));
+
+        yield '3.0 license identifier' => [
+            new OpenApi30Compiler(),
+            $specWithIdentifier,
+            'License identifier is not supported in OpenAPI 3.0, use url instead',
+        ];
+
+        $specNoInfo = new Specification();
+        $specNoInfo->openapi = new OA\OpenApi(version: '3.1.0');
+
+        yield '3.1 missing info' => [
+            new OpenApi31Compiler(),
+            $specNoInfo,
+            'info is required',
+        ];
+
+        $specArrayNoItems = new Specification();
+        $specArrayNoItems->openapi = new OA\OpenApi(version: '3.0.0');
+        $specArrayNoItems->info = new OA\Info(title: 'T', version: '1.0');
+        $specArrayNoItems->schemas[] = new OA\Schema(schema: 'Bad', type: 'array');
+
+        yield '3.0 array without items' => [
+            new OpenApi30Compiler(),
+            $specArrayNoItems,
+            'Schema "Bad" has type "array" but no items',
+        ];
+    }
+
+    #[DataProvider('validationProvider')]
+    public function testValidation(CompilerInterface $compiler, Specification $specification, string $expectedMessage): void
+    {
+        $diagnostics = $compiler->validate($specification);
+        $messages = array_column($diagnostics, 'message');
+
+        $this->assertContains($expectedMessage, $messages);
+    }
+
+    // --- x- extensions ---
+
+    public function testExtensionsEmitted(): void
+    {
+        $result = $this->compileSchema(
+            new OpenApi31Compiler(),
+            new OA\Schema(schema: 'Ext', type: 'object', x: ['custom' => 'value', 'flag' => true]),
+        );
+
+        $this->assertEquals('value', $result['x-custom']);
+        $this->assertTrue($result['x-flag']);
+    }
+
+    // --- Composition ---
+
+    public function testAllOfCompiled(): void
+    {
+        $result = $this->compileSchema(
+            new OpenApi31Compiler(),
+            new OA\Schema(
+                schema: 'Dog',
+                allOf: [
+                    new OA\Schema(ref: '#/components/schemas/Pet'),
+                    new OA\Schema(type: 'object', properties: [new OA\Property(property: 'breed', schema: new OA\Schema(type: 'string'))]),
+                ],
+            ),
+        );
+
+        $this->assertCount(2, $result['allOf']);
+        $this->assertEquals('#/components/schemas/Pet', $result['allOf'][0]['$ref']);
+        $this->assertArrayHasKey('properties', $result['allOf'][1]);
+    }
+
+    // --- Discriminator ---
+
+    public function testDiscriminatorCompiled(): void
+    {
+        $result = $this->compileSchema(
+            new OpenApi31Compiler(),
+            new OA\Schema(
+                schema: 'Pet',
+                oneOf: [
+                    new OA\Schema(ref: '#/components/schemas/Dog'),
+                    new OA\Schema(ref: '#/components/schemas/Cat'),
+                ],
+                discriminator: new OA\Discriminator(propertyName: 'petType', mapping: ['dog' => '#/components/schemas/Dog']),
+            ),
+        );
+
+        $this->assertEquals('petType', $result['discriminator']['propertyName']);
+        $this->assertEquals(['dog' => '#/components/schemas/Dog'], $result['discriminator']['mapping']);
+    }
+
+    // --- Security (raw array BC) ---
+
+    public function testSecurityWithRequirementDto(): void
+    {
+        $spec = $this->createSpecification('3.1.0');
+        $spec->openapi->security = [
+            new OA\Security\Requirement(scheme: 'bearerAuth'),
+            new OA\Security\Requirement(schemes: ['oauth2' => ['read', 'write'], 'apiKey' => []]),
+        ];
+
+        $output = (new OpenApi31Compiler())->compile($spec);
+
+        $this->assertCount(2, $output['security']);
+        $this->assertEquals(['bearerAuth' => []], $output['security'][0]);
+        $this->assertEquals(['oauth2' => ['read', 'write'], 'apiKey' => []], $output['security'][1]);
+    }
+
+    public function testSecurityWithRawArrayBc(): void
+    {
+        $spec = $this->createSpecification('3.1.0');
+        /* @phpstan-ignore assign.propertyType (intentionally testing BC with raw arrays) */
+        $spec->openapi->security = [
+            new OA\Security\Requirement(scheme: 'bearerAuth'),
+            ['oauth2' => ['read', 'write']],
+        ];
+
+        $output = (new OpenApi31Compiler())->compile($spec);
+
+        $this->assertCount(2, $output['security']);
+        $this->assertEquals(['bearerAuth' => []], $output['security'][0]);
+        $this->assertEquals(['oauth2' => ['read', 'write']], $output['security'][1]);
+    }
+}


### PR DESCRIPTION
## Summary

Introduces `CompilerInterface` and three version-specific implementations that transform a `Specification` into an OpenAPI document array. This is the compilation stage of the spec pipeline:

```
Specification → Compiler → OpenAPI document (array)
```

Builds on #2054 (merged).

## Design

### Version-aware compilers

Each OpenAPI version (3.0, 3.1, 3.2) has its own compiler that handles version-specific differences rather than branching inside a single serializer.

- `OpenApi31Compiler` — base implementation (JSON Schema 2020-12, full 3.1 feature set)
- `OpenApi30Compiler` — extends 3.1, overrides for the draft-04 JSON Schema subset:
  - `type` is always a string (not array)
  - `nullable` as separate boolean keyword
  - `exclusiveMinimum`/`exclusiveMaximum` are booleans (alongside `minimum`/`maximum`)
  - No `$ref` siblings (summary/description stripped)
  - No webhooks, no `const`, no `examples` array (only singular `example`)
  - License: no `identifier` field (only `url`)
- `OpenApi32Compiler` — extends 3.1, adds Tag `summary`/`parent`/`kind` and PathItem `query`

### CompilerInterface

```php
interface CompilerInterface
{
    public function getVersion(): string;
    public function supports(string $version): bool;
    public function compile(Specification $specification): array;
    public function validate(Specification $specification): array;
}
```

The compile step is a pure function (Specification in → array out), making it independently testable without the rest of the pipeline.

### Compiler responsibilities (from classic processor mapping)

| Classic Processor | Compiler Equivalent |
|---|---|
| MergeIntoComponents | Groups schemas/parameters/responses etc. into components |
| BuildPaths | Groups operations by resolved path |
| AugmentSchemas (allOf merge) | Emits allOf when both properties + allOf exist |

### Inheritance strategy

3.0 and 3.2 extend the 3.1 compiler, overriding only the methods that differ. This keeps version-specific logic minimal and co-located rather than scattered across conditionals.