### PR TITLE
feat(BETA): add hybrid and spec mode to `Builder`

### DIFF
--- a/docs/spec-attributes-status.md
+++ b/docs/spec-attributes-status.md
@@ -165,6 +165,7 @@ The `Builder` class supports three modes via `setMode('classic'|'spec'|'hybrid')
 | `MediaType` | augment | Re-keys encoding by property name | Done |
 | `CleanUnused` | reduce | Removes unreferenced components (iterative, handles nested deps) | Done |
 | `PathFilter` | reduce | Filters operations by tag/path regex patterns | Done |
+| `EnumDescriptions` | augment | Generates descriptions for enum-based properties (BETA, disabled by default) | Done |
 | `PathItemResolve` | resolve | Prefix composition, clone-down of tags/security/responses, path inference | Done |
 
 ## Example coverage
@@ -374,7 +375,7 @@ Need to document the general pattern for shortcut attributes: how they participa
 
 ### Additional augmenter pipes
 
-- **`EnumDescription`** — generate human-readable descriptions from PHP enum cases (ported from openapi-extras). Ships in the default pipeline but disabled by default; enable via `$builder->getAugmenters()->get(EnumDescription::class)->setEnabled(true)`.
+None planned at this time.
 
 ### Design decisions
 

--- a/src/AttributeInterface.php
+++ b/src/AttributeInterface.php
@@ -30,7 +30,7 @@ use OpenApi\Utils\SourceLocation;
 interface AttributeInterface
 {
     /**
-     * Whether this attribute is a root-level element that goes directly into the Specification.
+     * Whether this attribute is a root-level element that goes directly into the `Specification`.
      */
     public function isRoot(): bool;
 

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -279,6 +279,7 @@ class Builder
             new Augmenter\Docblock(),
             new Augmenter\OperationId(),
             new Augmenter\Tag(),
+            new Augmenter\EnumDescriptions(),
         ];
     }
 

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -7,8 +7,11 @@
 namespace OpenApi;
 
 use OpenApi\Builder\CollectingLogger;
+use OpenApi\Builder\Mode;
 use OpenApi\Builder\Result;
+use OpenApi\Utils\PipeInterface;
 use OpenApi\Utils\SourceScanner;
+use OpenApi\Utils\TokenScanner;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
@@ -16,18 +19,31 @@ use Psr\Log\NullLogger;
  * Unified entry point for generating OpenAPI documents.
  *
  * Mode:
- *   setMode('classic') — annotation/attribute pipeline via Generator (default)
+ *   setMode(Builder\Mode::CLASSIC) — annotation/attribute pipeline via Generator (default)
+ *   setMode(Builder\Mode::SPEC)    — spec attribute pipeline via Assembler + Compiler
+ *   setMode(Builder\Mode::HYBRID)  — reduced classic pipeline → HybridBridge → spec Compiler
+ *
+ * Version resolution (spec/hybrid pipeline):
+ *   setVersion() > #[OpenApi(version: ...)] from source > '3.1.0' fallback
+ *
+ * Compiler resolution (spec/hybrid pipeline):
+ *   setCompiler() explicit > auto-resolved from version
  */
 class Builder
 {
     /** @var list<string|iterable> */
     protected array $sources = [];
 
-    protected string $mode = 'classic';
+    protected Mode $mode = Mode::CLASSIC;
 
     protected ?string $version = null;
 
     protected ?LoggerInterface $logger = null;
+
+    protected ?CompilerInterface $compiler = null;
+
+    /** @var Utils\Pipeline<Specification>|null */
+    protected ?Utils\Pipeline $augmenters = null;
 
     /** @var callable|null */
     protected $generatorHook;
@@ -49,18 +65,9 @@ class Builder
         return $this;
     }
 
-    /**
-     * Select the processing mode.
-     *
-     * Available modes:
-     *   - 'classic': scans source files for annotations/attributes and assembles
-     *                the OpenAPI document via Generator (default)
-     *
-     * @param string $mode 'classic' (default)
-     */
-    public function setMode(string $mode): static
+    public function setMode(string|Mode $mode): static
     {
-        $this->mode = $mode;
+        $this->mode = $mode instanceof Mode ? $mode : Mode::from($mode);
 
         return $this;
     }
@@ -75,6 +82,47 @@ class Builder
     public function setLogger(LoggerInterface $logger): static
     {
         $this->logger = $logger;
+
+        return $this;
+    }
+
+    public function setCompiler(CompilerInterface $compiler): static
+    {
+        $this->compiler = $compiler;
+
+        return $this;
+    }
+
+    /**
+     * @return Utils\Pipeline<Specification>
+     */
+    public function getAugmenters(): Utils\Pipeline
+    {
+        $this->augmenters ??= new Utils\Pipeline(
+            $this->getDefaultAugmenters(),
+            groups: [Augmenter\Group::Resolve, Augmenter\Group::Reduce, Augmenter\Group::Augment],
+            defaultGroup: Augmenter\Group::Augment,
+            logger: $this->getLogger(),
+        );
+
+        return $this->augmenters;
+    }
+
+    public function setAugmenters(Utils\Pipeline $augmenters): static
+    {
+        $this->augmenters = $augmenters;
+
+        return $this;
+    }
+
+    /**
+     * Configure the augmenter pipeline via callable.
+     *
+     * @param callable(Utils\Pipeline): void $hook
+     */
+    public function withAugmenters(callable $hook): static
+    {
+        $hook($this->getAugmenters());
 
         return $this;
     }
@@ -97,7 +145,9 @@ class Builder
     public function build(): Result
     {
         return match ($this->mode) {
-            default => $this->doBuild(),
+            Mode::SPEC => $this->doBuildSpec(),
+            Mode::HYBRID => $this->doBuildHybrid(),
+            default => $this->doBuildClassic(),
         };
     }
 
@@ -108,7 +158,7 @@ class Builder
         return $this->logger;
     }
 
-    protected function doBuild(): Result
+    protected function doBuildClassic(): Result
     {
         $collecting = new CollectingLogger($this->getLogger());
         $generator = new Generator($collecting);
@@ -124,6 +174,112 @@ class Builder
         $openApi = $generator->generate($this->sources);
 
         return Result::fromClassic($this->resolveFiles(), $openApi, $collecting->entries());
+    }
+
+    protected function doBuildSpec(): Result
+    {
+        $files = $this->resolveFiles();
+        $tokenScanner = new TokenScanner();
+        $assembler = new Assembler();
+
+        foreach ($files as $file) {
+            require_once $file;
+            foreach (array_keys($tokenScanner->scanFile($file)) as $class) {
+                if (class_exists($class) || interface_exists($class) || enum_exists($class) || trait_exists($class)) {
+                    $assembler->collect(new \ReflectionClass($class));
+                }
+            }
+        }
+
+        $specification = $assembler->getSpecification();
+
+        $this->getAugmenters()->process($specification);
+
+        $version = $this->version ?? $specification->openapi->version ?? '3.1.0';
+        $specification->openapi->version = $version;
+        $compiler = $this->compiler ?? $this->resolveCompiler($version);
+
+        $diagnostics = $compiler->validate($specification);
+        $output = $compiler->compile($specification);
+
+        return Result::fromSpec($files, $output, $diagnostics);
+    }
+
+    protected function doBuildHybrid(): Result
+    {
+        $collectingLogger = new CollectingLogger($this->getLogger());
+        $generator = new Generator($collectingLogger);
+
+        if ($this->version !== null) {
+            $generator->setVersion($this->version);
+        }
+
+        $generator->setProcessorPipeline(new Utils\Pipeline([
+            new Processors\MergeJsonContent(),
+            new Processors\MergeXmlContent(),
+        ]));
+
+        if ($this->generatorHook !== null) {
+            $generator = ($this->generatorHook)($generator) ?? $generator;
+        }
+
+        $analysis = new Analysis([], new Context([
+            'version' => $generator->getVersion(),
+            'logger' => $collectingLogger,
+        ]));
+        $generator->generate($this->sources, $analysis, validate: false);
+
+        $bridge = new HybridBridge();
+        $specification = $bridge->fromAnalysis($analysis);
+
+        $this->getAugmenters()->process($specification);
+
+        $version = $this->version ?? $specification->openapi->version ?? '3.1.0';
+        $specification->openapi->version = $version;
+        $compiler = $this->compiler ?? $this->resolveCompiler($version);
+
+        $diagnostics = $compiler->validate($specification);
+        $output = $compiler->compile($specification);
+
+        return Result::fromSpec($this->resolveFiles(), $output, array_merge($collectingLogger->entries(), $diagnostics));
+    }
+
+    protected function resolveCompiler(string $version): CompilerInterface
+    {
+        $compilers = [
+            new Compiler\OpenApi30Compiler(),
+            new Compiler\OpenApi31Compiler(),
+            new Compiler\OpenApi32Compiler(),
+        ];
+
+        foreach ($compilers as $compiler) {
+            if ($compiler->supports($version)) {
+                return $compiler;
+            }
+        }
+
+        throw new OpenApiException("No compiler available for version '{$version}'");
+    }
+
+    /**
+     * @return list<PipeInterface>
+     */
+    protected function getDefaultAugmenters(): array
+    {
+        return [
+            new Augmenter\ExpandHierarchy(),
+            new Augmenter\InferNames(),
+            new Augmenter\Enums(),
+            new Augmenter\PathItemResolve(),
+            new Augmenter\Type(),
+            new Augmenter\Ref(),
+            new Augmenter\PathFilter(),
+            new Augmenter\CleanUnused(),
+            new Augmenter\MediaType(),
+            new Augmenter\Docblock(),
+            new Augmenter\OperationId(),
+            new Augmenter\Tag(),
+        ];
     }
 
     /**

--- a/src/Builder/Mode.php
+++ b/src/Builder/Mode.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Builder;
+
+enum Mode: string
+{
+    case CLASSIC = 'classic';
+    case HYBRID = 'hybrid';
+    case SPEC = 'spec';
+
+    public function isClassic(): bool
+    {
+        return $this === Mode::CLASSIC;
+    }
+
+    public function isHybrid(): bool
+    {
+        return $this === Mode::HYBRID;
+    }
+
+    public function isSpec(): bool
+    {
+        return $this === Mode::SPEC;
+    }
+}

--- a/src/Builder/Result.php
+++ b/src/Builder/Result.php
@@ -8,6 +8,7 @@ namespace OpenApi\Builder;
 
 use OpenApi\Annotations\OpenApi;
 use OpenApi\OpenApiException;
+use Symfony\Component\Yaml\Yaml;
 
 /**
  * Result container for a build operation.
@@ -17,21 +18,37 @@ class Result
     /**
      * @param list<string>                                $files
      * @param list<array{level: string, message: string}> $log
+     * @param array<string,mixed>|null                    $specOutput
      */
     protected function __construct(
         protected array $files,
         protected ?OpenApi $openApi,
         protected array $log = [],
+        protected ?array $specOutput = null,
     ) {
     }
 
     /**
+     * Create a Result from the classic annotation pipeline.
+     *
      * @param list<string>                                $files
      * @param list<array{level: string, message: string}> $log
      */
     public static function fromClassic(array $files, ?OpenApi $openApi, array $log = []): self
     {
         return new self($files, $openApi, $log);
+    }
+
+    /**
+     * Create a Result from the spec attribute pipeline.
+     *
+     * @param list<string>                                $files
+     * @param array<string,mixed>                         $output
+     * @param list<array{level: string, message: string}> $log
+     */
+    public static function fromSpec(array $files, array $output, array $log = []): self
+    {
+        return new self($files, null, $log, $output);
     }
 
     /**
@@ -49,7 +66,7 @@ class Result
 
     public function isValid(): bool
     {
-        return $this->openApi instanceof OpenApi;
+        return $this->openApi instanceof OpenApi || $this->specOutput !== null;
     }
 
     /**
@@ -87,6 +104,10 @@ class Result
      */
     public function toArray(): array
     {
+        if ($this->specOutput !== null) {
+            return $this->specOutput;
+        }
+
         if (!$this->openApi instanceof OpenApi) {
             return [];
         }
@@ -96,6 +117,10 @@ class Result
 
     public function toJson(int $flags = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE): string
     {
+        if ($this->specOutput !== null) {
+            return json_encode($this->specOutput, $flags) ?: '{}';
+        }
+
         if (!$this->openApi instanceof OpenApi) {
             return '{}';
         }
@@ -105,6 +130,10 @@ class Result
 
     public function toYaml(int $inline = 10, int $indent = 4): string
     {
+        if ($this->specOutput !== null) {
+            return Yaml::dump($this->specOutput, $inline, $indent, Yaml::DUMP_OBJECT_AS_MAP | Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE);
+        }
+
         if (!$this->openApi instanceof OpenApi) {
             return '';
         }

--- a/src/Console/GenerateFormat.php
+++ b/src/Console/GenerateFormat.php
@@ -17,7 +17,7 @@ enum GenerateFormat: string
         return $this === GenerateFormat::JSON;
     }
 
-    public function isYAML(): bool
+    public function isYaml(): bool
     {
         return $this === GenerateFormat::YAML;
     }

--- a/src/Console/GenerateInput.php
+++ b/src/Console/GenerateInput.php
@@ -6,6 +6,7 @@
 
 namespace OpenApi\Console;
 
+use OpenApi\Builder\Mode;
 use Symfony\Component\Console\Attribute\Argument;
 use Symfony\Component\Console\Attribute\Option;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
@@ -45,8 +46,8 @@ class GenerateInput
     #[Option('The OpenAPI version')]
     public ?string $version = null;
 
-    #[Option('Processing mode; "classic" uses the annotation/attribute pipeline', shortcut: 'm')]
-    public string $mode = 'classic';
+    #[Option('Set mode classic, hybrid or spec', shortcut: 'm')]
+    public Mode $mode = Mode::CLASSIC;
 
     #[Option('Show additional error information', shortcut: 'd')]
     public bool $debug = false;

--- a/src/HybridBridge.php
+++ b/src/HybridBridge.php
@@ -1,0 +1,846 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi;
+
+/**
+ * Converts classic annotations into a Specification by iterating the Analysis directly.
+ *
+ * Expects only MergeJsonContent/MergeXmlContent to have run (unwraps pseudo-annotations).
+ * All enrichment (types, refs, descriptions, hierarchy) is left to the spec augmenter chain.
+ */
+class HybridBridge
+{
+    public function fromAnalysis(Analysis $analysis): Specification
+    {
+        $spec = new Specification();
+
+        $classSchemas = [];
+        $memberProperties = [];
+
+        foreach ($analysis->annotations as $annotation) {
+            if (!$annotation->_context->reflector instanceof \Reflector) {
+                continue;
+            }
+
+            match (true) {
+                $annotation instanceof Annotations\OpenApi => $this->convertOpenApiMeta($annotation, $spec),
+                $annotation instanceof Annotations\Info => $spec->info = $this->convertInfo($annotation),
+                $annotation instanceof Annotations\Server => $spec->servers[] = $this->convertServer($annotation),
+                $annotation instanceof Annotations\Tag => $spec->tags[] = $this->convertTag($annotation),
+                $annotation instanceof Annotations\SecurityScheme => $spec->securitySchemes[] = $this->convertSecurityScheme($annotation),
+                $annotation instanceof Annotations\PathItem && !$annotation->_context->is('nested') && !Undefined::isDefault($annotation->path) && !($annotation instanceof Annotations\Webhook) => $spec->pathItems[] = $this->convertPathItem($annotation),
+                $annotation instanceof Annotations\Components && !$annotation->_context->is('nested') => $this->convertComponents($annotation, $spec),
+                $annotation instanceof Annotations\Operation => $spec->operations[] = $this->convertOperation($annotation, $this->val($annotation->path), $this->methodFromAnnotation($annotation)),
+                $annotation instanceof Annotations\Schema && $annotation->_context->reflector instanceof \ReflectionClass && !$annotation->_context->is('nested') => $classSchemas[$annotation->_context->reflector->getName()] = $annotation,
+                $annotation instanceof Annotations\Property && $this->isClassMember($annotation) => $memberProperties[] = $annotation,
+                $annotation instanceof Annotations\Response && !$annotation->_context->is('nested') && !Undefined::isDefault($annotation->response) => $spec->responses[] = $this->convertResponse($annotation),
+                $annotation instanceof Annotations\RequestBody && !$annotation->_context->is('nested') && !Undefined::isDefault($annotation->request) => $spec->requestBodies[] = $this->convertRequestBody($annotation),
+                $annotation instanceof Annotations\Parameter && !$annotation->_context->is('nested') && !Undefined::isDefault($annotation->parameter) => $spec->parameters[] = $this->convertParameter($annotation),
+                $annotation instanceof Annotations\Header && !$annotation->_context->is('nested') && !Undefined::isDefault($annotation->header) => $spec->headers[] = $this->convertHeader($annotation),
+                $annotation instanceof Annotations\Link && !$annotation->_context->is('nested') => $spec->links[] = $this->convertLink($annotation),
+                $annotation instanceof Annotations\ExternalDocumentation && !$annotation->_context->is('nested') => $spec->externalDocs[] = $this->convertExternalDocs($annotation),
+                default => null,
+            };
+        }
+
+        foreach ($classSchemas as $className => $schema) {
+            $converted = $this->convertSchemaWithMembers($schema, $className, $classSchemas, $memberProperties);
+            $spec->schemas[] = $converted;
+        }
+
+        $spec->openapi ??= new Spec\OpenApi();
+
+        return $spec;
+    }
+
+    protected function isClassMember(Annotations\Property $property): bool
+    {
+        $reflector = $property->_context->reflector;
+
+        return $reflector instanceof \ReflectionProperty
+            || $reflector instanceof \ReflectionParameter
+            || $reflector instanceof \ReflectionClassConstant
+            || $reflector instanceof \ReflectionMethod;
+    }
+
+    /**
+     * @param array<string, Annotations\Schema> $classSchemas
+     * @param list<Annotations\Property>        $allMembers
+     */
+    protected function convertSchemaWithMembers(Annotations\Schema $schema, string $className, array $classSchemas, array $allMembers): Spec\Schema
+    {
+        $converted = $this->convertSchema($schema);
+
+        $ownClasses = $this->getOwnClasses($className, $classSchemas);
+        $ownProperties = [];
+        foreach ($allMembers as $property) {
+            $declarer = $this->getDeclaringClass($property);
+            if ($declarer !== null && in_array($declarer, $ownClasses, true)) {
+                $ownProperties[] = $this->convertProperty($property);
+            }
+        }
+
+        if ($ownProperties !== []) {
+            $converted->properties = [...$ownProperties, ...($converted->properties ?? [])];
+        }
+
+        return $converted;
+    }
+
+    /**
+     * Get the class itself plus non-schema ancestors and interfaces (they contribute properties to this schema).
+     *
+     * @param array<string, Annotations\Schema> $classSchemas
+     *
+     * @return list<string>
+     */
+    protected function getOwnClasses(string $className, array $classSchemas): array
+    {
+        $classes = [$className];
+
+        if (!class_exists($className) && !interface_exists($className) && !trait_exists($className)) {
+            return $classes;
+        }
+
+        $ref = new \ReflectionClass($className);
+
+        $parent = $ref->getParentClass();
+        while ($parent !== false) {
+            if (isset($classSchemas[$parent->getName()])) {
+                break;
+            }
+            $classes[] = $parent->getName();
+            foreach ($parent->getTraits() as $trait) {
+                if (!isset($classSchemas[$trait->getName()])) {
+                    $classes[] = $trait->getName();
+                }
+            }
+            $parent = $parent->getParentClass();
+        }
+
+        foreach ($ref->getInterfaces() as $interface) {
+            if (!isset($classSchemas[$interface->getName()])) {
+                $classes[] = $interface->getName();
+            }
+        }
+
+        foreach ($ref->getTraits() as $trait) {
+            if (!isset($classSchemas[$trait->getName()])) {
+                $classes[] = $trait->getName();
+            }
+        }
+
+        return $classes;
+    }
+
+    protected function getDeclaringClass(Annotations\Property $property): ?string
+    {
+        $reflector = $property->_context->reflector;
+
+        if ($reflector instanceof \ReflectionProperty || $reflector instanceof \ReflectionClassConstant) {
+            return $reflector->getDeclaringClass()->getName();
+        }
+        if ($reflector instanceof \ReflectionMethod) {
+            return $reflector->getDeclaringClass()->getName();
+        }
+        if ($reflector instanceof \ReflectionParameter) {
+            $method = $reflector->getDeclaringFunction();
+            if ($method instanceof \ReflectionMethod) {
+                return $method->getDeclaringClass()->getName();
+            }
+        }
+
+        return null;
+    }
+
+    protected function convertOpenApiMeta(Annotations\OpenApi $openApi, Specification $spec): void
+    {
+        $spec->openapi = new Spec\OpenApi(
+            version: $this->val($openApi->openapi),
+        );
+
+        if (!Undefined::isDefault($openApi->security)) {
+            $spec->openapi->security = $this->convertSecurityRequirements($openApi->security);
+        }
+
+        if (!Undefined::isDefault($openApi->externalDocs)) {
+            $spec->externalDocs[] = $this->convertExternalDocs($openApi->externalDocs);
+        }
+
+        if (!Undefined::isDefault($openApi->webhooks)) {
+            foreach ($openApi->webhooks as $webhook) {
+                $this->convertWebhook($webhook, $spec);
+            }
+        }
+    }
+
+    protected function methodFromAnnotation(Annotations\Operation $op): string
+    {
+        return match (true) {
+            $op instanceof Annotations\Get => 'get',
+            $op instanceof Annotations\Post => 'post',
+            $op instanceof Annotations\Put => 'put',
+            $op instanceof Annotations\Delete => 'delete',
+            $op instanceof Annotations\Patch => 'patch',
+            $op instanceof Annotations\Head => 'head',
+            $op instanceof Annotations\Options => 'options',
+            $op instanceof Annotations\Trace => 'trace',
+            default => strtolower($this->val($op->method) ?? 'get'),
+        };
+    }
+
+    protected function convertInfo(Annotations\Info $info): Spec\Info
+    {
+        $contact = null;
+        if (!Undefined::isDefault($info->contact)) {
+            $contact = new Spec\Contact(
+                name: $this->val($info->contact->name),
+                url: $this->val($info->contact->url),
+                email: $this->val($info->contact->email),
+            );
+        }
+
+        $license = null;
+        if (!Undefined::isDefault($info->license)) {
+            $license = new Spec\License(
+                name: $this->val($info->license->name),
+                identifier: $this->val($info->license->identifier),
+                url: $this->val($info->license->url),
+            );
+        }
+
+        return new Spec\Info(
+            title: $this->val($info->title),
+            description: $this->val($info->description),
+            termsOfService: $this->val($info->termsOfService),
+            version: $this->val($info->version),
+            contact: $contact,
+            license: $license,
+            x: $this->extensions($info),
+        );
+    }
+
+    protected function convertServer(Annotations\Server $server): Spec\Server
+    {
+        $variables = null;
+        if (!Undefined::isDefault($server->variables)) {
+            $variables = [];
+            foreach ($server->variables as $variable) {
+                $variables[] = new Spec\ServerVariable(
+                    serverVariable: $this->val($variable->serverVariable),
+                    default: $this->val($variable->default),
+                    description: $this->val($variable->description),
+                    enum: Undefined::isDefault($variable->enum) ? null : $variable->enum,
+                    x: $this->extensions($variable),
+                );
+            }
+        }
+
+        return new Spec\Server(
+            url: $this->val($server->url),
+            description: $this->val($server->description),
+            variables: $variables,
+            x: $this->extensions($server),
+        );
+    }
+
+    protected function convertTag(Annotations\Tag $tag): Spec\Tag
+    {
+        return new Spec\Tag(
+            name: $this->val($tag->name),
+            description: $this->val($tag->description),
+            externalDocs: Undefined::isDefault($tag->externalDocs)
+                ? null
+                : $this->convertExternalDocs($tag->externalDocs),
+            x: $this->extensions($tag),
+        );
+    }
+
+    protected function convertExternalDocs(Annotations\ExternalDocumentation $docs): Spec\ExternalDocumentation
+    {
+        return new Spec\ExternalDocumentation(
+            url: $this->val($docs->url),
+            description: $this->val($docs->description),
+            x: $this->extensions($docs),
+        );
+    }
+
+    protected function convertWebhook(Annotations\PathItem $webhook, Specification $spec): void
+    {
+        $methods = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'];
+        $name = $webhook instanceof Annotations\Webhook
+            ? $this->val($webhook->webhook)
+            : $this->val($webhook->path);
+
+        foreach ($methods as $method) {
+            if (!Undefined::isDefault($webhook->{$method})) {
+                $operation = $this->convertOperation($webhook->{$method}, null, $method);
+                $operation->webhook = $name;
+                $spec->operations[] = $operation;
+            }
+        }
+    }
+
+    protected function convertPathItem(Annotations\PathItem $pathItem): Spec\PathItem
+    {
+        $parameters = null;
+        if (!Undefined::isDefault($pathItem->parameters)) {
+            $parameters = [];
+            foreach ($pathItem->parameters as $param) {
+                $parameters[] = $this->convertParameter($param);
+            }
+        }
+
+        $result = new Spec\PathItem(
+            ref: $this->val($pathItem->ref),
+            summary: $this->val($pathItem->summary),
+            description: $this->val($pathItem->description),
+            parameters: $parameters,
+            servers: Undefined::isDefault($pathItem->servers)
+                ? null
+                : array_map($this->convertServer(...), $pathItem->servers),
+            x: $this->extensions($pathItem),
+        );
+        $result->path = $this->val($pathItem->path);
+        $this->copyReflector($pathItem, $result);
+
+        return $result;
+    }
+
+    protected function convertOperation(Annotations\Operation $op, ?string $path, string $method): Spec\Operation
+    {
+        $parameters = null;
+        if (!Undefined::isDefault($op->parameters)) {
+            $parameters = [];
+            foreach ($op->parameters as $param) {
+                $parameters[] = $this->convertParameter($param);
+            }
+        }
+
+        $responses = null;
+        if (!Undefined::isDefault($op->responses)) {
+            $responses = [];
+            foreach ($op->responses as $response) {
+                $responses[] = $this->convertResponse($response);
+            }
+        }
+
+        $requestBody = null;
+        if (!Undefined::isDefault($op->requestBody)) {
+            $requestBody = $this->convertRequestBody($op->requestBody);
+        }
+
+        $callbacks = null;
+        if (!Undefined::isDefault($op->callbacks)) {
+            $callbacks = $this->convertCallbacks($op->callbacks);
+        }
+
+        $security = null;
+        if (!Undefined::isDefault($op->security)) {
+            $security = $this->convertSecurityRequirements($op->security);
+        }
+
+        $result = new Spec\Operation(
+            path: $path,
+            method: $method,
+            operationId: $this->val($op->operationId),
+            summary: $this->val($op->summary),
+            description: $this->val($op->description),
+            tags: Undefined::isDefault($op->tags) ? null : $op->tags,
+            parameters: $parameters,
+            requestBody: $requestBody,
+            responses: $responses,
+            callbacks: $callbacks,
+            deprecated: $this->val($op->deprecated),
+            security: $security,
+            servers: Undefined::isDefault($op->servers)
+                ? null
+                : array_map($this->convertServer(...), $op->servers),
+            externalDocs: Undefined::isDefault($op->externalDocs)
+                ? null
+                : $this->convertExternalDocs($op->externalDocs),
+            x: $this->extensions($op),
+        );
+        $this->copyReflector($op, $result);
+
+        return $result;
+    }
+
+    protected function convertParameter(Annotations\Parameter $param): Spec\Parameter
+    {
+        $result = new Spec\Parameter(
+            parameter: $this->val($param->parameter),
+            name: $this->val($param->name),
+            in: $this->val($param->in),
+            description: $this->val($param->description),
+            required: $this->val($param->required),
+            deprecated: $this->val($param->deprecated),
+            allowEmptyValue: $this->val($param->allowEmptyValue),
+            ref: $this->val($param->ref),
+            style: $this->val($param->style),
+            explode: $this->val($param->explode),
+            allowReserved: $this->val($param->allowReserved),
+            schema: Undefined::isDefault($param->schema) ? null : $this->convertSchema($param->schema),
+            example: Undefined::isDefault($param->example) ? Undefined::UNDEFINED : $param->example,
+            examples: Undefined::isDefault($param->examples)
+                ? null
+                : array_map($this->convertExample(...), $param->examples),
+            content: Undefined::isDefault($param->content)
+                ? null
+                : array_map($this->convertMediaType(...), $param->content),
+            x: $this->extensions($param),
+        );
+        $this->copyReflector($param, $result);
+
+        return $result;
+    }
+
+    protected function convertResponse(Annotations\Response $response): Spec\Response
+    {
+        $headers = null;
+        if (!Undefined::isDefault($response->headers)) {
+            $headers = [];
+            foreach ($response->headers as $header) {
+                $headers[] = $this->convertHeader($header);
+            }
+        }
+
+        $links = null;
+        if (!Undefined::isDefault($response->links)) {
+            $links = [];
+            foreach ($response->links as $link) {
+                $links[] = $this->convertLink($link);
+            }
+        }
+
+        $result = new Spec\Response(
+            response: $this->val($response->response),
+            description: $this->val($response->description),
+            ref: $this->val($response->ref),
+            headers: $headers,
+            content: Undefined::isDefault($response->content)
+                ? null
+                : array_map($this->convertMediaType(...), $response->content),
+            links: $links,
+            x: $this->extensions($response),
+        );
+        $this->copyReflector($response, $result);
+
+        return $result;
+    }
+
+    protected function convertRequestBody(Annotations\RequestBody $body): Spec\RequestBody
+    {
+        $result = new Spec\RequestBody(
+            request: $this->val($body->request),
+            description: $this->val($body->description),
+            required: $this->val($body->required),
+            ref: $this->val($body->ref),
+            content: Undefined::isDefault($body->content)
+                ? null
+                : array_map($this->convertMediaType(...), $body->content),
+            x: $this->extensions($body),
+        );
+        $this->copyReflector($body, $result);
+
+        return $result;
+    }
+
+    protected function convertMediaType(Annotations\MediaType $mediaType): Spec\MediaType
+    {
+        $encoding = null;
+        if (!Undefined::isDefault($mediaType->encoding)) {
+            $encoding = [];
+            foreach ($mediaType->encoding as $enc) {
+                $encoding[] = $this->convertEncoding($enc);
+            }
+        }
+
+        return new Spec\MediaType(
+            mediaType: $this->val($mediaType->mediaType),
+            schema: Undefined::isDefault($mediaType->schema) ? null : $this->convertSchema($mediaType->schema),
+            example: Undefined::isDefault($mediaType->example) ? Undefined::UNDEFINED : $mediaType->example,
+            examples: Undefined::isDefault($mediaType->examples)
+                ? null
+                : array_map($this->convertExample(...), $mediaType->examples),
+            encoding: $encoding,
+            x: $this->extensions($mediaType),
+        );
+    }
+
+    protected function convertHeader(Annotations\Header $header): Spec\Header
+    {
+        $result = new Spec\Header(
+            header: $this->val($header->header),
+            description: $this->val($header->description),
+            required: $this->val($header->required),
+            deprecated: $this->val($header->deprecated),
+            ref: $this->val($header->ref),
+            schema: Undefined::isDefault($header->schema) ? null : $this->convertSchema($header->schema),
+            x: $this->extensions($header),
+        );
+        $this->copyReflector($header, $result);
+
+        return $result;
+    }
+
+    protected function convertLink(Annotations\Link $link): Spec\Link
+    {
+        $result = new Spec\Link(
+            link: $this->val($link->link),
+            operationRef: $this->val($link->operationRef),
+            operationId: $this->val($link->operationId),
+            parameters: Undefined::isDefault($link->parameters) ? null : $link->parameters,
+            requestBody: $this->val($link->requestBody),
+            description: $this->val($link->description),
+            ref: $this->val($link->ref),
+            server: Undefined::isDefault($link->server) ? null : $this->convertServer($link->server),
+            x: $this->extensions($link),
+        );
+        $this->copyReflector($link, $result);
+
+        return $result;
+    }
+
+    protected function convertEncoding(Annotations\Encoding $encoding): Spec\Encoding
+    {
+        return new Spec\Encoding(
+            encoding: $this->val($encoding->property),
+            contentType: $this->val($encoding->contentType),
+            style: $this->val($encoding->style),
+            explode: $this->val($encoding->explode),
+            allowReserved: $this->val($encoding->allowReserved),
+            x: $this->extensions($encoding),
+        );
+    }
+
+    protected function convertSchema(Annotations\Schema $schema): Spec\Schema
+    {
+        $properties = null;
+        if (!Undefined::isDefault($schema->properties)) {
+            $properties = [];
+            foreach ($schema->properties as $prop) {
+                $properties[] = $this->convertProperty($prop);
+            }
+        }
+
+        $result = new Spec\Schema(
+            schema: $this->val($schema->schema),
+            title: $this->val($schema->title),
+            description: $this->val($schema->description),
+            ref: $this->val($schema->ref) ?? $this->typeAsRef($schema->type),
+            type: Undefined::isDefault($schema->type) ? null : $this->filterType($schema->type),
+            format: $this->val($schema->format),
+            nullable: $this->val($schema->nullable),
+            minLength: $this->val($schema->minLength),
+            maxLength: $this->val($schema->maxLength),
+            pattern: $this->val($schema->pattern),
+            minimum: $this->val($schema->minimum),
+            maximum: $this->val($schema->maximum),
+            exclusiveMinimum: $this->val($schema->exclusiveMinimum),
+            exclusiveMaximum: $this->val($schema->exclusiveMaximum),
+            multipleOf: $this->val($schema->multipleOf),
+            items: Undefined::isDefault($schema->items) ? null : $this->convertSchema($schema->items),
+            minItems: $this->val($schema->minItems),
+            maxItems: $this->val($schema->maxItems),
+            uniqueItems: $this->val($schema->uniqueItems),
+            properties: $properties,
+            required: Undefined::isDefault($schema->required) ? null : $schema->required,
+            additionalProperties: $this->convertAdditionalProperties($schema),
+            minProperties: $this->val($schema->minProperties),
+            maxProperties: $this->val($schema->maxProperties),
+            allOf: Undefined::isDefault($schema->allOf) ? null : array_map($this->convertSchema(...), $schema->allOf),
+            anyOf: Undefined::isDefault($schema->anyOf) ? null : array_map($this->convertSchema(...), $schema->anyOf),
+            oneOf: Undefined::isDefault($schema->oneOf) ? null : array_map($this->convertSchema(...), $schema->oneOf),
+            not: Undefined::isDefault($schema->not) ? null : $this->convertSchema($schema->not),
+            enum: Undefined::isDefault($schema->enum) ? null : $schema->enum,
+            const: Undefined::isDefault($schema->const) ? Undefined::UNDEFINED : $schema->const,
+            example: Undefined::isDefault($schema->example) ? Undefined::UNDEFINED : $schema->example,
+            deprecated: $this->val($schema->deprecated),
+            readOnly: $this->val($schema->readOnly),
+            writeOnly: $this->val($schema->writeOnly),
+            default: Undefined::isDefault($schema->default) ? Undefined::UNDEFINED : $schema->default,
+            discriminator: Undefined::isDefault($schema->discriminator)
+                ? null
+                : $this->convertDiscriminator($schema->discriminator),
+            externalDocs: Undefined::isDefault($schema->externalDocs)
+                ? null
+                : $this->convertExternalDocs($schema->externalDocs),
+            xml: Undefined::isDefault($schema->xml) ? null : $this->convertXml($schema->xml),
+            x: $this->extensions($schema),
+        );
+        $this->copyReflector($schema, $result);
+
+        return $result;
+    }
+
+    protected function convertProperty(Annotations\Property $prop): Spec\Property
+    {
+        $schema = $this->convertSchema($prop);
+
+        $result = new Spec\Property(
+            property: $this->val($prop->property),
+            schema: $schema,
+        );
+        $this->copyReflector($prop, $result);
+
+        return $result;
+    }
+
+    protected function convertAdditionalProperties(Annotations\Schema $schema): Spec\Schema|bool|null
+    {
+        if (Undefined::isDefault($schema->additionalProperties)) {
+            return null;
+        }
+
+        if (is_bool($schema->additionalProperties)) {
+            return $schema->additionalProperties;
+        }
+
+        return $this->convertSchema($schema->additionalProperties);
+    }
+
+    protected function convertDiscriminator(Annotations\Discriminator $disc): Spec\Discriminator
+    {
+        return new Spec\Discriminator(
+            propertyName: $this->val($disc->propertyName),
+            mapping: Undefined::isDefault($disc->mapping) ? null : $disc->mapping,
+            x: $this->extensions($disc),
+        );
+    }
+
+    protected function convertXml(Annotations\Xml $xml): Spec\Xml
+    {
+        return new Spec\Xml(
+            name: $this->val($xml->name),
+            namespace: $this->val($xml->namespace),
+            prefix: $this->val($xml->prefix),
+            attribute: $this->val($xml->attribute),
+            wrapped: $this->val($xml->wrapped),
+            x: $this->extensions($xml),
+        );
+    }
+
+    protected function convertSecurityScheme(Annotations\SecurityScheme $scheme): Spec\Security\Scheme
+    {
+        $flows = null;
+        if (!Undefined::isDefault($scheme->flows)) {
+            $flows = [];
+            foreach ($scheme->flows as $flow) {
+                $flows[] = $this->convertFlow($flow);
+            }
+        }
+
+        $result = new Spec\Security\Scheme(
+            securityScheme: $this->val($scheme->securityScheme),
+            type: $this->val($scheme->type),
+            description: $this->val($scheme->description),
+            name: $this->val($scheme->name),
+            in: $this->val($scheme->in),
+            scheme: $this->val($scheme->scheme),
+            bearerFormat: $this->val($scheme->bearerFormat),
+            openIdConnectUrl: $this->val($scheme->openIdConnectUrl),
+            flows: $flows,
+            ref: $this->val($scheme->ref),
+            x: $this->extensions($scheme),
+        );
+        $this->copyReflector($scheme, $result);
+
+        return $result;
+    }
+
+    protected function convertFlow(Annotations\Flow $flow): Spec\Flow
+    {
+        return new Spec\Flow(
+            flow: $this->val($flow->flow),
+            authorizationUrl: $this->val($flow->authorizationUrl),
+            tokenUrl: $this->val($flow->tokenUrl),
+            refreshUrl: $this->val($flow->refreshUrl),
+            scopes: Undefined::isDefault($flow->scopes) ? null : (array) $flow->scopes,
+            x: $this->extensions($flow),
+        );
+    }
+
+    protected function convertExample(Annotations\Examples $example): Spec\Example
+    {
+        $key = $this->val($example->example);
+
+        $result = new Spec\Example(
+            example: $key !== null ? (string) $key : null,
+            summary: $this->val($example->summary),
+            description: $this->val($example->description),
+            value: Undefined::isDefault($example->value) ? null : $example->value,
+            externalValue: $this->val($example->externalValue),
+            ref: $this->val($example->ref),
+            x: $this->extensions($example),
+        );
+        $this->copyReflector($example, $result);
+
+        return $result;
+    }
+
+    /**
+     * @return list<Spec\Security\Requirement>
+     */
+    protected function convertSecurityRequirements(array $security): array
+    {
+        $requirements = [];
+        foreach ($security as $item) {
+            if (is_array($item)) {
+                $requirements[] = new Spec\Security\Requirement(schemes: $item);
+            }
+        }
+
+        return $requirements;
+    }
+
+    protected function convertComponents(Annotations\Components $components, Specification $spec): void
+    {
+        if (!Undefined::isDefault($components->schemas)) {
+            foreach ($components->schemas as $schema) {
+                $spec->schemas[] = $this->convertSchema($schema);
+            }
+        }
+
+        if (!Undefined::isDefault($components->responses)) {
+            foreach ($components->responses as $response) {
+                $spec->responses[] = $this->convertResponse($response);
+            }
+        }
+
+        if (!Undefined::isDefault($components->parameters)) {
+            foreach ($components->parameters as $parameter) {
+                $spec->parameters[] = $this->convertParameter($parameter);
+            }
+        }
+
+        if (!Undefined::isDefault($components->requestBodies)) {
+            foreach ($components->requestBodies as $body) {
+                $spec->requestBodies[] = $this->convertRequestBody($body);
+            }
+        }
+
+        if (!Undefined::isDefault($components->headers)) {
+            foreach ($components->headers as $header) {
+                $spec->headers[] = $this->convertHeader($header);
+            }
+        }
+
+        if (!Undefined::isDefault($components->securitySchemes)) {
+            foreach ($components->securitySchemes as $scheme) {
+                $spec->securitySchemes[] = $this->convertSecurityScheme($scheme);
+            }
+        }
+
+        if (!Undefined::isDefault($components->links)) {
+            foreach ($components->links as $link) {
+                $spec->links[] = $this->convertLink($link);
+            }
+        }
+
+        if (!Undefined::isDefault($components->examples)) {
+            foreach ($components->examples as $example) {
+                $spec->examples[] = $this->convertExample($example);
+            }
+        }
+    }
+
+    protected function convertCallbacks(array $callbacks): array
+    {
+        $result = [];
+        foreach ($callbacks as $key => $value) {
+            if ($value instanceof Annotations\PathItem) {
+                $path = $this->val($value->path);
+                $methods = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'];
+                foreach ($methods as $method) {
+                    if (!Undefined::isDefault($value->{$method})) {
+                        $result[$key][$path][$method] = $this->convertOperation($value->{$method}, $path, $method);
+                    }
+                }
+            } else {
+                $result[$key] = $this->convertCallbackValue($value);
+            }
+        }
+
+        return $result;
+    }
+
+    protected function convertCallbackValue(mixed $value): mixed
+    {
+        if ($value instanceof Annotations\Operation) {
+            return $this->convertOperation($value, null, $this->methodFromAnnotation($value));
+        }
+        if ($value instanceof Annotations\RequestBody) {
+            return $this->convertRequestBody($value);
+        }
+        if ($value instanceof Annotations\Response) {
+            return $this->convertResponse($value);
+        }
+        if ($value instanceof Annotations\Schema) {
+            return $this->convertSchema($value);
+        }
+        if ($value instanceof Annotations\MediaType) {
+            return $this->convertMediaType($value);
+        }
+        if (is_array($value)) {
+            $result = [];
+            foreach ($value as $k => $v) {
+                $result[$k] = $this->convertCallbackValue($v);
+            }
+
+            return $result;
+        }
+
+        return $value;
+    }
+
+    protected function val(mixed $value): mixed
+    {
+        return Undefined::isDefault($value) ? null : $value;
+    }
+
+    protected function typeAsRef(mixed $type): ?string
+    {
+        if (is_string($type) && !Undefined::isDefault($type) && str_contains($type, '\\')) {
+            return $type;
+        }
+
+        return null;
+    }
+
+    protected function filterType(mixed $type): string|array|null
+    {
+        if (Undefined::isDefault($type)) {
+            return null;
+        }
+
+        if (is_string($type) && str_contains($type, '\\')) {
+            return null;
+        }
+
+        return $type;
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    protected function extensions(Annotations\AbstractAnnotation $annotation): ?array
+    {
+        if (Undefined::isDefault($annotation->x)) {
+            return null;
+        }
+
+        return is_array($annotation->x) ? $annotation->x : null;
+    }
+
+    protected function copyReflector(Annotations\AbstractAnnotation $from, Spec\AbstractAttribute $to): void
+    {
+        if ($from->_context->reflector !== null && $from->_context->reflector instanceof \Reflector) {
+            $to->setReflector($from->_context->reflector);
+        }
+    }
+}

--- a/src/Utils/SpecificationWalker.php
+++ b/src/Utils/SpecificationWalker.php
@@ -222,10 +222,10 @@ class SpecificationWalker
 
     protected function walkSchemaTree(OA\Schema $schema, ?callable $schemaVisitor, ?callable $refVisitor): void
     {
-        if ($this->visited->contains($schema)) {
+        if ($this->visited->offsetExists($schema)) {
             return;
         }
-        $this->visited->attach($schema);
+        $this->visited->offsetSet($schema);
 
         if ($schemaVisitor) {
             $schemaVisitor($schema);

--- a/tests/Augmenter/ExpandHierarchyBcTest.php
+++ b/tests/Augmenter/ExpandHierarchyBcTest.php
@@ -67,7 +67,7 @@ final class ExpandHierarchyBcTest extends TestCase
     protected static function buildClassic(string $directory): array
     {
         $result = (new Builder())
-            ->setMode('classic')
+            ->setMode(Builder\Mode::CLASSIC)
             ->addSource($directory)
             ->setVersion('3.1.0')
             ->build();

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -6,6 +6,7 @@
 
 namespace OpenApi\Tests;
 
+use OpenApi\Augmenter\OperationId;
 use OpenApi\Builder;
 use OpenApi\Generator;
 use OpenApi\Tests\Concerns\UsesExamples;
@@ -130,5 +131,33 @@ final class BuilderTest extends OpenApiTestCase
         $this->assertNotEmpty($result->warnings());
         $this->assertContains('Required @OA\Info() not found', $result->warnings());
         $this->assertContains('Required @OA\PathItem() not found', $result->warnings());
+    }
+
+    public function testGetAugmentersReturnsDefaultPipeline(): void
+    {
+        $builder = new Builder();
+        $pipeline = $builder->getAugmenters();
+
+        $found = false;
+        $pipeline->walk(function (callable $pipe) use (&$found): void {
+            if ($pipe instanceof OperationId) {
+                $found = true;
+            }
+        });
+
+        $this->assertTrue($found, 'Default augmenters should include OperationId');
+    }
+
+    public function testPipelineGetReturnsTypedInstance(): void
+    {
+        $builder = new Builder();
+        $operationId = $builder->getAugmenters()->get(OperationId::class);
+
+        $this->assertInstanceOf(OperationId::class, $operationId);
+
+        $operationId->setHash(false);
+
+        $rc = new \ReflectionProperty($operationId, 'hash');
+        $this->assertFalse($rc->getValue($operationId));
     }
 }

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -8,6 +8,7 @@ namespace OpenApi\Tests;
 
 use OpenApi\Annotations as OA;
 use OpenApi\Builder;
+use OpenApi\Builder\Mode;
 use OpenApi\Context;
 use OpenApi\Generator;
 use OpenApi\Tests\Fixtures\Customer;
@@ -19,6 +20,7 @@ final class ContextTest extends OpenApiTestCase
     {
         $this->assertOpenApiLogEntryContains('Required @OA\PathItem() not found');
         $result = (new Builder())
+            ->setMode(Mode::CLASSIC)
             ->addSource($this->fixture('Customer.php'))
             ->setLogger($this->getTrackingLogger())
             ->withGenerator(fn (Generator $generator): Generator => $generator
@@ -59,6 +61,7 @@ final class ContextTest extends OpenApiTestCase
     {
         $this->assertOpenApiLogEntryContains('Required @OA\PathItem() not found');
         $result = (new Builder())
+            ->setMode(Mode::CLASSIC)
             ->addSource($this->fixture('Customer.php'))
             ->setLogger($this->getTrackingLogger())
             ->withGenerator(fn (Generator $generator): Generator => $generator->setTypeResolver($this->getTypeResolver()))

--- a/tests/Processors/AugmentParametersTest.php
+++ b/tests/Processors/AugmentParametersTest.php
@@ -10,6 +10,7 @@ use OpenApi\Annotations\Operation;
 use OpenApi\Annotations\Parameter;
 use OpenApi\Annotations\PathItem;
 use OpenApi\Builder;
+use OpenApi\Builder\Mode;
 use OpenApi\Generator;
 use OpenApi\Processors\AugmentParameters;
 use OpenApi\Processors\BuildPaths;
@@ -26,6 +27,7 @@ final class AugmentParametersTest extends OpenApiTestCase
     public function testAugmentParameter(): void
     {
         $result = (new Builder())
+            ->setMode(Mode::CLASSIC)
             ->addSource($this->fixture('UsingRefs.php'))
             ->withGenerator(fn (Generator $generator): Generator => $generator
                 ->setAnalyser($this->getAnalyzer())

--- a/tests/ScratchTest.php
+++ b/tests/ScratchTest.php
@@ -7,9 +7,11 @@
 namespace OpenApi\Tests;
 
 use OpenApi\Annotations as OA;
+use OpenApi\Augmenter\CleanUnused;
 use OpenApi\Builder;
 use OpenApi\Generator;
 use OpenApi\TypeResolverInterface;
+use OpenApi\Utils\Pipeline;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 final class ScratchTest extends OpenApiTestCase
@@ -59,15 +61,18 @@ final class ScratchTest extends OpenApiTestCase
             'Examples-3.0.0' => ['@OA\Schema() is only allowed as of 3.1.0'],
         ];
 
-        foreach ($scratchIterator() as $scratchName => $scratch) {
-            foreach ($specIterator($scratchName) as $caseName => $details) {
-                yield $caseName => [
-                    $details['typeResolver'],
-                    $scratch,
-                    $details['spec'],
-                    $details['version'],
-                    array_key_exists($caseName, $expectedLogs) ? $expectedLogs[$caseName] : [],
-                ];
+        foreach ([Builder\Mode::CLASSIC] as $mode) {
+            foreach ($scratchIterator() as $scratchName => $scratch) {
+                foreach ($specIterator($scratchName) as $caseName => $details) {
+                    yield "{$caseName}-{$mode->value}" => [
+                        $details['typeResolver'],
+                        $scratch,
+                        $mode,
+                        $details['spec'],
+                        $details['version'],
+                        array_key_exists($caseName, $expectedLogs) ? $expectedLogs[$caseName] : [],
+                    ];
+                }
             }
         }
     }
@@ -76,7 +81,7 @@ final class ScratchTest extends OpenApiTestCase
      * Test scratch fixtures.
      */
     #[DataProvider('scratchTestCases')]
-    public function testScratch(TypeResolverInterface $typeResolver, string $scratch, string $spec, string $version, array $expectedLogs): void
+    public function testScratch(TypeResolverInterface $typeResolver, string $scratch, Builder\Mode $mode, string $spec, string $version, array $expectedLogs): void
     {
         foreach ($expectedLogs as $logLine) {
             $this->assertOpenApiLogEntryContains($logLine);
@@ -85,9 +90,15 @@ final class ScratchTest extends OpenApiTestCase
         require_once $scratch;
 
         $result = (new Builder())
+            ->setMode($mode)
             ->addSource($scratch)
             ->setVersion($version)
             ->setLogger($this->getTrackingLogger())
+            ->withAugmenters(function (Pipeline $pipeline) use ($mode): void {
+                if ($mode->isHybrid()) {
+                    $pipeline->get(CleanUnused::class)->setEnabled(false);
+                }
+            })
             ->withGenerator(fn (Generator $generator): Generator => $generator
                 ->setTypeResolver($typeResolver)
                 ->setConfig(['mergeIntoOpenApi' => ['mergeComponents' => true]]))


### PR DESCRIPTION
## Summary
* Add `hybrid` and `spec` mode support to `Builder` and CLI
* Adds `HybridBrige` that translates classic `Annotations`/`Attributes` to spec attributes
* Minor fixes / tweaks

## General Notes
This is the final bit to make the new spec attributes usable.
The current code is definitely **BETA**, subject to change and not complete. 
However, it is usable and feedback would be much appreciated.
Progress and updates are tracked in [spec-attributes.md](https://github.com/zircote/swagger-php/blob/master/docs/spec-attributes-status.md)
