### PR TITLE
fix: replace `CustomName/Blink` with `CustomName-Blink` in examples and annotations

### DIFF
--- a/docs/examples/specs/using-traits/annotations/Blink.php
+++ b/docs/examples/specs/using-traits/annotations/Blink.php
@@ -9,7 +9,7 @@ namespace OpenApi\Examples\Specs\UsingTraits\Annotations;
 use OpenApi\Annotations as OA;
 
 /**
- * @OA\Schema(title="Blink trait", schema="CustomName/Blink")
+ * @OA\Schema(title="Blink trait", schema="CustomName-Blink")
  */
 trait Blink
 {

--- a/docs/examples/specs/using-traits/using-traits-3.0.0.yaml
+++ b/docs/examples/specs/using-traits/using-traits-3.0.0.yaml
@@ -58,7 +58,7 @@ components:
               description: 'The plating.'
               example: gold
           type: object
-    CustomName/Blink:
+    'CustomName-Blink':
       title: 'Blink trait'
       properties:
         frequency:
@@ -126,7 +126,7 @@ components:
         -
           $ref: '#/components/schemas/SimpleProduct'
         -
-          $ref: '#/components/schemas/CustomName~1Blink'
+          $ref: '#/components/schemas/CustomName-Blink'
         -
           properties:
             trick:

--- a/docs/examples/specs/using-traits/using-traits-3.1.0.yaml
+++ b/docs/examples/specs/using-traits/using-traits-3.1.0.yaml
@@ -58,7 +58,7 @@ components:
               description: 'The plating.'
               example: gold
           type: object
-    CustomName/Blink:
+    'CustomName-Blink':
       title: 'Blink trait'
       properties:
         frequency:
@@ -126,7 +126,7 @@ components:
         -
           $ref: '#/components/schemas/SimpleProduct'
         -
-          $ref: '#/components/schemas/CustomName~1Blink'
+          $ref: '#/components/schemas/CustomName-Blink'
         -
           properties:
             trick:

--- a/docs/examples/specs/using-traits/using-traits-3.2.0.yaml
+++ b/docs/examples/specs/using-traits/using-traits-3.2.0.yaml
@@ -58,7 +58,7 @@ components:
               description: 'The plating.'
               example: gold
           type: object
-    CustomName/Blink:
+    'CustomName-Blink':
       title: 'Blink trait'
       properties:
         frequency:
@@ -126,7 +126,7 @@ components:
         -
           $ref: '#/components/schemas/SimpleProduct'
         -
-          $ref: '#/components/schemas/CustomName~1Blink'
+          $ref: '#/components/schemas/CustomName-Blink'
         -
           properties:
             trick:


### PR DESCRIPTION
## Summary

Fix invalid schema name: replace `CustomName/Blink` with `CustomName-Blink` in examples and annotations