### PR TITLE
feat: add augmenter pipeline pipes

### DIFF
--- a/src/Augmenter/CleanUnused.php
+++ b/src/Augmenter/CleanUnused.php
@@ -1,0 +1,121 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Augmenter;
+
+use OpenApi\Spec as OA;
+use OpenApi\Specification;
+use OpenApi\Utils\PipeInterface;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+
+/**
+ * Removes unreferenced components from the specification.
+ *
+ * Iterates multiple times to catch nested dependencies (a schema only
+ * referenced by another unused schema should also be removed).
+ *
+ * @implements PipeInterface<Specification>
+ */
+class CleanUnused implements PipeInterface, LoggerAwareInterface
+{
+    use LoggerAwareTrait;
+
+    protected const MAX_ITERATIONS = 10;
+
+    public function __construct(
+        protected bool $enabled = true,
+    ) {
+    }
+
+    /**
+     * Enables/disables removal of unreferenced components.
+     */
+    public function setEnabled(bool $enabled): static
+    {
+        $this->enabled = $enabled;
+
+        return $this;
+    }
+
+    public function group(): string|\BackedEnum
+    {
+        return Group::Reduce;
+    }
+
+    public function __invoke(mixed $payload): mixed
+    {
+        if (!$this->enabled) {
+            return null;
+        }
+
+        for ($i = 0; $i < self::MAX_ITERATIONS; ++$i) {
+            if (!$this->cleanup($payload)) {
+                return null;
+            }
+        }
+
+        $this->logger?->warning('CleanUnused: maximum iterations ({max}) reached, some unused components may remain', [
+            'max' => self::MAX_ITERATIONS,
+        ]);
+
+        return null;
+    }
+
+    protected function cleanup(Specification $specification): bool
+    {
+        $usedRefs = [];
+        $specification->getWalker()->eachRef(static function (OA\AbstractAttribute $a) use (&$usedRefs): void {
+            $usedRefs[$a->ref] = true;
+        });
+
+        $removed = false;
+        foreach ($this->componentDescriptors() as [$field, $refPrefix, $nameExtractor]) {
+            if ($this->removeUnused($specification, $field, $refPrefix, $nameExtractor, $usedRefs)) {
+                $removed = true;
+            }
+        }
+
+        return $removed;
+    }
+
+    /**
+     * @return list<array{string, string, \Closure}>
+     */
+    protected function componentDescriptors(): array
+    {
+        return [
+            ['schemas', 'schemas', static fn (OA\Schema $s): ?string => $s->schema ?? $s->title],
+            ['responses', 'responses', static fn (OA\Response $r): ?string => $r->response !== null ? (string) $r->response : null],
+            ['parameters', 'parameters', static fn (OA\Parameter $p): ?string => $p->parameter ?? $p->name],
+            ['requestBodies', 'requestBodies', static fn (OA\RequestBody $b): ?string => $b->request],
+            ['headers', 'headers', static fn (OA\Header $h): ?string => $h->header],
+            ['securitySchemes', 'securitySchemes', static fn (OA\Security\Scheme $s): ?string => $s->securityScheme],
+            ['links', 'links', static fn (OA\Link $l): ?string => $l->link],
+            ['examples', 'examples', static fn (OA\Example $e): ?string => $e->example],
+        ];
+    }
+
+    /**
+     * @param array<string, true> $usedRefs
+     */
+    protected function removeUnused(Specification $specification, string $field, string $refPrefix, \Closure $nameExtractor, array $usedRefs): bool
+    {
+        $removed = false;
+        foreach ($specification->{$field} as $index => $item) {
+            $name = $nameExtractor($item);
+            if ($name !== null && !isset($usedRefs['#/components/' . $refPrefix . '/' . $name])) {
+                unset($specification->{$field}[$index]);
+                $removed = true;
+            }
+        }
+        if ($removed) {
+            $specification->{$field} = array_values($specification->{$field});
+        }
+
+        return $removed;
+    }
+}

--- a/src/Augmenter/Docblock.php
+++ b/src/Augmenter/Docblock.php
@@ -1,0 +1,254 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Augmenter;
+
+use OpenApi\AttributeInterface;
+use OpenApi\Spec as OA;
+use OpenApi\Specification;
+use OpenApi\Undefined;
+use OpenApi\Utils\DocBlockParser;
+use OpenApi\Utils\PipeInterface;
+
+/**
+ * Fills summary, description, and deprecated from PHP docblock comments.
+ *
+ * Walks all attributes in the specification that have summary/description
+ * properties and populates them from the reflector's docblock when not
+ * explicitly set.
+ *
+ * @implements PipeInterface<Specification>
+ */
+class Docblock implements PipeInterface
+{
+    public function __construct(
+        protected DocBlockParser $parser = new DocBlockParser(),
+    ) {
+    }
+
+    /**
+     * Override the docblock parser used to extract summaries and descriptions.
+     */
+    public function setParser(DocBlockParser $parser): static
+    {
+        $this->parser = $parser;
+
+        return $this;
+    }
+
+    public function group(): string|\BackedEnum
+    {
+        return Group::Augment;
+    }
+
+    public function __invoke(mixed $payload): mixed
+    {
+        foreach ($payload->operations as $operation) {
+            $this->augmentSummaryAndDescription($operation);
+            $this->augmentDeprecated($operation);
+            $this->augmentOperationParameters($operation);
+        }
+
+        foreach ($payload->schemas as $schema) {
+            $this->augmentDescription($schema);
+            $this->augmentDeprecated($schema);
+            $this->augmentProperties($schema);
+        }
+
+        foreach ($payload->parameters as $parameter) {
+            $this->augmentParameterDescription($parameter);
+        }
+
+        return null;
+    }
+
+    protected function augmentSummaryAndDescription(OA\Operation $operation): void
+    {
+        if ($operation->summary !== null && $operation->description !== null) {
+            return;
+        }
+
+        $docblock = $this->getDocComment($operation);
+        if ($docblock === null) {
+            return;
+        }
+
+        $content = $this->parser->parseDocblock($docblock);
+        if ($content === '' || Undefined::isDefault($content)) {
+            return;
+        }
+
+        if ($operation->summary === null && $operation->description === null) {
+            $operation->summary = $this->extractSummary($content);
+            $operation->description = $this->extractDescription($content);
+        } elseif ($operation->summary === null) {
+            $operation->summary = $content;
+        } elseif ($operation->description === null) {
+            $operation->description = $content;
+        }
+    }
+
+    protected function augmentDescription(OA\Schema $schema): void
+    {
+        if ($schema->description !== null) {
+            return;
+        }
+
+        $docblock = $this->getDocComment($schema);
+        if ($docblock === null) {
+            return;
+        }
+
+        $content = $this->parser->parseDocblock($docblock);
+        if ($content === '' || Undefined::isDefault($content)) {
+            return;
+        }
+
+        $schema->description = $content;
+    }
+
+    protected function augmentDeprecated(OA\Operation|OA\Schema $attribute): void
+    {
+        if ($attribute->deprecated !== null) {
+            return;
+        }
+
+        $docblock = $this->getDocComment($attribute);
+        if ($docblock === null) {
+            return;
+        }
+
+        if ($this->parser->isDeprecated($docblock)) {
+            $attribute->deprecated = true;
+        }
+    }
+
+    protected function augmentOperationParameters(OA\Operation $operation): void
+    {
+        if (!$operation->parameters) {
+            return;
+        }
+
+        $methodDoc = $this->getDocComment($operation);
+        $paramTags = [];
+        if ($methodDoc !== null) {
+            $this->parser->parseDocblock($methodDoc, $paramTags);
+        }
+        $paramDescriptions = $paramTags['param'] ?? [];
+
+        foreach ($operation->parameters as $parameter) {
+            $this->augmentParameterDescription($parameter, $paramDescriptions);
+        }
+    }
+
+    /**
+     * @param array<string, array{type: ?string, description: ?string}> $parentParamTags
+     */
+    protected function augmentParameterDescription(OA\Parameter $parameter, array $parentParamTags = []): void
+    {
+        if ($parameter->description !== null) {
+            return;
+        }
+
+        $reflector = $parameter->getReflector();
+
+        if ($reflector instanceof \ReflectionParameter) {
+            $name = $reflector->getName();
+            if (isset($parentParamTags[$name]) && $parentParamTags[$name]['description'] !== null) {
+                $parameter->description = $parentParamTags[$name]['description'];
+
+                return;
+            }
+
+            $method = $reflector->getDeclaringFunction();
+            if ($method instanceof \ReflectionMethod || $method instanceof \ReflectionFunction) {
+                $tags = [];
+                $doc = $method->getDocComment();
+                if ($doc !== false) {
+                    $this->parser->parseDocblock($doc, $tags);
+                    $params = $tags['param'] ?? [];
+                    if (isset($params[$name]) && $params[$name]['description'] !== null) {
+                        $parameter->description = $params[$name]['description'];
+                    }
+                }
+            }
+
+            return;
+        }
+
+        if ($parameter->name !== null && isset($parentParamTags[$parameter->name]) && $parentParamTags[$parameter->name]['description'] !== null) {
+            $parameter->description = $parentParamTags[$parameter->name]['description'];
+        }
+    }
+
+    protected function augmentProperties(OA\Schema $schema): void
+    {
+        $properties = $schema->properties ?? [];
+
+        // Also walk properties inside allOf entries (placed there by ExpandHierarchy)
+        foreach ($schema->allOf ?? [] as $entry) {
+            if ($entry->properties) {
+                array_push($properties, ...$entry->properties);
+            }
+        }
+
+        foreach ($properties as $property) {
+            if (!$property instanceof OA\Property) {
+                continue;
+            }
+
+            if ($property->schema instanceof OA\Schema && $property->schema->description === null) {
+                // Schema may have its own reflector (inline), otherwise fall back to
+                // the property's reflector (e.g. class constants where schema is synthetic)
+                $doc = $this->getDocComment($property->schema) ?? $this->getDocComment($property);
+                if ($doc !== null) {
+                    $content = $this->parser->parseDocblock($doc);
+                    if ($content !== '' && !Undefined::isDefault($content)) {
+                        $property->schema->description = $content;
+                    }
+                }
+            }
+        }
+    }
+
+    protected function getDocComment(AttributeInterface $attribute): ?string
+    {
+        $reflector = $attribute->getReflector();
+        if (!$reflector instanceof \Reflector) {
+            return null;
+        }
+
+        if ($reflector instanceof \ReflectionParameter && $reflector->isPromoted()) {
+            $function = $reflector->getDeclaringFunction();
+            $class = $function instanceof \ReflectionMethod ? $function->getDeclaringClass() : null;
+            if ($class?->hasProperty($reflector->getName())) {
+                $reflector = $class->getProperty($reflector->getName());
+            }
+        }
+
+        if (!method_exists($reflector, 'getDocComment')) {
+            return null;
+        }
+
+        $doc = $reflector->getDocComment();
+
+        return $doc !== false ? $doc : null;
+    }
+
+    protected function extractSummary(string $content): ?string
+    {
+        $summary = $this->parser->extractCommentSummary($content);
+
+        return Undefined::isDefault($summary) ? null : $summary;
+    }
+
+    protected function extractDescription(string $content): ?string
+    {
+        $description = $this->parser->extractCommentDescription($content);
+
+        return Undefined::isDefault($description) ? null : $description;
+    }
+}

--- a/src/Augmenter/Enums.php
+++ b/src/Augmenter/Enums.php
@@ -1,0 +1,133 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Augmenter;
+
+use OpenApi\Spec as OA;
+use OpenApi\Specification;
+use OpenApi\Utils\PipeInterface;
+
+/**
+ * Expands PHP enums into schema enum values.
+ *
+ * For schemas attached to a PHP enum, determines schema name, type, and enum values.
+ * Also resolves UnitEnum instances and enum class-strings in any schema's enum array.
+ *
+ * Rules for name vs. value:
+ * - Unit enums (not backed): always use case names, type becomes "string"
+ * - Backed enums without explicit schema type: use case names, type becomes "string"
+ * - Backed enums with schema type matching backing type (int→"integer", string→"string"):
+ *   use backing values, type preserved
+ * - Backed enums with schema type NOT matching backing type: use case names
+ *
+ * @implements PipeInterface<Specification>
+ */
+class Enums implements PipeInterface
+{
+    public function __construct(
+        protected ?string $enumNames = null,
+    ) {
+    }
+
+    /**
+     * If set, stores enum case names in a vendor extension with this key (e.g. <code>x-enum-varnames</code>).
+     */
+    public function setEnumNames(?string $enumNames): static
+    {
+        $this->enumNames = $enumNames;
+
+        return $this;
+    }
+
+    public function group(): string|\BackedEnum
+    {
+        return Group::Resolve;
+    }
+
+    public function __invoke(mixed $payload): mixed
+    {
+        $this->expandEnumSchemas($payload);
+        $this->resolveEnumValues($payload);
+
+        return null;
+    }
+
+    protected function expandEnumSchemas(Specification $specification): void
+    {
+        foreach ($specification->schemas as $schema) {
+            $reflector = $schema->getReflector();
+            if (!$reflector instanceof \ReflectionClass || !$reflector->isEnum()) {
+                continue;
+            }
+
+            $reflector = new \ReflectionEnum($reflector->getName());
+
+            $schema->schema ??= $reflector->getShortName();
+
+            $useName = $this->shouldUseName($schema, $reflector);
+
+            $schema->enum = array_map(
+                static fn (\ReflectionEnumUnitCase $case): int|string => ($useName || !$case instanceof \ReflectionEnumBackedCase)
+                    ? $case->name
+                    : $case->getBackingValue(),
+                $reflector->getCases(),
+            );
+
+            if ($useName) {
+                $schema->type = 'string';
+            } else {
+                $schema->type = $reflector->getBackingType()->getName() === 'int' ? 'integer' : 'string';
+            }
+
+            if ($this->enumNames !== null && !$useName && $reflector->isBacked()) {
+                $names = array_map(
+                    static fn (\ReflectionEnumUnitCase $case): string => $case->name,
+                    $reflector->getCases(),
+                );
+                $schema->x = array_merge($schema->x ?? [], [$this->enumNames => $names]);
+            }
+        }
+    }
+
+    protected function shouldUseName(OA\Schema $schema, \ReflectionEnum $reflector): bool
+    {
+        if ($schema->type === null) {
+            return true;
+        }
+
+        if (!$reflector->isBacked()) {
+            return true;
+        }
+
+        $backingType = $reflector->getBackingType()->getName() === 'int' ? 'integer' : 'string';
+
+        return $schema->type !== $backingType;
+    }
+
+    protected function resolveEnumValues(Specification $specification): void
+    {
+        $specification->getWalker()->eachSchema(function (OA\Schema $schema): void {
+            if ($schema->enum === null) {
+                return;
+            }
+
+            $resolved = [];
+            foreach ($schema->enum as $value) {
+                if ($value instanceof \UnitEnum) {
+                    $resolved[] = $value instanceof \BackedEnum ? $value->value : $value->name;
+                } elseif (is_string($value) && function_exists('enum_exists') && enum_exists($value)) {
+                    foreach ($value::cases() as $case) {
+                        $resolved[] = $case instanceof \BackedEnum ? $case->value : $case->name;
+                    }
+                } else {
+                    $resolved[] = $value;
+                }
+            }
+
+            $schema->enum = $resolved;
+        });
+    }
+}

--- a/src/Augmenter/ExpandHierarchy.php
+++ b/src/Augmenter/ExpandHierarchy.php
@@ -1,0 +1,249 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Augmenter;
+
+use OpenApi\Spec as OA;
+use OpenApi\Specification;
+use OpenApi\Utils\AttributeFactory;
+use OpenApi\Utils\PipeInterface;
+
+/**
+ * Expands PHP class hierarchy into OpenAPI composition (allOf).
+ *
+ * For each schema backed by a class reflector, walks parents, traits, and interfaces:
+ * - Ancestor with #[Schema] → adds $ref to allOf, stops walking up (parents only)
+ * - Ancestor without #[Schema] → merges its own members into the current schema
+ *
+ * After expansion, if a schema has both allOf and properties, the properties are
+ * moved into a dedicated allOf entry (anonymous schema with type: object).
+ *
+ * @implements PipeInterface<Specification>
+ */
+class ExpandHierarchy implements PipeInterface
+{
+    public function __construct(
+        protected AttributeFactory $factory = new AttributeFactory(),
+    ) {
+    }
+
+    public function group(): string|\BackedEnum
+    {
+        return Group::Resolve;
+    }
+
+    public function __invoke(mixed $payload): mixed
+    {
+        $schemaMap = $this->buildSchemaMap($payload);
+
+        foreach ($payload->schemas as $schema) {
+            $reflector = $schema->getClassReflector();
+            if ($reflector === null) {
+                continue;
+            }
+
+            $this->expandParents($schema, $reflector, $schemaMap);
+            $this->expandTraits($schema, $reflector, $schemaMap);
+            $this->expandInterfaces($schema, $reflector, $schemaMap);
+            $this->mergeAllOf($schema);
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string, OA\Schema> class name → schema
+     */
+    protected function buildSchemaMap(Specification $specification): array
+    {
+        $map = [];
+        foreach ($specification->schemas as $schema) {
+            $className = $schema->getClassName();
+            if ($className !== null) {
+                $map[$className] = $schema;
+            }
+        }
+
+        return $map;
+    }
+
+    /**
+     * @param array<string, OA\Schema> $schemaMap
+     */
+    protected function expandParents(OA\Schema $schema, \ReflectionClass $reflector, array $schemaMap): void
+    {
+        // Walk up the inheritance chain; stop at the first ancestor that has its own schema
+        // (it becomes a $ref). Non-schema ancestors have their members inlined.
+        $parent = $reflector->getParentClass();
+        while ($parent !== false) {
+            if (isset($schemaMap[$parent->getName()])) {
+                $this->addAllOfRef($schema, $schemaMap[$parent->getName()]);
+                break;
+            }
+
+            $this->mergeMembers($schema, $parent);
+            $parent = $parent->getParentClass();
+        }
+    }
+
+    /**
+     * @param array<string, OA\Schema> $schemaMap
+     */
+    protected function expandTraits(OA\Schema $schema, \ReflectionClass $reflector, array $schemaMap): void
+    {
+        // PHP reports trait properties as declared by the using class, so the
+        // assembler already collected them as own properties. For traits with a
+        // schema we add an allOf $ref and strip those properties; for traits
+        // without a schema we leave them in place (already present, no merge needed).
+        foreach ($this->getDirectTraits($reflector) as $trait) {
+            if (isset($schemaMap[$trait->getName()])) {
+                $this->addAllOfRef($schema, $schemaMap[$trait->getName()]);
+                $this->stripTraitProperties($schema, $trait);
+            }
+        }
+
+        // Traits from non-schema ancestors also belong to this schema (the ancestor
+        // itself was inlined in expandParents, but its traits weren't covered there).
+        $parent = $reflector->getParentClass();
+        while ($parent !== false) {
+            if (isset($schemaMap[$parent->getName()])) {
+                break;
+            }
+
+            foreach ($this->getDirectTraits($parent) as $trait) {
+                if (isset($schemaMap[$trait->getName()])) {
+                    $this->addAllOfRef($schema, $schemaMap[$trait->getName()]);
+                    $this->stripTraitProperties($schema, $trait);
+                }
+            }
+
+            $parent = $parent->getParentClass();
+        }
+    }
+
+    /**
+     * @param array<string, OA\Schema> $schemaMap
+     */
+    protected function expandInterfaces(OA\Schema $schema, \ReflectionClass $reflector, array $schemaMap): void
+    {
+        $ownInterfaces = $this->getDirectInterfaces($reflector);
+
+        foreach ($ownInterfaces as $interface) {
+            if (isset($schemaMap[$interface->getName()])) {
+                $this->addAllOfRef($schema, $schemaMap[$interface->getName()]);
+            } else {
+                $this->mergeMembers($schema, $interface);
+            }
+        }
+    }
+
+    protected function addAllOfRef(OA\Schema $schema, OA\Schema $referenced): void
+    {
+        $schema->allOf ??= [];
+        $name = $referenced->schema ?? $referenced->getShortClassName();
+        if ($name !== null) {
+            $schema->allOf[] = new OA\Schema(ref: '#/components/schemas/' . $name);
+        }
+    }
+
+    protected function mergeMembers(OA\Schema $schema, \ReflectionClass $class): void
+    {
+        $members = $this->factory->membersOf($class);
+        $merged = [];
+        foreach ($members as $member) {
+            if ($member instanceof OA\Property) {
+                $merged[] = $member;
+            }
+        }
+
+        if ($merged !== []) {
+            $schema->properties = [...$merged, ...($schema->properties ?? [])];
+        }
+    }
+
+    protected function stripTraitProperties(OA\Schema $schema, \ReflectionClass $trait): void
+    {
+        if ($schema->properties === null) {
+            return;
+        }
+
+        $traitPropertyNames = array_map(
+            fn (\ReflectionProperty $p): string => $p->getName(),
+            $trait->getProperties(),
+        );
+
+        $schema->properties = array_values(array_filter(
+            $schema->properties,
+            fn (OA\Property $p): bool => !in_array($p->property, $traitPropertyNames, true),
+        ));
+
+        if ($schema->properties === []) {
+            $schema->properties = null;
+        }
+    }
+
+    /**
+     * When allOf refs were added but the schema also has own properties, wrap them
+     * in a dedicated allOf entry so the final output is a pure allOf composition.
+     */
+    protected function mergeAllOf(OA\Schema $schema): void
+    {
+        if ($schema->allOf === null || $schema->properties === null) {
+            return;
+        }
+
+        $schema->allOf[] = new OA\Schema(type: 'object', properties: $schema->properties);
+        $schema->properties = null;
+    }
+
+    /**
+     * Get traits directly used by a class (not inherited via parents).
+     *
+     * @return list<\ReflectionClass>
+     */
+    protected function getDirectTraits(\ReflectionClass $class): array
+    {
+        $traits = $class->getTraits();
+        // Exclude traits inherited from parent
+        $parent = $class->getParentClass();
+        if ($parent !== false) {
+            $parentTraitNames = array_map(
+                fn (\ReflectionClass $t): string => $t->getName(),
+                $parent->getTraits(),
+            );
+            $traits = array_filter(
+                $traits,
+                fn (\ReflectionClass $t): bool => !in_array($t->getName(), $parentTraitNames, true),
+            );
+        }
+
+        return array_values($traits);
+    }
+
+    /**
+     * Get interfaces directly implemented by a class (not inherited from parents).
+     *
+     * @return list<\ReflectionClass>
+     */
+    protected function getDirectInterfaces(\ReflectionClass $class): array
+    {
+        $interfaces = $class->getInterfaces();
+
+        $parent = $class->getParentClass();
+        if ($parent !== false) {
+            $parentInterfaceNames = array_map(
+                fn (\ReflectionClass $i): string => $i->getName(),
+                $parent->getInterfaces(),
+            );
+            $interfaces = array_filter(
+                $interfaces,
+                fn (\ReflectionClass $i): bool => !in_array($i->getName(), $parentInterfaceNames, true),
+            );
+        }
+
+        return array_values($interfaces);
+    }
+}

--- a/src/Augmenter/Group.php
+++ b/src/Augmenter/Group.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Augmenter;
+
+enum Group: string
+{
+    case Resolve = 'resolve';
+    case Reduce = 'reduce';
+    case Augment = 'augment';
+}

--- a/src/Augmenter/InferNames.php
+++ b/src/Augmenter/InferNames.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Augmenter;
+
+use OpenApi\Specification;
+use OpenApi\Utils\PipeInterface;
+
+/**
+ * Infers component names from PHP reflectors when not explicitly set.
+ *
+ * Sets schema name from the class/interface/trait/enum short name,
+ * and parameter component key from its name property.
+ *
+ * @implements PipeInterface<Specification>
+ */
+class InferNames implements PipeInterface
+{
+    public function group(): string|\BackedEnum
+    {
+        return Group::Resolve;
+    }
+
+    public function __invoke(mixed $payload): mixed
+    {
+        $this->inferSchemaNames($payload);
+        $this->inferParameterNames($payload);
+
+        return null;
+    }
+
+    protected function inferSchemaNames(Specification $specification): void
+    {
+        foreach ($specification->schemas as $schema) {
+            $schema->schema ??= $schema->getShortClassName();
+        }
+    }
+
+    protected function inferParameterNames(Specification $specification): void
+    {
+        foreach ($specification->parameters as $parameter) {
+            $parameter->parameter ??= $parameter->name;
+        }
+    }
+}

--- a/src/Augmenter/MediaType.php
+++ b/src/Augmenter/MediaType.php
@@ -1,0 +1,93 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Augmenter;
+
+use OpenApi\Spec as OA;
+use OpenApi\Specification;
+use OpenApi\Utils\PipeInterface;
+
+/**
+ * Re-keys MediaType encoding lists by property name.
+ *
+ * The assembler collects Encoding objects as a flat list via contains().
+ * The compiler expects them as an associative array keyed by the property name
+ * the encoding applies to.
+ *
+ * @implements PipeInterface<Specification>
+ */
+class MediaType implements PipeInterface
+{
+    public function group(): string|\BackedEnum
+    {
+        return Group::Augment;
+    }
+
+    public function __invoke(mixed $payload): mixed
+    {
+        $this->processMediaTypes($payload);
+
+        return null;
+    }
+
+    protected function processMediaTypes(Specification $specification): void
+    {
+        foreach ($specification->operations as $operation) {
+            if ($operation->requestBody instanceof OA\RequestBody) {
+                $this->rekeyEncodings($operation->requestBody->content);
+            }
+
+            if ($operation->responses) {
+                foreach ($operation->responses as $response) {
+                    $this->rekeyEncodings($response->content);
+                }
+            }
+
+            if ($operation->parameters) {
+                foreach ($operation->parameters as $parameter) {
+                    $this->rekeyEncodings($parameter->content);
+                }
+            }
+        }
+
+        foreach ($specification->requestBodies as $body) {
+            $this->rekeyEncodings($body->content);
+        }
+
+        foreach ($specification->responses as $response) {
+            $this->rekeyEncodings($response->content);
+        }
+
+        foreach ($specification->parameters as $parameter) {
+            $this->rekeyEncodings($parameter->content);
+        }
+    }
+
+    /**
+     * @param list<OA\MediaType>|null $mediaTypes
+     */
+    protected function rekeyEncodings(?array $mediaTypes): void
+    {
+        if (!$mediaTypes) {
+            return;
+        }
+
+        foreach ($mediaTypes as $mediaType) {
+            if (!$mediaType->encoding) {
+                continue;
+            }
+
+            $keyed = [];
+            foreach ($mediaType->encoding as $encoding) {
+                if ($encoding instanceof OA\Encoding && $encoding->encoding !== null) {
+                    $keyed[$encoding->encoding] = $encoding;
+                }
+            }
+
+            $mediaType->encoding = $keyed !== [] ? $keyed : null;
+        }
+    }
+}

--- a/src/Augmenter/OperationId.php
+++ b/src/Augmenter/OperationId.php
@@ -1,0 +1,79 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Augmenter;
+
+use OpenApi\Spec as OA;
+use OpenApi\Specification;
+use OpenApi\Utils\PipeInterface;
+
+/**
+ * Generates operationId for operations that don't have one explicitly set.
+ *
+ * @implements PipeInterface<Specification>
+ */
+class OperationId implements PipeInterface
+{
+    /**
+     * @param bool $hash If set to true, generate ids (md5) instead of clear text operation ids
+     */
+    public function __construct(
+        protected bool $hash = true,
+    ) {
+    }
+
+    /**
+     * If set to <code>true</code> generate ids (md5) instead of clear text operation ids.
+     */
+    public function setHash(bool $hash): static
+    {
+        $this->hash = $hash;
+
+        return $this;
+    }
+
+    public function group(): string|\BackedEnum
+    {
+        return Group::Augment;
+    }
+
+    public function __invoke(mixed $payload): mixed
+    {
+        foreach ($payload->operations as $operation) {
+            if ($operation->operationId !== null) {
+                continue;
+            }
+
+            $operationId = $this->generateId($operation);
+            if ($operationId !== null) {
+                $operation->operationId = $this->hash ? md5($operationId) : $operationId;
+            }
+        }
+
+        return null;
+    }
+
+    protected function generateId(OA\Operation $operation): ?string
+    {
+        $reflector = $operation->getReflector();
+
+        $source = match (true) {
+            $reflector instanceof \ReflectionMethod => $operation->getClassName() . '::' . $reflector->getName(),
+            $reflector instanceof \ReflectionFunction => $reflector->getName(),
+            $reflector instanceof \ReflectionClass => $reflector->getName(),
+            default => null,
+        };
+
+        if ($source === null) {
+            return null;
+        }
+
+        $method = strtoupper($operation->method ?? 'GET');
+        $path = $operation->path ?? '';
+
+        return $method . '::' . $path . '::' . $source;
+    }
+}

--- a/src/Augmenter/PathFilter.php
+++ b/src/Augmenter/PathFilter.php
@@ -1,0 +1,112 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Augmenter;
+
+use OpenApi\Spec as OA;
+use OpenApi\Specification;
+use OpenApi\Utils\PipeInterface;
+
+/**
+ * Filters operations by tag and/or path patterns.
+ *
+ * If no tags or paths filters are set, no filtering is performed.
+ * All filter expressions must be valid regular expressions (with delimiters).
+ *
+ * @implements PipeInterface<Specification>
+ */
+class PathFilter implements PipeInterface
+{
+    /**
+     * @param list<string> $tags  Regular expressions to match operation tags
+     * @param list<string> $paths Regular expressions to match operation paths
+     */
+    public function __construct(
+        protected array $tags = [],
+        protected array $paths = [],
+    ) {
+    }
+
+    /**
+     * A list of regular expressions to match <code>tags</code> to include.
+     *
+     * @param list<string> $tags
+     */
+    public function setTags(array $tags): static
+    {
+        $this->tags = $tags;
+
+        return $this;
+    }
+
+    /**
+     * A list of regular expressions to match <code>paths</code> to include.
+     *
+     * @param list<string> $paths
+     */
+    public function setPaths(array $paths): static
+    {
+        $this->paths = $paths;
+
+        return $this;
+    }
+
+    public function group(): string|\BackedEnum
+    {
+        return Group::Reduce;
+    }
+
+    public function __invoke(mixed $payload): mixed
+    {
+        if (!$this->tags && !$this->paths) {
+            return null;
+        }
+
+        $payload->operations = array_values(array_filter(
+            $payload->operations,
+            $this->matches(...),
+        ));
+
+        return null;
+    }
+
+    protected function matches(OA\Operation $operation): bool
+    {
+        return $this->matchesTags($operation) || $this->matchesPath($operation);
+    }
+
+    protected function matchesTags(OA\Operation $operation): bool
+    {
+        if (!$this->tags || !$operation->tags) {
+            return false;
+        }
+
+        foreach ($this->tags as $pattern) {
+            foreach ($operation->tags as $tag) {
+                if (preg_match($pattern, $tag)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    protected function matchesPath(OA\Operation $operation): bool
+    {
+        if (!$this->paths || $operation->path === null) {
+            return false;
+        }
+
+        foreach ($this->paths as $pattern) {
+            if (preg_match($pattern, $operation->path)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Augmenter/PathItemResolve.php
+++ b/src/Augmenter/PathItemResolve.php
@@ -1,0 +1,329 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Augmenter;
+
+use OpenApi\Spec as OA;
+use OpenApi\Specification;
+use OpenApi\Utils\PipeInterface;
+
+/**
+ * Resolves PathItem prefixes, clones metadata to operations, and sets path-level output.
+ *
+ * Walks the class hierarchy to compose path prefixes from ancestor PathItems,
+ * prepends them to operation paths, clones tags/security/responses to operations
+ * that don't declare their own, and marks PathItems that have spec-level output
+ * (parameters, summary, description, servers) with their resolved path.
+ *
+ * @implements PipeInterface<Specification>
+ */
+class PathItemResolve implements PipeInterface
+{
+    public function group(): string|\BackedEnum
+    {
+        return Group::Resolve;
+    }
+
+    public function __invoke(mixed $payload): mixed
+    {
+        $classToPathItem = $this->indexPathItems($payload);
+
+        if ($classToPathItem === []) {
+            return null;
+        }
+
+        $prefixCache = [];
+
+        foreach ($payload->operations as $operation) {
+            $className = $operation->getClassName();
+            if ($className === null) {
+                continue;
+            }
+
+            $pathItem = $this->findGoverningPathItem($className, $classToPathItem);
+            if (!$pathItem instanceof OA\PathItem) {
+                continue;
+            }
+
+            $prefix = $this->resolvePrefix($pathItem, $classToPathItem, $prefixCache);
+            if ($prefix !== '' && $operation->path !== null) {
+                $operationPath = ltrim($operation->path, '/');
+                $operation->path = $operationPath !== '' ? $prefix . '/' . $operationPath : $prefix;
+            }
+
+            $this->cloneMetadata($pathItem, $operation, $classToPathItem);
+        }
+
+        $this->resolvePathItemPaths($payload, $classToPathItem, $prefixCache);
+
+        return null;
+    }
+
+    /**
+     * @return array<class-string, OA\PathItem>
+     */
+    protected function indexPathItems(Specification $specification): array
+    {
+        $map = [];
+
+        foreach ($specification->pathItems as $pathItem) {
+            $className = $pathItem->getClassName();
+            if ($className !== null) {
+                $map[$className] = $pathItem;
+            }
+        }
+
+        return $map;
+    }
+
+    /**
+     * @param array<class-string, OA\PathItem> $classToPathItem
+     * @param array<class-string, string>      $cache
+     */
+    protected function resolvePrefix(OA\PathItem $pathItem, array $classToPathItem, array &$cache): string
+    {
+        $reflector = $pathItem->getClassReflector();
+        if (!$reflector instanceof \ReflectionClass) {
+            return $pathItem->prefix ?? '';
+        }
+
+        $className = $reflector->getName();
+        if (isset($cache[$className])) {
+            return $cache[$className];
+        }
+
+        $parts = [];
+        $current = $reflector;
+        while ($current !== false) {
+            if (isset($classToPathItem[$current->getName()])) {
+                $pi = $classToPathItem[$current->getName()];
+                if ($pi->prefix !== null) {
+                    $parts[] = trim($pi->prefix, '/');
+                }
+            }
+            $current = $current->getParentClass();
+        }
+
+        $parts = array_filter(array_reverse($parts), static fn (string $p): bool => $p !== '');
+        $prefix = $parts !== [] ? '/' . implode('/', $parts) : '';
+        $cache[$className] = $prefix;
+
+        return $prefix;
+    }
+
+    /**
+     * @param array<class-string, OA\PathItem> $classToPathItem
+     */
+    protected function findGoverningPathItem(string $className, array $classToPathItem): ?OA\PathItem
+    {
+        if (isset($classToPathItem[$className])) {
+            return $classToPathItem[$className];
+        }
+
+        try {
+            $rc = new \ReflectionClass($className);
+        } catch (\ReflectionException) {
+            return null;
+        }
+
+        $parent = $rc->getParentClass();
+        while ($parent !== false) {
+            if (isset($classToPathItem[$parent->getName()])) {
+                return $classToPathItem[$parent->getName()];
+            }
+            $parent = $parent->getParentClass();
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<class-string, OA\PathItem> $classToPathItem
+     */
+    protected function cloneMetadata(OA\PathItem $pathItem, OA\Operation $operation, array $classToPathItem): void
+    {
+        $merged = $this->collectMergedMetadata($pathItem, $classToPathItem);
+
+        if ($merged['tags'] !== null) {
+            $operation->tags = array_values(array_unique([...$operation->tags ?? [], ...$merged['tags']]));
+        }
+
+        if ($merged['security'] !== null) {
+            $existingSchemes = [];
+            foreach ($operation->security ?? [] as $req) {
+                $existingSchemes[$req->scheme] = true;
+            }
+            foreach ($merged['security'] as $req) {
+                if (!isset($existingSchemes[$req->scheme])) {
+                    $operation->security ??= [];
+                    $operation->security[] = $req;
+                }
+            }
+        }
+
+        if ($merged['responses'] !== null) {
+            $existingCodes = [];
+            foreach ($operation->responses ?? [] as $response) {
+                if ($response->response !== null) {
+                    $existingCodes[(string) $response->response] = true;
+                }
+            }
+
+            foreach ($merged['responses'] as $response) {
+                if ($response->response !== null && !isset($existingCodes[(string) $response->response])) {
+                    $operation->responses ??= [];
+                    $operation->responses[] = $response;
+                }
+            }
+        }
+    }
+
+    /**
+     * Collect merged metadata walking up the class hierarchy.
+     * All collections merge additively — tags, security, and responses accumulate from all ancestors.
+     *
+     * @param  array<class-string, OA\PathItem>                                                                                $classToPathItem
+     * @return array{tags: list<string>|null, security: list<OA\Security\Requirement>|null, responses: list<OA\Response>|null}
+     */
+    protected function collectMergedMetadata(OA\PathItem $pathItem, array $classToPathItem): array
+    {
+        $reflector = $pathItem->getClassReflector();
+        if (!$reflector instanceof \ReflectionClass) {
+            return [
+                'tags' => $pathItem->tags,
+                'security' => $pathItem->security,
+                'responses' => $pathItem->responses,
+            ];
+        }
+
+        $tags = [];
+        $security = [];
+        $responses = [];
+
+        $current = $reflector;
+        while ($current !== false) {
+            $pi = $classToPathItem[$current->getName()] ?? null;
+            if ($pi !== null) {
+                if ($pi->tags !== null) {
+                    array_push($tags, ...$pi->tags);
+                }
+                if ($pi->security !== null) {
+                    array_push($security, ...$pi->security);
+                }
+                if ($pi->responses !== null) {
+                    array_push($responses, ...$pi->responses);
+                }
+            }
+            $current = $current->getParentClass();
+        }
+
+        return [
+            'tags' => $tags !== [] ? array_values(array_unique($tags)) : null,
+            'security' => $security !== [] ? $security : null,
+            'responses' => $responses !== [] ? $responses : null,
+        ];
+    }
+
+    /**
+     * @param array<class-string, OA\PathItem> $classToPathItem
+     * @param array<class-string, string>      $prefixCache
+     */
+    protected function resolvePathItemPaths(Specification $specification, array $classToPathItem, array $prefixCache): void
+    {
+        foreach ($specification->pathItems as $pathItem) {
+            $this->mergeAncestorParameters($pathItem, $classToPathItem);
+
+            if (!$this->hasSpecProperties($pathItem)) {
+                continue;
+            }
+
+            $paths = $this->findOperationPaths($pathItem, $specification, $classToPathItem);
+
+            if ($paths === []) {
+                continue;
+            }
+
+            foreach ($paths as $path) {
+                if ($pathItem->path === null) {
+                    $pathItem->path = $path;
+                } elseif ($pathItem->path !== $path) {
+                    $clone = clone $pathItem;
+                    $clone->path = $path;
+                    $specification->pathItems[] = $clone;
+                }
+            }
+        }
+    }
+
+    /**
+     * @param array<class-string, OA\PathItem> $classToPathItem
+     */
+    protected function mergeAncestorParameters(OA\PathItem $pathItem, array $classToPathItem): void
+    {
+        $reflector = $pathItem->getClassReflector();
+        if (!$reflector instanceof \ReflectionClass) {
+            return;
+        }
+
+        $parent = $reflector->getParentClass();
+        while ($parent !== false) {
+            $ancestorPi = $classToPathItem[$parent->getName()] ?? null;
+            if ($ancestorPi !== null && $ancestorPi->parameters !== null) {
+                $existingKeys = [];
+                foreach ($pathItem->parameters ?? [] as $param) {
+                    $existingKeys[$param->name . ':' . ($param->in ?? '')] = true;
+                }
+
+                foreach ($ancestorPi->parameters as $param) {
+                    if (!isset($existingKeys[$param->name . ':' . ($param->in ?? '')])) {
+                        $pathItem->parameters ??= [];
+                        $pathItem->parameters[] = $param;
+                    }
+                }
+            }
+            $parent = $parent->getParentClass();
+        }
+    }
+
+    protected function hasSpecProperties(OA\PathItem $pathItem): bool
+    {
+        return $pathItem->parameters !== null
+            || $pathItem->summary !== null
+            || $pathItem->description !== null
+            || $pathItem->servers !== null;
+    }
+
+    /**
+     * @param  array<class-string, OA\PathItem> $classToPathItem
+     * @return list<string>
+     */
+    protected function findOperationPaths(OA\PathItem $pathItem, Specification $specification, array $classToPathItem): array
+    {
+        if (!$pathItem->getClassReflector() instanceof \ReflectionClass) {
+            return [];
+        }
+
+        $paths = [];
+
+        foreach ($specification->operations as $operation) {
+            if ($operation->path === null) {
+                continue;
+            }
+
+            $opClass = $operation->getClassName();
+            if ($opClass === null) {
+                continue;
+            }
+
+            $governing = $this->findGoverningPathItem($opClass, $classToPathItem);
+            if ($governing === $pathItem && !in_array($operation->path, $paths, true)) {
+                $paths[] = $operation->path;
+            }
+        }
+
+        return $paths;
+    }
+}

--- a/src/Augmenter/Ref.php
+++ b/src/Augmenter/Ref.php
@@ -1,0 +1,135 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Augmenter;
+
+use OpenApi\Spec as OA;
+use OpenApi\Specification;
+use OpenApi\Utils\PipeInterface;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+
+/**
+ * Resolves FQCN-based $ref values to JSON Reference paths.
+ *
+ * Builds a map of class names to their component paths and rewrites
+ * any $ref that looks like a FQCN into the proper #/components/... path.
+ *
+ * @implements PipeInterface<Specification>
+ */
+class Ref implements PipeInterface, LoggerAwareInterface
+{
+    use LoggerAwareTrait;
+
+    public function group(): string|\BackedEnum
+    {
+        return Group::Resolve;
+    }
+
+    public function __invoke(mixed $payload): mixed
+    {
+        $refMap = $this->buildRefMap($payload);
+
+        if ($refMap === []) {
+            return null;
+        }
+
+        $unresolved = [];
+        $payload->getWalker()->eachRef(function (OA\AbstractAttribute $attribute) use ($refMap, &$unresolved): void {
+            if (str_starts_with($attribute->ref, '#/')) {
+                return;
+            }
+            if (isset($refMap[$attribute->ref])) {
+                $attribute->ref = $refMap[$attribute->ref];
+            } else {
+                $unresolved[$attribute->ref] = true;
+            }
+        });
+
+        foreach (array_keys($unresolved) as $ref) {
+            $this->logger?->warning('Ref: unresolved reference "{ref}" — no matching component found', [
+                'ref' => $ref,
+            ]);
+        }
+
+        $this->resolveDiscriminatorMappings($payload, $refMap);
+
+        return null;
+    }
+
+    /**
+     * Build a map of FQCN → #/components/{type}/{name}.
+     *
+     * @return array<string, string>
+     */
+    protected function buildRefMap(Specification $specification): array
+    {
+        $map = [];
+
+        foreach ($specification->schemas as $schema) {
+            $name = $schema->schema ?? $schema->title;
+            $fqcn = $schema->getClassName();
+            if ($name !== null && $fqcn !== null) {
+                $map[$fqcn] = '#/components/schemas/' . $name;
+            }
+        }
+
+        foreach ($specification->responses as $response) {
+            $name = $response->response;
+            $fqcn = $response->getClassName();
+            if ($name !== null && $fqcn !== null) {
+                $map[$fqcn] = '#/components/responses/' . $name;
+            }
+        }
+
+        foreach ($specification->requestBodies as $body) {
+            $name = $body->request;
+            $fqcn = $body->getClassName();
+            if ($name !== null && $fqcn !== null) {
+                $map[$fqcn] = '#/components/requestBodies/' . $name;
+            }
+        }
+
+        foreach ($specification->headers as $header) {
+            $name = $header->header;
+            $fqcn = $header->getClassName();
+            if ($name !== null && $fqcn !== null) {
+                $map[$fqcn] = '#/components/headers/' . $name;
+            }
+        }
+
+        foreach ($specification->parameters as $parameter) {
+            $name = $parameter->parameter ?? $parameter->name;
+            $fqcn = $parameter->getClassName();
+            if ($name !== null && $fqcn !== null) {
+                $map[$fqcn] = '#/components/parameters/' . $name;
+            }
+        }
+
+        return $map;
+    }
+
+    /**
+     * @param array<string, string> $refMap
+     */
+    protected function resolveDiscriminatorMappings(Specification $specification, array $refMap): void
+    {
+        foreach ($specification->schemas as $schema) {
+            if (!$schema->discriminator instanceof OA\Discriminator || $schema->discriminator->mapping === null) {
+                continue;
+            }
+
+            foreach ($schema->discriminator->mapping as $value => $type) {
+                if (str_starts_with($type, '#/')) {
+                    continue;
+                }
+                if (isset($refMap[$type])) {
+                    $schema->discriminator->mapping[$value] = $refMap[$type];
+                }
+            }
+        }
+    }
+}

--- a/src/Augmenter/Tag.php
+++ b/src/Augmenter/Tag.php
@@ -1,0 +1,114 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Augmenter;
+
+use OpenApi\Spec as OA;
+use OpenApi\Specification;
+use OpenApi\Utils\PipeInterface;
+
+/**
+ * Ensures all tags used on operations exist in the global tags list.
+ *
+ * Adds missing Tag objects for any tag name referenced by operations.
+ * Removes unused declared tags unless whitelisted.
+ *
+ * @implements PipeInterface<Specification>
+ */
+class Tag implements PipeInterface
+{
+    /**
+     * @param list<string> $whitelist
+     */
+    public function __construct(
+        protected array $whitelist = [],
+        protected bool $withDescription = true,
+    ) {
+    }
+
+    /**
+     * Whitelist tags to keep even if not used. Use '*' to keep all.
+     *
+     * @param list<string> $whitelist
+     */
+    public function setWhitelist(array $whitelist): static
+    {
+        $this->whitelist = $whitelist;
+
+        return $this;
+    }
+
+    /**
+     * Enables/disables generation of default tag descriptions.
+     */
+    public function setWithDescription(bool $withDescription): static
+    {
+        $this->withDescription = $withDescription;
+
+        return $this;
+    }
+
+    public function group(): string|\BackedEnum
+    {
+        return Group::Augment;
+    }
+
+    public function __invoke(mixed $payload): mixed
+    {
+        $usedTagNames = $this->collectUsedTags($payload);
+
+        $declaredTags = [];
+        foreach ($payload->tags as $tag) {
+            if ($tag->name !== null) {
+                $declaredTags[$tag->name] = $tag;
+            }
+        }
+
+        foreach ($usedTagNames as $tagName) {
+            if (!isset($declaredTags[$tagName])) {
+                $tag = new OA\Tag(
+                    name: $tagName,
+                    description: $this->withDescription ? $tagName : null,
+                );
+                $payload->tags[] = $tag;
+                $declaredTags[$tagName] = $tag;
+            }
+        }
+
+        $this->removeUnusedTags($usedTagNames, $declaredTags, $payload);
+
+        return null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    protected function collectUsedTags(mixed $payload): array
+    {
+        $names = [];
+        foreach ($payload->operations as $operation) {
+            if ($operation->tags !== null) {
+                array_push($names, ...$operation->tags);
+            }
+        }
+
+        return array_values(array_unique($names));
+    }
+
+    protected function removeUnusedTags(array $usedTagNames, array $declaredTags, mixed $payload): void
+    {
+        if (in_array('*', $this->whitelist, true)) {
+            return;
+        }
+
+        $tagsToKeep = array_merge($usedTagNames, $this->whitelist);
+
+        $payload->tags = array_values(array_filter(
+            $payload->tags,
+            fn (OA\Tag $tag): bool => $tag->name === null || in_array($tag->name, $tagsToKeep, true),
+        ));
+    }
+}

--- a/src/Augmenter/Type.php
+++ b/src/Augmenter/Type.php
@@ -1,0 +1,352 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Augmenter;
+
+use OpenApi\Spec as OA;
+use OpenApi\Specification;
+use OpenApi\Type\SchemaType;
+use OpenApi\Type\TypeResolver;
+use OpenApi\Undefined;
+use OpenApi\Utils\PipeInterface;
+
+/**
+ * Infers schema type, format, nullable, items, etc. from PHP type declarations and docblocks.
+ *
+ * Walks all properties and parameters in the specification and fills their schema
+ * fields from the attached reflector's type information.
+ *
+ * @implements PipeInterface<Specification>
+ */
+class Type implements PipeInterface
+{
+    public function __construct(
+        protected TypeResolver $typeResolver = new TypeResolver(),
+    ) {
+    }
+
+    /**
+     * Override the type resolver used to infer schema types from PHP type declarations.
+     */
+    public function setTypeResolver(TypeResolver $typeResolver): static
+    {
+        $this->typeResolver = $typeResolver;
+
+        return $this;
+    }
+
+    public function group(): string|\BackedEnum
+    {
+        return Group::Resolve;
+    }
+
+    public function __invoke(mixed $payload): mixed
+    {
+        foreach ($payload->schemas as $schema) {
+            $this->inferSchemaType($schema);
+            $this->walkSchema($schema);
+        }
+
+        foreach ($payload->operations as $operation) {
+            $this->augmentOperationParameters($operation);
+            $this->walkOperationSchemas($operation);
+        }
+
+        foreach ($payload->parameters as $parameter) {
+            $this->augmentParameter($parameter);
+        }
+
+        foreach ($payload->requestBodies as $requestBody) {
+            $this->walkMediaTypes($requestBody->content);
+        }
+
+        foreach ($payload->responses as $response) {
+            $this->walkMediaTypes($response->content);
+        }
+
+        foreach ($payload->headers as $header) {
+            $this->walkSchema($header->schema);
+        }
+
+        return null;
+    }
+
+    protected function inferSchemaType(OA\Schema $schema): void
+    {
+        if ($schema->type !== null) {
+            return;
+        }
+
+        if ($schema->items instanceof OA\Schema) {
+            $schema->type = 'array';
+        } elseif ($schema->properties || $schema->allOf || $schema->patternProperties) {
+            $schema->type = 'object';
+        }
+    }
+
+    protected function walkSchema(?OA\Schema $schema): void
+    {
+        if (!$schema instanceof OA\Schema) {
+            return;
+        }
+
+        $this->inferSchemaType($schema);
+
+        if ($schema->properties) {
+            foreach ($schema->properties as $property) {
+                if (!$property instanceof OA\Property) {
+                    continue;
+                }
+
+                $this->augmentProperty($property);
+
+                if ($property->schema instanceof OA\Schema) {
+                    $this->walkSchema($property->schema);
+                }
+            }
+        }
+
+        $this->walkSchema($schema->items instanceof OA\Schema ? $schema->items : null);
+        $this->walkSchema($schema->additionalProperties instanceof OA\Schema ? $schema->additionalProperties : null);
+
+        foreach ($schema->allOf ?? [] as $child) {
+            $this->walkSchema($child);
+        }
+        foreach ($schema->anyOf ?? [] as $child) {
+            $this->walkSchema($child);
+        }
+        foreach ($schema->oneOf ?? [] as $child) {
+            $this->walkSchema($child);
+        }
+    }
+
+    protected function walkOperationSchemas(OA\Operation $operation): void
+    {
+        foreach ($operation->responses ?? [] as $response) {
+            $this->walkMediaTypes($response->content);
+        }
+
+        if ($operation->requestBody instanceof OA\RequestBody) {
+            $this->walkMediaTypes($operation->requestBody->content);
+        }
+    }
+
+    /**
+     * @param list<OA\MediaType>|null $mediaTypes
+     */
+    protected function walkMediaTypes(?array $mediaTypes): void
+    {
+        if (!$mediaTypes) {
+            return;
+        }
+
+        foreach ($mediaTypes as $mediaType) {
+            $this->walkSchema($mediaType->schema);
+        }
+    }
+
+    protected function augmentProperty(OA\Property $property): void
+    {
+        $reflector = $property->getReflector();
+        if ($reflector instanceof \ReflectionMethod) {
+            $this->augmentMethodProperty($property, $reflector);
+
+            return;
+        }
+
+        if (!$reflector instanceof \ReflectionProperty
+            && !$reflector instanceof \ReflectionParameter
+            && !$reflector instanceof \ReflectionClassConstant
+        ) {
+            return;
+        }
+
+        $property->property ??= $reflector->getName();
+
+        if ($reflector instanceof \ReflectionClassConstant) {
+            $this->augmentConstantProperty($property, $reflector);
+
+            return;
+        }
+
+        if ($property->schema instanceof OA\Schema && $property->schema->ref !== null) {
+            return;
+        }
+
+        $resolved = $this->typeResolver->resolve($reflector);
+        if (!$resolved instanceof SchemaType) {
+            return;
+        }
+
+        if (!$property->schema instanceof OA\Schema) {
+            $property->schema = $this->schemaTypeToSchema($resolved);
+        } else {
+            $this->mergeIntoSchema($property->schema, $resolved);
+        }
+    }
+
+    protected function augmentConstantProperty(OA\Property $property, \ReflectionClassConstant $reflector): void
+    {
+        $value = $reflector->getValue();
+
+        $schema = $property->schema ?? new OA\Schema();
+        // Can't use ??= here — const defaults to Undefined::UNDEFINED, not null
+        if (Undefined::isDefault($schema->const)) {
+            $schema->const = $value;
+        }
+        $schema->type ??= match (true) {
+            is_string($value) => 'string',
+            is_int($value) => 'integer',
+            is_float($value) => 'number',
+            is_bool($value) => 'boolean',
+            default => null,
+        };
+        $property->schema = $schema;
+    }
+
+    protected function augmentMethodProperty(OA\Property $property, \ReflectionMethod $method): void
+    {
+        if ($property->schema instanceof OA\Schema && $property->schema->ref !== null) {
+            return;
+        }
+
+        $resolved = $this->typeResolver->resolve($method);
+        if (!$resolved instanceof SchemaType) {
+            return;
+        }
+
+        if (!$property->schema instanceof OA\Schema) {
+            $property->schema = new OA\Schema();
+        }
+
+        $this->applySchemaType($property->schema, $resolved);
+    }
+
+    protected function augmentOperationParameters(OA\Operation $operation): void
+    {
+        if (!$operation->parameters) {
+            return;
+        }
+
+        foreach ($operation->parameters as $parameter) {
+            $this->augmentParameter($parameter);
+            $this->walkMediaTypes($parameter->content);
+        }
+    }
+
+    protected function augmentParameter(OA\Parameter $parameter): void
+    {
+        $reflector = $parameter->getReflector();
+        if (!$reflector instanceof \ReflectionParameter) {
+            return;
+        }
+
+        $parameter->name ??= $reflector->getName();
+
+        if ($parameter->schema instanceof OA\Schema && $parameter->schema->ref !== null) {
+            return;
+        }
+
+        $resolved = $this->typeResolver->resolve($reflector);
+        if (!$resolved instanceof SchemaType) {
+            return;
+        }
+
+        $isNullable = $resolved->nullable === true;
+
+        // PHP nullable type on a parameter means "can be omitted" (required: false),
+        // not "accepts null when present" — suppress nullable on the schema
+        if ($parameter->required === true || $isNullable) {
+            $resolved->nullable = null;
+        }
+
+        if (!$parameter->schema instanceof OA\Schema) {
+            $parameter->schema = $this->schemaTypeToSchema($resolved);
+        } else {
+            $this->mergeIntoSchema($parameter->schema, $resolved);
+        }
+
+        $parameter->required ??= !$isNullable;
+    }
+
+    protected function schemaTypeToSchema(SchemaType $schemaType): OA\Schema
+    {
+        $schema = new OA\Schema();
+        $this->applySchemaType($schema, $schemaType);
+
+        return $schema;
+    }
+
+    protected function mergeIntoSchema(OA\Schema $schema, SchemaType $schemaType): void
+    {
+        if ($schema->type === null && $schema->oneOf === null && $schema->allOf === null && $schema->anyOf === null) {
+            $this->applySchemaType($schema, $schemaType);
+        }
+    }
+
+    protected function applySchemaType(OA\Schema $schema, SchemaType $schemaType): void
+    {
+        if ($schemaType->nullable !== null && $schema->nullable === null) {
+            $schema->nullable = $schemaType->nullable;
+        }
+
+        if ($schemaType->type !== null) {
+            if ($schemaType->isRef()) {
+                $schema->ref = $schemaType->type;
+            } else {
+                $schema->type = $schemaType->type;
+            }
+        }
+
+        if ($schemaType->format !== null && $schema->format === null) {
+            $schema->format = $schemaType->format;
+        }
+
+        if ($schemaType->minimum !== null && $schema->minimum === null) {
+            $schema->minimum = $schemaType->minimum;
+        }
+
+        if ($schemaType->maximum !== null && $schema->maximum === null) {
+            $schema->maximum = $schemaType->maximum;
+        }
+
+        if ($schemaType->not !== null && !$schema->not instanceof OA\Schema) {
+            $schema->not = new OA\Schema(const: $schemaType->not['const']);
+        }
+
+        if ($schemaType->items instanceof SchemaType) {
+            $schema->type = 'array';
+            $schema->items ??= $this->schemaTypeToSchema($schemaType->items);
+        }
+
+        if ($schemaType->additionalProperties instanceof SchemaType) {
+            $schema->additionalProperties ??= $this->schemaTypeToSchema($schemaType->additionalProperties);
+        } elseif ($schemaType->additionalProperties === true) {
+            $schema->additionalProperties ??= true;
+        }
+
+        if ($schemaType->oneOf !== null) {
+            $schema->oneOf = array_map($this->schemaTypeToSchema(...), $schemaType->oneOf);
+        }
+
+        if ($schemaType->allOf !== null) {
+            $schema->allOf = array_map($this->schemaTypeToSchema(...), $schemaType->allOf);
+        }
+
+        if ($schemaType->properties !== null) {
+            $schema->type = 'object';
+            $schema->properties = [];
+            foreach ($schemaType->properties as $name => $propType) {
+                $propSchema = $this->schemaTypeToSchema($propType);
+                $property = new OA\Property(property: $name, schema: $propSchema);
+                $schema->properties[] = $property;
+            }
+            if ($schemaType->required !== null) {
+                $schema->required = $schemaType->required;
+            }
+        }
+    }
+}

--- a/tests/Augmenter/CleanUnusedPerformanceTest.php
+++ b/tests/Augmenter/CleanUnusedPerformanceTest.php
@@ -1,0 +1,97 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Augmenter;
+
+use OpenApi\Augmenter;
+use OpenApi\Spec as OA;
+use OpenApi\Specification;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Performance regression test for CleanUnused augmenter.
+ *
+ * Run with: phpunit --group performance
+ */
+#[Group('performance')]
+final class CleanUnusedPerformanceTest extends TestCase
+{
+    protected const SCHEMA_COUNT = 300;
+
+    protected const UNUSED_RATIO = 0.4;
+
+    protected const MAX_CLEANUP_OVERHEAD_MS = 50;
+
+    public function testCleanupPerformance(): void
+    {
+        $spec = $this->buildLargeSpec();
+
+        // Warmup
+        $warmup = clone $spec;
+        (new Augmenter\CleanUnused())($warmup);
+
+        // Measure
+        $start = microtime(true);
+        (new Augmenter\CleanUnused())($spec);
+        $elapsed = (microtime(true) - $start) * 1000;
+
+        $this->assertLessThan(
+            self::MAX_CLEANUP_OVERHEAD_MS,
+            $elapsed,
+            sprintf('CleanUnused took %.1fms, max allowed: %dms', $elapsed, self::MAX_CLEANUP_OVERHEAD_MS),
+        );
+    }
+
+    public function testCleanupRemovesExpectedSchemas(): void
+    {
+        $spec = $this->buildLargeSpec();
+        $usedCount = (int) round(self::SCHEMA_COUNT * (1 - self::UNUSED_RATIO));
+
+        (new Augmenter\CleanUnused())($spec);
+
+        $this->assertCount($usedCount, $spec->schemas, 'All unused schemas should be removed');
+    }
+
+    protected function buildLargeSpec(): Specification
+    {
+        $spec = new Specification();
+
+        $usedCount = (int) round(self::SCHEMA_COUNT * (1 - self::UNUSED_RATIO));
+
+        for ($i = 0; $i < self::SCHEMA_COUNT; $i++) {
+            $properties = [
+                new OA\Property(property: 'id', schema: new OA\Schema(type: 'integer')),
+                new OA\Property(property: 'name', schema: new OA\Schema(type: 'string')),
+            ];
+
+            if ($i < $usedCount) {
+                $refIdx = ($i + 1) % $usedCount;
+                $properties[] = new OA\Property(
+                    property: 'related',
+                    schema: new OA\Schema(ref: '#/components/schemas/PerfSchema' . $refIdx),
+                );
+            }
+
+            $spec->schemas[] = new OA\Schema(schema: 'PerfSchema' . $i, properties: $properties);
+        }
+
+        for ($i = 0; $i < $usedCount; $i++) {
+            $operation = new OA\Operation(path: '/perf/' . $i, method: 'get');
+            $operation->responses = [
+                new OA\Response(response: 200, description: 'OK', content: [
+                    new OA\MediaType(
+                        mediaType: 'application/json',
+                        schema: new OA\Schema(ref: '#/components/schemas/PerfSchema' . $i),
+                    ),
+                ]),
+            ];
+            $spec->operations[] = $operation;
+        }
+
+        return $spec;
+    }
+}

--- a/tests/Augmenter/CleanUnusedTest.php
+++ b/tests/Augmenter/CleanUnusedTest.php
@@ -1,0 +1,168 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Augmenter;
+
+use OpenApi\Augmenter;
+use OpenApi\Spec as OA;
+use OpenApi\Specification;
+use PHPUnit\Framework\TestCase;
+
+final class CleanUnusedTest extends TestCase
+{
+    public function testRemovesUnreferencedSchema(): void
+    {
+        $spec = new Specification();
+
+        $usedSchema = new OA\Schema(schema: 'Used');
+        $unusedSchema = new OA\Schema(schema: 'Unused');
+        $spec->schemas = [$usedSchema, $unusedSchema];
+
+        $operation = new OA\Operation(path: '/test', method: 'get');
+        $response = new OA\Response(response: 200, description: 'OK', content: [
+            new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: '#/components/schemas/Used')),
+        ]);
+        $operation->responses = [$response];
+        $spec->operations[] = $operation;
+
+        (new Augmenter\CleanUnused())($spec);
+
+        $this->assertCount(1, $spec->schemas);
+        $this->assertSame('Used', $spec->schemas[0]->schema);
+    }
+
+    public function testKeepsReferencedSchemaInProperty(): void
+    {
+        $spec = new Specification();
+
+        $childSchema = new OA\Schema(schema: 'Child');
+        $parentSchema = new OA\Schema(schema: 'Parent', properties: [
+            new OA\Property(property: 'child', schema: new OA\Schema(ref: '#/components/schemas/Child')),
+        ]);
+        $spec->schemas = [$childSchema, $parentSchema];
+
+        $operation = new OA\Operation(path: '/test', method: 'get');
+        $response = new OA\Response(response: 200, description: 'OK', content: [
+            new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: '#/components/schemas/Parent')),
+        ]);
+        $operation->responses = [$response];
+        $spec->operations[] = $operation;
+
+        (new Augmenter\CleanUnused())($spec);
+
+        $this->assertCount(2, $spec->schemas);
+    }
+
+    public function testRemovesNestedDependencies(): void
+    {
+        $spec = new Specification();
+
+        $deepSchema = new OA\Schema(schema: 'Deep');
+        $middleSchema = new OA\Schema(schema: 'Middle', properties: [
+            new OA\Property(property: 'deep', schema: new OA\Schema(ref: '#/components/schemas/Deep')),
+        ]);
+        $usedSchema = new OA\Schema(schema: 'Used');
+        $spec->schemas = [$deepSchema, $middleSchema, $usedSchema];
+
+        $operation = new OA\Operation(path: '/test', method: 'get');
+        $response = new OA\Response(response: 200, description: 'OK', content: [
+            new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: '#/components/schemas/Used')),
+        ]);
+        $operation->responses = [$response];
+        $spec->operations[] = $operation;
+
+        (new Augmenter\CleanUnused())($spec);
+
+        $this->assertCount(1, $spec->schemas);
+        $this->assertSame('Used', $spec->schemas[0]->schema);
+    }
+
+    public function testDisabledDoesNothing(): void
+    {
+        $spec = new Specification();
+        $spec->schemas = [new OA\Schema(schema: 'Orphan')];
+
+        $augmenter = new Augmenter\CleanUnused(enabled: false);
+        $augmenter($spec);
+
+        $this->assertCount(1, $spec->schemas);
+    }
+
+    public function testKeepsSchemaReferencedViaAllOf(): void
+    {
+        $spec = new Specification();
+
+        $baseSchema = new OA\Schema(schema: 'Base');
+        $compositeSchema = new OA\Schema(schema: 'Composite', allOf: [
+            new OA\Schema(ref: '#/components/schemas/Base'),
+        ]);
+        $spec->schemas = [$baseSchema, $compositeSchema];
+
+        $operation = new OA\Operation(path: '/test', method: 'get');
+        $response = new OA\Response(response: 200, description: 'OK', content: [
+            new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: '#/components/schemas/Composite')),
+        ]);
+        $operation->responses = [$response];
+        $spec->operations[] = $operation;
+
+        (new Augmenter\CleanUnused())($spec);
+
+        $this->assertCount(2, $spec->schemas);
+    }
+
+    public function testRemovesUnusedResponse(): void
+    {
+        $spec = new Specification();
+
+        $spec->responses = [
+            new OA\Response(response: 'NotFound', description: 'Not found'),
+        ];
+
+        $operation = new OA\Operation(path: '/test', method: 'get');
+        $operation->responses = [new OA\Response(response: 200, description: 'OK')];
+        $spec->operations[] = $operation;
+
+        (new Augmenter\CleanUnused())($spec);
+
+        $this->assertCount(0, $spec->responses);
+    }
+
+    public function testKeepsSecuritySchemeReferencedByOperation(): void
+    {
+        $spec = new Specification();
+
+        $scheme = new OA\Security\Scheme(securityScheme: 'bearerAuth', type: 'http');
+        $unusedScheme = new OA\Security\Scheme(securityScheme: 'unused', type: 'http');
+        $spec->securitySchemes = [$scheme, $unusedScheme];
+
+        $operation = new OA\Operation(path: '/test', method: 'get');
+        $operation->security = [new OA\Security\Requirement(scheme: 'bearerAuth')];
+        $operation->responses = [new OA\Response(response: 200, description: 'OK')];
+        $spec->operations[] = $operation;
+
+        (new Augmenter\CleanUnused())($spec);
+
+        $this->assertCount(1, $spec->securitySchemes);
+        $this->assertSame('bearerAuth', $spec->securitySchemes[0]->securityScheme);
+    }
+
+    public function testKeepsSecuritySchemeReferencedGlobally(): void
+    {
+        $spec = new Specification();
+
+        $scheme = new OA\Security\Scheme(securityScheme: 'apiKey', type: 'apiKey');
+        $spec->securitySchemes = [$scheme];
+        $spec->openapi->security = [new OA\Security\Requirement(scheme: 'apiKey')];
+
+        $operation = new OA\Operation(path: '/test', method: 'get');
+        $operation->responses = [new OA\Response(response: 200, description: 'OK')];
+        $spec->operations[] = $operation;
+
+        (new Augmenter\CleanUnused())($spec);
+
+        $this->assertCount(1, $spec->securitySchemes);
+    }
+}

--- a/tests/Augmenter/DocblockTest.php
+++ b/tests/Augmenter/DocblockTest.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Augmenter;
+
+use OpenApi\Augmenter;
+use OpenApi\Tests\Concerns\AssemblesSpecification;
+use OpenApi\Tests\Fixtures;
+use PHPUnit\Framework\TestCase;
+
+final class DocblockTest extends TestCase
+{
+    use AssemblesSpecification;
+
+    public function testAugmentsOperationSummaryAndDescription(): void
+    {
+        $spec = $this->assemble(Fixtures\Augmenter\DocblockController::class);
+
+        (new Augmenter\Docblock())($spec);
+
+        $this->assertSame('Get a thing.', $spec->operations[0]->summary);
+        $this->assertSame('Returns the thing by ID.', $spec->operations[0]->description);
+    }
+
+    public function testAugmentsDeprecated(): void
+    {
+        $spec = $this->assemble(Fixtures\Augmenter\DocblockController::class);
+
+        (new Augmenter\Docblock())($spec);
+
+        $this->assertTrue($spec->operations[0]->deprecated);
+    }
+
+    public function testAugmentsSchemaDescription(): void
+    {
+        $spec = $this->assemble(Fixtures\Augmenter\DocblockSchema::class);
+
+        (new Augmenter\Docblock())($spec);
+
+        $this->assertSame('A documented schema.', $spec->schemas[0]->description);
+        $this->assertTrue($spec->schemas[0]->deprecated);
+    }
+
+    public function testAugmentsParameterDescription(): void
+    {
+        $spec = $this->assemble(Fixtures\Augmenter\DocblockController::class);
+
+        (new Augmenter\Docblock())($spec);
+
+        $this->assertSame('the thing identifier', $spec->operations[0]->parameters[0]->description);
+    }
+}

--- a/tests/Augmenter/EnumsTest.php
+++ b/tests/Augmenter/EnumsTest.php
@@ -1,0 +1,127 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Augmenter;
+
+use OpenApi\Augmenter;
+use OpenApi\Spec as OA;
+use OpenApi\Specification;
+use OpenApi\Tests\Concerns\AssemblesSpecification;
+use OpenApi\Tests\Fixtures;
+use PHPUnit\Framework\TestCase;
+
+final class EnumsTest extends TestCase
+{
+    use AssemblesSpecification;
+
+    public function testBasicEnumUsesNames(): void
+    {
+        $spec = $this->assemble(Fixtures\Augmenter\BasicEnum::class);
+
+        (new Augmenter\Enums())($spec);
+
+        $schema = $spec->schemas[0];
+        $this->assertSame('BasicEnum', $schema->schema);
+        $this->assertSame('string', $schema->type);
+        $this->assertSame(['GREEN', 'BLUE', 'RED'], $schema->enum);
+    }
+
+    public function testBackedEnumWithoutTypeUsesNames(): void
+    {
+        $spec = $this->assemble(Fixtures\Augmenter\BackedStringEnum::class);
+
+        (new Augmenter\Enums())($spec);
+
+        $schema = $spec->schemas[0];
+        $this->assertSame('BackedStringEnum', $schema->schema);
+        $this->assertSame('string', $schema->type);
+        $this->assertSame(['ACTIVE', 'INACTIVE'], $schema->enum);
+    }
+
+    public function testBackedEnumWithMatchingTypeUsesValues(): void
+    {
+        $spec = $this->assemble(Fixtures\Augmenter\BackedIntEnum::class);
+
+        (new Augmenter\Enums())($spec);
+
+        $schema = $spec->schemas[0];
+        $this->assertSame('BackedIntEnum', $schema->schema);
+        $this->assertSame('integer', $schema->type);
+        $this->assertSame([1, 2, 3], $schema->enum);
+    }
+
+    public function testEnumNamesExtension(): void
+    {
+        $spec = $this->assemble(Fixtures\Augmenter\BackedIntEnum::class);
+
+        (new Augmenter\Enums(enumNames: 'enumNames'))($spec);
+
+        $schema = $spec->schemas[0];
+        $this->assertSame(['enumNames' => ['GREEN', 'BLUE', 'RED']], $schema->x);
+    }
+
+    public function testEnumNamesNotSetForNameMode(): void
+    {
+        $spec = $this->assemble(Fixtures\Augmenter\BasicEnum::class);
+
+        (new Augmenter\Enums(enumNames: 'enumNames'))($spec);
+
+        $schema = $spec->schemas[0];
+        $this->assertNull($schema->x);
+    }
+
+    public function testResolvesEnumInstancesInValues(): void
+    {
+        $spec = new Specification();
+        $schema = new OA\Schema(
+            schema: 'Test',
+            enum: [Fixtures\Augmenter\BasicEnum::GREEN, Fixtures\Augmenter\BasicEnum::RED],
+        );
+        $spec->schemas[] = $schema;
+
+        (new Augmenter\Enums())($spec);
+
+        $this->assertSame(['GREEN', 'RED'], $schema->enum);
+    }
+
+    public function testResolvesBackedEnumInstancesInValues(): void
+    {
+        $spec = new Specification();
+        $schema = new OA\Schema(
+            schema: 'Test',
+            enum: [Fixtures\Augmenter\BackedIntEnum::GREEN, Fixtures\Augmenter\BackedIntEnum::BLUE],
+        );
+        $spec->schemas[] = $schema;
+
+        (new Augmenter\Enums())($spec);
+
+        $this->assertSame([1, 2], $schema->enum);
+    }
+
+    public function testResolvesEnumClassStringInValues(): void
+    {
+        $spec = new Specification();
+        $schema = new OA\Schema(
+            schema: 'Test',
+            enum: [Fixtures\Augmenter\BasicEnum::class],
+        );
+        $spec->schemas[] = $schema;
+
+        (new Augmenter\Enums())($spec);
+
+        $this->assertSame(['GREEN', 'BLUE', 'RED'], $schema->enum);
+    }
+
+    public function testPreservesExplicitSchemaName(): void
+    {
+        $spec = $this->assemble(Fixtures\Augmenter\BasicEnum::class);
+        $spec->schemas[0]->schema = 'CustomName';
+
+        (new Augmenter\Enums())($spec);
+
+        $this->assertSame('CustomName', $spec->schemas[0]->schema);
+    }
+}

--- a/tests/Augmenter/ExpandHierarchyBcTest.php
+++ b/tests/Augmenter/ExpandHierarchyBcTest.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Augmenter;
+
+use OpenApi\Assembler;
+use OpenApi\Augmenter;
+use OpenApi\Builder;
+use OpenApi\Compiler\OpenApi31Compiler;
+use OpenApi\Tests\Concerns\AssertsSchemaStructure;
+use OpenApi\Utils\TokenScanner;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Verifies that both spec and classic pipelines produce the same structural
+ * composition (allOf refs + property names) for identical class hierarchies.
+ */
+final class ExpandHierarchyBcTest extends TestCase
+{
+    use AssertsSchemaStructure;
+
+    private const EXPECTED_FILE = __DIR__ . '/../Fixtures/Augmenter/Hierarchy/expected.yaml';
+
+    #[DataProvider('pipelines')]
+    public function testMatchesExpected(string $pipeline, array $schemas): void
+    {
+        $this->assertCompiledSchemasMatchFile($schemas, self::EXPECTED_FILE, $pipeline);
+    }
+
+    public static function pipelines(): iterable
+    {
+        yield 'spec' => ['spec', self::buildSpec(__DIR__ . '/../Fixtures/Augmenter/Hierarchy/Spec')];
+        yield 'classic' => ['classic', self::buildClassic(__DIR__ . '/../Fixtures/Augmenter/Hierarchy/Classic')];
+    }
+
+    protected static function buildSpec(string $directory): array
+    {
+        $tokenScanner = new TokenScanner();
+        $assembler = new Assembler();
+
+        foreach (glob($directory . '/*.php') as $file) {
+            require_once $file;
+            foreach (array_keys($tokenScanner->scanFile($file)) as $class) {
+                if (class_exists($class) || interface_exists($class) || enum_exists($class) || trait_exists($class)) {
+                    $assembler->collect(new \ReflectionClass($class));
+                }
+            }
+        }
+
+        $specification = $assembler->getSpecification();
+
+        (new Augmenter\ExpandHierarchy())($specification);
+        (new Augmenter\InferNames())($specification);
+        (new Augmenter\Type())($specification);
+        (new Augmenter\Ref())($specification);
+
+        $compiler = new OpenApi31Compiler();
+        $output = $compiler->compile($specification);
+
+        return $output['components']['schemas'] ?? [];
+    }
+
+    protected static function buildClassic(string $directory): array
+    {
+        $result = (new Builder())
+            ->setMode('classic')
+            ->addSource($directory)
+            ->setVersion('3.1.0')
+            ->build();
+
+        return $result->toArray()['components']['schemas'] ?? [];
+    }
+}

--- a/tests/Augmenter/ExpandHierarchyTest.php
+++ b/tests/Augmenter/ExpandHierarchyTest.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Augmenter;
+
+use OpenApi\Assembler;
+use OpenApi\Augmenter;
+use OpenApi\Tests\Concerns\AssertsSchemaStructure;
+use OpenApi\Tests\Fixtures\Augmenter\Hierarchy\Spec as Fixtures;
+use PHPUnit\Framework\TestCase;
+
+final class ExpandHierarchyTest extends TestCase
+{
+    use AssertsSchemaStructure;
+
+    public function testAllSchemasMatchExpected(): void
+    {
+        $assembler = new Assembler();
+        $assembler->collect(
+            new \ReflectionClass(Fixtures\TraitWithSchema::class),
+            new \ReflectionClass(Fixtures\ClassUsingTraitWithSchema::class),
+            new \ReflectionClass(Fixtures\PlainTrait::class),
+            new \ReflectionClass(Fixtures\ClassUsingPlainTrait::class),
+            new \ReflectionClass(Fixtures\ParentWithSchema::class),
+            new \ReflectionClass(Fixtures\ChildOfParentWithSchema::class),
+            new \ReflectionClass(Fixtures\PlainParent::class),
+            new \ReflectionClass(Fixtures\ChildOfPlainParent::class),
+            new \ReflectionClass(Fixtures\StandaloneSchema::class),
+        );
+
+        $spec = $assembler->getSpecification();
+        (new Augmenter\ExpandHierarchy())($spec);
+
+        $this->assertSpecificationSchemasMatchFile(
+            $spec,
+            __DIR__ . '/../Fixtures/Augmenter/Hierarchy/expected.yaml',
+        );
+    }
+}

--- a/tests/Augmenter/InferNamesTest.php
+++ b/tests/Augmenter/InferNamesTest.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Augmenter;
+
+use OpenApi\Augmenter;
+use OpenApi\Spec as OA;
+use OpenApi\Specification;
+use OpenApi\Tests\Concerns\AssemblesSpecification;
+use OpenApi\Tests\Fixtures;
+use PHPUnit\Framework\TestCase;
+
+final class InferNamesTest extends TestCase
+{
+    use AssemblesSpecification;
+
+    public function testInfersSchemaNameFromClass(): void
+    {
+        $spec = $this->assemble(Fixtures\Augmenter\TypeSchema::class);
+
+        (new Augmenter\InferNames())($spec);
+
+        $this->assertSame('TypeSchema', $spec->schemas[0]->schema);
+    }
+
+    public function testInfersSchemaNameFromEnum(): void
+    {
+        $spec = $this->assemble(Fixtures\Augmenter\BasicEnum::class);
+
+        (new Augmenter\InferNames())($spec);
+
+        $this->assertSame('BasicEnum', $spec->schemas[0]->schema);
+    }
+
+    public function testPreservesExplicitSchemaName(): void
+    {
+        $spec = $this->assemble(Fixtures\Augmenter\TypeSchema::class);
+        $spec->schemas[0]->schema = 'CustomName';
+
+        (new Augmenter\InferNames())($spec);
+
+        $this->assertSame('CustomName', $spec->schemas[0]->schema);
+    }
+
+    public function testInfersParameterKeyFromName(): void
+    {
+        $spec = new Specification();
+        $param = new OA\Parameter(name: 'page', in: 'query');
+        $spec->parameters[] = $param;
+
+        (new Augmenter\InferNames())($spec);
+
+        $this->assertSame('page', $param->parameter);
+    }
+
+    public function testPreservesExplicitParameterKey(): void
+    {
+        $spec = new Specification();
+        $param = new OA\Parameter(parameter: 'custom', name: 'page', in: 'query');
+        $spec->parameters[] = $param;
+
+        (new Augmenter\InferNames())($spec);
+
+        $this->assertSame('custom', $param->parameter);
+    }
+}

--- a/tests/Augmenter/MediaTypeTest.php
+++ b/tests/Augmenter/MediaTypeTest.php
@@ -1,0 +1,125 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Augmenter;
+
+use OpenApi\Augmenter;
+use OpenApi\Spec as OA;
+use OpenApi\Specification;
+use PHPUnit\Framework\TestCase;
+
+final class MediaTypeTest extends TestCase
+{
+    public function testRekeysEncodingsByPropertyName(): void
+    {
+        $spec = new Specification();
+
+        $mediaType = new OA\MediaType(
+            mediaType: 'multipart/form-data',
+            schema: new OA\Schema(type: 'object'),
+            encoding: [
+                new OA\Encoding(encoding: 'metadata', contentType: 'application/xml'),
+                new OA\Encoding(encoding: 'avatar', contentType: 'image/png'),
+            ],
+        );
+
+        $spec->operations[] = new OA\Operation(
+            path: '/upload',
+            method: 'post',
+            requestBody: new OA\RequestBody(content: [$mediaType]),
+        );
+
+        (new Augmenter\MediaType())($spec);
+
+        $this->assertArrayHasKey('metadata', $mediaType->encoding);
+        $this->assertArrayHasKey('avatar', $mediaType->encoding);
+        $this->assertSame('application/xml', $mediaType->encoding['metadata']->contentType);
+        $this->assertSame('image/png', $mediaType->encoding['avatar']->contentType);
+    }
+
+    public function testNoEncodingLeftUntouched(): void
+    {
+        $spec = new Specification();
+
+        $mediaType = new OA\MediaType(
+            mediaType: 'application/json',
+            schema: new OA\Schema(type: 'object'),
+        );
+
+        $spec->operations[] = new OA\Operation(
+            path: '/data',
+            method: 'post',
+            requestBody: new OA\RequestBody(content: [$mediaType]),
+        );
+
+        (new Augmenter\MediaType())($spec);
+
+        $this->assertNull($mediaType->encoding);
+    }
+
+    public function testEncodingWithoutPropertyNameDiscarded(): void
+    {
+        $spec = new Specification();
+
+        $mediaType = new OA\MediaType(
+            mediaType: 'multipart/form-data',
+            schema: new OA\Schema(type: 'object'),
+            encoding: [
+                new OA\Encoding(contentType: 'text/plain'),
+            ],
+        );
+
+        $spec->operations[] = new OA\Operation(
+            path: '/upload',
+            method: 'post',
+            requestBody: new OA\RequestBody(content: [$mediaType]),
+        );
+
+        (new Augmenter\MediaType())($spec);
+
+        $this->assertNull($mediaType->encoding);
+    }
+
+    public function testRekeysEncodingOnResponses(): void
+    {
+        $spec = new Specification();
+
+        $mediaType = new OA\MediaType(
+            mediaType: 'multipart/form-data',
+            encoding: [
+                new OA\Encoding(encoding: 'file', contentType: 'application/octet-stream'),
+            ],
+        );
+
+        $spec->operations[] = new OA\Operation(
+            path: '/download',
+            method: 'get',
+            responses: [new OA\Response(response: '200', description: 'OK', content: [$mediaType])],
+        );
+
+        (new Augmenter\MediaType())($spec);
+
+        $this->assertArrayHasKey('file', $mediaType->encoding);
+    }
+
+    public function testRekeysEncodingOnReusableRequestBodies(): void
+    {
+        $spec = new Specification();
+
+        $mediaType = new OA\MediaType(
+            mediaType: 'multipart/form-data',
+            encoding: [
+                new OA\Encoding(encoding: 'doc', contentType: 'application/pdf'),
+            ],
+        );
+
+        $spec->requestBodies[] = new OA\RequestBody(content: [$mediaType]);
+
+        (new Augmenter\MediaType())($spec);
+
+        $this->assertArrayHasKey('doc', $mediaType->encoding);
+    }
+}

--- a/tests/Augmenter/OperationIdTest.php
+++ b/tests/Augmenter/OperationIdTest.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Augmenter;
+
+use OpenApi\Augmenter;
+use OpenApi\Tests\Concerns\AssemblesSpecification;
+use OpenApi\Tests\Fixtures;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class OperationIdTest extends TestCase
+{
+    use AssemblesSpecification;
+
+    #[DataProvider('operationIdProvider')]
+    public function testGeneration(bool $hash): void
+    {
+        $spec = $this->assemble(Fixtures\Augmenter\DocblockController::class);
+
+        $augmenter = new Augmenter\OperationId(hash: $hash);
+        $augmenter($spec);
+
+        $operationId = $spec->operations[0]->operationId;
+        $this->assertNotNull($operationId);
+
+        if ($hash) {
+            $this->assertMatchesRegularExpression('/^[a-f0-9]{32}$/', $operationId);
+        } else {
+            $this->assertStringContainsString('getThing', $operationId);
+        }
+    }
+
+    public static function operationIdProvider(): \Generator
+    {
+        yield 'hashed' => [true];
+        yield 'clear text' => [false];
+    }
+
+    public function testSkipsExplicit(): void
+    {
+        $spec = $this->assemble(Fixtures\Augmenter\DocblockController::class);
+        $spec->operations[0]->operationId = 'custom';
+
+        (new Augmenter\OperationId())($spec);
+
+        $this->assertSame('custom', $spec->operations[0]->operationId);
+    }
+}

--- a/tests/Augmenter/PathFilterTest.php
+++ b/tests/Augmenter/PathFilterTest.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Augmenter;
+
+use OpenApi\Augmenter;
+use OpenApi\Spec as OA;
+use OpenApi\Specification;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class PathFilterTest extends TestCase
+{
+    protected function createSpec(): Specification
+    {
+        $spec = new Specification();
+        $spec->operations[] = new OA\Operation(path: '/products', method: 'get', tags: ['products']);
+        $spec->operations[] = new OA\Operation(path: '/products/{id}', method: 'get', tags: ['products']);
+        $spec->operations[] = new OA\Operation(path: '/users', method: 'get', tags: ['users']);
+        $spec->operations[] = new OA\Operation(path: '/users/{id}', method: 'get', tags: ['users', 'admin']);
+
+        return $spec;
+    }
+
+    /**
+     * @return \Generator<string, array{list<string>, list<string>, list<string>}>
+     */
+    public static function filterProvider(): \Generator
+    {
+        yield 'no filter keeps all' => [[], [], ['/products', '/products/{id}', '/users', '/users/{id}']];
+        yield 'filter by tag' => [['/^products$/'], [], ['/products', '/products/{id}']];
+        yield 'filter by path' => [[], ['#^/users#'], ['/users', '/users/{id}']];
+        yield 'tag or path (union)' => [['/admin/'], ['#/products$#'], ['/products', '/users/{id}']];
+        yield 'no match' => [['/^nonexistent$/'], [], []];
+    }
+
+    #[DataProvider('filterProvider')]
+    public function testFilter(array $tags, array $paths, array $expectedPaths): void
+    {
+        $spec = $this->createSpec();
+
+        (new Augmenter\PathFilter(tags: $tags, paths: $paths))($spec);
+
+        $actualPaths = array_map(fn (OA\Operation $op): ?string => $op->path, $spec->operations);
+        $this->assertSame($expectedPaths, $actualPaths);
+    }
+
+    public function testSettersAreFluent(): void
+    {
+        $filter = new Augmenter\PathFilter();
+        $result = $filter->setTags(['/test/'])->setPaths(['/path/']);
+
+        $this->assertSame($filter, $result);
+    }
+}

--- a/tests/Augmenter/PathItemResolveTest.php
+++ b/tests/Augmenter/PathItemResolveTest.php
@@ -1,0 +1,250 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Augmenter;
+
+use OpenApi\Augmenter;
+use OpenApi\Spec as OA;
+use OpenApi\Specification;
+use OpenApi\Tests\Concerns\AssemblesSpecification;
+use OpenApi\Tests\Fixtures;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class PathItemResolveTest extends TestCase
+{
+    use AssemblesSpecification;
+
+    private function resolve(Specification $spec): Specification
+    {
+        (new Augmenter\PathItemResolve())($spec);
+
+        return $spec;
+    }
+
+    private function findPathItemByClass(Specification $spec, string $class): ?OA\PathItem
+    {
+        foreach ($spec->pathItems as $pi) {
+            $reflector = $pi->getReflector();
+            if ($reflector instanceof \ReflectionClass && $reflector->getName() === $class) {
+                return $pi;
+            }
+        }
+
+        return null;
+    }
+
+    private function findOperationByMethod(Specification $spec, string $method): ?OA\Operation
+    {
+        foreach ($spec->operations as $operation) {
+            if ($operation->method === $method) {
+                return $operation;
+            }
+        }
+
+        return null;
+    }
+
+    public static function prefixCompositionProvider(): \Generator
+    {
+        yield '2-level' => [
+            [Fixtures\Augmenter\PathItemBaseController::class, Fixtures\Augmenter\PathItemUserController::class],
+            ['/api/v1/users/list', '/api/v1/users/{id}'],
+        ];
+
+        yield '3-level' => [
+            [Fixtures\Augmenter\PathItemGrandparentController::class, Fixtures\Augmenter\PathItemMiddleController::class, Fixtures\Augmenter\PathItemLeafController::class],
+            ['/api/v2/orders', '/api/v2/orders/{id}'],
+        ];
+    }
+
+    #[DataProvider('prefixCompositionProvider')]
+    public function testPrefixComposition(array $classes, array $expectedPaths): void
+    {
+        $spec = $this->resolve($this->assemble(...$classes));
+
+        $paths = array_map(fn (OA\Operation $op): ?string => $op->path, $spec->operations);
+        sort($paths);
+
+        $this->assertSame($expectedPaths, $paths);
+    }
+
+    public static function tagsProvider(): \Generator
+    {
+        yield 'direct' => [
+            [Fixtures\Augmenter\PathItemBaseController::class, Fixtures\Augmenter\PathItemUserController::class],
+            ['Users'],
+        ];
+
+        yield 'inherited from middle' => [
+            [Fixtures\Augmenter\PathItemGrandparentController::class, Fixtures\Augmenter\PathItemMiddleController::class, Fixtures\Augmenter\PathItemLeafController::class],
+            ['V2'],
+        ];
+    }
+
+    #[DataProvider('tagsProvider')]
+    public function testTagsClonedToOperations(array $classes, array $expectedTags): void
+    {
+        $spec = $this->resolve($this->assemble(...$classes));
+
+        foreach ($spec->operations as $operation) {
+            $this->assertSame($expectedTags, $operation->tags);
+        }
+    }
+
+    public function testSecurityClonedToOperations(): void
+    {
+        $spec = $this->resolve($this->assemble(
+            Fixtures\Augmenter\PathItemBaseController::class,
+            Fixtures\Augmenter\PathItemUserController::class,
+        ));
+
+        foreach ($spec->operations as $operation) {
+            $this->assertNotNull($operation->security);
+            $this->assertCount(1, $operation->security);
+            $this->assertSame('bearerAuth', $operation->security[0]->scheme);
+        }
+    }
+
+    public function testExplicitTagsMergedAdditively(): void
+    {
+        $spec = $this->assemble(
+            Fixtures\Augmenter\PathItemBaseController::class,
+            Fixtures\Augmenter\PathItemUserController::class,
+        );
+        $spec->operations[0]->tags = ['Custom'];
+
+        $this->resolve($spec);
+
+        $this->assertSame(['Custom', 'Users'], $spec->operations[0]->tags);
+    }
+
+    public function testPathItemPathResolved(): void
+    {
+        $spec = $this->resolve($this->assemble(
+            Fixtures\Augmenter\PathItemBaseController::class,
+            Fixtures\Augmenter\PathItemUserController::class,
+        ));
+
+        $pathItemsWithPath = array_filter($spec->pathItems, fn (OA\PathItem $pi): bool => $pi->path !== null);
+
+        $this->assertNotEmpty($pathItemsWithPath);
+        foreach ($pathItemsWithPath as $pi) {
+            $this->assertStringStartsWith('/api/v1/users/', $pi->path);
+        }
+    }
+
+    public function testPathItemWithSummaryGetsPath(): void
+    {
+        $spec = $this->resolve($this->assemble(Fixtures\Augmenter\PathItemPlainController::class));
+
+        $paths = array_map(
+            fn (OA\PathItem $pi): string => $pi->path,
+            array_values(array_filter($spec->pathItems, fn (OA\PathItem $pi): bool => $pi->path !== null)),
+        );
+        sort($paths);
+
+        $this->assertSame(['/products', '/products/{id}'], $paths);
+    }
+
+    public function testNoPrefixNoPathItem(): void
+    {
+        $spec = new Specification();
+        $spec->operations[] = new OA\Operation(path: '/test', method: 'get');
+
+        $this->resolve($spec);
+
+        $this->assertSame('/test', $spec->operations[0]->path);
+    }
+
+    public function testSharedResponsesCloned(): void
+    {
+        $spec = $this->resolve($this->assemble(Fixtures\Augmenter\PathItemSharedResponseController::class));
+
+        $postOp = $this->findOperationByMethod($spec, 'post');
+        $this->assertInstanceOf(OA\Operation::class, $postOp);
+
+        $codes = array_map(fn (OA\Response $r): string => (string) $r->response, $postOp->responses);
+        sort($codes);
+
+        $this->assertSame(['201', '401', '500'], $codes);
+    }
+
+    public function testSharedSecurityCloned(): void
+    {
+        $spec = $this->resolve($this->assemble(Fixtures\Augmenter\PathItemSharedResponseController::class));
+
+        foreach ($spec->operations as $operation) {
+            $this->assertNotNull($operation->security);
+            $this->assertCount(1, $operation->security);
+            $this->assertSame('apiKey', $operation->security[0]->scheme);
+        }
+    }
+
+    public function testSharedParametersEmittedAtPathLevel(): void
+    {
+        $spec = $this->resolve($this->assemble(Fixtures\Augmenter\PathItemSharedResponseController::class));
+
+        $pathItemsWithPath = array_filter($spec->pathItems, fn (OA\PathItem $pi): bool => $pi->path !== null);
+
+        $this->assertNotEmpty($pathItemsWithPath);
+        foreach ($pathItemsWithPath as $pi) {
+            $this->assertNotNull($pi->parameters);
+            $this->assertCount(1, $pi->parameters);
+            $this->assertSame('X-Request-Id', $pi->parameters[0]->name);
+        }
+    }
+
+    public function testSharedResponseNotOverriddenWhenCodeExists(): void
+    {
+        $spec = $this->resolve($this->assemble(Fixtures\Augmenter\PathItemSharedResponseController::class));
+
+        $getOp = $this->findOperationByMethod($spec, 'get');
+        $this->assertInstanceOf(OA\Operation::class, $getOp);
+
+        $responses401 = array_filter($getOp->responses, fn (OA\Response $r): bool => (string) $r->response === '401');
+        $this->assertCount(1, $responses401);
+        $this->assertSame('Custom unauthorized', array_values($responses401)[0]->description);
+    }
+
+    public function testReusablePathItemNoPath(): void
+    {
+        $spec = $this->resolve($this->assemble(
+            Fixtures\Augmenter\PathItemReusable::class,
+            Fixtures\Augmenter\PathItemRefController::class,
+        ));
+
+        $reusable = $this->findPathItemByClass($spec, Fixtures\Augmenter\PathItemReusable::class);
+        $this->assertInstanceOf(OA\PathItem::class, $reusable);
+        $this->assertNull($reusable->path);
+        $this->assertNotNull($reusable->parameters);
+        $this->assertCount(2, $reusable->parameters);
+    }
+
+    public function testRefPathItemGetsPathFromOperations(): void
+    {
+        $spec = $this->resolve($this->assemble(
+            Fixtures\Augmenter\PathItemReusable::class,
+            Fixtures\Augmenter\PathItemRefController::class,
+        ));
+
+        $refPi = $this->findPathItemByClass($spec, Fixtures\Augmenter\PathItemRefController::class);
+        $this->assertInstanceOf(OA\PathItem::class, $refPi);
+        $this->assertSame(Fixtures\Augmenter\PathItemReusable::class, $refPi->ref);
+    }
+
+    public function testPrefixOnlyPathItemNoPathSet(): void
+    {
+        $spec = $this->resolve($this->assemble(
+            Fixtures\Augmenter\PathItemBaseController::class,
+            Fixtures\Augmenter\PathItemUserController::class,
+        ));
+
+        $basePathItem = $this->findPathItemByClass($spec, Fixtures\Augmenter\PathItemBaseController::class);
+        $this->assertInstanceOf(OA\PathItem::class, $basePathItem);
+        $this->assertNull($basePathItem->path);
+    }
+}

--- a/tests/Augmenter/RefTest.php
+++ b/tests/Augmenter/RefTest.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Augmenter;
+
+use OpenApi\Augmenter;
+use OpenApi\Spec as OA;
+use OpenApi\Specification;
+use OpenApi\Tests\Concerns\AssemblesSpecification;
+use OpenApi\Tests\Fixtures;
+use PHPUnit\Framework\TestCase;
+
+final class RefTest extends TestCase
+{
+    use AssemblesSpecification;
+
+    public function testResolvesFqcnToComponentPath(): void
+    {
+        $spec = $this->assemble(
+            Fixtures\Augmenter\RefTarget::class,
+            Fixtures\Augmenter\RefController::class,
+        );
+
+        (new Augmenter\Ref())($spec);
+
+        $schema = $spec->operations[0]->responses[0]->content[0]->schema;
+        $this->assertSame('#/components/schemas/RefTarget', $schema->ref);
+    }
+
+    public function testLeavesAlreadyResolvedUntouched(): void
+    {
+        $spec = new Specification();
+        $schema = new OA\Schema(schema: 'Foo');
+        $schema->setReflector(new \ReflectionClass(Fixtures\Augmenter\RefTarget::class));
+        $spec->schemas[] = $schema;
+
+        $operation = new OA\Operation(path: '/test', method: 'get');
+        $response = new OA\Response(response: 200, description: 'OK', content: [
+            new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: '#/components/schemas/Foo')),
+        ]);
+        $operation->responses = [$response];
+        $spec->operations[] = $operation;
+
+        (new Augmenter\Ref())($spec);
+
+        $this->assertSame('#/components/schemas/Foo', $response->content[0]->schema->ref);
+    }
+
+    public function testResolvesDiscriminatorMapping(): void
+    {
+        $spec = $this->assemble(
+            Fixtures\Augmenter\RefTarget::class,
+            Fixtures\Augmenter\DiscriminatorSchema::class,
+        );
+
+        (new Augmenter\Ref())($spec);
+
+        $discriminatorSchema = null;
+        foreach ($spec->schemas as $schema) {
+            if ($schema->schema === 'DiscriminatorSchema') {
+                $discriminatorSchema = $schema;
+                break;
+            }
+        }
+
+        $this->assertInstanceOf(OA\Schema::class, $discriminatorSchema);
+        $this->assertSame(
+            ['target' => '#/components/schemas/RefTarget'],
+            $discriminatorSchema->discriminator->mapping,
+        );
+    }
+}

--- a/tests/Augmenter/TagTest.php
+++ b/tests/Augmenter/TagTest.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Augmenter;
+
+use OpenApi\Augmenter;
+use OpenApi\Spec as OA;
+use OpenApi\Tests\Concerns\AssemblesSpecification;
+use OpenApi\Tests\Fixtures;
+use PHPUnit\Framework\TestCase;
+
+final class TagTest extends TestCase
+{
+    use AssemblesSpecification;
+
+    public function testCreatesFromOperationUsage(): void
+    {
+        $spec = $this->assemble(Fixtures\Augmenter\TagController::class);
+
+        (new Augmenter\Tag())($spec);
+
+        $tagNames = array_map(fn (OA\Tag $t): ?string => $t->name, $spec->tags);
+        $this->assertContains('alpha', $tagNames);
+        $this->assertContains('beta', $tagNames);
+    }
+
+    public function testRemovesUnused(): void
+    {
+        $spec = $this->assemble(Fixtures\Augmenter\TagController::class);
+        $spec->tags[] = new OA\Tag(name: 'unused');
+
+        (new Augmenter\Tag())($spec);
+
+        $tagNames = array_map(fn (OA\Tag $t): ?string => $t->name, $spec->tags);
+        $this->assertNotContains('unused', $tagNames);
+    }
+
+    public function testWhitelistKeepsUnused(): void
+    {
+        $spec = $this->assemble(Fixtures\Augmenter\TagController::class);
+        $spec->tags[] = new OA\Tag(name: 'unused');
+
+        $augmenter = new Augmenter\Tag(whitelist: ['*']);
+        $augmenter($spec);
+
+        $tagNames = array_map(fn (OA\Tag $t): ?string => $t->name, $spec->tags);
+        $this->assertContains('unused', $tagNames);
+    }
+}

--- a/tests/Augmenter/TypeTest.php
+++ b/tests/Augmenter/TypeTest.php
@@ -1,0 +1,88 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Augmenter;
+
+use OpenApi\Augmenter;
+use OpenApi\Spec as OA;
+use OpenApi\Tests\Concerns\AssemblesSpecification;
+use OpenApi\Tests\Fixtures;
+use PHPUnit\Framework\TestCase;
+
+final class TypeTest extends TestCase
+{
+    use AssemblesSpecification;
+
+    public function testInfersPropertyTypes(): void
+    {
+        $spec = $this->assemble(Fixtures\Augmenter\TypeSchema::class);
+
+        (new Augmenter\Type())($spec);
+
+        $schema = $spec->schemas[0];
+        $this->assertSame('TypeSchema', $schema->schema);
+
+        $props = [];
+        foreach ($schema->properties as $property) {
+            $props[$property->property] = $property->schema;
+        }
+
+        $this->assertSame('integer', $props['id']->type);
+        $this->assertSame('string', $props['name']->type);
+        $this->assertSame('number', $props['score']->type);
+        $this->assertTrue($props['score']->nullable);
+        $this->assertSame('boolean', $props['active']->type);
+        $this->assertSame('array', $props['tags']->type);
+        $this->assertSame('string', $props['tags']->items->type);
+    }
+
+    public function testInfersParameterSchema(): void
+    {
+        $spec = $this->assemble(Fixtures\Augmenter\TypeController::class);
+
+        (new Augmenter\Type())($spec);
+
+        $params = $spec->operations[0]->parameters;
+        $this->assertSame('integer', $params[0]->schema->type);
+        $this->assertTrue($params[0]->required);
+
+        $this->assertSame('string', $params[1]->schema->type);
+        $this->assertNull($params[1]->schema->nullable);
+        $this->assertFalse($params[1]->required);
+    }
+
+    public function testInfersParameterName(): void
+    {
+        $spec = $this->assemble(Fixtures\Augmenter\TypeController::class);
+
+        (new Augmenter\Type())($spec);
+
+        $this->assertSame('filter', $spec->operations[0]->parameters[1]->name);
+    }
+
+    public function testSkipsExplicitSchema(): void
+    {
+        $spec = $this->assemble(Fixtures\Augmenter\TypeController::class);
+        $spec->operations[0]->parameters[0]->schema = new OA\Schema(type: 'string');
+
+        (new Augmenter\Type())($spec);
+
+        $this->assertSame('string', $spec->operations[0]->parameters[0]->schema->type);
+    }
+
+    public function testResolvesRefFromObjectType(): void
+    {
+        $spec = $this->assemble(
+            Fixtures\Augmenter\RefTarget::class,
+            Fixtures\Augmenter\RefController::class,
+        );
+
+        (new Augmenter\Type())($spec);
+
+        $schema = $spec->operations[0]->responses[0]->content[0]->schema;
+        $this->assertSame(Fixtures\Augmenter\RefTarget::class, $schema->ref);
+    }
+}

--- a/tests/Concerns/AssemblesSpecification.php
+++ b/tests/Concerns/AssemblesSpecification.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Concerns;
+
+use OpenApi\Assembler;
+use OpenApi\Specification;
+
+trait AssemblesSpecification
+{
+    /**
+     * @param class-string ...$classes
+     */
+    protected function assemble(string ...$classes): Specification
+    {
+        $assembler = new Assembler();
+        foreach ($classes as $class) {
+            $assembler->collect(new \ReflectionClass($class));
+        }
+
+        return $assembler->getSpecification();
+    }
+}

--- a/tests/Concerns/AssertsSchemaStructure.php
+++ b/tests/Concerns/AssertsSchemaStructure.php
@@ -1,0 +1,136 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Concerns;
+
+use OpenApi\Spec as OA;
+use OpenApi\Specification;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Assertions for comparing schema structure (allOf refs + property names)
+ * against an expected YAML fixture, independent of property order.
+ */
+trait AssertsSchemaStructure
+{
+    /**
+     * Assert that compiled schemas (arrays) match the expected structure file.
+     *
+     * @param array<string, array> $schemas compiled schema arrays keyed by name
+     */
+    protected function assertCompiledSchemasMatchFile(array $schemas, string $expectedFile, string $context = ''): void
+    {
+        $expected = Yaml::parseFile($expectedFile);
+        $prefix = $context !== '' ? "[{$context}] " : '';
+
+        ksort($schemas);
+
+        $this->assertSame(
+            array_keys($expected),
+            array_keys($schemas),
+            $prefix . 'Schema names should match expected',
+        );
+
+        foreach ($expected as $name => $expectedSchema) {
+            $actual = $schemas[$name];
+
+            if (isset($expectedSchema['allOf'])) {
+                $this->assertArrayHasKey('allOf', $actual, "{$prefix}Schema '{$name}' should have allOf");
+
+                $actualRefs = array_values(array_filter(array_map(
+                    fn (array $entry): ?string => $entry['$ref'] ?? null,
+                    $actual['allOf'],
+                )));
+                $this->assertSame($expectedSchema['allOf'], $actualRefs, "{$prefix}Schema '{$name}' allOf refs");
+
+                $actualProps = $this->extractAllOfPropertyNames($actual['allOf']);
+            } else {
+                $this->assertArrayNotHasKey('allOf', $actual, "{$prefix}Schema '{$name}' should not have allOf");
+                $actualProps = array_keys($actual['properties'] ?? []);
+            }
+
+            $expectedProps = $expectedSchema['properties'];
+            sort($expectedProps);
+            sort($actualProps);
+            $this->assertSame($expectedProps, $actualProps, "{$prefix}Schema '{$name}' properties");
+        }
+    }
+
+    /**
+     * Assert that Specification schemas (DTO objects) match the expected structure file.
+     */
+    protected function assertSpecificationSchemasMatchFile(Specification $specification, string $expectedFile, string $context = ''): void
+    {
+        $expected = Yaml::parseFile($expectedFile);
+        $prefix = $context !== '' ? "[{$context}] " : '';
+
+        foreach ($expected as $name => $expectedSchema) {
+            $schema = $this->findSchemaByName($specification, $name);
+            $this->assertInstanceOf(OA\Schema::class, $schema, "{$prefix}Schema '{$name}' should exist");
+
+            if (isset($expectedSchema['allOf'])) {
+                $this->assertNotNull($schema->allOf, "{$prefix}Schema '{$name}' should have allOf");
+
+                $actualRefs = array_values(array_filter(
+                    array_map(fn (OA\Schema $s): ?string => $s->ref, $schema->allOf),
+                ));
+                $this->assertSame($expectedSchema['allOf'], $actualRefs, "{$prefix}Schema '{$name}' allOf refs");
+
+                $this->assertNull($schema->properties, "{$prefix}Schema '{$name}' properties should be in allOf");
+
+                $actualProps = [];
+                foreach ($schema->allOf as $entry) {
+                    if ($entry->properties !== null) {
+                        foreach ($entry->properties as $p) {
+                            $actualProps[] = $p->property;
+                        }
+                    }
+                }
+            } else {
+                $this->assertNull($schema->allOf, "{$prefix}Schema '{$name}' should not have allOf");
+                $this->assertNotNull($schema->properties, "{$prefix}Schema '{$name}' should have properties");
+
+                $actualProps = array_map(fn (OA\Property $p): string => $p->property, $schema->properties);
+            }
+
+            $expectedProps = $expectedSchema['properties'];
+            sort($expectedProps);
+            sort($actualProps);
+            $this->assertSame($expectedProps, $actualProps, "{$prefix}Schema '{$name}' properties");
+        }
+    }
+
+    protected function findSchemaByName(Specification $specification, string $name): ?OA\Schema
+    {
+        foreach ($specification->schemas as $schema) {
+            if ($schema->schema === $name) {
+                return $schema;
+            }
+
+            $reflector = $schema->getReflector();
+            if ($reflector instanceof \ReflectionClass && $reflector->getShortName() === $name) {
+                return $schema;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    protected function extractAllOfPropertyNames(array $allOf): array
+    {
+        $names = [];
+        foreach ($allOf as $entry) {
+            if (isset($entry['properties'])) {
+                array_push($names, ...array_keys($entry['properties']));
+            }
+        }
+
+        return $names;
+    }
+}

--- a/tests/Fixtures/Augmenter/BackedIntEnum.php
+++ b/tests/Fixtures/Augmenter/BackedIntEnum.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema(type: 'integer')]
+enum BackedIntEnum: int
+{
+    case GREEN = 1;
+    case BLUE = 2;
+    case RED = 3;
+}

--- a/tests/Fixtures/Augmenter/BackedStringEnum.php
+++ b/tests/Fixtures/Augmenter/BackedStringEnum.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema]
+enum BackedStringEnum: string
+{
+    case ACTIVE = 'active';
+    case INACTIVE = 'inactive';
+}

--- a/tests/Fixtures/Augmenter/BasicEnum.php
+++ b/tests/Fixtures/Augmenter/BasicEnum.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema]
+enum BasicEnum
+{
+    case GREEN;
+    case BLUE;
+    case RED;
+}

--- a/tests/Fixtures/Augmenter/DiscriminatorSchema.php
+++ b/tests/Fixtures/Augmenter/DiscriminatorSchema.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema(
+    schema: 'DiscriminatorSchema',
+    oneOf: [new OA\Schema(ref: RefTarget::class)],
+    discriminator: new OA\Discriminator(propertyName: 'type', mapping: ['target' => RefTarget::class]),
+)]
+class DiscriminatorSchema
+{
+}

--- a/tests/Fixtures/Augmenter/DocblockController.php
+++ b/tests/Fixtures/Augmenter/DocblockController.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter;
+
+use OpenApi\Spec as OA;
+
+class DocblockController
+{
+    /**
+     * Get a thing.
+     *
+     * Returns the thing by ID.
+     *
+     * @param int $id the thing identifier
+     * @deprecated
+     */
+    #[OA\Operation\Get(path: '/things/{id}')]
+    #[OA\Response(response: 200, description: 'OK')]
+    public function getThing(
+        #[OA\Parameter\Path(name: 'id')]
+        int $id,
+    ) {
+    }
+}

--- a/tests/Fixtures/Augmenter/DocblockSchema.php
+++ b/tests/Fixtures/Augmenter/DocblockSchema.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter;
+
+use OpenApi\Spec as OA;
+
+/**
+ * A documented schema.
+ *
+ * @deprecated
+ */
+#[OA\Schema(schema: 'DocblockSchema')]
+class DocblockSchema
+{
+    #[OA\Property(property: 'name')]
+    public string $name;
+}

--- a/tests/Fixtures/Augmenter/Hierarchy/Classic/ChildOfParentWithSchema.php
+++ b/tests/Fixtures/Augmenter/Hierarchy/Classic/ChildOfParentWithSchema.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter\Hierarchy\Classic;
+
+use OpenApi\Attributes as OAT;
+
+#[OAT\Schema]
+class ChildOfParentWithSchema extends ParentWithSchema
+{
+    #[OAT\Property(type: 'integer')]
+    public int $childProp;
+}

--- a/tests/Fixtures/Augmenter/Hierarchy/Classic/ChildOfPlainParent.php
+++ b/tests/Fixtures/Augmenter/Hierarchy/Classic/ChildOfPlainParent.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter\Hierarchy\Classic;
+
+use OpenApi\Attributes as OAT;
+
+#[OAT\Schema]
+class ChildOfPlainParent extends PlainParent
+{
+    #[OAT\Property(type: 'integer')]
+    public int $childProp;
+}

--- a/tests/Fixtures/Augmenter/Hierarchy/Classic/ClassUsingPlainTrait.php
+++ b/tests/Fixtures/Augmenter/Hierarchy/Classic/ClassUsingPlainTrait.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter\Hierarchy\Classic;
+
+use OpenApi\Attributes as OAT;
+
+#[OAT\Schema]
+class ClassUsingPlainTrait
+{
+    use PlainTrait;
+
+    #[OAT\Property(type: 'integer')]
+    public int $ownProp;
+}

--- a/tests/Fixtures/Augmenter/Hierarchy/Classic/ClassUsingTraitWithSchema.php
+++ b/tests/Fixtures/Augmenter/Hierarchy/Classic/ClassUsingTraitWithSchema.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter\Hierarchy\Classic;
+
+use OpenApi\Attributes as OAT;
+
+#[OAT\Schema]
+class ClassUsingTraitWithSchema
+{
+    use TraitWithSchema;
+
+    #[OAT\Property(type: 'integer')]
+    public int $age;
+}

--- a/tests/Fixtures/Augmenter/Hierarchy/Classic/ParentWithSchema.php
+++ b/tests/Fixtures/Augmenter/Hierarchy/Classic/ParentWithSchema.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter\Hierarchy\Classic;
+
+use OpenApi\Attributes as OAT;
+
+#[OAT\Schema]
+class ParentWithSchema
+{
+    #[OAT\Property(type: 'string')]
+    public string $baseProp;
+}

--- a/tests/Fixtures/Augmenter/Hierarchy/Classic/PlainParent.php
+++ b/tests/Fixtures/Augmenter/Hierarchy/Classic/PlainParent.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter\Hierarchy\Classic;
+
+use OpenApi\Attributes as OAT;
+
+class PlainParent
+{
+    #[OAT\Property(type: 'string')]
+    public string $parentProp;
+}

--- a/tests/Fixtures/Augmenter/Hierarchy/Classic/PlainTrait.php
+++ b/tests/Fixtures/Augmenter/Hierarchy/Classic/PlainTrait.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter\Hierarchy\Classic;
+
+use OpenApi\Attributes as OAT;
+
+trait PlainTrait
+{
+    #[OAT\Property(type: 'string')]
+    public string $traitProp;
+}

--- a/tests/Fixtures/Augmenter/Hierarchy/Classic/StandaloneSchema.php
+++ b/tests/Fixtures/Augmenter/Hierarchy/Classic/StandaloneSchema.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter\Hierarchy\Classic;
+
+use OpenApi\Attributes as OAT;
+
+#[OAT\Schema]
+class StandaloneSchema
+{
+    #[OAT\Property(type: 'string')]
+    public string $value;
+}

--- a/tests/Fixtures/Augmenter/Hierarchy/Classic/TraitWithSchema.php
+++ b/tests/Fixtures/Augmenter/Hierarchy/Classic/TraitWithSchema.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter\Hierarchy\Classic;
+
+use OpenApi\Attributes as OAT;
+
+#[OAT\Schema(schema: 'NameTrait')]
+trait TraitWithSchema
+{
+    #[OAT\Property(description: 'The name.')]
+    public string $name;
+}

--- a/tests/Fixtures/Augmenter/Hierarchy/Spec/ChildOfParentWithSchema.php
+++ b/tests/Fixtures/Augmenter/Hierarchy/Spec/ChildOfParentWithSchema.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter\Hierarchy\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema]
+class ChildOfParentWithSchema extends ParentWithSchema
+{
+    #[OA\Property(property: 'childProp')]
+    #[OA\Schema(type: 'integer')]
+    public int $childProp;
+}

--- a/tests/Fixtures/Augmenter/Hierarchy/Spec/ChildOfPlainParent.php
+++ b/tests/Fixtures/Augmenter/Hierarchy/Spec/ChildOfPlainParent.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter\Hierarchy\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema]
+class ChildOfPlainParent extends PlainParent
+{
+    #[OA\Property(property: 'childProp')]
+    #[OA\Schema(type: 'integer')]
+    public int $childProp;
+}

--- a/tests/Fixtures/Augmenter/Hierarchy/Spec/ClassUsingPlainTrait.php
+++ b/tests/Fixtures/Augmenter/Hierarchy/Spec/ClassUsingPlainTrait.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter\Hierarchy\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema]
+class ClassUsingPlainTrait
+{
+    use PlainTrait;
+
+    #[OA\Property(property: 'ownProp')]
+    #[OA\Schema(type: 'integer')]
+    public int $ownProp;
+}

--- a/tests/Fixtures/Augmenter/Hierarchy/Spec/ClassUsingTraitWithSchema.php
+++ b/tests/Fixtures/Augmenter/Hierarchy/Spec/ClassUsingTraitWithSchema.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter\Hierarchy\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema]
+class ClassUsingTraitWithSchema
+{
+    use TraitWithSchema;
+
+    #[OA\Property(property: 'age')]
+    #[OA\Schema(type: 'integer')]
+    public int $age;
+}

--- a/tests/Fixtures/Augmenter/Hierarchy/Spec/ParentWithSchema.php
+++ b/tests/Fixtures/Augmenter/Hierarchy/Spec/ParentWithSchema.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter\Hierarchy\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema]
+class ParentWithSchema
+{
+    #[OA\Property(property: 'baseProp')]
+    #[OA\Schema(type: 'string')]
+    public string $baseProp;
+}

--- a/tests/Fixtures/Augmenter/Hierarchy/Spec/PlainParent.php
+++ b/tests/Fixtures/Augmenter/Hierarchy/Spec/PlainParent.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter\Hierarchy\Spec;
+
+use OpenApi\Spec as OA;
+
+class PlainParent
+{
+    #[OA\Property(property: 'parentProp')]
+    #[OA\Schema(type: 'string')]
+    public string $parentProp;
+}

--- a/tests/Fixtures/Augmenter/Hierarchy/Spec/PlainTrait.php
+++ b/tests/Fixtures/Augmenter/Hierarchy/Spec/PlainTrait.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter\Hierarchy\Spec;
+
+use OpenApi\Spec as OA;
+
+trait PlainTrait
+{
+    #[OA\Property(property: 'traitProp')]
+    #[OA\Schema(type: 'string')]
+    public string $traitProp;
+}

--- a/tests/Fixtures/Augmenter/Hierarchy/Spec/StandaloneSchema.php
+++ b/tests/Fixtures/Augmenter/Hierarchy/Spec/StandaloneSchema.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter\Hierarchy\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema]
+class StandaloneSchema
+{
+    #[OA\Property(property: 'value')]
+    #[OA\Schema(type: 'string')]
+    public string $value;
+}

--- a/tests/Fixtures/Augmenter/Hierarchy/Spec/TraitWithSchema.php
+++ b/tests/Fixtures/Augmenter/Hierarchy/Spec/TraitWithSchema.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter\Hierarchy\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema(schema: 'NameTrait')]
+trait TraitWithSchema
+{
+    #[OA\Property(property: 'name')]
+    #[OA\Schema(description: 'The name.')]
+    public string $name;
+}

--- a/tests/Fixtures/Augmenter/Hierarchy/expected.yaml
+++ b/tests/Fixtures/Augmenter/Hierarchy/expected.yaml
@@ -1,0 +1,40 @@
+# Expected schema structure for the Hierarchy fixtures.
+# Both spec and classic pipelines should produce this composition.
+# Compared by: schema names, allOf refs, and property names (order-independent).
+#
+# allOf: list of $ref strings pointing to referenced schemas
+# properties: list of property names owned by this schema (inside allOf inline entry if allOf present)
+
+ChildOfParentWithSchema:
+    allOf:
+        - '#/components/schemas/ParentWithSchema'
+    properties:
+        - childProp
+
+ChildOfPlainParent:
+    properties:
+        - parentProp
+        - childProp
+
+ClassUsingPlainTrait:
+    properties:
+        - traitProp
+        - ownProp
+
+ClassUsingTraitWithSchema:
+    allOf:
+        - '#/components/schemas/NameTrait'
+    properties:
+        - age
+
+NameTrait:
+    properties:
+        - name
+
+ParentWithSchema:
+    properties:
+        - baseProp
+
+StandaloneSchema:
+    properties:
+        - value

--- a/tests/Fixtures/Augmenter/PathItemBaseController.php
+++ b/tests/Fixtures/Augmenter/PathItemBaseController.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter;
+
+use OpenApi\Spec as OA;
+
+#[OA\PathItem(prefix: '/api/v1')]
+class PathItemBaseController
+{
+}

--- a/tests/Fixtures/Augmenter/PathItemGrandparentController.php
+++ b/tests/Fixtures/Augmenter/PathItemGrandparentController.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter;
+
+use OpenApi\Spec as OA;
+
+#[OA\PathItem(prefix: '/api')]
+class PathItemGrandparentController
+{
+}

--- a/tests/Fixtures/Augmenter/PathItemLeafController.php
+++ b/tests/Fixtures/Augmenter/PathItemLeafController.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter;
+
+use OpenApi\Spec as OA;
+
+#[OA\PathItem(prefix: '/orders')]
+class PathItemLeafController extends PathItemMiddleController
+{
+    #[OA\Operation\Get(path: '')]
+    #[OA\Response(response: 200, description: 'Order list')]
+    public function index()
+    {
+    }
+
+    #[OA\Operation\Get(path: '/{id}')]
+    #[OA\Response(response: 200, description: 'Single order')]
+    public function show(int $id)
+    {
+    }
+}

--- a/tests/Fixtures/Augmenter/PathItemMiddleController.php
+++ b/tests/Fixtures/Augmenter/PathItemMiddleController.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter;
+
+use OpenApi\Spec as OA;
+
+#[OA\PathItem(prefix: '/v2', tags: ['V2'])]
+class PathItemMiddleController extends PathItemGrandparentController
+{
+}

--- a/tests/Fixtures/Augmenter/PathItemPlainController.php
+++ b/tests/Fixtures/Augmenter/PathItemPlainController.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter;
+
+use OpenApi\Spec as OA;
+
+#[OA\PathItem(
+    summary: 'Product operations',
+    description: 'CRUD for products',
+)]
+class PathItemPlainController
+{
+    #[OA\Operation\Get(path: '/products')]
+    #[OA\Response(response: 200, description: 'Product list')]
+    public function index()
+    {
+    }
+
+    #[OA\Operation\Get(path: '/products/{id}')]
+    #[OA\Response(response: 200, description: 'Single product')]
+    public function show(int $id)
+    {
+    }
+}

--- a/tests/Fixtures/Augmenter/PathItemRefController.php
+++ b/tests/Fixtures/Augmenter/PathItemRefController.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter;
+
+use OpenApi\Spec as OA;
+
+#[OA\PathItem(ref: PathItemReusable::class)]
+class PathItemRefController
+{
+    #[OA\Operation\Get(path: '/articles')]
+    #[OA\Response(response: 200, description: 'Article list')]
+    public function list()
+    {
+    }
+}

--- a/tests/Fixtures/Augmenter/PathItemReusable.php
+++ b/tests/Fixtures/Augmenter/PathItemReusable.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter;
+
+use OpenApi\Spec as OA;
+
+#[OA\PathItem(
+    summary: 'Paginated collection',
+    parameters: [
+        new OA\Parameter\Query(name: 'page', schema: new OA\Schema(type: 'integer')),
+        new OA\Parameter\Query(name: 'per_page', schema: new OA\Schema(type: 'integer')),
+    ],
+)]
+class PathItemReusable
+{
+}

--- a/tests/Fixtures/Augmenter/PathItemSharedResponseController.php
+++ b/tests/Fixtures/Augmenter/PathItemSharedResponseController.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter;
+
+use OpenApi\Spec as OA;
+
+#[OA\PathItem(
+    parameters: [new OA\Parameter\Header(name: 'X-Request-Id', schema: new OA\Schema(type: 'string'))],
+    security: [new OA\Security\Requirement(scheme: 'apiKey')],
+    responses: [
+        new OA\Response(response: 401, description: 'Unauthorized'),
+        new OA\Response(response: 500, description: 'Server error'),
+    ],
+)]
+class PathItemSharedResponseController
+{
+    #[OA\Operation\Get(path: '/items')]
+    #[OA\Response(response: 200, description: 'Item list')]
+    #[OA\Response(response: 401, description: 'Custom unauthorized')]
+    public function index()
+    {
+    }
+
+    #[OA\Operation\Post(path: '/items')]
+    #[OA\Response(response: 201, description: 'Created')]
+    public function create()
+    {
+    }
+}

--- a/tests/Fixtures/Augmenter/PathItemUserController.php
+++ b/tests/Fixtures/Augmenter/PathItemUserController.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter;
+
+use OpenApi\Spec as OA;
+
+#[OA\PathItem(
+    prefix: '/users',
+    tags: ['Users'],
+)]
+#[OA\Security\Requirement(scheme: 'bearerAuth')]
+#[OA\Parameter\Path(name: 'tenant', schema: new OA\Schema(type: 'string'))]
+class PathItemUserController extends PathItemBaseController
+{
+    #[OA\Operation\Get(path: '/list')]
+    #[OA\Response(response: 200, description: 'User list')]
+    public function list()
+    {
+    }
+
+    #[OA\Operation\Get(path: '/{id}')]
+    #[OA\Response(response: 200, description: 'Single user')]
+    public function get(int $id)
+    {
+    }
+}

--- a/tests/Fixtures/Augmenter/RefController.php
+++ b/tests/Fixtures/Augmenter/RefController.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter;
+
+use OpenApi\Spec as OA;
+
+class RefController
+{
+    #[OA\Operation\Get(path: '/ref-targets')]
+    #[OA\Response(response: 200, description: 'OK', content: [
+        new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: RefTarget::class)),
+    ])]
+    public function list()
+    {
+    }
+}

--- a/tests/Fixtures/Augmenter/RefTarget.php
+++ b/tests/Fixtures/Augmenter/RefTarget.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema(schema: 'RefTarget', description: 'A target for refs.')]
+class RefTarget
+{
+    #[OA\Property(property: 'id')]
+    public int $id;
+}

--- a/tests/Fixtures/Augmenter/TagController.php
+++ b/tests/Fixtures/Augmenter/TagController.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter;
+
+use OpenApi\Spec as OA;
+
+class TagController
+{
+    #[OA\Operation\Get(path: '/tagged', tags: ['alpha', 'beta'])]
+    #[OA\Response(response: 200, description: 'OK')]
+    public function tagged()
+    {
+    }
+}

--- a/tests/Fixtures/Augmenter/TypeController.php
+++ b/tests/Fixtures/Augmenter/TypeController.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter;
+
+use OpenApi\Spec as OA;
+
+class TypeController
+{
+    #[OA\Operation\Get(path: '/typed/{id}')]
+    #[OA\Response(response: 200, description: 'OK')]
+    public function getTyped(
+        #[OA\Parameter\Path(name: 'id')]
+        int $id,
+        #[OA\Parameter\Query]
+        ?string $filter = null,
+    ) {
+    }
+}

--- a/tests/Fixtures/Augmenter/TypeSchema.php
+++ b/tests/Fixtures/Augmenter/TypeSchema.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema(schema: 'TypeSchema')]
+class TypeSchema
+{
+    #[OA\Property]
+    public int $id;
+
+    #[OA\Property]
+    public string $name;
+
+    #[OA\Property]
+    public ?float $score = null;
+
+    #[OA\Property]
+    public bool $active;
+
+    /** @var list<string> */
+    #[OA\Property]
+    public array $tags;
+}


### PR DESCRIPTION
  ## Summary
  - Adds 13 augmenter pipes that enrich a `Specification` after assembly: `CleanUnused`, `Docblock`, `Enums`, `ExpandHierarchy`, `InferNames`, `MediaType`, `OperationId`, `PathFilter`,
  `PathItemResolve`, `Ref`, `Tag`, `Type`, and the `Group` enum
  - Adds shared test traits `AssemblesSpecification` and `AssertsSchemaStructure`

  These pipes are not yet wired into `Builder`.

