### PR TITLE
feat(BETA): add spec versions of all examples

### DIFF
--- a/docs/examples/specs/api/spec/Colour.php
+++ b/docs/examples/specs/api/spec/Colour.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Api\Spec;
+
+use OpenApi\Spec as OA;
+
+/**
+ * A Colour.
+ */
+// schema name inferred from enum name
+#[OA\Schema]
+enum Colour
+{
+    case GREEN;
+    case BLUE;
+    case RED;
+}

--- a/docs/examples/specs/api/spec/NameTrait.php
+++ b/docs/examples/specs/api/spec/NameTrait.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Api\Spec;
+
+use OpenApi\Spec as OA;
+
+/**
+ * A Name.
+ */
+#[OA\Schema(schema: 'NameTrait')]
+trait NameTrait
+{
+    #[OA\Property(property: 'name')]
+    #[OA\Schema(description: 'The name.')]
+    public $name;
+}

--- a/docs/examples/specs/api/spec/OpenApiSpec.php
+++ b/docs/examples/specs/api/spec/OpenApiSpec.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Api\Spec;
+
+use OpenApi\Spec as OA;
+
+/**
+ * The Spec.
+ */
+#[OA\OpenApi(version: '3.1.0')]
+#[OA\Security\Requirement(scheme: 'bearerAuth')]
+#[OA\Info(
+    title: 'Basic single file API',
+    version: '1.0.0',
+    license: new OA\License(name: 'MIT', identifier: 'MIT'),
+)]
+#[OA\Server(url: 'https://localhost/api', description: 'API server')]
+#[OA\Security\Scheme\Http(securityScheme: 'bearerAuth', description: 'Basic Auth', scheme: 'bearer')]
+#[OA\Tag(name: 'products', description: 'All about products')]
+#[OA\Tag(name: 'catalog', description: 'Catalog API')]
+class OpenApiSpec
+{
+}

--- a/docs/examples/specs/api/spec/Product.php
+++ b/docs/examples/specs/api/spec/Product.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Api\Spec;
+
+use OpenApi\Spec as OA;
+
+/**
+ * A Product description ignored.
+ */
+#[OA\Schema(title: 'Product', description: 'A Product.')]
+class Product
+{
+    use NameTrait;
+
+    /**
+     * The kind.
+     */
+    #[OA\Property(property: 'kind')]
+    public const KIND = 'Virtual';
+
+    #[OA\Property(property: 'id', schema: new OA\Schema(description: 'The id.', format: 'int64', example: 1))]
+    /**
+     * The id.
+     */
+    public $id;
+
+    public function __construct(
+        #[OA\Property(property: 'quantity')]
+        public int $quantity,
+        #[OA\Property(property: 'brand')]
+        #[OA\Schema(example: null, default: null)]
+        public ?string $brand,
+        #[OA\Property(property: 'colour')]
+        #[OA\Schema(description: 'The colour')]
+        public Colour $colour,
+        #[OA\Property(property: 'releasedAt')]
+        #[OA\Schema(type: 'string')]
+        public \DateTimeInterface $releasedAt,
+    ) {
+    }
+}

--- a/docs/examples/specs/api/spec/ProductController.php
+++ b/docs/examples/specs/api/spec/ProductController.php
@@ -1,0 +1,123 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Api\Spec;
+
+use OpenApi\Spec as OA;
+
+/**
+ * The Controller.
+ */
+class ProductController
+{
+    /**
+     * Get a product.
+     *
+     * @param ?int $product_id the product id
+     */
+    #[OA\Operation(path: '/products/{product_id}', method: 'get', operationId: 'getProducts', tags: ['products'])]
+    #[OA\Response(
+        response: 200,
+        description: 'successful operation',
+        headers: [new OA\Header(header: 'X-Rate-Limit', description: 'calls per hour allowed by the user', schema: new OA\Schema(type: 'integer', format: 'int32'))],
+        content: [new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: Product::class))],
+    )]
+    #[OA\Response(response: 401, description: 'oops')]
+    public function getProduct(
+        #[OA\Parameter(name: 'product_id', in: 'path', required: true)]
+        ?int $product_id
+    ) {
+    }
+
+    /**
+     * Add a product.
+     */
+    #[OA\Operation(path: '/products', method: 'post', operationId: 'addProducts', summary: 'Add products', tags: ['products'])]
+    #[OA\Response(
+        response: 200,
+        description: 'successful operation',
+        content: [new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: Product::class))],
+    )]
+    #[OA\RequestBody(
+        description: 'New product',
+        required: true,
+        content: [new OA\MediaType(
+            mediaType: 'application/json',
+            schema: new OA\Schema(type: 'array', items: new OA\Schema(ref: Product::class)),
+        )],
+    )]
+    public function addProduct()
+    {
+    }
+
+    /**
+     * Get all.
+     */
+    #[OA\Operation(path: '/products', method: 'get', operationId: 'getAll', tags: ['products', 'catalog'])]
+    #[OA\Response(
+        response: 200,
+        description: 'successful operation',
+        content: [new OA\MediaType(
+            mediaType: 'application/json',
+            schema: new OA\Schema(
+                type: 'object',
+                properties: [
+                    new OA\Property(
+                        property: 'data',
+                        schema: new OA\Schema(type: 'array', items: new OA\Schema(ref: Product::class)),
+                    ),
+                ],
+                required: ['data'],
+            ),
+        )],
+    )]
+    #[OA\Response(response: 401, description: 'oops')]
+    public function getAll()
+    {
+    }
+
+    #[OA\Operation(
+        path: '/subscribe',
+        method: 'post',
+        operationId: 'subscribe',
+        summary: 'Subscribe to product webhook',
+        tags: ['products'],
+        callbacks: [
+            'onChange' => [
+                '{$request.query.callbackUrl}' => [
+                    'post' => [
+                        'requestBody' => new OA\RequestBody(
+                            description: 'subscription payload',
+                            content: [
+                                new OA\MediaType(
+                                    mediaType: 'application/json',
+                                    schema: new OA\Schema(
+                                        properties: [
+                                            new OA\Property(
+                                                property: 'timestamp',
+                                                schema: new OA\Schema(description: 'time of change', type: 'string', format: 'date-time'),
+                                            ),
+                                        ],
+                                    ),
+                                ),
+                            ],
+                        ),
+                    ],
+                    'responses' => [
+                        '200' => [
+                            'description' => 'Your server implementation should return this HTTP status code if the data was received successfully',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    )]
+    #[OA\Parameter(name: 'callbackUrl', in: 'query')]
+    #[OA\Response(response: 200, description: 'callbackUrl registered')]
+    public function subscribe()
+    {
+    }
+}

--- a/docs/examples/specs/api/spec/Server.php
+++ b/docs/examples/specs/api/spec/Server.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Api\Spec;
+
+use OpenApi\Spec as OA;
+
+/**
+ * A Server.
+ */
+#[OA\Server(url: 'https://example.localhost', description: 'The local environment.')]
+#[OA\Server(url: 'https://example.com', description: 'The production server.')]
+class Server
+{
+}

--- a/docs/examples/specs/misc/spec/Endpoint.php
+++ b/docs/examples/specs/misc/spec/Endpoint.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Misc\Spec;
+
+use OpenApi\Spec as OA;
+
+/**
+ * An API endpoint.
+ */
+class Endpoint
+{
+    /**
+     * An API endpoint.
+     */
+    #[OA\Operation\Get(
+        path: '/api/endpoint',
+        operationId: 'endpoint',
+        description: 'An endpoint',
+        tags: ['endpoints'],
+        parameters: [
+            new OA\Parameter(
+                name: 'filter',
+                in: 'query',
+                content: [new OA\MediaType(
+                    mediaType: 'application/json',
+                    schema: new OA\Schema(properties: [
+                        new OA\Property(property: 'type', schema: new OA\Schema(type: 'string')),
+                        new OA\Property(property: 'color', schema: new OA\Schema(type: 'string')),
+                    ]),
+                )],
+            ),
+        ],
+        responses: [
+            new OA\Response(response: 200, ref: '#/components/responses/200'),
+        ],
+        security: [new OA\Security\Requirement(scheme: 'bearerAuth', scopes: [])],
+    )]
+    public function endpoint()
+    {
+    }
+}

--- a/docs/examples/specs/misc/spec/MultiValueQueryParamEndpoint.php
+++ b/docs/examples/specs/misc/spec/MultiValueQueryParamEndpoint.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Misc\Spec;
+
+use OpenApi\Spec as OA;
+
+/**
+ * Another API endpoint.
+ */
+class MultiValueQueryParamEndpoint
+{
+    /**
+     * Another API endpoint.
+     */
+    #[OA\Operation\Get(
+        path: '/api/anotherendpoint',
+        operationId: 'anotherendpoints',
+        description: 'Another endpoint',
+        tags: ['endpoints'],
+        parameters: [
+            new OA\Parameter(
+                name: 'things[]',
+                in: 'query',
+                description: 'A list of things.',
+                required: false,
+                schema: new OA\Schema(type: 'array', items: new OA\Schema(type: 'integer')),
+            ),
+        ],
+        responses: [
+            new OA\Response(response: 200, ref: '#/components/responses/200'),
+        ],
+        security: [new OA\Security\Requirement(scheme: 'bearerAuth', scopes: [])],
+    )]
+    public function anotherEndpoint()
+    {
+    }
+}

--- a/docs/examples/specs/misc/spec/OpenApiSpec.php
+++ b/docs/examples/specs/misc/spec/OpenApiSpec.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Misc\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\OpenApi(version: '3.1.0', security: [
+    new OA\Security\Requirement(scheme: 'bearerAuth', scopes: []),
+])]
+#[OA\Info(
+    title: 'Testing annotations from bugreports',
+    description: "NOTE:\nThis sentence is on a new line",
+    version: '1.0.0',
+    contact: new OA\Contact(name: 'Swagger API Team'),
+    license: new OA\License(name: 'apache', url: 'https://github.com/zircote/swagger-php/blob/master/LICENSE'),
+)]
+#[OA\Tag(name: 'endpoints')]
+#[OA\Server(
+    url: '{schema}://host.dev',
+    description: 'OpenApi parameters',
+    variables: [new OA\ServerVariable(serverVariable: 'schema', default: 'https', enum: ['https', 'http'])],
+)]
+#[OA\Security\Scheme\Http(securityScheme: 'bearerAuth', scheme: 'bearer')]
+class OpenApiSpec
+{
+}

--- a/docs/examples/specs/misc/spec/Response.php
+++ b/docs/examples/specs/misc/spec/Response.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Misc\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Response(
+    response: 200,
+    description: 'Success',
+    content: [
+        new OA\MediaType(
+            mediaType: 'application/json',
+            schema: new OA\Schema(properties: [
+                new OA\Property(property: 'name', schema: new OA\Schema(description: 'demo', type: 'integer')),
+            ]),
+            examples: [
+                new OA\Example(example: '200', summary: '', value: ['name' => 1]),
+                new OA\Example(example: '300', summary: '', value: ['name' => 1]),
+                new OA\Example(example: '400', summary: '', value: ['name' => 1]),
+            ],
+        ),
+    ],
+)]
+class Response
+{
+}

--- a/docs/examples/specs/misc/spec/ResultSchema.php
+++ b/docs/examples/specs/misc/spec/ResultSchema.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Misc\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema(schema: 'Result', title: 'Sample schema for using references')]
+class ResultSchema
+{
+    #[OA\Property(property: 'status')]
+    #[OA\Schema(type: 'string')]
+    public $status;
+
+    #[OA\Property(property: 'error')]
+    #[OA\Schema(type: 'string')]
+    public $error;
+}

--- a/docs/examples/specs/misc/spec/UserAddEndpoint.php
+++ b/docs/examples/specs/misc/spec/UserAddEndpoint.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Misc\Spec;
+
+use OpenApi\Spec as OA;
+
+class UserAddEndpoint
+{
+    #[OA\Operation\Post(
+        path: '/users',
+        operationId: 'addUser',
+        summary: 'Adds a new user - with oneOf examples',
+        description: 'Adds a new user',
+        tags: ['user'],
+        requestBody: new OA\RequestBody(
+            content: [new OA\MediaType(
+                mediaType: 'application/json',
+                schema: new OA\Schema(
+                    properties: [
+                        new OA\Property(property: 'id', schema: new OA\Schema(type: 'string')),
+                        new OA\Property(property: 'name', schema: new OA\Schema(type: 'string')),
+                        new OA\Property(property: 'phone', schema: new OA\Schema(oneOf: [
+                            new OA\Schema(type: 'string'),
+                            new OA\Schema(type: 'integer'),
+                        ])),
+                    ],
+                    example: ['id' => 'a3fb6', 'name' => 'Jessica Smith', 'phone' => 12345678],
+                ),
+            )],
+        ),
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'OK',
+                content: [new OA\MediaType(
+                    mediaType: 'application/json',
+                    schema: new OA\Schema(oneOf: [
+                        new OA\Schema(ref: '#/components/schemas/Result'),
+                        new OA\Schema(type: 'boolean'),
+                    ]),
+                    examples: [
+                        new OA\Example(example: 'result', summary: 'An result object.', value: ['success' => true]),
+                        new OA\Example(example: 'bool', summary: 'A boolean value.', value: false),
+                    ],
+                )],
+            ),
+        ],
+    )]
+    public function addUser()
+    {
+    }
+}

--- a/docs/examples/specs/misc/spec/UserUpdateEndpoint.php
+++ b/docs/examples/specs/misc/spec/UserUpdateEndpoint.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Misc\Spec;
+
+use OpenApi\Spec as OA;
+
+class UserUpdateEndpoint
+{
+    #[OA\Operation\Put(
+        path: '/users/{id}',
+        operationId: 'updateUser',
+        summary: 'Updates a user',
+        description: 'Updates a user',
+        tags: ['user'],
+        parameters: [
+            new OA\Parameter(
+                name: 'id',
+                in: 'path',
+                description: 'Parameter with mutliple examples',
+                required: true,
+                schema: new OA\Schema(type: 'string'),
+                examples: [
+                    new OA\Example(example: 'int', summary: 'An int value.', value: '1'),
+                    new OA\Example(example: 'uuid', summary: 'An UUID value.', value: '0006faf6-7a61-426c-9034-579f2cfcfa83'),
+                ],
+            ),
+        ],
+        responses: [
+            new OA\Response(response: 200, description: 'OK'),
+        ],
+    )]
+    public function updateUser()
+    {
+    }
+}

--- a/docs/examples/specs/nesting/annotations/ApiController.php
+++ b/docs/examples/specs/nesting/annotations/ApiController.php
@@ -33,6 +33,7 @@ class ApiController
      *     tags={"api"},
      *     path="/entity/{id}",
      *     description="Get the entity",
+     *     operationId="getEntity",
      *     @OA\Parameter(
      *         name="id",
      *         in="path",

--- a/docs/examples/specs/nesting/nesting-3.0.0.yaml
+++ b/docs/examples/specs/nesting/nesting-3.0.0.yaml
@@ -15,7 +15,7 @@ paths:
       tags:
         - api
       description: 'Get the entity'
-      operationId: 7b9aa57df112f7e2940c95632a59f78d
+      operationId: getEntity
       parameters:
         -
           name: id

--- a/docs/examples/specs/nesting/nesting-3.1.0.yaml
+++ b/docs/examples/specs/nesting/nesting-3.1.0.yaml
@@ -15,7 +15,7 @@ paths:
       tags:
         - api
       description: 'Get the entity'
-      operationId: 7b9aa57df112f7e2940c95632a59f78d
+      operationId: getEntity
       parameters:
         -
           name: id

--- a/docs/examples/specs/nesting/nesting-3.2.0.yaml
+++ b/docs/examples/specs/nesting/nesting-3.2.0.yaml
@@ -15,7 +15,7 @@ paths:
       tags:
         - api
       description: 'Get the entity'
-      operationId: 7b9aa57df112f7e2940c95632a59f78d
+      operationId: getEntity
       parameters:
         -
           name: id

--- a/docs/examples/specs/nesting/spec/ActualModel.php
+++ b/docs/examples/specs/nesting/spec/ActualModel.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Nesting\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema]
+class ActualModel extends SoCloseModel
+{
+    #[OA\Property]
+    public string $actual;
+}

--- a/docs/examples/specs/nesting/spec/AlmostModel.php
+++ b/docs/examples/specs/nesting/spec/AlmostModel.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Nesting\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema]
+class AlmostModel extends IntermediateModel
+{
+    #[OA\Property]
+    public string $almost;
+}

--- a/docs/examples/specs/nesting/spec/ApiController.php
+++ b/docs/examples/specs/nesting/spec/ApiController.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Nesting\Spec;
+
+use OpenApi\Spec as OA;
+
+/**
+ * An entity controller class.
+ */
+#[OA\Info(title: 'Nested schemas', description: 'Example info', version: '1.0.0', contact: new OA\Contact(name: 'Swagger API Team'))]
+#[OA\Server(url: 'https://example.localhost', description: 'API server')]
+#[OA\Tag(name: 'api', description: 'All API endpoints')]
+class ApiController
+{
+    #[OA\Operation\Get(
+        path: '/entity/{id}',
+        operationId: 'getEntity',
+        description: 'Get the entity',
+        tags: ['api'],
+        parameters: [
+            new OA\Parameter(
+                name: 'id',
+                in: 'path',
+                required: true,
+                schema: new OA\Schema(type: 'integer', format: 'int64'),
+            ),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'successful operation',
+                content: [new OA\MediaType(
+                    mediaType: 'application/json',
+                    schema: new OA\Schema(ref: '#/components/schemas/ActualModel'),
+                )],
+            ),
+        ],
+    )]
+    public function get($id)
+    {
+    }
+}

--- a/docs/examples/specs/nesting/spec/BaseModel.php
+++ b/docs/examples/specs/nesting/spec/BaseModel.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Nesting\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema]
+class BaseModel
+{
+    #[OA\Property]
+    public string $base;
+}

--- a/docs/examples/specs/nesting/spec/IntermediateModel.php
+++ b/docs/examples/specs/nesting/spec/IntermediateModel.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Nesting\Spec;
+
+use OpenApi\Spec as OA;
+
+/**
+ * No schema!
+ */
+class IntermediateModel extends BaseModel
+{
+    #[OA\Property]
+    public string $intermediate;
+}

--- a/docs/examples/specs/nesting/spec/SoCloseModel.php
+++ b/docs/examples/specs/nesting/spec/SoCloseModel.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Nesting\Spec;
+
+use OpenApi\Spec as OA;
+
+/**
+ * No schema!
+ */
+class SoCloseModel extends AlmostModel
+{
+    #[OA\Property]
+    public string $soClose;
+}

--- a/docs/examples/specs/petstore/spec/Controllers/PetController.php
+++ b/docs/examples/specs/petstore/spec/Controllers/PetController.php
@@ -1,0 +1,195 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Petstore\Spec\Controllers;
+
+use OpenApi\Examples\Specs\Petstore\Spec\Models\ApiResponse;
+use OpenApi\Examples\Specs\Petstore\Spec\Models\Pet;
+use OpenApi\Examples\Specs\Petstore\Spec\Models\PetRequestBody;
+use OpenApi\Spec as OA;
+
+/**
+ * Class Pet.
+ */
+class PetController
+{
+    /**
+     * Add a new pet to the store.
+     */
+    #[OA\Operation\Post(path: '/pet', operationId: 'addPet', tags: ['pet'], requestBody: new OA\RequestBody(ref: PetRequestBody::class), responses: [
+        new OA\Response(response: 405, description: 'Invalid input'),
+    ], security: [
+        new OA\Security\Requirement(scheme: 'petstore_auth', scopes: ['write:pets', 'read:pets']),
+    ])]
+    public function addPet()
+    {
+    }
+
+    /**
+     * Update an existing pet.
+     */
+    #[OA\Operation\Put(path: '/pet', operationId: 'updatePet', tags: ['pet'], requestBody: new OA\RequestBody(ref: PetRequestBody::class), responses: [
+        new OA\Response(response: 400, description: 'Invalid ID supplied'),
+        new OA\Response(response: 404, description: 'Pet not found'),
+        new OA\Response(response: 405, description: 'Validation exception'),
+    ], security: [
+        new OA\Security\Requirement(scheme: 'petstore_auth', scopes: ['write:pets', 'read:pets']),
+    ])]
+    public function updatePet()
+    {
+    }
+
+    #[OA\Operation\Get(path: '/pet/findByStatus', operationId: 'findPetsByStatus', summary: 'Finds Pets by status', description: 'Multiple status values can be provided with comma separated string', tags: ['pet'], parameters: [
+        new OA\Parameter(
+            name: 'status',
+            in: 'query',
+            description: 'Status values that needed to be considered for filter',
+            required: true,
+            explode: true,
+            schema: new OA\Schema(type: 'string', enum: ['available', 'pending', 'sold'], default: 'available'),
+        ),
+    ], responses: [
+        new OA\Response(
+            response: 200,
+            description: 'successful operation',
+            content: [
+                new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(type: 'array', items: new OA\Schema(ref: Pet::class))),
+                new OA\MediaType(mediaType: 'application/xml', schema: new OA\Schema(type: 'array', items: new OA\Schema(ref: Pet::class))),
+            ],
+        ),
+        new OA\Response(response: 400, description: 'Invalid status value'),
+    ], deprecated: true, security: [
+        new OA\Security\Requirement(scheme: 'petstore_auth', scopes: ['write:pets', 'read:pets']),
+    ])]
+    public function findPetsByStatus()
+    {
+    }
+
+    #[OA\Operation\Get(path: '/pet/findByTags', operationId: 'findByTags', summary: 'Finds Pets by tags', description: 'Muliple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.', tags: ['pet'], parameters: [
+        new OA\Parameter(
+            name: 'tags',
+            in: 'query',
+            description: 'Tags to filter by',
+            required: true,
+            explode: true,
+            schema: new OA\Schema(type: 'array', items: new OA\Schema(type: 'string')),
+        ),
+    ], responses: [
+        new OA\Response(
+            response: 200,
+            description: 'successful operation',
+            content: [
+                new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(type: 'array', items: new OA\Schema(ref: Pet::class))),
+                new OA\MediaType(mediaType: 'application/xml', schema: new OA\Schema(type: 'array', items: new OA\Schema(ref: Pet::class))),
+            ],
+        ),
+        new OA\Response(response: 400, description: 'Invalid tag value'),
+    ], security: [
+        new OA\Security\Requirement(scheme: 'petstore_auth', scopes: ['write:pets', 'read:pets']),
+    ])]
+    public function findByTags()
+    {
+    }
+
+    #[OA\Operation\Get(path: '/pet/{petId}', operationId: 'getPetById', summary: 'Find pet by ID', description: 'Returns a single pet', tags: ['pet'], parameters: [
+        new OA\Parameter(
+            name: 'petId',
+            in: 'path',
+            description: 'ID of pet to return',
+            required: true,
+            schema: new OA\Schema(type: 'integer', format: 'int64'),
+        ),
+    ], responses: [
+        new OA\Response(
+            response: 200,
+            description: 'successful operation',
+            content: [
+                new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: Pet::class)),
+                new OA\MediaType(mediaType: 'application/xml', schema: new OA\Schema(ref: Pet::class)),
+            ],
+        ),
+        new OA\Response(response: 400, description: 'Invalid ID supplier'),
+        new OA\Response(response: 404, description: 'Pet not found'),
+    ], security: [
+        new OA\Security\Requirement(scheme: 'api_key', scopes: []),
+    ])]
+    public function getPetById(int $id)
+    {
+    }
+
+    #[OA\Operation\Post(path: '/pet/{petId}', operationId: 'updatePetWithForm', summary: 'Updates a pet in the store with form data', tags: ['pet'], parameters: [
+        new OA\Parameter(
+            name: 'petId',
+            in: 'path',
+            description: 'ID of pet that needs to be updated',
+            required: true,
+            schema: new OA\Schema(type: 'integer', format: 'int64'),
+        ),
+    ], requestBody: new OA\RequestBody(
+        description: 'Input data format',
+        content: [
+            new OA\MediaType(
+                mediaType: 'application/x-www-form-urlencoded',
+                schema: new OA\Schema(
+                    type: 'object',
+                    properties: [
+                        new OA\Property(property: 'name', schema: new OA\Schema(description: 'Updated name of the pet', type: 'string')),
+                        new OA\Property(property: 'status', schema: new OA\Schema(description: 'Updated status of the pet', type: 'string')),
+                    ],
+                ),
+            ),
+        ],
+    ), responses: [
+        new OA\Response(response: 405, description: 'Invalid input'),
+    ], security: [
+        new OA\Security\Requirement(scheme: 'petstore_auth', scopes: ['write:pets', 'read:pets']),
+    ])]
+    public function updatePetWithForm()
+    {
+    }
+
+    #[OA\Operation\Delete(path: '/pet/{petId}', operationId: 'deletePet', summary: 'Deletes a pet', tags: ['pet'], parameters: [
+        new OA\Parameter(name: 'api_key', in: 'header', required: false, schema: new OA\Schema(type: 'string')),
+        new OA\Parameter(name: 'petId', in: 'path', description: 'Pet id to delete', required: true, schema: new OA\Schema(type: 'integer', format: 'int64')),
+    ], responses: [
+        new OA\Response(response: 400, description: 'Invalid ID supplied'),
+        new OA\Response(response: 404, description: 'Pet not found'),
+    ], security: [
+        new OA\Security\Requirement(scheme: 'petstore_auth', scopes: ['write:pets', 'read:pets']),
+    ])]
+    public function deletePet()
+    {
+    }
+
+    #[OA\Operation\Post(path: '/pet/{petId}/uploadImage', operationId: 'uploadFile', summary: 'uploads an image', tags: ['pet'], parameters: [
+        new OA\Parameter(
+            name: 'petId',
+            in: 'path',
+            description: 'ID of pet to update',
+            required: true,
+            schema: new OA\Schema(type: 'integer', format: 'int64', example: 1),
+        ),
+    ], requestBody: new OA\RequestBody(
+        description: 'Upload images request body',
+        content: [
+            new OA\MediaType(
+                mediaType: 'application/octet-stream',
+                schema: new OA\Schema(type: 'string', format: 'binary'),
+            ),
+        ],
+    ), responses: [
+        new OA\Response(
+            response: 200,
+            description: 'successful operation',
+            content: [new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: ApiResponse::class))],
+        ),
+    ], security: [
+        new OA\Security\Requirement(scheme: 'petstore_auth', scopes: ['write:pets', 'read:pets']),
+    ])]
+    public function uploadFile()
+    {
+    }
+}

--- a/docs/examples/specs/petstore/spec/Controllers/StoreController.php
+++ b/docs/examples/specs/petstore/spec/Controllers/StoreController.php
@@ -1,0 +1,114 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Petstore\Spec\Controllers;
+
+use OpenApi\Examples\Specs\Petstore\Spec\Models\Order;
+use OpenApi\Spec as OA;
+
+/**
+ * Class Store.
+ */
+class StoreController
+{
+    #[OA\Operation\Get(path: '/store', operationId: 'getInventory', summary: 'Returns pet inventories by status', description: 'Returns a map of status codes to quantities', tags: ['store'], responses: [
+        new OA\Response(
+            response: 200,
+            description: 'successful operation',
+            content: [
+                new OA\MediaType(
+                    mediaType: 'application/json',
+                    schema: new OA\Schema(additionalProperties: new OA\Schema(type: 'integer', format: 'int32')),
+                ),
+            ],
+        ),
+    ], security: [
+        new OA\Security\Requirement(scheme: 'api_key', scopes: []),
+    ])]
+    public function getInventory()
+    {
+    }
+
+    #[OA\Operation\Post(
+        path: '/store/order',
+        operationId: 'placeOrder',
+        summary: 'Place an order for a pet',
+        tags: ['store'],
+        requestBody: new OA\RequestBody(
+            description: 'order placed for purchasing the pet',
+            required: true,
+            content: [new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: Order::class))],
+        ),
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'successful operation',
+                content: [
+                    new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: Order::class)),
+                    new OA\MediaType(mediaType: 'application/xml', schema: new OA\Schema(ref: Order::class)),
+                ],
+            ),
+        ],
+    )]
+    public function placeOrder()
+    {
+    }
+
+    #[OA\Operation\Get(
+        path: '/store/order/{orderId}',
+        operationId: 'getOrderById',
+        description: 'For valid response try integer IDs with value >= 1 and <= 10. Other values will generated exceptions',
+        tags: ['store'],
+        parameters: [
+            new OA\Parameter(
+                name: 'orderId',
+                in: 'path',
+                description: 'ID of pet that needs to be fetched',
+                required: true,
+                schema: new OA\Schema(type: 'integer', format: 'int64', minimum: 1, maximum: 10),
+            ),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'successful operation',
+                content: [
+                    new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: Order::class)),
+                    new OA\MediaType(mediaType: 'application/xml', schema: new OA\Schema(ref: Order::class)),
+                ],
+            ),
+            new OA\Response(response: 400, description: 'Invalid ID supplied'),
+            new OA\Response(response: 404, description: 'Order not found'),
+        ],
+    )]
+    public function getOrderById()
+    {
+    }
+
+    #[OA\Operation\Delete(
+        path: '/store/order/{orderId}',
+        operationId: 'deleteOrder',
+        summary: 'Delete purchase order by ID',
+        description: 'For valid response try integer IDs with positive integer value. Negative or non-integer values will generate API errors',
+        tags: ['store'],
+        parameters: [
+            new OA\Parameter(
+                name: 'orderId',
+                in: 'path',
+                description: 'ID of the order that needs to be deleted',
+                required: true,
+                schema: new OA\Schema(type: 'integer', format: 'int64', minimum: 1),
+            ),
+        ],
+        responses: [
+            new OA\Response(response: 400, description: 'Invalid ID supplied'),
+            new OA\Response(response: 404, description: 'Order not found'),
+        ],
+    )]
+    public function deleteOrder()
+    {
+    }
+}

--- a/docs/examples/specs/petstore/spec/Controllers/UserController.php
+++ b/docs/examples/specs/petstore/spec/Controllers/UserController.php
@@ -1,0 +1,155 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Petstore\Spec\Controllers;
+
+use OpenApi\Examples\Specs\Petstore\Spec\Models\User;
+use OpenApi\Examples\Specs\Petstore\Spec\Models\UserArrayRequestBody;
+use OpenApi\Spec as OA;
+
+/**
+ * Class User.
+ */
+class UserController
+{
+    #[OA\Operation\Post(
+        path: '/user',
+        operationId: 'createUser',
+        summary: 'Create user',
+        description: 'This can only be done by the logged in user.',
+        tags: ['user'],
+        requestBody: new OA\RequestBody(
+            description: 'Create user object',
+            required: true,
+            content: [new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: User::class))],
+        ),
+        responses: [
+            new OA\Response(response: 'default', description: 'successful operation'),
+        ],
+    )]
+    public function createUser()
+    {
+    }
+
+    #[OA\Operation\Post(
+        path: '/user/createWithArray',
+        operationId: 'createUsersWithListInput',
+        summary: 'Create list of users with given input array',
+        tags: ['user'],
+        requestBody: new OA\RequestBody(ref: UserArrayRequestBody::class),
+        responses: [
+            new OA\Response(response: 'default', description: 'successful operation'),
+        ],
+    )]
+    public function createUsersWithListInput()
+    {
+    }
+
+    #[OA\Operation\Get(
+        path: '/user/login',
+        operationId: 'loginUser',
+        summary: 'Logs user into system',
+        tags: ['user'],
+        parameters: [
+            new OA\Parameter(name: 'username', in: 'query', description: 'The user name for login', required: true, schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(name: 'password', in: 'query', required: true, schema: new OA\Schema(type: 'string')),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'successful operation',
+                headers: [
+                    new OA\Header(header: 'X-Rate-Limit', description: 'calls per hour allowed by the user', schema: new OA\Schema(type: 'integer', format: 'int32')),
+                    new OA\Header(header: 'X-Expires-After', description: 'date in UTC when token expires', schema: new OA\Schema(type: 'string', format: 'datetime')),
+                ],
+                content: [
+                    new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(type: 'string')),
+                    new OA\MediaType(mediaType: 'application/xml', schema: new OA\Schema(type: 'string')),
+                ],
+            ),
+            new OA\Response(response: 400, description: 'Invalid username/password supplied'),
+        ],
+    )]
+    public function loginUser()
+    {
+    }
+
+    #[OA\Operation\Get(
+        path: '/user/logout',
+        operationId: 'logoutUser',
+        summary: 'Logs out current logged in user session',
+        tags: ['user'],
+        responses: [
+            new OA\Response(response: 'default', description: 'successful operation'),
+        ],
+    )]
+    public function logoutUser()
+    {
+    }
+
+    #[OA\Operation\Get(
+        path: '/user/{username}',
+        operationId: 'getUserByName',
+        summary: 'Get user by user name',
+        parameters: [
+            new OA\Parameter(name: 'username', in: 'path', required: true, schema: new OA\Schema(type: 'string')),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'successful operation',
+                content: [
+                    new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: User::class)),
+                    new OA\MediaType(mediaType: 'application/xml', schema: new OA\Schema(ref: User::class)),
+                ],
+            ),
+            new OA\Response(response: 400, description: 'Invalid username supplied'),
+            new OA\Response(response: 404, description: 'User not found'),
+        ],
+    )]
+    public function getUserByName()
+    {
+    }
+
+    #[OA\Operation\Put(
+        path: '/user/{username}',
+        operationId: 'updateUser',
+        summary: 'Update user',
+        description: 'This can only be done by the logged in user.',
+        parameters: [
+            new OA\Parameter(name: 'username', in: 'path', description: 'name that to be updated', required: true, schema: new OA\Schema(type: 'string')),
+        ],
+        requestBody: new OA\RequestBody(
+            description: 'Updated user object',
+            required: true,
+            content: [new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: User::class))],
+        ),
+        responses: [
+            new OA\Response(response: 400, description: 'Invalid user supplied'),
+            new OA\Response(response: 404, description: 'User not found'),
+        ],
+    )]
+    public function updateUser()
+    {
+    }
+
+    #[OA\Operation\Delete(
+        path: '/user/{username}',
+        operationId: 'deleteUser',
+        summary: 'Delete user',
+        description: 'This can only be done by the logged in user.',
+        parameters: [
+            new OA\Parameter(name: 'username', in: 'path', description: 'The name that needs to be deleted', required: true, schema: new OA\Schema(type: 'string')),
+        ],
+        responses: [
+            new OA\Response(response: 400, description: 'Invalid username supplied'),
+            new OA\Response(response: 404, description: 'User not found'),
+        ],
+    )]
+    public function deleteUser()
+    {
+    }
+}

--- a/docs/examples/specs/petstore/spec/Models/ApiResponse.php
+++ b/docs/examples/specs/petstore/spec/Models/ApiResponse.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Petstore\Spec\Models;
+
+use OpenApi\Spec as OA;
+
+/**
+ * Class ApiResponse.
+ */
+#[OA\Schema(title: 'Api response', description: 'Api response')]
+class ApiResponse
+{
+    #[OA\Property(property: 'code')]
+    #[OA\Schema(title: 'Code', description: 'Code', format: 'int32')]
+    private int $code;
+
+    #[OA\Property(property: 'type')]
+    #[OA\Schema(title: 'Type', description: 'Type')]
+    private string $type;
+
+    #[OA\Property(property: 'message')]
+    #[OA\Schema(title: 'Message', description: 'Message')]
+    private string $message;
+}

--- a/docs/examples/specs/petstore/spec/Models/Category.php
+++ b/docs/examples/specs/petstore/spec/Models/Category.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Petstore\Spec\Models;
+
+use OpenApi\Spec as OA;
+
+/**
+ * Pets Category.
+ */
+#[OA\Schema(
+    title: 'Pets Category.',
+    xml: new OA\Xml(name: 'Category'),
+)]
+class Category
+{
+    #[OA\Property(property: 'id')]
+    #[OA\Schema(title: 'ID', description: 'ID', format: 'int64')]
+    private int $id;
+
+    #[OA\Property(property: 'name')]
+    #[OA\Schema(title: 'Category name', description: 'Category name')]
+    private string $name;
+}

--- a/docs/examples/specs/petstore/spec/Models/Order.php
+++ b/docs/examples/specs/petstore/spec/Models/Order.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Petstore\Spec\Models;
+
+use OpenApi\Spec as OA;
+
+/**
+ * Class Order.
+ */
+#[OA\Schema(title: 'Order model', description: 'Order model')]
+class Order
+{
+    #[OA\Property(property: 'id')]
+    #[OA\Schema(title: 'ID', description: 'ID', format: 'int64', default: 1)]
+    private int $id;
+
+    #[OA\Property(property: 'petId')]
+    #[OA\Schema(title: 'Pet ID', description: 'Pet ID', format: 'int64', default: 1)]
+    private int $petId;
+
+    #[OA\Property(property: 'quantity')]
+    #[OA\Schema(title: 'Quantity', description: 'Quantity', format: 'int32', default: 12)]
+    private int $quantity;
+
+    #[OA\Property(property: 'shipDate')]
+    #[OA\Schema(title: 'Shipping date', description: 'Shipping date', type: 'string', format: 'datetime', default: '2017-02-02 18:31:45')]
+    private \DateTime $shipDate;
+
+    #[OA\Property(property: 'status')]
+    #[OA\Schema(title: 'Order status', description: 'Order status', enum: ['placed', 'approved', 'delivered'], default: 'placed')]
+    private string $status;
+
+    #[OA\Property(property: 'complete')]
+    #[OA\Schema(title: 'Complete status', description: 'Complete status', type: 'boolean', default: false)]
+    private bool $complete;
+}

--- a/docs/examples/specs/petstore/spec/Models/Pet.php
+++ b/docs/examples/specs/petstore/spec/Models/Pet.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Petstore\Spec\Models;
+
+use OpenApi\Spec as OA;
+
+/**
+ * Class Pet.
+ */
+#[OA\Schema(title: 'Pet model', description: 'Pet model', required: [
+    'name',
+    'photoUrls',
+], xml: new OA\Xml(name: 'Pet'))]
+class Pet
+{
+    #[OA\Property(property: 'id')]
+    #[OA\Schema(title: 'ID', description: 'ID', format: 'int64')]
+    private int $id;
+
+    #[OA\Property(property: 'category')]
+    #[OA\Schema(title: 'Category', ref: Category::class)]
+    private Category $category;
+
+    #[OA\Property(property: 'name')]
+    #[OA\Schema(title: 'Pet name', description: 'Pet name', format: 'int64')]
+    private string $name;
+
+    /**
+     * @var array<string>
+     */
+    #[OA\Property(property: 'photoUrls')]
+    #[OA\Schema(
+        title: 'Photo urls',
+        description: 'Photo urls',
+        type: 'array',
+        items: new OA\Schema(type: 'string', default: 'images/image-1.png'),
+        xml: new OA\Xml(name: 'photoUrl', wrapped: true),
+    )]
+    private array $photoUrls;
+
+    /**
+     * @var array<Tag>
+     */
+    #[OA\Property(property: 'tags')]
+    #[OA\Schema(
+        title: 'Pet tags',
+        description: 'Pet tags',
+        type: 'array',
+        items: new OA\Schema(ref: Tag::class),
+        xml: new OA\Xml(name: 'tag', wrapped: true),
+    )]
+    private array $tags;
+}

--- a/docs/examples/specs/petstore/spec/Models/PetRequestBody.php
+++ b/docs/examples/specs/petstore/spec/Models/PetRequestBody.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Petstore\Spec\Models;
+
+use OpenApi\Spec as OA;
+
+#[OA\RequestBody(
+    request: 'Pet',
+    description: 'Pet object that needs to be added to the store',
+    required: true,
+    content: [
+        new OA\MediaType(
+            mediaType: 'application/json',
+            schema: new OA\Schema(ref: Pet::class),
+        ),
+        new OA\MediaType(
+            mediaType: 'application/xml',
+            schema: new OA\Schema(ref: Pet::class),
+        ),
+    ],
+)]
+class PetRequestBody
+{
+}

--- a/docs/examples/specs/petstore/spec/Models/Tag.php
+++ b/docs/examples/specs/petstore/spec/Models/Tag.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Petstore\Spec\Models;
+
+use OpenApi\Spec as OA;
+
+/**
+ * Tag.
+ */
+#[OA\Schema(
+    title: 'Tag',
+    xml: new OA\Xml(name: 'Tag'),
+)]
+class Tag
+{
+    #[OA\Property(property: 'id')]
+    #[OA\Schema(title: 'ID', description: 'ID', format: 'int64')]
+    private int $id;
+
+    #[OA\Property(property: 'name')]
+    #[OA\Schema(title: 'Name', description: 'Name')]
+    private string $name;
+}

--- a/docs/examples/specs/petstore/spec/Models/User.php
+++ b/docs/examples/specs/petstore/spec/Models/User.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Petstore\Spec\Models;
+
+use OpenApi\Spec as OA;
+
+/**
+ * Class User.
+ */
+#[OA\Schema(title: 'User model', description: 'User model')]
+class User
+{
+    #[OA\Property(property: 'id')]
+    #[OA\Schema(title: 'ID', description: 'ID', format: 'int64')]
+    private int $id;
+
+    #[OA\Property(property: 'username')]
+    #[OA\Schema(title: 'Username', description: 'Username')]
+    private string $username;
+
+    #[OA\Property(property: 'firstName')]
+    #[OA\Schema(title: 'First name', description: 'First name')]
+    private string $firstName;
+
+    #[OA\Property(property: 'lastName')]
+    #[OA\Schema(title: 'Last name', description: 'Last name')]
+    private string $lastName;
+
+    #[OA\Property(property: 'email')]
+    #[OA\Schema(title: 'Email', description: 'Email', format: 'email')]
+    private string $email;
+
+    #[OA\Property(property: 'password')]
+    #[OA\Schema(title: 'Password', description: 'Password', maximum: 255)]
+    private string $password;
+
+    #[OA\Property(property: 'phone')]
+    #[OA\Schema(title: 'Phone', description: 'Phone', format: 'msisdn')]
+    private string $phone;
+
+    #[OA\Property(property: 'userStatus')]
+    #[OA\Schema(title: 'User status', description: 'User status', format: 'int32')]
+    private int $userStatus;
+}

--- a/docs/examples/specs/petstore/spec/Models/UserArrayRequestBody.php
+++ b/docs/examples/specs/petstore/spec/Models/UserArrayRequestBody.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Petstore\Spec\Models;
+
+use OpenApi\Spec as OA;
+
+#[OA\RequestBody(
+    request: 'UserArray',
+    description: 'List of user object',
+    required: true,
+    content: [
+        new OA\MediaType(
+            mediaType: 'application/json',
+            schema: new OA\Schema(type: 'array', items: new OA\Schema(ref: User::class)),
+        ),
+    ],
+)]
+class UserArrayRequestBody
+{
+}

--- a/docs/examples/specs/petstore/spec/Petstore.php
+++ b/docs/examples/specs/petstore/spec/Petstore.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Petstore\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\OpenApi(version: '3.1.0')]
+#[OA\Info(title: 'Swagger Petstore', description: "This is a sample Petstore server.\nYou can find out more about Swagger at [http://swagger.io](http://swagger.io)\nor on [irc.freenode.net, #swagger](http://swagger.io/irc/).", termsOfService: 'http://swagger.io/terms/', version: '1.0.0', contact: new OA\Contact(email: 'apiteam@swagger.io'), license: new OA\License(
+    name: 'Apache 2.0',
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+))]
+#[OA\Server(url: 'https://petstore.com/1.0.0', description: 'Petstore API')]
+#[OA\Tag(
+    name: 'pet',
+    description: 'Everything about your Pets',
+    externalDocs: new OA\ExternalDocumentation(url: 'http://swagger.io', description: 'Find out more'),
+)]
+#[OA\Tag(name: 'store', description: 'Access to Petstore orders')]
+#[OA\Tag(
+    name: 'user',
+    description: 'Operations about user',
+    externalDocs: new OA\ExternalDocumentation(url: 'http://swagger.io', description: 'Find out more about store'),
+)]
+#[OA\ExternalDocumentation(url: 'http://swagger.io', description: 'Find out more about Swagger')]
+class Petstore
+{
+}

--- a/docs/examples/specs/petstore/spec/Security.php
+++ b/docs/examples/specs/petstore/spec/Security.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Petstore\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Security\Scheme\OAuth2(securityScheme: 'petstore_auth', flows: [
+    new OA\Flow\Implicit(
+        authorizationUrl: 'http://petstore.swagger.io/oauth/dialog',
+        scopes: [
+            'write:pets' => 'modify pets in your account',
+            'read:pets' => 'read your pets',
+        ],
+    ),
+])]
+#[OA\Security\Scheme\ApiKey(securityScheme: 'api_key', name: 'api_key', in: 'header')]
+class Security
+{
+}

--- a/docs/examples/specs/polymorphism/spec/AbstractResponsible.php
+++ b/docs/examples/specs/polymorphism/spec/AbstractResponsible.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Polymorphism\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema(schema: 'Responsible', oneOf: [
+    new OA\Schema(ref: Fl::class),
+    new OA\Schema(ref: Employee::class),
+], discriminator: new OA\Discriminator(
+    propertyName: 'type',
+    mapping: [
+        'fl' => Fl::class,
+        'employee' => Employee::class,
+    ],
+))]
+abstract class AbstractResponsible
+{
+    protected const TYPE = null;
+
+    #[OA\Property(property: 'type')]
+    #[OA\Schema(nullable: false, enum: ['employee', 'assignee', 'fl'])]
+    protected string $type;
+
+    public function __construct()
+    {
+        $this->type = static::TYPE;
+    }
+}

--- a/docs/examples/specs/polymorphism/spec/Controller.php
+++ b/docs/examples/specs/polymorphism/spec/Controller.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Polymorphism\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Info(title: 'Polymorphism', description: 'Polymorphism example', version: '1', contact: new OA\Contact(name: 'Swagger API Team'))]
+#[OA\Server(url: 'https://example.localhost', description: 'API server')]
+#[OA\Tag(name: 'api', description: 'API operations')]
+class Controller
+{
+    #[OA\Operation\Get(
+        path: '/test',
+        operationId: 'test',
+        description: 'Get test',
+        tags: ['api'],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Polymorphism',
+                content: [new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: Request::class))],
+            ),
+        ],
+    )]
+    public function getProduct($id)
+    {
+    }
+}

--- a/docs/examples/specs/polymorphism/spec/Employee.php
+++ b/docs/examples/specs/polymorphism/spec/Employee.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Polymorphism\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema(schema: 'EmployeeResponsible')]
+final class Employee extends AbstractResponsible
+{
+    #[OA\Property(property: 'type')]
+    protected const TYPE = 'Virtual';
+
+    #[OA\Property(property: 'property2')]
+    #[OA\Schema(nullable: false)]
+    public string $property2;
+}

--- a/docs/examples/specs/polymorphism/spec/Fl.php
+++ b/docs/examples/specs/polymorphism/spec/Fl.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Polymorphism\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema(schema: 'FlResponsible')]
+final class Fl extends AbstractResponsible
+{
+    public const TYPE = 'fl';
+
+    #[OA\Property(property: 'property3')]
+    public ?string $property3 = null;
+}

--- a/docs/examples/specs/polymorphism/spec/Request.php
+++ b/docs/examples/specs/polymorphism/spec/Request.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Polymorphism\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema]
+final class Request
+{
+    protected const TYPE = 'employee';
+
+    #[OA\Property(property: 'payload')]
+    public AbstractResponsible $payload;
+}

--- a/docs/examples/specs/using-interfaces/annotations/ProductController.php
+++ b/docs/examples/specs/using-interfaces/annotations/ProductController.php
@@ -15,6 +15,7 @@ class ProductController
      *     tags={"Products"},
      *     path="/products/{id}",
      *     description="Get product in any colour for id",
+     *     operationId="getProduct",
      *     tags={"api"},
      *     @OA\Parameter(
      *         description="ID of product to return",
@@ -41,6 +42,7 @@ class ProductController
      *     tags={"Products"},
      *     path="/products/green/{id}",
      *     description="Get green products",
+     *     operationId="getGreenProduct",
      *     tags={"api"},
      *     @OA\Parameter(
      *         description="ID of product to return",

--- a/docs/examples/specs/using-interfaces/spec/ColorInterface.php
+++ b/docs/examples/specs/using-interfaces/spec/ColorInterface.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\UsingInterfaces\Spec;
+
+use OpenApi\Spec as OA;
+
+/**
+ * Not a schema.
+ */
+interface ColorInterface
+{
+    /**
+     * The product color.
+     */
+    #[OA\Property(property: 'color')]
+    #[OA\Schema(example: 'blue')]
+    public function getColor();
+}

--- a/docs/examples/specs/using-interfaces/spec/GreenProduct.php
+++ b/docs/examples/specs/using-interfaces/spec/GreenProduct.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\UsingInterfaces\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema(title: 'GreenProduct')]
+class GreenProduct extends Product implements ColorInterface
+{
+    public function getColor(): string
+    {
+        return 'green';
+    }
+}

--- a/docs/examples/specs/using-interfaces/spec/OpenApiSpec.php
+++ b/docs/examples/specs/using-interfaces/spec/OpenApiSpec.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\UsingInterfaces\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Info(title: 'Example of using interfaces in swagger-php', description: 'Using interfaces', version: '1.0.0', contact: new OA\Contact(name: 'Swagger API Team'))]
+#[OA\Server(url: 'https://example.localhost', description: 'API server')]
+#[OA\Tag(name: 'api', description: 'API operations')]
+class OpenApiSpec
+{
+}

--- a/docs/examples/specs/using-interfaces/spec/Product.php
+++ b/docs/examples/specs/using-interfaces/spec/Product.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\UsingInterfaces\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema(title: 'Product model')]
+class Product implements ProductInterface
+{
+    /**
+     * The unique identifier of a product in our catalog.
+     */
+    #[OA\Property(property: 'id')]
+    #[OA\Schema(type: 'integer', format: 'int64', example: 1)]
+    public int $id;
+
+    public function getName(): string
+    {
+        return 'kettle';
+    }
+}

--- a/docs/examples/specs/using-interfaces/spec/ProductController.php
+++ b/docs/examples/specs/using-interfaces/spec/ProductController.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\UsingInterfaces\Spec;
+
+use OpenApi\Spec as OA;
+
+class ProductController
+{
+    #[OA\Operation\Get(
+        path: '/products/{id}',
+        operationId: 'getProduct',
+        description: 'Get product in any colour for id',
+        tags: ['api'],
+        parameters: [
+            new OA\Parameter(
+                name: 'id',
+                in: 'path',
+                description: 'ID of product to return',
+                required: true,
+                schema: new OA\Schema(type: 'string'),
+            ),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'successful operation',
+                content: [new OA\MediaType(
+                    mediaType: 'application/json',
+                    schema: new OA\Schema(ref: '#/components/schemas/Product'),
+                )],
+            ),
+        ],
+    )]
+    public function getProduct($id)
+    {
+    }
+
+    #[OA\Operation\Get(
+        path: '/products/green/{id}',
+        operationId: 'getGreenProduct',
+        description: 'Get green products',
+        tags: ['api'],
+        parameters: [
+            new OA\Parameter(
+                name: 'id',
+                in: 'path',
+                description: 'ID of product to return',
+                required: true,
+                schema: new OA\Schema(type: 'string'),
+            ),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'successful operation',
+                content: [new OA\MediaType(
+                    mediaType: 'application/json',
+                    schema: new OA\Schema(ref: '#/components/schemas/GreenProduct'),
+                )],
+            ),
+        ],
+    )]
+    public function getGreenProduct($id)
+    {
+    }
+}

--- a/docs/examples/specs/using-interfaces/spec/ProductInterface.php
+++ b/docs/examples/specs/using-interfaces/spec/ProductInterface.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\UsingInterfaces\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema]
+interface ProductInterface
+{
+    /**
+     * The product name.
+     */
+    #[OA\Property(property: 'name')]
+    #[OA\Schema(example: 'toaster')]
+    public function getName();
+}

--- a/docs/examples/specs/using-interfaces/using-interfaces-3.0.0.yaml
+++ b/docs/examples/specs/using-interfaces/using-interfaces-3.0.0.yaml
@@ -15,7 +15,7 @@ paths:
       tags:
         - api
       description: 'Get product in any colour for id'
-      operationId: 0787cf008b6d08a91ee494a88d16a4cd
+      operationId: getProduct
       parameters:
         -
           name: id
@@ -36,7 +36,7 @@ paths:
       tags:
         - api
       description: 'Get green products'
-      operationId: 3e21c50a909c7623a326e8ae9848f40a
+      operationId: getGreenProduct
       parameters:
         -
           name: id

--- a/docs/examples/specs/using-interfaces/using-interfaces-3.1.0.yaml
+++ b/docs/examples/specs/using-interfaces/using-interfaces-3.1.0.yaml
@@ -15,7 +15,7 @@ paths:
       tags:
         - api
       description: 'Get product in any colour for id'
-      operationId: 0787cf008b6d08a91ee494a88d16a4cd
+      operationId: getProduct
       parameters:
         -
           name: id
@@ -36,7 +36,7 @@ paths:
       tags:
         - api
       description: 'Get green products'
-      operationId: 3e21c50a909c7623a326e8ae9848f40a
+      operationId: getGreenProduct
       parameters:
         -
           name: id

--- a/docs/examples/specs/using-interfaces/using-interfaces-3.2.0.yaml
+++ b/docs/examples/specs/using-interfaces/using-interfaces-3.2.0.yaml
@@ -15,7 +15,7 @@ paths:
       tags:
         - api
       description: 'Get product in any colour for id'
-      operationId: 0787cf008b6d08a91ee494a88d16a4cd
+      operationId: getProduct
       parameters:
         -
           name: id
@@ -36,7 +36,7 @@ paths:
       tags:
         - api
       description: 'Get green products'
-      operationId: 3e21c50a909c7623a326e8ae9848f40a
+      operationId: getGreenProduct
       parameters:
         -
           name: id

--- a/docs/examples/specs/using-links/spec/OpenApiSpec.php
+++ b/docs/examples/specs/using-links/spec/OpenApiSpec.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\UsingLinks\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Info(title: 'Link Example', description: 'Using links', version: '1.0.0', contact: new OA\Contact(name: 'Contact Name', email: 'support@example.com'))]
+class OpenApiSpec
+{
+}

--- a/docs/examples/specs/using-links/spec/PullRequest.php
+++ b/docs/examples/specs/using-links/spec/PullRequest.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\UsingLinks\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema(schema: 'pullrequest')]
+class PullRequest
+{
+    #[OA\Property(property: 'id')]
+    #[OA\Schema(type: 'integer')]
+    public $id;
+
+    #[OA\Property(property: 'title')]
+    #[OA\Schema(type: 'string')]
+    public $title;
+
+    #[OA\Property(property: 'repository')]
+    #[OA\Schema(ref: Repository::class)]
+    public $repository;
+
+    #[OA\Property(property: 'author')]
+    #[OA\Schema(ref: User::class)]
+    public $author;
+
+    public function __construct(
+        #[OA\Property(property: 'state')]
+        public State $state,
+    ) {
+    }
+}

--- a/docs/examples/specs/using-links/spec/RepositoriesController.php
+++ b/docs/examples/specs/using-links/spec/RepositoriesController.php
@@ -1,0 +1,119 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\UsingLinks\Spec;
+
+use OpenApi\Spec as OA;
+
+class RepositoriesController
+{
+    #[OA\Operation\Get(
+        path: '/2.0/repositories/{username}',
+        operationId: 'getRepositoriesByOwner',
+        parameters: [
+            new OA\Parameter(name: 'username', in: 'path', required: true, schema: new OA\Schema(type: 'string')),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Repositories owned by the supplied user',
+                content: [new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(type: 'array', items: new OA\Schema(ref: '#/components/schemas/repository')))],
+                links: [new OA\Link(link: 'userRepository', ref: '#/components/links/UserRepository')],
+            ),
+        ],
+    )]
+    #[OA\Link(link: 'UserRepositories', operationId: 'getRepositoriesByOwner', parameters: ['username' => '$response.body#/username'])]
+    public function getRepositoriesByOwner($username)
+    {
+    }
+
+    #[OA\Operation\Get(
+        path: '/2.0/repositories/{username}/{slug}',
+        operationId: 'getRepository',
+        parameters: [
+            new OA\Parameter(name: 'username', in: 'path', required: true, schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(name: 'slug', in: 'path', required: true, schema: new OA\Schema(type: 'string')),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'The repository',
+                content: [new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: '#/components/schemas/repository'))],
+                links: [new OA\Link(link: 'repositoryPullRequests', ref: '#/components/links/RepositoryPullRequests')],
+            ),
+        ],
+    )]
+    #[OA\Link(link: 'UserRepository', operationId: 'getRepository', parameters: ['username' => '$response.body#/owner/username', 'slug' => '$response.body#/slug'])]
+    public function getRepository()
+    {
+    }
+
+    #[OA\Operation\Get(
+        path: '/2.0/repositories/{username}/{slug}/{state}/pullrequests',
+        operationId: 'getPullRequestsByRepository',
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'An array of pull request objects',
+                content: [new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(type: 'array', items: new OA\Schema(ref: '#/components/schemas/pullrequest')))],
+            ),
+        ],
+    )]
+    #[OA\Link(link: 'RepositoryPullRequests', operationId: 'getPullRequestsByRepository', parameters: ['username' => '$response.body#/owner/username', 'slug' => '$response.body#/slug'])]
+    public function getPullRequestsByRepository(
+        #[OA\Parameter\Path]
+        string $username,
+        #[OA\Parameter\Path]
+        string $slug,
+        #[OA\Parameter\Path]
+        State $state,
+        #[OA\Parameter\Query]
+        ?string $label,
+    ) {
+    }
+
+    #[OA\Operation\Get(
+        path: '/2.0/repositories/{username}/{slug}/pullrequests/{pid}',
+        operationId: 'getPullRequestsById',
+        parameters: [
+            new OA\Parameter(name: 'username', in: 'path', required: true, schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(name: 'slug', in: 'path', required: true, schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(name: 'pid', in: 'path', required: true, schema: new OA\Schema(type: 'string')),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'A pull request object',
+                content: [new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: '#/components/schemas/pullrequest'))],
+                links: [new OA\Link(link: 'pullRequestMerge', ref: '#/components/links/PullRequestMerge')],
+            ),
+        ],
+    )]
+    public function getPullRequestsById()
+    {
+    }
+
+    #[OA\Operation\Post(
+        path: '/2.0/repositories/{username}/{slug}/pullrequests/{pid}/merge',
+        operationId: 'mergePullRequest',
+        parameters: [
+            new OA\Parameter(name: 'username', in: 'path', required: true, schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(name: 'slug', in: 'path', required: true, schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(name: 'pid', in: 'path', required: true, schema: new OA\Schema(type: 'string')),
+        ],
+        responses: [
+            new OA\Response(response: 204, description: 'The PR was successfully merged'),
+        ],
+    )]
+    #[OA\Link(link: 'PullRequestMerge', operationId: 'mergePullRequest', parameters: ['username' => '$response.body#/author/username', 'slug' => '$response.body#/repository/slug', 'pid' => '$response.body#/id'])]
+    public function mergePullRequest(
+        #[OA\Parameter\Header(name: 'X-NONCE-ID')]
+        string $nonceId,
+        #[OA\Parameter\Cookie(name: 'User-Bind-Session')]
+        ?string $bindCookie,
+    ) {
+    }
+}

--- a/docs/examples/specs/using-links/spec/Repository.php
+++ b/docs/examples/specs/using-links/spec/Repository.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\UsingLinks\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema(schema: 'repository')]
+class Repository
+{
+    #[OA\Property(property: 'slug')]
+    #[OA\Schema(type: 'string')]
+    public $slug;
+
+    #[OA\Property(property: 'owner')]
+    public User $owner;
+}

--- a/docs/examples/specs/using-links/spec/State.php
+++ b/docs/examples/specs/using-links/spec/State.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\UsingLinks\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema]
+enum State
+{
+    case OPEN;
+    case MERGED;
+    case DECLINED;
+}

--- a/docs/examples/specs/using-links/spec/User.php
+++ b/docs/examples/specs/using-links/spec/User.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\UsingLinks\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema(schema: 'user')]
+class User
+{
+    #[OA\Property(property: 'username')]
+    #[OA\Schema(type: 'string')]
+    public $username;
+
+    #[OA\Property(property: 'uuid')]
+    #[OA\Schema(type: 'string')]
+    public $uuid;
+}

--- a/docs/examples/specs/using-links/spec/UsersController.php
+++ b/docs/examples/specs/using-links/spec/UsersController.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\UsingLinks\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Tag(name: 'Users', description: 'Users')]
+class UsersController
+{
+    #[OA\Operation\Get(
+        path: '/2.0/users/{username}',
+        operationId: 'getUserByName',
+        summary: 'Get user details by username',
+        tags: ['Users'],
+        parameters: [
+            new OA\Parameter(name: 'username', in: 'path', required: true, schema: new OA\Schema(type: 'string')),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'The User',
+                content: [new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: '#/components/schemas/user'))],
+                links: [new OA\Link(link: 'userRepositories', ref: '#/components/links/UserRepositories')],
+            ),
+        ],
+    )]
+    public function getUserByName(string $username)
+    {
+    }
+}

--- a/docs/examples/specs/using-refs/annotations/ProductController.php
+++ b/docs/examples/specs/using-refs/annotations/ProductController.php
@@ -20,6 +20,7 @@ class ProductController
      * @OA\Get(
      *     tags={"Products"},
      *     path="/products/{product_id}",
+     *     operationId="getProduct",
      *     @OA\Response(
      *         response="default",
      *         ref="#/components/responses/product"
@@ -34,6 +35,7 @@ class ProductController
      * @OA\Patch(
      *     tags={"Products"},
      *     path="/products/{product_id}",
+     *     operationId="updateProduct",
      *     @OA\RequestBody(ref="#/components/requestBodies/product_in_body"),
      *     @OA\Response(
      *         response="default",

--- a/docs/examples/specs/using-refs/annotations/PropertyRefController.php
+++ b/docs/examples/specs/using-refs/annotations/PropertyRefController.php
@@ -14,6 +14,7 @@ class PropertyRefController
      * @OA\Get(
      *     tags={"Products"},
      *     path="/products/{product_id}/do-other-stuff",
+     *     operationId="doStuff",
      *     @OA\Parameter(ref="#/components/schemas/Product/properties/id"),
      *     @OA\Response(
      *         response="default",

--- a/docs/examples/specs/using-refs/spec/Model.php
+++ b/docs/examples/specs/using-refs/spec/Model.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\UsingRefs\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema(description: 'A model')]
+class Model
+{
+}

--- a/docs/examples/specs/using-refs/spec/OpenApiSpec.php
+++ b/docs/examples/specs/using-refs/spec/OpenApiSpec.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\UsingRefs\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Info(title: 'Example of using references in swagger-php', version: '1.0.0')]
+class OpenApiSpec
+{
+}

--- a/docs/examples/specs/using-refs/spec/Product.php
+++ b/docs/examples/specs/using-refs/spec/Product.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\UsingRefs\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema(title: 'Product model', description: 'Product model', type: 'object')]
+class Product extends Model
+{
+    /**
+     * The unique identifier of a product in our catalog.
+     */
+    #[OA\Property]
+    #[OA\Schema(type: 'integer', format: 'int64', example: 1)]
+    public int $id;
+
+    #[OA\Property(schema: new OA\Schema(ref: '#/components/schemas/product_status'))]
+    public string $status;
+
+    #[OA\Property]
+    public StockLevel $stockLevel;
+}

--- a/docs/examples/specs/using-refs/spec/ProductController.php
+++ b/docs/examples/specs/using-refs/spec/ProductController.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\UsingRefs\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\PathItem(parameters: [
+    new OA\Parameter(ref: '#/components/parameters/product_id_in_path_required'),
+])]
+class ProductController
+{
+    #[OA\Operation\Get(
+        path: '/products/{product_id}',
+        operationId: 'getProduct',
+        tags: ['Products'],
+        responses: [
+            new OA\Response(response: 'default', ref: '#/components/responses/product'),
+        ],
+    )]
+    public function getProduct($id)
+    {
+    }
+
+    #[OA\Operation\Patch(
+        path: '/products/{product_id}',
+        operationId: 'updateProduct',
+        tags: ['Products'],
+        requestBody: new OA\RequestBody(ref: '#/components/requestBodies/product_in_body'),
+        responses: [
+            new OA\Response(response: 'default', ref: '#/components/responses/product'),
+        ],
+    )]
+    public function updateProduct($id)
+    {
+    }
+}

--- a/docs/examples/specs/using-refs/spec/ProductParameter.php
+++ b/docs/examples/specs/using-refs/spec/ProductParameter.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\UsingRefs\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Components]
+class ProductParameter
+{
+    #[OA\Parameter(
+        parameter: 'product_id_in_path_required',
+        name: 'product_id',
+        in: 'path',
+        description: 'The ID of the product',
+        required: true,
+        schema: new OA\Schema(type: 'integer', format: 'int64'),
+    )]
+    public int $product_id;
+}

--- a/docs/examples/specs/using-refs/spec/ProductRequestBody.php
+++ b/docs/examples/specs/using-refs/spec/ProductRequestBody.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\UsingRefs\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\RequestBody(
+    request: 'product_in_body',
+    description: 'product_request',
+    required: true,
+    content: [new OA\MediaType(
+        mediaType: 'application/json',
+        schema: new OA\Schema(ref: '#/components/schemas/Product'),
+    )],
+)]
+class ProductRequestBody
+{
+}

--- a/docs/examples/specs/using-refs/spec/ProductResponse.php
+++ b/docs/examples/specs/using-refs/spec/ProductResponse.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\UsingRefs\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Response(
+    response: 'product',
+    description: 'All information about a product',
+    content: [new OA\MediaType(
+        mediaType: 'application/json',
+        schema: new OA\Schema(ref: '#/components/schemas/Product'),
+    )],
+)]
+class ProductResponse
+{
+}

--- a/docs/examples/specs/using-refs/spec/ProductStatus.php
+++ b/docs/examples/specs/using-refs/spec/ProductStatus.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\UsingRefs\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema(schema: 'product_status', description: 'The status of a product', type: 'string', enum: ['available', 'discontinued'], default: 'available')]
+class ProductStatus
+{
+}

--- a/docs/examples/specs/using-refs/spec/PropertyRefController.php
+++ b/docs/examples/specs/using-refs/spec/PropertyRefController.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\UsingRefs\Spec;
+
+use OpenApi\Spec as OA;
+
+class PropertyRefController
+{
+    #[OA\Operation\Get(
+        path: '/products/{product_id}/do-other-stuff',
+        operationId: 'doStuff',
+        tags: ['Products'],
+        parameters: [
+            new OA\Parameter(ref: '#/components/schemas/Product/properties/id'),
+        ],
+        responses: [
+            new OA\Response(response: 'default', ref: '#/components/responses/todo'),
+        ],
+    )]
+    public function doStuff($id)
+    {
+    }
+}

--- a/docs/examples/specs/using-refs/spec/StockLevel.php
+++ b/docs/examples/specs/using-refs/spec/StockLevel.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\UsingRefs\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema]
+enum StockLevel: int
+{
+    case AVAILABLE = 1;
+    case SOLD_OUT = 2;
+    case BACK_ORDER = 3;
+}

--- a/docs/examples/specs/using-refs/spec/TodoResponse.php
+++ b/docs/examples/specs/using-refs/spec/TodoResponse.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\UsingRefs\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Response(
+    response: 'todo',
+    description: 'This API call has no documentated response (yet)',
+)]
+class TodoResponse
+{
+}

--- a/docs/examples/specs/using-refs/using-refs-3.0.0.yaml
+++ b/docs/examples/specs/using-refs/using-refs-3.0.0.yaml
@@ -7,14 +7,14 @@ paths:
     get:
       tags:
         - Products
-      operationId: f5eb54ff316bd7b5255abc39c03636c3
+      operationId: getProduct
       responses:
         default:
           $ref: '#/components/responses/product'
     patch:
       tags:
         - Products
-      operationId: 8324867747a5d4de63ad0910f1e69188
+      operationId: updateProduct
       requestBody:
         $ref: '#/components/requestBodies/product_in_body'
       responses:
@@ -27,7 +27,7 @@ paths:
     get:
       tags:
         - Products
-      operationId: 94496bbfc18b0bb7d67302b6bafd6548
+      operationId: doStuff
       parameters:
         -
           $ref: '#/components/schemas/Product/allOf/1/properties/id'

--- a/docs/examples/specs/using-refs/using-refs-3.1.0.yaml
+++ b/docs/examples/specs/using-refs/using-refs-3.1.0.yaml
@@ -7,14 +7,14 @@ paths:
     get:
       tags:
         - Products
-      operationId: f5eb54ff316bd7b5255abc39c03636c3
+      operationId: getProduct
       responses:
         default:
           $ref: '#/components/responses/product'
     patch:
       tags:
         - Products
-      operationId: 8324867747a5d4de63ad0910f1e69188
+      operationId: updateProduct
       requestBody:
         $ref: '#/components/requestBodies/product_in_body'
       responses:
@@ -27,7 +27,7 @@ paths:
     get:
       tags:
         - Products
-      operationId: 94496bbfc18b0bb7d67302b6bafd6548
+      operationId: doStuff
       parameters:
         -
           $ref: '#/components/schemas/Product/allOf/1/properties/id'

--- a/docs/examples/specs/using-refs/using-refs-3.2.0.yaml
+++ b/docs/examples/specs/using-refs/using-refs-3.2.0.yaml
@@ -7,14 +7,14 @@ paths:
     get:
       tags:
         - Products
-      operationId: f5eb54ff316bd7b5255abc39c03636c3
+      operationId: getProduct
       responses:
         default:
           $ref: '#/components/responses/product'
     patch:
       tags:
         - Products
-      operationId: 8324867747a5d4de63ad0910f1e69188
+      operationId: updateProduct
       requestBody:
         $ref: '#/components/requestBodies/product_in_body'
       responses:
@@ -27,7 +27,7 @@ paths:
     get:
       tags:
         - Products
-      operationId: 94496bbfc18b0bb7d67302b6bafd6548
+      operationId: doStuff
       parameters:
         -
           $ref: '#/components/schemas/Product/allOf/1/properties/id'

--- a/docs/examples/specs/using-traits/annotations/ProductController.php
+++ b/docs/examples/specs/using-traits/annotations/ProductController.php
@@ -19,6 +19,7 @@ class ProductController
      * @OA\Get(
      *     tags={"Products"},
      *     path="/products/{product_id}",
+     *     operationId="getProduct",
      *     @OA\Parameter(
      *         description="ID of product to return",
      *         in="path",

--- a/docs/examples/specs/using-traits/spec/BellsAndWhistles.php
+++ b/docs/examples/specs/using-traits/spec/BellsAndWhistles.php
@@ -18,5 +18,5 @@ trait BellsAndWhistles
      * The plating.
      */
     #[OA\Property]
-    public string $plating;
+    public $plating;
 }

--- a/docs/examples/specs/using-traits/spec/BellsAndWhistles.php
+++ b/docs/examples/specs/using-traits/spec/BellsAndWhistles.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\UsingTraits\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema(title: 'Bells and Whistles trait')]
+trait BellsAndWhistles
+{
+    use Decoration\Bells;
+    use Decoration\Whistles;
+
+    /**
+     * The plating.
+     */
+    #[OA\Property]
+    public string $plating;
+}

--- a/docs/examples/specs/using-traits/spec/Blink.php
+++ b/docs/examples/specs/using-traits/spec/Blink.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\UsingTraits\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema(schema: 'CustomName-Blink', title: 'Blink trait')]
+trait Blink
+{
+    /**
+     * The frequency.
+     */
+    #[OA\Property]
+    public int $frequency;
+}

--- a/docs/examples/specs/using-traits/spec/Colour.php
+++ b/docs/examples/specs/using-traits/spec/Colour.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\UsingTraits\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema(title: 'Colour trait')]
+trait Colour
+{
+    /**
+     * The colour.
+     */
+    #[OA\Property]
+    public string $colour;
+}

--- a/docs/examples/specs/using-traits/spec/Decoration/Bells.php
+++ b/docs/examples/specs/using-traits/spec/Decoration/Bells.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\UsingTraits\Spec\Decoration;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema(title: 'Bells trait')]
+trait Bells
+{
+    /**
+     * The bell (clashes with Product::bell).
+     */
+    #[OA\Property]
+    public string $bell;
+}

--- a/docs/examples/specs/using-traits/spec/Decoration/UndocumentedBell.php
+++ b/docs/examples/specs/using-traits/spec/Decoration/UndocumentedBell.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\UsingTraits\Spec\Decoration;
+
+trait UndocumentedBell
+{
+    public string $undocumentedBell;
+}

--- a/docs/examples/specs/using-traits/spec/Decoration/Whistles.php
+++ b/docs/examples/specs/using-traits/spec/Decoration/Whistles.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\UsingTraits\Spec\Decoration;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema(title: 'Whistles trait')]
+trait Whistles
+{
+    /**
+     * The bell.
+     */
+    #[OA\Property]
+    public string $whistle;
+}

--- a/docs/examples/specs/using-traits/spec/DeleteEntity.php
+++ b/docs/examples/specs/using-traits/spec/DeleteEntity.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\UsingTraits\Spec;
+
+use OpenApi\Spec as OA;
+
+trait DeleteEntity
+{
+    #[OA\Operation\Delete(
+        path: '/entities/{id}',
+        operationId: 'deleteEntity',
+        tags: ['Entities'],
+        parameters: [
+            new OA\Parameter(
+                name: 'id',
+                in: 'path',
+                description: 'ID of entity to delete',
+                required: true,
+                schema: new OA\Schema(type: 'string'),
+            ),
+        ],
+        responses: [
+            new OA\Response(response: 'default', description: 'successful operation'),
+        ],
+    )]
+    public function deleteEntity($id)
+    {
+    }
+}

--- a/docs/examples/specs/using-traits/spec/OpenApiSpec.php
+++ b/docs/examples/specs/using-traits/spec/OpenApiSpec.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\UsingTraits\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Info(title: 'Example of using traits in swagger-php', version: '1.0.0')]
+class OpenApiSpec
+{
+}

--- a/docs/examples/specs/using-traits/spec/Product.php
+++ b/docs/examples/specs/using-traits/spec/Product.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\UsingTraits\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema(title: 'Product model')]
+class Product
+{
+    use Colour;
+    use BellsAndWhistles;
+
+    /**
+     * The unique identifier of a product in our catalog.
+     */
+    #[OA\Property]
+    #[OA\Schema(type: 'integer', format: 'int64', example: 1)]
+    public int $id;
+
+    /**
+     * The product bell.
+     */
+    #[OA\Property]
+    #[OA\Schema(example: 'gong')]
+    public string $bell;
+}

--- a/docs/examples/specs/using-traits/spec/ProductController.php
+++ b/docs/examples/specs/using-traits/spec/ProductController.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\UsingTraits\Spec;
+
+use OpenApi\Spec as OA;
+
+class ProductController
+{
+    use DeleteEntity;
+
+    #[OA\Operation\Get(
+        path: '/products/{product_id}',
+        operationId: 'getProduct',
+        tags: ['Products'],
+        parameters: [
+            new OA\Parameter(
+                name: 'product_id',
+                in: 'path',
+                description: 'ID of product to return',
+                required: true,
+                schema: new OA\Schema(type: 'string'),
+            ),
+        ],
+        responses: [
+            new OA\Response(
+                response: 'default',
+                description: 'successful operation',
+                content: [new OA\MediaType(
+                    mediaType: 'application/json',
+                    schema: new OA\Schema(oneOf: [
+                        new OA\Schema(ref: '#/components/schemas/SimpleProduct'),
+                        new OA\Schema(ref: '#/components/schemas/Product'),
+                        new OA\Schema(ref: '#/components/schemas/TrickyProduct'),
+                    ]),
+                )],
+            ),
+        ],
+    )]
+    public function getProduct($id)
+    {
+    }
+}

--- a/docs/examples/specs/using-traits/spec/SimpleProduct.php
+++ b/docs/examples/specs/using-traits/spec/SimpleProduct.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\UsingTraits\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema(title: 'SimpleProduct model')]
+class SimpleProduct
+{
+    use Decoration\Bells;
+    use Decoration\UndocumentedBell;
+
+    /**
+     * The unique identifier of a simple product in our catalog.
+     */
+    #[OA\Property]
+    #[OA\Schema(type: 'integer', format: 'int64', example: 1)]
+    public int $id;
+}

--- a/docs/examples/specs/using-traits/spec/TrickyProduct.php
+++ b/docs/examples/specs/using-traits/spec/TrickyProduct.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\UsingTraits\Spec;
+
+use OpenApi\Examples\Specs\UsingTraits\Spec\Blink as TheBlink;
+use OpenApi\Spec as OA;
+
+#[OA\Schema(title: 'TrickyProduct model')]
+class TrickyProduct extends SimpleProduct
+{
+    use TheBlink;
+
+    /**
+     * The trick.
+     */
+    #[OA\Property]
+    #[OA\Schema(example: 'recite poem')]
+    public string $trick;
+}

--- a/docs/examples/specs/using-traits/using-traits-3.0.0.yaml
+++ b/docs/examples/specs/using-traits/using-traits-3.0.0.yaml
@@ -23,7 +23,7 @@ paths:
     get:
       tags:
         - Products
-      operationId: 800a772c33d928e6e783311ad2797c9e
+      operationId: getProduct
       parameters:
         -
           name: product_id

--- a/docs/examples/specs/using-traits/using-traits-3.1.0.yaml
+++ b/docs/examples/specs/using-traits/using-traits-3.1.0.yaml
@@ -23,7 +23,7 @@ paths:
     get:
       tags:
         - Products
-      operationId: 800a772c33d928e6e783311ad2797c9e
+      operationId: getProduct
       parameters:
         -
           name: product_id

--- a/docs/examples/specs/using-traits/using-traits-3.2.0.yaml
+++ b/docs/examples/specs/using-traits/using-traits-3.2.0.yaml
@@ -23,7 +23,7 @@ paths:
     get:
       tags:
         - Products
-      operationId: 800a772c33d928e6e783311ad2797c9e
+      operationId: getProduct
       parameters:
         -
           name: product_id

--- a/docs/examples/specs/webhooks/spec/NewPetWebhook.php
+++ b/docs/examples/specs/webhooks/spec/NewPetWebhook.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Webhooks\Spec;
+
+use OpenApi\Spec as OA;
+
+class NewPetWebhook
+{
+    #[OA\Operation(
+        webhook: 'newPet',
+        method: 'post',
+        operationId: 'new-pet',
+        requestBody: new OA\RequestBody(
+            description: 'Information about a new pet in the system',
+            content: [new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: Pet::class))],
+        ),
+        responses: [
+            new OA\Response(response: 200, description: 'Return a 200 status to indicate that the data was received successfully'),
+        ],
+    )]
+    public function newPet()
+    {
+    }
+}

--- a/docs/examples/specs/webhooks/spec/OpenApiSpec.php
+++ b/docs/examples/specs/webhooks/spec/OpenApiSpec.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Webhooks\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\OpenApi(version: '3.1.0')]
+#[OA\Info(title: 'Webhook Example', version: '1.0.0')]
+class OpenApiSpec
+{
+}

--- a/docs/examples/specs/webhooks/spec/Pet.php
+++ b/docs/examples/specs/webhooks/spec/Pet.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Examples\Specs\Webhooks\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema(required: ['id', 'name'])]
+final class Pet
+{
+    #[OA\Property(property: 'id')]
+    #[OA\Schema(format: 'int64')]
+    public int $id;
+
+    #[OA\Property(property: 'name')]
+    public string $name;
+
+    #[OA\Property(property: 'tag')]
+    public string $tag;
+}

--- a/src/Augmenter/Inheritance.php
+++ b/src/Augmenter/Inheritance.php
@@ -171,13 +171,13 @@ class Inheritance implements PipeInterface
         }
 
         $traitPropertyNames = array_map(
-            fn (\ReflectionProperty $p): string => $p->getName(),
+            fn (\ReflectionProperty $property): string => $property->getName(),
             $trait->getProperties(),
         );
 
         $schema->properties = array_values(array_filter(
             $schema->properties,
-            fn (OA\Property $p): bool => !in_array($p->property, $traitPropertyNames, true),
+            fn (OA\Property $property): bool => !in_array($property->property, $traitPropertyNames, true),
         ));
 
         if ($schema->properties === []) {
@@ -186,8 +186,10 @@ class Inheritance implements PipeInterface
     }
 
     /**
-     * When allOf refs were added but the schema also has own properties, wrap them
+     * When allOf refs were added, but the schema also has own properties, wrap them
      * in a dedicated allOf entry so the final output is a pure allOf composition.
+     *
+     * Own properties are always first.
      */
     protected function mergeAllOf(OA\Schema $schema): void
     {
@@ -195,7 +197,7 @@ class Inheritance implements PipeInterface
             return;
         }
 
-        $schema->allOf[] = new OA\Schema(type: 'object', properties: $schema->properties);
+        array_unshift($schema->allOf,new OA\Schema(type: 'object', properties: $schema->properties));
         $schema->properties = null;
     }
 
@@ -211,12 +213,12 @@ class Inheritance implements PipeInterface
         $parent = $class->getParentClass();
         if ($parent !== false) {
             $parentTraitNames = array_map(
-                fn (\ReflectionClass $t): string => $t->getName(),
+                fn (\ReflectionClass $trait): string => $trait->getName(),
                 $parent->getTraits(),
             );
             $traits = array_filter(
                 $traits,
-                fn (\ReflectionClass $t): bool => !in_array($t->getName(), $parentTraitNames, true),
+                fn (\ReflectionClass $trait): bool => !in_array($trait->getName(), $parentTraitNames, true),
             );
         }
 
@@ -235,12 +237,12 @@ class Inheritance implements PipeInterface
         $parent = $class->getParentClass();
         if ($parent !== false) {
             $parentInterfaceNames = array_map(
-                fn (\ReflectionClass $i): string => $i->getName(),
+                fn (\ReflectionClass $interface): string => $interface->getName(),
                 $parent->getInterfaces(),
             );
             $interfaces = array_filter(
                 $interfaces,
-                fn (\ReflectionClass $i): bool => !in_array($i->getName(), $parentInterfaceNames, true),
+                fn (\ReflectionClass $interface): bool => !in_array($interface->getName(), $parentInterfaceNames, true),
             );
         }
 

--- a/src/Augmenter/Refs.php
+++ b/src/Augmenter/Refs.php
@@ -84,7 +84,8 @@ class Refs implements PipeInterface, LoggerAwareInterface
                 foreach ($details['attributes'] as $attribute) {
                     $attribute->ref = str_replace(
                         "{$details['name']}/{$details['propertyPath']}",
-                        "{$details['name']}/allOf/1/{$details['propertyPath']}",
+                        // own properties are always first
+                        "{$details['name']}/allOf/0/{$details['propertyPath']}",
                         $attribute->ref
                     );
                 }

--- a/src/Augmenter/Refs.php
+++ b/src/Augmenter/Refs.php
@@ -40,7 +40,60 @@ class Refs implements PipeInterface, LoggerAwareInterface
         $this->resolveFQCNRefs($payload, $refMap);
         $this->resolveDiscriminatorMappings($payload, $refMap);
 
+        $schemaPropertyRefMap = $this->getSchemaPropertyRefMap($payload);
+
+        if ($schemaPropertyRefMap === []) {
+            return null;
+        }
+
+        $this->verifySchemaPropertyRefs($payload, $schemaPropertyRefMap);
+
         return null;
+    }
+
+    protected function getSchemaPropertyRefMap(Specification $specification): array
+    {
+        $refMap = [];
+        $specification->getWalker()->eachRef(function (OA\AbstractAttribute $attribute) use (&$refMap): void {
+            preg_match('/#\/components\/schemas\/([^\/]+)\/(properties\/.+)/', $attribute->ref, $matches);
+            if (count($matches) !== 3) {
+                return;
+            }
+
+            $refMap[$attribute->ref] ??= [
+                'attributes' => [],
+                'name' => $matches[1],
+                'propertyPath' => $matches[2],
+            ];
+            $refMap[$attribute->ref]['attributes'][] = $attribute;
+        });
+
+        return $refMap;
+    }
+
+    protected function verifySchemaPropertyRefs(Specification $specification, array $schemaPropertyRefMap): void
+    {
+        $schemaLookup = array_combine(
+            array_map(fn (OA\Schema $schema): ?string => $schema->schema, $specification->schemas),
+            $specification->schemas,
+        );
+
+        foreach ($schemaPropertyRefMap as $ref => $details) {
+            $schema = $schemaLookup[$details['name']] ?? null;
+            if ($schema?->allOf !== null) {
+                foreach ($details['attributes'] as $attribute) {
+                    $attribute->ref = str_replace(
+                        "{$details['name']}/{$details['propertyPath']}",
+                        "{$details['name']}/allOf/1/{$details['propertyPath']}",
+                        $attribute->ref
+                    );
+                }
+            } else {
+                $this->logger?->warning('Ref: unresolved reference "{ref}" — no matching component found', [
+                    'ref' => $ref,
+                ]);
+            }
+        }
     }
 
     protected function resolveFQCNRefs(Specification $specification, array &$refMap): array

--- a/src/Augmenter/Refs.php
+++ b/src/Augmenter/Refs.php
@@ -37,8 +37,17 @@ class Refs implements PipeInterface, LoggerAwareInterface
             return null;
         }
 
+        $this->resolveFQCNRefs($payload, $refMap);
+        $this->resolveDiscriminatorMappings($payload, $refMap);
+
+        return null;
+    }
+
+    protected function resolveFQCNRefs(Specification $specification, array &$refMap): array
+    {
         $unresolved = [];
-        $payload->getWalker()->eachRef(function (OA\AbstractAttribute $attribute) use ($refMap, &$unresolved): void {
+
+        $specification->getWalker()->eachRef(function (OA\AbstractAttribute $attribute) use ($refMap, &$unresolved): void {
             if (str_starts_with($attribute->ref, '#/')) {
                 return;
             }
@@ -55,9 +64,7 @@ class Refs implements PipeInterface, LoggerAwareInterface
             ]);
         }
 
-        $this->resolveDiscriminatorMappings($payload, $refMap);
-
-        return null;
+        return $refMap;
     }
 
     /**

--- a/tests/Augmenter/EnumDescriptionsTest.php
+++ b/tests/Augmenter/EnumDescriptionsTest.php
@@ -7,6 +7,7 @@
 namespace OpenApi\Tests\Augmenter;
 
 use OpenApi\Augmenter;
+use OpenApi\Spec as OA;
 use OpenApi\Tests\Concerns\AssemblesSpecification;
 use OpenApi\Tests\Fixtures;
 use PHPUnit\Framework\TestCase;
@@ -27,7 +28,7 @@ final class EnumDescriptionsTest extends TestCase
 
         $this->assertCount(2, $schema->properties);
         $properties = array_combine(
-            array_map(fn ($item) => $item->property, $schema->properties),
+            array_map(fn (OA\Property $property): ?string => $property->property, $schema->properties),
             $schema->properties,
         );
 

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -8,6 +8,7 @@ namespace OpenApi\Tests;
 
 use OpenApi\Augmenter\OperationIds;
 use OpenApi\Builder;
+use OpenApi\Builder\Mode;
 use OpenApi\Generator;
 use OpenApi\Tests\Concerns\UsesExamples;
 use OpenApi\Utils\SourceFinder;
@@ -47,6 +48,7 @@ final class BuilderTest extends OpenApiTestCase
             ->generate([$sourceDir]);
 
         $builderResult = (new Builder())
+            ->setMode(Mode::CLASSIC)
             ->addSource($sourceDir)
             ->withGenerator(function (Generator $generator): void {
                 $generator->setAnalyser($this->getAnalyzer());
@@ -114,6 +116,7 @@ final class BuilderTest extends OpenApiTestCase
         $this->assertOpenApiLogEntryContains('Required @OA\PathItem() not found');
 
         $result = (new Builder())
+            ->setMode(Mode::CLASSIC)
             ->setSources([])
             ->setLogger($this->getTrackingLogger())
             ->build();
@@ -124,6 +127,7 @@ final class BuilderTest extends OpenApiTestCase
     public function testBuildCollectsWarnings(): void
     {
         $result = (new Builder())
+            ->setMode(Mode::CLASSIC)
             ->setSources([])
             ->setLogger(new NullLogger())
             ->build();

--- a/tests/Concerns/AssertsBuilderResult.php
+++ b/tests/Concerns/AssertsBuilderResult.php
@@ -28,7 +28,7 @@ trait AssertsBuilderResult
     {
         $this->assertTrue($result->isValid());
 
-        $filterByContains = (fn(array $list, array $patterns): array => array_filter($list, function (string $item) use ($patterns): bool {
+        $filterByContains = (fn (array $list, array $patterns): array => array_filter($list, function (string $item) use ($patterns): bool {
             foreach ($patterns as $pattern) {
                 if (str_contains($item, $pattern)) {
                     return false;

--- a/tests/Concerns/AssertsBuilderResult.php
+++ b/tests/Concerns/AssertsBuilderResult.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Concerns;
+
+use OpenApi\Builder\Result;
+
+trait AssertsBuilderResult
+{
+    public function assertBuilderResult(Result $result, int $warnCount = -1, int $errorCount = 0): void
+    {
+        $this->assertTrue($result->isValid());
+
+        if ($warnCount > -1) {
+            $this->assertCount($warnCount, $result->warnings(), '[Warning] ' . implode("\n[Warning] ", $result->warnings()));
+        }
+
+        if ($errorCount > -1) {
+            $this->assertCount($errorCount, $result->errors(), '[Error] ' . implode("\n[Error] ", $result->errors()));
+        }
+    }
+}

--- a/tests/Concerns/AssertsBuilderResult.php
+++ b/tests/Concerns/AssertsBuilderResult.php
@@ -10,16 +10,38 @@ use OpenApi\Builder\Result;
 
 trait AssertsBuilderResult
 {
-    public function assertBuilderResult(Result $result, int $warnCount = -1, int $errorCount = 0): void
+    protected array $warningExcludes = [];
+
+    protected array $errorExcludes = [];
+
+    public function expectResultWarnings(array $warnings): void
+    {
+        $this->warningExcludes = $warnings;
+    }
+
+    public function expectResultErrors(array $errors): void
+    {
+        $this->errorExcludes = $errors;
+    }
+
+    public function assertBuilderResult(Result $result): void
     {
         $this->assertTrue($result->isValid());
 
-        if ($warnCount > -1) {
-            $this->assertCount($warnCount, $result->warnings(), '[Warning] ' . implode("\n[Warning] ", $result->warnings()));
-        }
+        $filterByContains = (fn(array $list, array $patterns): array => array_filter($list, function (string $item) use ($patterns): bool {
+            foreach ($patterns as $pattern) {
+                if (str_contains($item, $pattern)) {
+                    return false;
+                }
+            }
 
-        if ($errorCount > -1) {
-            $this->assertCount($errorCount, $result->errors(), '[Error] ' . implode("\n[Error] ", $result->errors()));
-        }
+            return true;
+        }));
+
+        $warnings = $filterByContains($result->warnings(), $this->warningExcludes);
+        $errors = $filterByContains($result->errors(), $this->errorExcludes);
+
+        $this->assertCount(0, $warnings, '[Warning] ' . implode("\n[Warning] ", $result->warnings()));
+        $this->assertCount(0, $errors, '[Error] ' . implode("\n[Error] ", $result->errors()));
     }
 }

--- a/tests/Concerns/UsesExamples.php
+++ b/tests/Concerns/UsesExamples.php
@@ -48,8 +48,18 @@ trait UsesExamples
         $implementationNamerspaceBase = sprintf("{$namerspaceBase}%s\\", ucfirst($implementation));
 
         $classloader = new ClassLoader();
-        $classloader->addPsr4($namerspaceBase, $basePath);
         $classloader->addPsr4($implementationNamerspaceBase, $path);
+
+        $sharedFiles = glob("{$basePath}/*.php");
+        if ($sharedFiles) {
+            $classMap = [];
+            foreach ($sharedFiles as $file) {
+                $className = $namerspaceBase . pathinfo($file, PATHINFO_FILENAME);
+                $classMap[$className] = $file;
+            }
+            $classloader->addClassMap($classMap);
+        }
+
         $classloader->register();
     }
 }

--- a/tests/Concerns/UsesExamples.php
+++ b/tests/Concerns/UsesExamples.php
@@ -7,7 +7,7 @@
 namespace OpenApi\Tests\Concerns;
 
 use Composer\Autoload\ClassLoader;
-use OpenApi\Attributes\OpenApi;
+use OpenApi\Builder\Mode;
 
 trait UsesExamples
 {
@@ -16,9 +16,12 @@ trait UsesExamples
         return sprintf('%s/docs/examples/specs/%s', dirname(__DIR__, 2), $name);
     }
 
-    public static function getSpecFilename(string $name, string $implementation = 'annotations', string $version = OpenApi::VERSION_3_0_0): string
+    public static function getSpecFilename(string $name, string $implementation = 'annotations', string $version = '3.0.0', Mode $mode = Mode::CLASSIC): string
     {
         $specs = [
+            "{$name}-{$implementation}-{$mode->value}-{$version}.yaml",
+            "{$name}-{$implementation}-{$version}.yaml",
+            "{$name}-{$mode->value}-{$version}.yaml",
             "{$name}-{$version}.yaml",
             "{$name}-{$implementation}-{$version}.yaml",
         ];

--- a/tests/ExamplesTest.php
+++ b/tests/ExamplesTest.php
@@ -96,6 +96,11 @@ final class ExamplesTest extends OpenApiTestCase
     {
         $this->registerExampleClassloader($name, $implementation);
 
+        $this->expectResultWarnings([
+            'Schema: const is not supported in OpenAPI 3.0, using enum fallback',
+            'License identifier is not supported in OpenAPI 3.0, use url instead',
+        ]);
+
         $path = self::examplePath("{$name}/{$implementation}");
         $specFilename = self::getSpecFilename($name, $implementation, $version, $mode);
 

--- a/tests/ExamplesTest.php
+++ b/tests/ExamplesTest.php
@@ -47,7 +47,7 @@ final class ExamplesTest extends OpenApiTestCase
             '3.2.0',
         ];
         $modes = [
-            Mode::CLASSIC,
+            //Mode::CLASSIC,
             //Mode::HYBRID,
             Mode::SPEC,
         ];

--- a/tests/ExamplesTest.php
+++ b/tests/ExamplesTest.php
@@ -47,8 +47,8 @@ final class ExamplesTest extends OpenApiTestCase
             '3.2.0',
         ];
         $modes = [
-            //Mode::CLASSIC,
-            //Mode::HYBRID,
+            Mode::CLASSIC,
+            Mode::HYBRID,
             Mode::SPEC,
         ];
 
@@ -118,8 +118,8 @@ final class ExamplesTest extends OpenApiTestCase
     #[DataProvider('exampleSpecs')]
     public function testSerializer(TypeResolverInterface $typeResolver, string $name, string $implementation, string $version, Mode $mode): void
     {
-        if ($mode === Mode::SPEC) {
-            $this->markTestSkipped('Serializer tests are not supported for spec mode');
+        if ($mode !== Mode::HYBRID) {
+            return;
         }
 
         $specFilename = self::getSpecFilename($name, $implementation, $version);

--- a/tests/ExamplesTest.php
+++ b/tests/ExamplesTest.php
@@ -6,16 +6,19 @@
 
 namespace OpenApi\Tests;
 
-use OpenApi\Annotations as OA;
 use OpenApi\Builder;
+use OpenApi\Builder\Mode;
 use OpenApi\Generator;
 use OpenApi\Serializer;
+use OpenApi\Tests\Concerns\AssertsBuilderResult;
 use OpenApi\Tests\Concerns\UsesExamples;
+use OpenApi\Type\LegacyTypeResolver;
 use OpenApi\TypeResolverInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 final class ExamplesTest extends OpenApiTestCase
 {
+    use AssertsBuilderResult;
     use UsesExamples;
 
     public static function exampleSpecs(): iterable
@@ -32,11 +35,21 @@ final class ExamplesTest extends OpenApiTestCase
             'using-traits',
             'webhooks',
         ];
-        $implementations = ['annotations', 'attributes', 'mixed'];
+        $implementations = [
+            'annotations',
+            'attributes',
+            'mixed', // classic annotations + attributes
+            'spec',
+        ];
         $versions = [
-            OA\OpenApi::VERSION_3_0_0,
-            OA\OpenApi::VERSION_3_1_0,
-            OA\OpenApi::VERSION_3_2_0,
+            '3.0.0',
+            '3.1.0',
+            '3.2.0',
+        ];
+        $modes = [
+            Mode::CLASSIC,
+            //Mode::HYBRID,
+            Mode::SPEC,
         ];
 
         foreach (self::getTypeResolvers() as $resolverName => $typeResolver) {
@@ -47,16 +60,28 @@ final class ExamplesTest extends OpenApiTestCase
                     }
 
                     foreach ($versions as $version) {
-                        if (!file_exists(self::getSpecFilename($example, $implementation, $version))) {
-                            continue;
-                        }
+                        foreach ($modes as $mode) {
+                            if (
+                                ($implementation === 'spec' && in_array($mode, [Mode::CLASSIC, Mode::HYBRID], true))
+                                || ($implementation !== 'spec' && $mode === Mode::SPEC)
+                                || ($typeResolver instanceof LegacyTypeResolver && $mode !== Mode::CLASSIC)
+                            ) {
+                                continue;
+                            }
 
-                        yield "{$example}:{$resolverName}-{$implementation}-{$version}" => [
-                            $typeResolver,
-                            $example,
-                            $implementation,
-                            $version,
-                        ];
+                            if (!file_exists(self::getSpecFilename($example, $implementation, $version, $mode))) {
+                                continue;
+                            }
+
+                            $key = "{$example}:{$resolverName}-{$implementation}-{$mode->value}-{$version}";
+                            yield $key => [
+                                $typeResolver,
+                                $example,
+                                $implementation,
+                                $version,
+                                $mode,
+                            ];
+                        }
                     }
                 }
             }
@@ -67,20 +92,22 @@ final class ExamplesTest extends OpenApiTestCase
      * Validate openapi definitions of the included examples.
      */
     #[DataProvider('exampleSpecs')]
-    public function testExample(TypeResolverInterface $typeResolver, string $name, string $implementation, string $version): void
+    public function testExample(TypeResolverInterface $typeResolver, string $name, string $implementation, string $version, Mode $mode): void
     {
         $this->registerExampleClassloader($name, $implementation);
 
         $path = self::examplePath("{$name}/{$implementation}");
-        $specFilename = self::getSpecFilename($name, $implementation, $version);
+        $specFilename = self::getSpecFilename($name, $implementation, $version, $mode);
 
         $result = (new Builder())
+            ->setMode($mode)
             ->addSource($path)
             ->setVersion($version)
             ->setLogger($this->getTrackingLogger())
             ->withGenerator(fn (Generator $generator): Generator => $generator->setTypeResolver($typeResolver))
             ->build();
         // file_put_contents($specFilename, $result->toYaml());
+        $this->assertBuilderResult($result);
         $this->assertSpecEquals(
             $result->toYaml(),
             file_get_contents($specFilename),
@@ -89,8 +116,12 @@ final class ExamplesTest extends OpenApiTestCase
     }
 
     #[DataProvider('exampleSpecs')]
-    public function testSerializer(TypeResolverInterface $typeResolver, string $name, string $implementation, string $version): void
+    public function testSerializer(TypeResolverInterface $typeResolver, string $name, string $implementation, string $version, Mode $mode): void
     {
+        if ($mode === Mode::SPEC) {
+            $this->markTestSkipped('Serializer tests are not supported for spec mode');
+        }
+
         $specFilename = self::getSpecFilename($name, $implementation, $version);
 
         $reserialized = (new Serializer())->deserializeFile($specFilename)->toYaml();


### PR DESCRIPTION
## Summary

Adds `spec` versions of all examples and extends the `ExamplesTest` to run with all three modes: `classic`, `hybrid` and `spec`.

Failing tests are due to the fact that the spec pipeline doesn't update refs when merging properties into `allOf` (yet).