### PR TITLE
feat(BETA): make TokenScanner available to spec-attributes pipeline

### DIFF
--- a/docs/spec-attributes-status.md
+++ b/docs/spec-attributes-status.md
@@ -240,6 +240,86 @@ How each classic processor maps to the new pipeline:
 3. Property merging into parent schema → Assembler via `merge()`/`contains()` (done)
 4. allOf merge when both properties + allOf exist → Compiler (done)
 
+## Inheritance expansion
+
+### Authoritative rules (derived from classic behavior)
+
+These rules define the agreed upon inheritance behavior. The classic path implements them via TokenScanner-filtered definitions; the spec path must produce identical results.
+
+The rules mirror PHP inheritance: a schema inherits everything its PHP class inherits. The same rule applies uniformly to parents, traits, and interfaces.
+
+#### Property ownership
+
+Each property belongs to exactly one source — the class-like that physically declares it:
+
+- A class's **own properties** are those declared in its class body (including promoted constructor parameters), but **not** properties contributed by traits.
+- Trait properties belong to the trait, not to the class that uses it.
+- Parent class properties belong to the parent.
+
+This matches PHP's source-level declaration. Trait properties appear on the using class at runtime, but for schema purposes they belong to the trait.
+
+#### The one rule
+
+For each parent, trait, or interface that a schema's class relates to:
+
+- **Has a schema** → add `$ref` to `allOf` (composition via reference)
+- **Has no schema** → merge its own members into the current schema (inlining)
+
+This rule is the same for all three relationship types. The only differences are PHP language constraints:
+
+- **Interfaces** can only contribute methods (PHP interfaces cannot declare properties)
+- **Parents** are walked linearly; stop at the first ancestor with a schema (everything above is inherited transitively through that ref)
+- **Traits on non-schema ancestors** are also processed (stop at the first ancestor with a schema)
+
+#### Deduplication of merged properties
+
+A running list of already-merged property names prevents duplicates. A property is merged only if its name is not already present on the schema.
+
+#### allOf refs are not deduplicated
+
+Refs are added for each direct relationship, without checking whether the referenced schema is already reachable transitively through another ref. This is unavoidable — we compose with predefined schemas and cannot inspect their contents to determine overlap.
+
+Example:
+```php
+#[Schema(schema: "Timestamps")]
+trait HasTimestamps { public string $createdAt; }
+
+#[Schema]
+class BaseModel { use HasTimestamps; public int $id; }
+
+#[Schema]
+class User extends BaseModel { use HasTimestamps; public string $email; }
+```
+
+Output for `User`:
+```yaml
+User:
+  allOf:
+    - $ref: '#/components/schemas/BaseModel'    # parent (which itself refs Timestamps)
+    - $ref: '#/components/schemas/Timestamps'   # direct trait usage
+    - properties: { email: ... }               # own properties only
+```
+
+The `$ref: Timestamps` is semantically redundant (already composed via BaseModel) but present because User explicitly declares `use HasTimestamps`. The alternative — inspecting ref targets for transitive overlap — would require resolving the full schema graph and is not feasible at this stage.
+
+#### allOf finalization
+
+After inheritance expansion, if a schema has both `allOf` refs **and** own properties, the properties are wrapped in a dedicated `allOf` entry (`type: object`) to produce a pure allOf composition.
+
+### Reflection limitation: trait member ownership
+
+PHP reflection lies about trait members: `getDeclaringClass()` for a trait property returns the **using class**, not the trait. This means `ReflectionClass::getProperties()` + `getDeclaringClass()` cannot distinguish a class's own properties from trait-contributed ones.
+
+```php
+trait T { public string $x; }
+class C { use T; public string $y; }
+// ReflectionClass("C")->getProperty("x")->getDeclaringClass()->getName() === "C"
+```
+
+### Resolution direction
+
+The spec path's `Builder::doBuildSpec()` already runs `TokenScanner` but discards the per-class details (only uses FQDN keys for class discovery). Making this data available — either to `AttributeFactory::membersOf()` as a property whitelist, or to the `Inheritance` augmenter for accurate own-vs-trait discrimination — would close the gap with the classic path.
+
 ## PathItem design
 
 PathItem is both an OpenAPI spec concept (path-level parameters, summary, description, servers) and a controller-grouping mechanism (prefix composition, shared tags/security). The DTO unifies both roles.

--- a/src/Assembler.php
+++ b/src/Assembler.php
@@ -7,6 +7,7 @@
 namespace OpenApi;
 
 use OpenApi\Utils\AttributeFactory;
+use OpenApi\Utils\TokenScanner;
 
 /**
  * Collects OpenAPI spec attributes from PHP reflectors and assembles them into a Specification.
@@ -28,6 +29,7 @@ class Assembler
     public function __construct(
         protected Specification $specification = new Specification(),
         protected AttributeFactory $factory = new AttributeFactory(),
+        protected TokenScanner $tokenScanner = new TokenScanner(),
     ) {
     }
 
@@ -39,6 +41,11 @@ class Assembler
     public function getFactory(): AttributeFactory
     {
         return $this->factory;
+    }
+
+    public function getTokenScanner(): TokenScanner
+    {
+        return $this->tokenScanner;
     }
 
     /**

--- a/src/Augmenter/Inheritance.php
+++ b/src/Augmenter/Inheritance.php
@@ -10,6 +10,7 @@ use OpenApi\Spec as OA;
 use OpenApi\Specification;
 use OpenApi\Utils\AttributeFactory;
 use OpenApi\Utils\PipeInterface;
+use OpenApi\Utils\TokenScanner;
 
 /**
  * Expands PHP class hierarchy into OpenAPI composition (allOf).
@@ -27,7 +28,18 @@ class Inheritance implements PipeInterface
 {
     public function __construct(
         protected AttributeFactory $factory = new AttributeFactory(),
+        protected TokenScanner $tokenScanner = new TokenScanner(),
     ) {
+    }
+
+    public function setFactory(AttributeFactory $factory): void
+    {
+        $this->factory = $factory;
+    }
+
+    public function setTokenScanner(TokenScanner $tokenScanner): void
+    {
+        $this->tokenScanner = $tokenScanner;
     }
 
     public function group(): string|\BackedEnum

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -180,7 +180,7 @@ class Builder
     {
         $files = $this->resolveFiles();
         $tokenScanner = new TokenScanner();
-        $assembler = new Assembler();
+        $assembler = new Assembler(tokenScanner: $tokenScanner);
 
         foreach ($files as $file) {
             require_once $file;

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -193,6 +193,8 @@ class Builder
 
         $specification = $assembler->getSpecification();
 
+        // share the token scanner cache ...
+        $this->getAugmenters()->get(Augmenter\Inheritance::class)?->setTokenScanner($tokenScanner);
         $this->getAugmenters()->process($specification);
 
         $version = $this->version ?? $specification->openapi->version ?? '3.1.0';

--- a/src/Utils/TokenScanner.php
+++ b/src/Utils/TokenScanner.php
@@ -22,8 +22,13 @@ use PhpParser\ParserFactory;
  */
 class TokenScanner
 {
+    /** @var array<string, array<class-string, array{uses: array<string, class-string>, interfaces: list<class-string>, traits: list<class-string>, enums: list<class-string>, methods: list<string>, properties: list<string>}>> */
+    protected array $cache = [];
+
     /**
      * Scan a given file for all classes, interfaces, and traits.
+     *
+     * Results are cached by filename — repeated calls with the same path return the cached result.
      *
      * @return array<class-string, array{
      *     uses: array<string, class-string>,
@@ -36,6 +41,10 @@ class TokenScanner
      */
     public function scanFile(string $filename): array
     {
+        if (isset($this->cache[$filename])) {
+            return $this->cache[$filename];
+        }
+
         $parser = (new ParserFactory())->createForNewestSupportedVersion();
         try {
             $stmts = $parser->parse(file_get_contents($filename));
@@ -53,7 +62,28 @@ class TokenScanner
             }
         }
 
+        $this->cache[$filename] = $result;
+
         return $result;
+    }
+
+    /**
+     * Look up scan details for a specific FQDN.
+     *
+     * Scans the file on demand if not already cached.
+     *
+     * @return array{uses: array<string, class-string>, interfaces: list<class-string>, traits: list<class-string>, enums: list<class-string>, methods: list<string>, properties: list<string>}|null
+     */
+    public function detailsFor(\ReflectionClass $class): ?array
+    {
+        $filename = $class->getFileName();
+        if ($filename === false) {
+            return null;
+        }
+
+        $results = $this->scanFile($filename);
+
+        return $results[$class->getName()] ?? null;
     }
 
     protected function collect_stmts(array $stmts, string $namespace): array

--- a/tests/Utils/TokenScannerTest.php
+++ b/tests/Utils/TokenScannerTest.php
@@ -395,4 +395,35 @@ final class TokenScannerTest extends OpenApiTestCase
         $result = (new TokenScanner())->scanFile($this->fixture($fixture));
         $this->assertEquals($expected, $result);
     }
+
+    public function testScanFileCachesResults(): void
+    {
+        $scanner = new TokenScanner();
+        $filename = $this->fixture('PHP/AbstractKeyword.php');
+
+        $first = $scanner->scanFile($filename);
+        $second = $scanner->scanFile($filename);
+
+        $this->assertSame($first, $second);
+    }
+
+    public function testDetailsForReturnsMatchingEntry(): void
+    {
+        $scanner = new TokenScanner();
+        $rc = new \ReflectionClass(\OpenApi\Tests\Fixtures\PHP\Inheritance\ExtendsClass::class);
+
+        $details = $scanner->detailsFor($rc);
+
+        $this->assertNotNull($details);
+        $this->assertSame(['extendsClassProp'], $details['properties']);
+        $this->assertSame(['extendsClassFunc'], $details['methods']);
+    }
+
+    public function testDetailsForReturnsNullForInternalClass(): void
+    {
+        $scanner = new TokenScanner();
+        $rc = new \ReflectionClass(\stdClass::class);
+
+        $this->assertNull($scanner->detailsFor($rc));
+    }
 }


### PR DESCRIPTION
## Summary

  - Add result caching to `TokenScanner` and a `detailsFor(\ReflectionClass)` convenience method for FQDN-based lookup
  - Inject `TokenScanner` into `Assembler` (shared instance, pre-warmed by Builder's file discovery loop)
  - Wire the same `TokenScanner` into the `Inheritance` augmenter via setter so it can access per-class scan details

## Motivation

PHP reflection for trait is limited. Just like classic, the new pipeline will need to depend on the details collected by the `TokenScanner`.

