### PR TITLE
feat(BETA): add `AttributeTranslatorInterface` concept

### DIFF
--- a/docs/spec-attributes-status.md
+++ b/docs/spec-attributes-status.md
@@ -132,19 +132,74 @@ The `Builder` class supports three modes via `setMode('classic'|'spec'|'hybrid')
 - **spec** — runs the new spec attributes pipeline end-to-end
 - **hybrid** — uses the classic `Generator` for scanning only (MergeJsonContent/MergeXmlContent), then iterates the `Analysis` annotations directly via `HybridBridge` into a `Specification` and runs it through the full spec augmenter chain and compilers
 
+### Full programmatic Builder example
+
+```php
+use OpenApi\Builder;
+use OpenApi\Builder\Mode;
+use OpenApi\Utils\AttributeFactory;
+use OpenApi\Augmenter;
+
+$result = (new Builder())
+    ->setMode(Mode::SPEC)
+    ->setVersion('3.1.0')
+    ->addSource('src/Api')
+
+    // Configure the attribute factory — add custom translators
+    ->withAttributeFactory(function (AttributeFactory $factory): void {
+        // Add a translator that converts Symfony validation attributes
+        // into OpenAPI schema constraints
+        $factory->getTranslators()->add(new SymfonyValidationTranslator());
+    })
+
+    // Configure the augmenter pipeline — add/remove/reorder pipes
+    ->withAugmenters(function (\OpenApi\Utils\Pipeline $pipeline): void {
+        // Disable cleanup (keep all components even if unreferenced)
+        $pipeline->get(Augmenter\Cleanup::class)?->setEnabled(false);
+
+        // Configure operationId generation to use hashing
+        $pipeline->get(Augmenter\OperationIds::class)?->setHash(true);
+
+        // Filter to only specific paths/tags
+        $pipeline->get(Augmenter\PathFilter::class)
+            ?->setPathFilter('/^\/api\/v2/')
+            ?->setTagFilter('/^(Users|Products)$/');
+
+        // Insert a custom augmenter before Inheritance
+        $pipeline->insert(new CustomAugmenter(), Augmenter\Inheritance::class);
+
+        // Remove an augmenter entirely
+        $pipeline->remove(Augmenter\EnumDescriptions::class);
+    })
+
+    // Classic-mode only: configure the underlying Generator
+    // ->withGenerator(function (\OpenApi\Generator $generator): void {
+    //     $generator->setProcessors([...]);
+    // })
+
+    ->build();
+
+// Access results
+$openapi = $result->openapi;     // compiled OpenAPI array
+$yaml = $result->toYaml();       // YAML string
+$json = $result->toJson();       // JSON string
+$warnings = $result->warnings(); // any non-fatal issues
+```
+
 ## What's done
 
 - All core spec DTOs (OpenApi, Info, Server, Tag, Operation, Schema, Parameter, Response, Header, PathItem, etc.)
 - Assembler with two-pass nesting resolution
-- `AttributeFactory` extracted from Assembler for standalone attribute instantiation
+- `AttributeFactory` extracted from Assembler for standalone attribute instantiation, with `TypedList<AttributeTranslatorInterface>` translators and `withTranslators()` hook
+- `TypedList<T>` generic collection (implements `IteratorAggregate`) — base class for `Pipeline`, also used for translator management
 - Three compilers (3.0, 3.1, 3.2) with version-specific handling and shared inheritance
-- Builder with tri-mode support (classic/spec/hybrid) and CLI integration
+- Builder with tri-mode support (classic/spec/hybrid), CLI integration, and callable hooks (`withAttributeFactory()`, `withAugmenters()`, `withGenerator()`)
 - `HybridBridge` iterates `Analysis` annotations directly into `Specification` DTOs (no tree assembly needed)
 - Security namespace (Scheme subclasses + Requirement)
 - Typed subclasses for Parameter, Flow, and Operation
 - All examples ported to spec attributes (see table below)
 - Pipeline classes tested (Assembler, Compilers, Builder)
-- Augmenter infrastructure: `PipeInterface` with `@template` generics, Pipeline grouping (resolve → reduce → augment), `Pipeline::get()` for typed configuration
+- Augmenter infrastructure: `PipeInterface` with `@template` generics, `Pipeline` (extends `TypedList`) with grouping (resolve → reduce → augment), `Pipeline::get()` for typed configuration
 - `SpecificationWalker` — instance-based tree traversal with unified schema descent
 - All augmenters implemented (see table below)
 - Shared `Type\TypeResolver` core producing `SchemaType` value objects — used by both the spec-attributes `Types` augmenter and the classic `TypeInfoTypeResolver`, confirming identical type resolution behavior
@@ -434,9 +489,9 @@ These components can then be referenced via `$ref` from operations, PathItems, o
 
 ### Extension systems
 
-Three extension points to implement:
+Three extension points:
 
-- **`AttributeEnricher`** — hook into assembly to translate non-OA attributes (e.g. Symfony `#[Assert\*]`, framework route annotations) into spec DTOs. Runs per-element during the factory/assembler phase.
+- ~~**`AttributeTranslatorInterface`**~~ — **Done.** (Originally named `AttributeEnricher` in planning.) Hook into assembly to translate non-OA attributes (e.g. Symfony `#[Assert\*]`, framework route annotations) into spec DTOs. Runs per-element during the factory/assembler phase. Translators are registered on `AttributeFactory` via `getTranslators()->add()` or `withTranslators()`. Each translator implements two methods: `getAttributes()` (collect `ReflectionAttribute` instances from a reflector) and `translate()` (transform the cumulative list of instantiated objects into `AttributeInterface` instances). The default `DefaultAttributeTranslator` handles native OA attributes; custom translators are appended and receive the accumulated result from prior translators.
 - **`CompilerExtension`** — lets custom `Attachable` DTOs produce spec output. Extensions declare which Attachable class(es) they handle and return key-value pairs merged into the parent's compiled output. Unhandled Attachables are silently omitted.
 - ~~**`Attachable` DTO**~~ — **Done.** `OA\Attachable` extends `AbstractAttribute`, is repeatable on any target, and `isRoot() === true` by default (gets its own `Specification::$attachables` bucket). Can also be inlined into any attribute via the `$attachables` constructor parameter or nested via custom `merge()` maps. Slot validation in `AttributeFactory::nestChild()` catches invalid merge targets early. Custom attachables subclass `OA\Attachable` and override `merge()` to specify where they nest.
 
@@ -449,7 +504,7 @@ Re-evaluate support for convenience attributes that reduce boilerplate in common
 - **`Items`** — shorthand for array item schema declaration
 - **`JsonContent`** / **`XmlContent`** — shorthand for wrapping a schema in a media type with the appropriate content type
 
-These could be implemented as assembler-level transforms (expand the shortcut into canonical DTOs during assembly) or as extension examples using `AttributeEnricher` + `CompilerExtension`. The latter approach would serve as both useful functionality and documentation of how the extension systems work in practice.
+These could be implemented as assembler-level transforms (expand the shortcut into canonical DTOs during assembly) or as extension examples using `AttributeTranslatorInterface` + `CompilerExtension`. The latter approach would serve as both useful functionality and documentation of how the extension systems work in practice.
 
 Need to document the general pattern for shortcut attributes: how they participate in nesting (via `merge()`), when they expand (assembly vs augmentation), and how custom shortcuts can be added by users.
 

--- a/docs/spec-attributes-status.md
+++ b/docs/spec-attributes-status.md
@@ -509,8 +509,8 @@ These extension systems should also address downstream integration needs (e.g. N
 
 Re-evaluate support for convenience attributes that reduce boilerplate in common patterns:
 
-- **`Items`** — shorthand for array item schema declaration
-- **`JsonContent`** / **`XmlContent`** — shorthand for wrapping a schema in a media type with the appropriate content type
+- **`Items`** — shorthand for array item schema declaration; this probably should be extending `OA\Items` and get a dedicated `PipeInterface` augmenter.
+- **`JsonContent`** / **`XmlContent`** — shorthand for wrapping a schema in a media type with the appropriate content type; a new `AttributeTranslatorInterface` should be implemented to handle the translation of these attributes.
 
 These could be implemented as assembler-level transforms (expand the shortcut into canonical DTOs during assembly). This would serve as both useful functionality and documentation of how the extension systems work in practice.
 

--- a/docs/spec-attributes-status.md
+++ b/docs/spec-attributes-status.md
@@ -227,24 +227,18 @@ $warnings = $result->warnings(); // any non-fatal issues
 
 All 10 example specs now have spec-attribute versions. Most produce identical output across classic, spec, and hybrid modes (shared yaml fixtures). Hybrid mode is tested for all examples and passes except using-refs (ref-path difference).
 
-| Example | Shared fixture | Spec-specific fixture | Notes |
-|---|---|---|---|
-| api | ✓ | — | Original spec example |
-| misc | ✓ | — | Callbacks, security, enums |
-| nesting | ✓ | — | Multi-level class inheritance |
-| petstore | ✓ | — | Classic CRUD example |
-| polymorphism | ✓ | — | oneOf/allOf/discriminator |
-| using-interfaces | ✓ | — | Interface-based allOf composition |
-| using-links | ✓ | — | Response links |
-| using-refs | — | ✓ | PathItem works; hybrid excluded due to ref-path difference |
-| using-traits | — | ✓ | Bug fix: explicit type inference |
-| webhooks | ✓ | — | 3.1+ webhooks |
-
-### Spec-specific fixture notes
-
-**using-refs** — PathItem with path-level parameters works correctly. The spec example uses `#[OA\PathItem(parameters: [...])]` to emit parameters at path level. The example uses a spec-specific fixture due to a ref-path difference: classic emits `Product/allOf/1/properties/id` while spec/hybrid emits `Product/properties/id` (spec puts properties directly rather than in an allOf wrapper).
-
-**using-traits** — Not a gap; intentional improvement. The spec/hybrid pipeline infers explicit types from PHP declarations more thoroughly than classic.
+| Example | Shared fixture | Spec-specific fixture | Notes                                                                                     |
+|---|---|---|-------------------------------------------------------------------------------------------|
+| api | ✓ | — | Original spec example                                                                     |
+| misc | ✓ | — | Callbacks, security, enums                                                                |
+| nesting | ✓ | — | Multi-level class inheritance                                                             |
+| petstore | ✓ | — | Classic CRUD example                                                                      |
+| polymorphism | ✓ | — | oneOf/allOf/discriminator                                                                 |
+| using-interfaces | ✓ | — | Interface-based allOf composition                                                         |
+| using-links | ✓ | — | Response links                                                                            |
+| using-refs | — | ✓ | Resolving of property refs that got moved into allOf still needs resolving                |
+| using-traits | — | ✓ | Trait inheritance needs to be refactored since reflection is too limited as only solution |
+| webhooks | ✓ | — | 3.1+ webhooks                                                                             |
 
 ### Behavioral differences from classic
 
@@ -254,10 +248,6 @@ Intentional improvements or corrections in the spec/hybrid pipeline that produce
 |---|---|---|---|
 | Empty `tags` | Always emits `tags: []` | Omits when empty | Per OpenAPI spec, optional fields should be omitted when empty |
 | Empty flow `scopes` | Emits `scopes: {}` | Was omitting empty scopes | Bug fix in compiler — scopes is required per OpenAPI spec |
-| Type inference on traits | Types often omitted | Explicit types from PHP declarations | Bug fix — classic failed to resolve types on trait properties |
-| Docblock on parameters | Only from `@param` on ReflectionParameter | Also matches by parameter name | More thorough — resolves descriptions for non-reflection parameters |
-| Promoted property descriptions | Resolved via constructor parameter context | Resolved via ReflectionProperty fallback | Different mechanism, same result |
-| Schema property refs | `Product/allOf/1/properties/id` | `Product/properties/id` | Spec pipeline places properties directly on the schema rather than wrapping in allOf — both specs are internally consistent, but `$ref` paths into schema internals differ |
 
 ## Classic processor mapping
 
@@ -429,7 +419,7 @@ Output paths:
 - `/api/v1/users/list` — get operation, tags: ['Users'], path-level parameter: tenant
 - `/api/v1/users/{id}` — get operation, tags: ['Users'], path-level parameter: tenant
 
-## Components container
+## DTO: `OA\Components`
 
 `#[OA\Components]` is a class-level attribute that acts as a container for reusable component definitions that cannot stand on their own as root attributes.
 
@@ -467,6 +457,24 @@ class SharedComponents {
 
 These components can then be referenced via `$ref` from operations, PathItems, or other DTOs.
 
+## DTO: `OA\Schema`
+
+The spec version of `OA\Schema` is a fully standalone attribute. No other attributes inherits from it - its all down to composition.
+Side effect is that `OA\Schema` now can be stacked next to other attributes (as long as it is not ambiguous).
+
+Inline nesting works also, as before.
+
+### Example
+
+```php
+#[OA\Schema]
+class Model {
+    #[OA\Property]
+    #[OA\Schema(type: 'integer')]
+    public int $page;
+}
+```
+
 ## What's next
 
 ### Hybrid mode hardening
@@ -491,9 +499,9 @@ These components can then be referenced via `$ref` from operations, PathItems, o
 
 Three extension points:
 
-- ~~**`AttributeTranslatorInterface`**~~ — **Done.** (Originally named `AttributeEnricher` in planning.) Hook into assembly to translate non-OA attributes (e.g. Symfony `#[Assert\*]`, framework route annotations) into spec DTOs. Runs per-element during the factory/assembler phase. Translators are registered on `AttributeFactory` via `getTranslators()->add()` or `withTranslators()`. Each translator implements two methods: `getAttributes()` (collect `ReflectionAttribute` instances from a reflector) and `translate()` (transform the cumulative list of instantiated objects into `AttributeInterface` instances). The default `DefaultAttributeTranslator` handles native OA attributes; custom translators are appended and receive the accumulated result from prior translators.
-- **`CompilerExtension`** — lets custom `Attachable` DTOs produce spec output. Extensions declare which Attachable class(es) they handle and return key-value pairs merged into the parent's compiled output. Unhandled Attachables are silently omitted.
+- ~~**`AttributeTranslatorInterface`**~~ — **Done.** Hook into assembly to translate non-OA attributes (e.g. Symfony `#[Assert\*]`, framework route annotations) into spec DTOs. Runs per-element during the factory/assembler phase. Translators are registered on `AttributeFactory` via `getTranslators()->add()` or `withTranslators()`. Each translator implements two methods: `getAttributes()` (collect `ReflectionAttribute` instances from a reflector) and `translate()` (transform the cumulative list of instantiated objects into `AttributeInterface` instances). The default `DefaultAttributeTranslator` handles native OA attributes; custom translators are appended and receive the accumulated result from prior translators.
 - ~~**`Attachable` DTO**~~ — **Done.** `OA\Attachable` extends `AbstractAttribute`, is repeatable on any target, and `isRoot() === true` by default (gets its own `Specification::$attachables` bucket). Can also be inlined into any attribute via the `$attachables` constructor parameter or nested via custom `merge()` maps. Slot validation in `AttributeFactory::nestChild()` catches invalid merge targets early. Custom attachables subclass `OA\Attachable` and override `merge()` to specify where they nest.
+- ~~**`CompilerExtension`**~~ — Abandoned for now. Since compiler can easiy be extended/swapped it feels overkill with the more powerfull alternatives of attribute translation and `OA\Attribute`
 
 These extension systems should also address downstream integration needs (e.g. Nelmio translating Symfony metadata, framework route annotations) without requiring those projects to couple to pipeline internals.
 
@@ -504,18 +512,13 @@ Re-evaluate support for convenience attributes that reduce boilerplate in common
 - **`Items`** — shorthand for array item schema declaration
 - **`JsonContent`** / **`XmlContent`** — shorthand for wrapping a schema in a media type with the appropriate content type
 
-These could be implemented as assembler-level transforms (expand the shortcut into canonical DTOs during assembly) or as extension examples using `AttributeTranslatorInterface` + `CompilerExtension`. The latter approach would serve as both useful functionality and documentation of how the extension systems work in practice.
+These could be implemented as assembler-level transforms (expand the shortcut into canonical DTOs during assembly). This would serve as both useful functionality and documentation of how the extension systems work in practice.
 
 Need to document the general pattern for shortcut attributes: how they participate in nesting (via `merge()`), when they expand (assembly vs augmentation), and how custom shortcuts can be added by users.
 
 ### Additional augmenter pipes
 
 None planned at this time.
-
-### Design decisions
-
-- **Error vs warning strategy** — currently the assembler throws `OpenApiException` for all validation issues. Some issues (orphan attributes, unknown Attachable types, duplicate attributes where last-wins is acceptable) could be warnings via PSR logger instead. Need to decide the boundary: structural issues that prevent valid output remain exceptions; issues that don't block compilation become warnings surfaced via `Result::warnings()`.
-- **Untyped pipe configuration** — currently pipes are configured via typed setters (`setHash(bool)`, `setEnabled(bool)`). Tools that load config from files (YAML/JSON) only have untyped arrays. Consider a generic `configure(array $options)` method on `PipeInterface` so external tooling can pass arbitrary key-value config without needing to know the typed API. Typed setters remain the primary API for programmatic use.
 
 ### Shipping
 

--- a/src/Assembler.php
+++ b/src/Assembler.php
@@ -28,7 +28,7 @@ class Assembler
 {
     public function __construct(
         protected Specification $specification = new Specification(),
-        protected AttributeFactory $factory = new AttributeFactory(),
+        protected AttributeFactory $attributeFactory = new AttributeFactory(),
         protected TokenScanner $tokenScanner = new TokenScanner(),
     ) {
     }
@@ -38,9 +38,9 @@ class Assembler
         return $this->specification;
     }
 
-    public function getFactory(): AttributeFactory
+    public function getAttributeFactory(): AttributeFactory
     {
-        return $this->factory;
+        return $this->attributeFactory;
     }
 
     public function getTokenScanner(): TokenScanner
@@ -68,7 +68,7 @@ class Assembler
             return;
         }
 
-        foreach ($this->factory->fromReflector($reflector) as $root) {
+        foreach ($this->attributeFactory->fromReflector($reflector) as $root) {
             $this->specification->add($root);
         }
     }
@@ -79,14 +79,14 @@ class Assembler
      */
     protected function collectFromClass(\ReflectionClass $class): void
     {
-        $outer = $this->factory->fromReflector($class);
+        $outer = $this->attributeFactory->fromReflector($class);
 
         if ($outer !== []) {
             // Only collect own members when the class has a root attribute (e.g. Schema).
             // Classes without root attributes (plain parents/traits) are handled later
             // by ExpandHierarchy which merges their members into the child schema.
-            $inner = $this->factory->membersOf($class);
-            $roots = $this->factory->resolveHierarchy($outer, $inner);
+            $inner = $this->attributeFactory->membersOf($class);
+            $roots = $this->attributeFactory->resolveHierarchy($outer, $inner);
 
             foreach ($roots as $root) {
                 $this->specification->add($root);
@@ -100,10 +100,10 @@ class Assembler
             if ($method->isConstructor() || $method->getDeclaringClass()->getName() !== $class->getName()) {
                 continue;
             }
-            if ($this->factory->hasOnlyProperties($method)) {
+            if ($this->attributeFactory->hasOnlyProperties($method)) {
                 continue;
             }
-            foreach ($this->factory->fromReflector($method) as $root) {
+            foreach ($this->attributeFactory->fromReflector($method) as $root) {
                 $this->specification->add($root);
             }
         }

--- a/src/Assembler.php
+++ b/src/Assembler.php
@@ -84,7 +84,7 @@ class Assembler
         if ($outer !== []) {
             // Only collect own members when the class has a root attribute (e.g. Schema).
             // Classes without root attributes (plain parents/traits) are handled later
-            // by ExpandHierarchy which merges their members into the child schema.
+            // by the `Inheritance` augmenter, which merges their members into the child schema.
             $inner = $this->attributeFactory->membersOf($class);
             $roots = $this->attributeFactory->resolveHierarchy($outer, $inner);
 

--- a/src/Assembler/DefaultAttributeTranslator.php
+++ b/src/Assembler/DefaultAttributeTranslator.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Assembler;
+
+use OpenApi\AttributeInterface;
+use OpenApi\AttributeTranslatorInterface;
+
+/**
+ * Default implementation dealing with native attributes.
+ */
+class DefaultAttributeTranslator implements AttributeTranslatorInterface
+{
+    public function getAttributes(\ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector): array
+    {
+        return $reflector->getAttributes(
+            AttributeInterface::class,
+            \ReflectionAttribute::IS_INSTANCEOF,
+        );
+    }
+
+    public function translate(array $attributes): array
+    {
+        return $attributes;
+    }
+}

--- a/src/AttributeTranslatorInterface.php
+++ b/src/AttributeTranslatorInterface.php
@@ -21,7 +21,12 @@ interface AttributeTranslatorInterface
     /**
      * Translates the given list of attributes into `AttributeInterface` instances.
      *
-     * @param  array<object>             $attributes
+     * When multiple translators are chained, each receives the cumulative result
+     * from prior translators — a mix of already-resolved `AttributeInterface`
+     * instances and newly instantiated objects from the current translator's
+     * `getAttributes()` call.
+     *
+     * @param  array<object|AttributeInterface> $attributes
      * @return array<AttributeInterface>
      */
     public function translate(array $attributes): array;

--- a/src/AttributeTranslatorInterface.php
+++ b/src/AttributeTranslatorInterface.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi;
+
+use ReflectionAttribute;
+use Reflector;
+
+/**
+ * Contract for creating raw attributes and translating them into `AttributeInterface` instances.
+ */
+interface AttributeTranslatorInterface
+{
+    /**
+     * @return array<ReflectionAttribute>
+     */
+    public function getAttributes(Reflector $reflector): array;
+
+    /**
+     * @return array<AttributeInterface>
+     */
+    public function translate(object $instance): array;
+}

--- a/src/AttributeTranslatorInterface.php
+++ b/src/AttributeTranslatorInterface.php
@@ -6,21 +6,23 @@
 
 namespace OpenApi;
 
-use ReflectionAttribute;
-use Reflector;
-
 /**
  * Contract for creating raw attributes and translating them into `AttributeInterface` instances.
  */
 interface AttributeTranslatorInterface
 {
     /**
-     * @return array<ReflectionAttribute>
+     * Get attributes to load from the given reflector.
+     *
+     * @return array<\ReflectionAttribute>
      */
-    public function getAttributes(Reflector $reflector): array;
+    public function getAttributes(\ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector): array;
 
     /**
+     * Translates the given list of attributes into `AttributeInterface` instances.
+     *
+     * @param  array<object>             $attributes
      * @return array<AttributeInterface>
      */
-    public function translate(object $instance): array;
+    public function translate(array $attributes): array;
 }

--- a/src/Augmenter/Inheritance.php
+++ b/src/Augmenter/Inheritance.php
@@ -27,14 +27,14 @@ use OpenApi\Utils\TokenScanner;
 class Inheritance implements PipeInterface
 {
     public function __construct(
-        protected AttributeFactory $factory = new AttributeFactory(),
+        protected AttributeFactory $attributeFactory = new AttributeFactory(),
         protected TokenScanner $tokenScanner = new TokenScanner(),
     ) {
     }
 
-    public function setFactory(AttributeFactory $factory): void
+    public function setAttributeFactory(AttributeFactory $attributeFactory): void
     {
-        $this->factory = $factory;
+        $this->attributeFactory = $attributeFactory;
     }
 
     public function setTokenScanner(TokenScanner $tokenScanner): void
@@ -163,7 +163,7 @@ class Inheritance implements PipeInterface
 
     protected function mergeMembers(OA\Schema $schema, \ReflectionClass $class): void
     {
-        $members = $this->factory->membersOf($class);
+        $members = $this->attributeFactory->membersOf($class);
         $merged = [];
         foreach ($members as $member) {
             if ($member instanceof OA\Property) {

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -98,7 +98,7 @@ class Builder
         return $this;
     }
 
-    public function getAttributeFactory(): ?AttributeFactory
+    public function getAttributeFactory(): AttributeFactory
     {
         $this->attributeFactory ??= new AttributeFactory();
 
@@ -113,7 +113,7 @@ class Builder
     }
 
     /**
-     * Configure the attribut factory via callable.
+     * Configure the attribute factory via callable.
      *
      * @param callable(AttributeFactory): void $hook
      */

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -8,6 +8,7 @@ namespace OpenApi;
 
 use OpenApi\Builder\Mode;
 use OpenApi\Builder\Result;
+use OpenApi\Utils\AttributeFactory;
 use OpenApi\Utils\CollectingLogger;
 use OpenApi\Utils\PipeInterface;
 use OpenApi\Utils\SourceScanner;
@@ -41,6 +42,8 @@ class Builder
     protected ?LoggerInterface $logger = null;
 
     protected ?CompilerInterface $compiler = null;
+
+    protected ?AttributeFactory $attributeFactory = null;
 
     /**
      * @var Utils\Pipeline<Specification>|null
@@ -91,6 +94,20 @@ class Builder
     public function setCompiler(CompilerInterface $compiler): static
     {
         $this->compiler = $compiler;
+
+        return $this;
+    }
+
+    public function getAttributeFactory(): ?AttributeFactory
+    {
+        $this->attributeFactory ??= new AttributeFactory();
+
+        return $this->attributeFactory;
+    }
+
+    public function setAttributeFactory(AttributeFactory $attributeFactory): static
+    {
+        $this->attributeFactory = $attributeFactory;
 
         return $this;
     }
@@ -185,7 +202,11 @@ class Builder
     {
         $files = $this->resolveFiles();
         $tokenScanner = new TokenScanner();
-        $assembler = new Assembler(tokenScanner: $tokenScanner);
+        $assembler = new Assembler(attributeFactory: $this->getAttributeFactory());
+        $assembler = new Assembler(
+            attributeFactory: $this->getAttributeFactory(),
+            tokenScanner: $tokenScanner,
+        );
 
         foreach ($files as $file) {
             require_once $file;
@@ -274,7 +295,7 @@ class Builder
     protected function getDefaultAugmenters(): array
     {
         return [
-            new Augmenter\Inheritance(),
+            new Augmenter\Inheritance(attributeFactory: $this->getAttributeFactory()),
             new Augmenter\Names(),
             new Augmenter\Enums(),
             new Augmenter\PathItems(),

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -113,6 +113,18 @@ class Builder
     }
 
     /**
+     * Configure the attribut factory via callable.
+     *
+     * @param callable(AttributeFactory): void $hook
+     */
+    public function withAttributeFactory(callable $hook): static
+    {
+        $hook($this->getAttributeFactory());
+
+        return $this;
+    }
+
+    /**
      * @return Utils\Pipeline<Specification>
      */
     public function getAugmenters(): Utils\Pipeline

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -42,7 +42,9 @@ class Builder
 
     protected ?CompilerInterface $compiler = null;
 
-    /** @var Utils\Pipeline<Specification>|null */
+    /**
+     * @var Utils\Pipeline<Specification>|null
+     */
     protected ?Utils\Pipeline $augmenters = null;
 
     /** @var callable|null */
@@ -108,6 +110,9 @@ class Builder
         return $this->augmenters;
     }
 
+    /**
+     * @param Utils\Pipeline<Specification> $augmenters
+     */
     public function setAugmenters(Utils\Pipeline $augmenters): static
     {
         $this->augmenters = $augmenters;
@@ -118,7 +123,7 @@ class Builder
     /**
      * Configure the augmenter pipeline via callable.
      *
-     * @param callable(Utils\Pipeline): void $hook
+     * @param callable(Utils\Pipeline<Specification>): void $hook
      */
     public function withAugmenters(callable $hook): static
     {

--- a/src/Utils/AttributeFactory.php
+++ b/src/Utils/AttributeFactory.php
@@ -8,6 +8,7 @@ namespace OpenApi\Utils;
 
 use OpenApi\Assembler\DefaultAttributeTranslator;
 use OpenApi\AttributeInterface;
+use OpenApi\AttributeTranslatorInterface;
 use OpenApi\OpenApiException;
 use OpenApi\Spec as OA;
 
@@ -21,6 +22,20 @@ use OpenApi\Spec as OA;
  */
 class AttributeFactory
 {
+    /**
+     * @var TypedList<AttributeTranslatorInterface>
+     */
+    protected TypedList $translators;
+
+    public function __construct()
+    {
+        /** @var list<AttributeTranslatorInterface> $translators */
+        $translators = [
+            new DefaultAttributeTranslator(),
+        ];
+        $this->translators = new TypedList($translators);
+    }
+
     /**
      * Read and resolve attributes from a single member reflector.
      *

--- a/src/Utils/AttributeFactory.php
+++ b/src/Utils/AttributeFactory.php
@@ -291,12 +291,8 @@ class AttributeFactory
      */
     protected function readAttributes(\ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector): array
     {
-        $translators = [
-            new DefaultAttributeTranslator(),
-        ];
-
         $attributes = [];
-        foreach ($translators as $translator) {
+        foreach ($this->translators as $translator) {
             foreach ($translator->getAttributes($reflector) as $attribute) {
                 try {
                     $instance = $attribute->newInstance();

--- a/src/Utils/AttributeFactory.php
+++ b/src/Utils/AttributeFactory.php
@@ -6,6 +6,7 @@
 
 namespace OpenApi\Utils;
 
+use OpenApi\Assembler\DefaultAttributeTranslator;
 use OpenApi\AttributeInterface;
 use OpenApi\OpenApiException;
 use OpenApi\Spec as OA;
@@ -275,32 +276,33 @@ class AttributeFactory
      */
     protected function readAttributes(\ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector): array
     {
-        $attributes = $reflector->getAttributes(
-            AttributeInterface::class,
-            \ReflectionAttribute::IS_INSTANCEOF,
-        );
+        $translators = [
+            new DefaultAttributeTranslator(),
+        ];
 
-        $result = [];
-        foreach ($attributes as $attribute) {
-            if (!class_exists($attribute->getName())) {
-                continue;
+        $attributes = [];
+        foreach ($translators as $translator) {
+            foreach ($translator->getAttributes($reflector) as $attribute) {
+                try {
+                    $instance = $attribute->newInstance();
+                } catch (\Error $e) {
+                    throw OpenApiException::fromSource(
+                        sprintf('Failed to instantiate attribute "%s": %s', $attribute->getName(), $e->getMessage()),
+                        SourceLocation::fromReflector($reflector),
+                        $e,
+                    );
+                }
+
+                if ($instance instanceof AttributeInterface) {
+                    $instance->setReflector($reflector);
+                }
+
+                $attributes[] = $instance;
             }
 
-            try {
-                $instance = $attribute->newInstance();
-            } catch (\Error $e) {
-                throw OpenApiException::fromSource(
-                    sprintf('Failed to instantiate attribute "%s": %s', $attribute->getName(), $e->getMessage()),
-                    SourceLocation::fromReflector($reflector),
-                    $e,
-                );
-            }
-
-            $instance->setReflector($reflector);
-
-            $result[] = $instance;
+            $attributes = $translator->translate($attributes);
         }
 
-        return $result;
+        return $attributes;
     }
 }

--- a/src/Utils/AttributeFactory.php
+++ b/src/Utils/AttributeFactory.php
@@ -37,6 +37,34 @@ class AttributeFactory
     }
 
     /**
+     * @return TypedList<AttributeTranslatorInterface>
+     */
+    public function getTranslators(): TypedList
+    {
+        return $this->translators;
+    }
+
+    /**
+     * @param TypedList<AttributeTranslatorInterface> $translators
+     */
+    public function setTranslators(TypedList $translators): static
+    {
+        $this->translators = $translators;
+
+        return $this;
+    }
+
+    /**
+     * @param callable(TypedList<AttributeTranslatorInterface>): void $hook
+     */
+    public function withTranslators(callable $hook): static
+    {
+        $hook($this->translators);
+
+        return $this;
+    }
+
+    /**
      * Read and resolve attributes from a single member reflector.
      *
      * For methods, also resolves parameter-level attributes into the method-level ones.

--- a/src/Utils/AttributeFactory.php
+++ b/src/Utils/AttributeFactory.php
@@ -139,7 +139,7 @@ class AttributeFactory
      */
     public function hasAttributes(\ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector): bool
     {
-        return $reflector->getAttributes(AttributeInterface::class, \ReflectionAttribute::IS_INSTANCEOF) !== [];
+        return $this->readAttributes($reflector) !== [];
     }
 
     /**
@@ -147,14 +147,13 @@ class AttributeFactory
      */
     public function hasOnlyProperties(\ReflectionMethod $method): bool
     {
-        $reflectionAttributes = $method->getAttributes(AttributeInterface::class, \ReflectionAttribute::IS_INSTANCEOF);
-        if ($reflectionAttributes === []) {
+        $attributes = $this->readAttributes($method);
+        if ($attributes === []) {
             return false;
         }
 
-        foreach ($reflectionAttributes as $reflectionAttribute) {
-            $name = $reflectionAttribute->getName();
-            if (!is_a($name, OA\Property::class, true) && !is_a($name, OA\Schema::class, true)) {
+        foreach ($attributes as $attribute) {
+            if (!$attribute instanceof OA\Property && !$attribute instanceof OA\Schema) {
                 return false;
             }
         }
@@ -342,6 +341,6 @@ class AttributeFactory
             $attributes = $translator->translate($attributes);
         }
 
-        return $attributes;
+        return array_values(array_filter($attributes, static fn (object $item): bool => $item instanceof AttributeInterface));
     }
 }

--- a/src/Utils/Pipeline.php
+++ b/src/Utils/Pipeline.php
@@ -13,14 +13,11 @@ use Psr\Log\NullLogger;
 
 /**
  * @template T
+ *
+ * @extends TypedList<callable(T): (T|null)>
  */
-class Pipeline
+class Pipeline extends TypedList
 {
-    /**
-     * @var array<callable(T): (T|null)>
-     */
-    protected $pipes = [];
-
     /**
      * @var list<string>|null ordered group keys; null means no grouping (insertion order only)
      */
@@ -36,7 +33,7 @@ class Pipeline
      */
     public function __construct(array $pipes = [], ?array $groups = null, string|\BackedEnum|null $defaultGroup = null, ?LoggerInterface $logger = null)
     {
-        $this->pipes = $pipes;
+        parent::__construct($pipes);
         $this->logger = $logger ?? new NullLogger();
 
         if ($groups !== null) {
@@ -56,99 +53,7 @@ class Pipeline
         }
     }
 
-    public function add(callable $pipe): Pipeline
-    {
-        $this->pipes[] = $pipe;
-
-        return $this;
-    }
-
-    /**
-     * @template P
-     *
-     * @param class-string<P> $class
-     *
-     * @return P|null
-     */
-    public function get(string $class): mixed
-    {
-        foreach ($this->pipes as $pipe) {
-            if ($pipe instanceof $class) {
-                return $pipe;
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * @param callable|class-string|null $pipe
-     */
-    public function remove($pipe = null, ?callable $matcher = null): Pipeline
-    {
-        if (!$pipe && !$matcher) {
-            throw new OpenApiException('pipe or callable must not be empty');
-        }
-
-        // allow matching on class name if $pipe in a string
-        if (is_string($pipe) && !$matcher) {
-            $pipeClass = $pipe;
-            $matcher = (static fn ($pipe): bool => !$pipe instanceof $pipeClass);
-        }
-
-        if ($matcher) {
-            $tmp = [];
-            foreach ($this->pipes as $pipe) {
-                if ($matcher($pipe)) {
-                    $tmp[] = $pipe;
-                }
-            }
-
-            $this->pipes = $tmp;
-        } else {
-            if (false === ($key = array_search($pipe, $this->pipes, true))) {
-                return $this;
-            }
-
-            unset($this->pipes[$key]);
-
-            $this->pipes = array_values($this->pipes);
-        }
-
-        return $this;
-    }
-
-    /**
-     * @param callable|class-string $matcher used to determine the position to insert
-     *                                       either an <code>int</code> from a callable or, in the case of <code>$matcher</code> being
-     *                                       a <code>class-string</code>, the position before the first pipe of that class
-     */
-    public function insert(callable $pipe, $matcher): Pipeline
-    {
-        if (is_string($matcher)) {
-            $before = $matcher;
-            $matcher = static function (array $pipes) use ($before): int|string|null {
-                foreach ($pipes as $ii => $current) {
-                    if ($current instanceof $before) {
-                        return $ii;
-                    }
-                }
-
-                return null;
-            };
-        }
-
-        $index = $matcher($this->pipes);
-        if (null === $index || $index < 0 || $index > count($this->pipes)) {
-            throw new OpenApiException('Matcher result out of range');
-        }
-
-        array_splice($this->pipes, $index, 0, [$pipe]);
-
-        return $this;
-    }
-
-    public function walk(callable $walker): Pipeline
+    public function walk(callable $walker): static
     {
         foreach ($this->ordered() as $pipe) {
             $walker($pipe);
@@ -182,12 +87,12 @@ class Pipeline
     protected function ordered(): array
     {
         if ($this->groups === null) {
-            return $this->pipes;
+            return $this->items;
         }
 
         $buckets = array_fill_keys($this->groups, []);
 
-        foreach ($this->pipes as $pipe) {
+        foreach ($this->items as $pipe) {
             $group = $pipe instanceof PipeInterface
                 ? self::groupKey($pipe->group())
                 : $this->defaultGroup;

--- a/src/Utils/Pipeline.php
+++ b/src/Utils/Pipeline.php
@@ -14,7 +14,7 @@ use Psr\Log\NullLogger;
 /**
  * @template T
  *
- * @extends TypedList<callable(T): (T|null)>
+ * @extends TypedList<PipeInterface|callable>
  */
 class Pipeline extends TypedList
 {
@@ -28,6 +28,7 @@ class Pipeline extends TypedList
     protected LoggerInterface $logger;
 
     /**
+     * @param list<PipeInterface|callable>                       $pipes
      * @param list<string|\BackedEnum>|null $groups       Ordered group names/enums. When set, process() executes pipes in group order.
      * @param string|\BackedEnum|null       $defaultGroup Group for pipes without PipeInterface. Must be in $groups if groups are set.
      */

--- a/src/Utils/Pipeline.php
+++ b/src/Utils/Pipeline.php
@@ -28,7 +28,7 @@ class Pipeline extends TypedList
     protected LoggerInterface $logger;
 
     /**
-     * @param list<PipeInterface|callable>                       $pipes
+     * @param list<PipeInterface|callable>  $pipes
      * @param list<string|\BackedEnum>|null $groups       Ordered group names/enums. When set, process() executes pipes in group order.
      * @param string|\BackedEnum|null       $defaultGroup Group for pipes without PipeInterface. Must be in $groups if groups are set.
      */

--- a/src/Utils/TypedList.php
+++ b/src/Utils/TypedList.php
@@ -11,7 +11,7 @@ use OpenApi\OpenApiException;
 /**
  * @template T
  */
-class TypedList
+class TypedList implements \IteratorAggregate
 {
     /**
      * @var list<T>
@@ -24,6 +24,11 @@ class TypedList
     public function __construct(array $items = [])
     {
         $this->items = $items;
+    }
+
+    public function getIterator(): \Traversable
+    {
+        return new \ArrayIterator($this->items);
     }
 
     /**

--- a/src/Utils/TypedList.php
+++ b/src/Utils/TypedList.php
@@ -37,9 +37,11 @@ class TypedList
     }
 
     /**
-     * @param class-string<T> $class
+     * @template P of object
      *
-     * @return T|null
+     * @param class-string<P> $class
+     *
+     * @return P|null
      */
     public function get(string $class): mixed
     {

--- a/src/Utils/TypedList.php
+++ b/src/Utils/TypedList.php
@@ -31,6 +31,11 @@ class TypedList implements \IteratorAggregate
         return new \ArrayIterator($this->items);
     }
 
+    public function count(): int
+    {
+        return count($this->items);
+    }
+
     /**
      * @param T $item
      */

--- a/src/Utils/TypedList.php
+++ b/src/Utils/TypedList.php
@@ -1,0 +1,134 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Utils;
+
+use OpenApi\OpenApiException;
+
+/**
+ * @template T
+ */
+class TypedList
+{
+    /**
+     * @var list<T>
+     */
+    protected array $items = [];
+
+    /**
+     * @param list<T> $items
+     */
+    public function __construct(array $items = [])
+    {
+        $this->items = $items;
+    }
+
+    /**
+     * @param T $item
+     */
+    public function add(mixed $item): static
+    {
+        $this->items[] = $item;
+
+        return $this;
+    }
+
+    /**
+     * @param class-string<T> $class
+     *
+     * @return T|null
+     */
+    public function get(string $class): mixed
+    {
+        foreach ($this->items as $item) {
+            if ($item instanceof $class) {
+                return $item;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param T|class-string|null $item
+     */
+    public function remove(mixed $item = null, ?callable $matcher = null): static
+    {
+        if (!$item && !$matcher) {
+            throw new OpenApiException('item or callable must not be empty');
+        }
+
+        if (is_string($item) && !$matcher) {
+            $itemClass = $item;
+            $matcher = (static fn ($item): bool => !$item instanceof $itemClass);
+        }
+
+        if ($matcher) {
+            $tmp = [];
+            foreach ($this->items as $item) {
+                if ($matcher($item)) {
+                    $tmp[] = $item;
+                }
+            }
+
+            $this->items = $tmp;
+        } else {
+            if (false === ($key = array_search($item, $this->items, true))) {
+                return $this;
+            }
+
+            unset($this->items[$key]);
+
+            $this->items = array_values($this->items);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Insert an item into the list at a specific position determined by a matcher.
+     *
+     * @param T                     $item
+     * @param callable|class-string $matcher either an <code>int</code> from a callable or, in the case of <code>$matcher</code> being
+     *                                       a <code>class-string</code>, the position before the first item of that class
+     */
+    public function insert(mixed $item, callable|string $matcher): static
+    {
+        if (is_string($matcher)) {
+            $before = $matcher;
+            $matcher = static function (array $items) use ($before): int|string|null {
+                foreach ($items as $ii => $current) {
+                    if ($current instanceof $before) {
+                        return $ii;
+                    }
+                }
+
+                return null;
+            };
+        }
+
+        $index = $matcher($this->items);
+        if (null === $index || $index < 0 || $index > count($this->items)) {
+            throw new OpenApiException('Matcher result out of range');
+        }
+
+        array_splice($this->items, $index, 0, [$item]);
+
+        return $this;
+    }
+
+    /**
+     * @param callable(T): void $walker
+     */
+    public function walk(callable $walker): static
+    {
+        foreach ($this->items as $item) {
+            $walker($item);
+        }
+
+        return $this;
+    }
+}

--- a/tests/Utils/PipelineTest.php
+++ b/tests/Utils/PipelineTest.php
@@ -85,12 +85,13 @@ final class PipelineTest extends TestCase
     {
         $keep = $this->namedPipe('keep');
         $remove = $this->namedPipe('remove');
+        /** @var Pipeline<object> $pipeline */
         $pipeline = new Pipeline([$keep, $remove]);
 
         $pipeline->remove(null, fn ($pipe): bool => $pipe->name !== 'remove');
 
         $found = [];
-        $pipeline->walk(function ($pipe) use (&$found): void {
+        $pipeline->walk(function (object $pipe) use (&$found): void {
             $found[] = $pipe->name;
         });
         $this->assertSame(['keep'], $found);
@@ -132,10 +133,11 @@ final class PipelineTest extends TestCase
     {
         $a = $this->namedPipe('a');
         $b = $this->namedPipe('b');
+        /** @var Pipeline<object> $pipeline */
         $pipeline = new Pipeline([$a, $b]);
 
         $names = [];
-        $pipeline->walk(function ($pipe) use (&$names): void {
+        $pipeline->walk(function (object $pipe) use (&$names): void {
             $names[] = $pipe->name;
         });
 


### PR DESCRIPTION
## Summary

Introduces a new interface `AttributeTranslatorInterface` and toolchain related methods.

This interface hooks deep into the `AttributeFactory` and allows custom implementations to be added. The contract includes two methods:

- `getAttributes()` - return a list of `ReflectionAttribute` instances to be instatiated for the given `\Reflector`. These can be `OpenApi` attributes or unrelated
- `translate()` - expected to convert the loaded attributes into `AttibuteInterface` instances. This allows to map custom/framework attributes directly into raw OpenApi attributes. If they are in the right place in the code structure, nothing else needs to be done and the `Assembler` should merge/nest them where they belong.

Apart from allowing to inject new attributes, this can also be used as low level customization. For example, a validation constrait attribute could be used to set some value on a `Schema` instance, etc.