### PR TITLE
fix(BETA): fix inheritance resolution

### DIFF
--- a/docs/examples/specs/using-traits/spec/Blink.php
+++ b/docs/examples/specs/using-traits/spec/Blink.php
@@ -15,5 +15,6 @@ trait Blink
      * The frequency.
      */
     #[OA\Property]
-    public int $frequency;
+    #[OA\Schema(example: 1)]
+    public $frequency;
 }

--- a/docs/examples/specs/using-traits/spec/Colour.php
+++ b/docs/examples/specs/using-traits/spec/Colour.php
@@ -15,5 +15,6 @@ trait Colour
      * The colour.
      */
     #[OA\Property]
-    public string $colour;
+    #[OA\Schema(example: 'red')]
+    public $colour;
 }

--- a/docs/examples/specs/using-traits/spec/Decoration/Bells.php
+++ b/docs/examples/specs/using-traits/spec/Decoration/Bells.php
@@ -15,5 +15,6 @@ trait Bells
      * The bell (clashes with Product::bell).
      */
     #[OA\Property]
-    public string $bell;
+    #[OA\Schema(example: 'chime')]
+    public $bell;
 }

--- a/docs/examples/specs/using-traits/spec/Decoration/UndocumentedBell.php
+++ b/docs/examples/specs/using-traits/spec/Decoration/UndocumentedBell.php
@@ -8,5 +8,5 @@ namespace OpenApi\Examples\Specs\UsingTraits\Spec\Decoration;
 
 trait UndocumentedBell
 {
-    public string $undocumentedBell;
+    public $undocumentedBell;
 }

--- a/docs/examples/specs/using-traits/spec/Decoration/Whistles.php
+++ b/docs/examples/specs/using-traits/spec/Decoration/Whistles.php
@@ -15,5 +15,6 @@ trait Whistles
      * The bell.
      */
     #[OA\Property]
-    public string $whistle;
+    #[OA\Schema(example: 'bone whistle')]
+    public $whistle;
 }

--- a/docs/examples/specs/using-traits/spec/Product.php
+++ b/docs/examples/specs/using-traits/spec/Product.php
@@ -26,5 +26,5 @@ class Product
      */
     #[OA\Property]
     #[OA\Schema(example: 'gong')]
-    public string $bell;
+    public $bell;
 }

--- a/docs/examples/specs/using-traits/spec/TrickyProduct.php
+++ b/docs/examples/specs/using-traits/spec/TrickyProduct.php
@@ -19,5 +19,5 @@ class TrickyProduct extends SimpleProduct
      */
     #[OA\Property]
     #[OA\Schema(example: 'recite poem')]
-    public string $trick;
+    public $trick;
 }

--- a/docs/spec-attributes-status.md
+++ b/docs/spec-attributes-status.md
@@ -361,10 +361,6 @@ class C { use T; public string $y; }
 // ReflectionClass("C")->getProperty("x")->getDeclaringClass()->getName() === "C"
 ```
 
-### Resolution direction
-
-The spec path's `Builder::doBuildSpec()` already runs `TokenScanner` but discards the per-class details (only uses FQDN keys for class discovery). Making this data available — either to `AttributeFactory::membersOf()` as a property whitelist, or to the `Inheritance` augmenter for accurate own-vs-trait discrimination — would close the gap with the classic path.
-
 ## PathItem design
 
 PathItem is both an OpenAPI spec concept (path-level parameters, summary, description, servers) and a controller-grouping mechanism (prefix composition, shared tags/security). The DTO unifies both roles.

--- a/docs/spec-attributes-status.md
+++ b/docs/spec-attributes-status.md
@@ -223,31 +223,12 @@ $warnings = $result->warnings(); // any non-fatal issues
 | `EnumDescriptions` | augment | Generates descriptions for enum-based properties (BETA, disabled by default) | Done |
 | `PathItems` | resolve | Prefix composition, clone-down of tags/security/responses, path inference | Done |
 
-## Example coverage
+## Test coverage
 
-All 10 example specs now have spec-attribute versions. Most produce identical output across classic, spec, and hybrid modes (shared yaml fixtures). Hybrid mode is tested for all examples and passes except using-refs (ref-path difference).
-
-| Example | Shared fixture | Spec-specific fixture | Notes                                                                                     |
-|---|---|---|-------------------------------------------------------------------------------------------|
-| api | ✓ | — | Original spec example                                                                     |
-| misc | ✓ | — | Callbacks, security, enums                                                                |
-| nesting | ✓ | — | Multi-level class inheritance                                                             |
-| petstore | ✓ | — | Classic CRUD example                                                                      |
-| polymorphism | ✓ | — | oneOf/allOf/discriminator                                                                 |
-| using-interfaces | ✓ | — | Interface-based allOf composition                                                         |
-| using-links | ✓ | — | Response links                                                                            |
-| using-refs | — | ✓ | Resolving of property refs that got moved into allOf still needs resolving                |
-| using-traits | — | ✓ | Trait inheritance needs to be refactored since reflection is too limited as only solution |
-| webhooks | ✓ | — | 3.1+ webhooks                                                                             |
-
-### Behavioral differences from classic
-
-Intentional improvements or corrections in the spec/hybrid pipeline that produce different output from classic:
-
-| Difference | Classic | Spec/Hybrid | Rationale |
-|---|---|---|---|
-| Empty `tags` | Always emits `tags: []` | Omits when empty | Per OpenAPI spec, optional fields should be omitted when empty |
-| Empty flow `scopes` | Emits `scopes: {}` | Was omitting empty scopes | Bug fix in compiler — scopes is required per OpenAPI spec |
+* New code is covered by new tests.
+* All examples tests pass in all modes (`CLASSIC`, `HYBRID` and `SPEC`). Spec versions have been added to all examples.
+* All tests that now rely on `Generator` or `AbstractAnnotation` specific features are passing in `HYBRID` mode.
+* Spec version of the performance test is passing and way faster than classic.
 
 ## Classic processor mapping
 
@@ -477,7 +458,6 @@ class Model {
 
 - Dedicated test coverage for `HybridBridge` (currently exercised only indirectly via examples)
 - Migrate scratch tests and doc snippet tests to run in spec and/or hybrid modes
-- Broad hybrid validation by forcing existing classic tests to use `setMode('hybrid')` on their Builder — most classic tests should pass through hybrid unchanged, exposing gaps
 
 ### Testing
 

--- a/src/Assembler.php
+++ b/src/Assembler.php
@@ -97,12 +97,18 @@ class Assembler
         // any class-level schema attribute. Properties on methods are handled via
         // membersOf() (absorbed into class schema) or ExpandHierarchy (non-schema interfaces).
         foreach ($class->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
-            if ($method->isConstructor() || $method->getDeclaringClass()->getName() !== $class->getName()) {
+            $scannerDetails = $this->tokenScanner->detailsFor($class);
+            if ($method->isConstructor()
+                || $method->getDeclaringClass()->getName() !== $class->getName()
+                || ($scannerDetails && !in_array($method->getName(), $scannerDetails['methods'], true))
+            ) {
                 continue;
             }
+
             if ($this->attributeFactory->hasOnlyProperties($method)) {
                 continue;
             }
+
             foreach ($this->attributeFactory->fromReflector($method) as $root) {
                 $this->specification->add($root);
             }

--- a/src/Augmenter/Inheritance.php
+++ b/src/Augmenter/Inheritance.php
@@ -57,9 +57,10 @@ class Inheritance implements PipeInterface
                 continue;
             }
 
-            $this->expandParents($schema, $reflector, $schemaMap);
-            $this->expandTraits($schema, $reflector, $schemaMap);
-            $this->expandInterfaces($schema, $reflector, $schemaMap);
+            $existingProperties = array_map(fn (OA\Property $p): ?string => $p->property, $schema->properties ?? []);
+            $this->expandParents($schema, $reflector, $schemaMap, $existingProperties);
+            $this->expandTraits($schema, $reflector, $schemaMap, $existingProperties);
+            $this->expandInterfaces($schema, $reflector, $schemaMap, $existingProperties);
             $this->mergeAllOf($schema);
         }
 
@@ -85,7 +86,7 @@ class Inheritance implements PipeInterface
     /**
      * @param array<string, OA\Schema> $schemaMap
      */
-    protected function expandParents(OA\Schema $schema, \ReflectionClass $reflector, array $schemaMap): void
+    protected function expandParents(OA\Schema $schema, \ReflectionClass $reflector, array $schemaMap, array &$existingProperties): void
     {
         // Walk up the inheritance chain; stop at the first ancestor that has its own schema
         // (it becomes a $ref). Non-schema ancestors have their members inlined.
@@ -96,7 +97,7 @@ class Inheritance implements PipeInterface
                 break;
             }
 
-            $this->mergeMembers($schema, $parent);
+            $this->mergeMembers($schema, $parent, $existingProperties);
             $parent = $parent->getParentClass();
         }
     }
@@ -104,21 +105,16 @@ class Inheritance implements PipeInterface
     /**
      * @param array<string, OA\Schema> $schemaMap
      */
-    protected function expandTraits(OA\Schema $schema, \ReflectionClass $reflector, array $schemaMap): void
+    protected function expandTraits(OA\Schema $schema, \ReflectionClass $reflector, array $schemaMap, array &$existingProperties): void
     {
-        // PHP reports trait properties as declared by the using class, so the
-        // assembler already collected them as own properties. For traits with a
-        // schema we add an allOf $ref and strip those properties; for traits
-        // without a schema we leave them in place (already present, no merge needed).
         foreach ($this->getDirectTraits($reflector) as $trait) {
             if (isset($schemaMap[$trait->getName()])) {
                 $this->addAllOfRef($schema, $schemaMap[$trait->getName()]);
-                $this->stripTraitProperties($schema, $trait);
+            } else {
+                $this->mergeMembers($schema, $trait, $existingProperties);
             }
         }
 
-        // Traits from non-schema ancestors also belong to this schema (the ancestor
-        // itself was inlined in expandParents, but its traits weren't covered there).
         $parent = $reflector->getParentClass();
         while ($parent !== false) {
             if (isset($schemaMap[$parent->getName()])) {
@@ -128,7 +124,6 @@ class Inheritance implements PipeInterface
             foreach ($this->getDirectTraits($parent) as $trait) {
                 if (isset($schemaMap[$trait->getName()])) {
                     $this->addAllOfRef($schema, $schemaMap[$trait->getName()]);
-                    $this->stripTraitProperties($schema, $trait);
                 }
             }
 
@@ -139,7 +134,7 @@ class Inheritance implements PipeInterface
     /**
      * @param array<string, OA\Schema> $schemaMap
      */
-    protected function expandInterfaces(OA\Schema $schema, \ReflectionClass $reflector, array $schemaMap): void
+    protected function expandInterfaces(OA\Schema $schema, \ReflectionClass $reflector, array $schemaMap, array &$existingProperties): void
     {
         $ownInterfaces = $this->getDirectInterfaces($reflector);
 
@@ -147,7 +142,7 @@ class Inheritance implements PipeInterface
             if (isset($schemaMap[$interface->getName()])) {
                 $this->addAllOfRef($schema, $schemaMap[$interface->getName()]);
             } else {
-                $this->mergeMembers($schema, $interface);
+                $this->mergeMembers($schema, $interface, $existingProperties);
             }
         }
     }
@@ -161,39 +156,19 @@ class Inheritance implements PipeInterface
         }
     }
 
-    protected function mergeMembers(OA\Schema $schema, \ReflectionClass $class): void
+    protected function mergeMembers(OA\Schema $schema, \ReflectionClass $class, array &$existingProperties): void
     {
         $members = $this->attributeFactory->membersOf($class);
         $merged = [];
         foreach ($members as $member) {
-            if ($member instanceof OA\Property) {
+            if ($member instanceof OA\Property && !in_array($member->property, $existingProperties, true)) {
+                $existingProperties[] = $member->property;
                 $merged[] = $member;
             }
         }
 
         if ($merged !== []) {
             $schema->properties = [...$merged, ...($schema->properties ?? [])];
-        }
-    }
-
-    protected function stripTraitProperties(OA\Schema $schema, \ReflectionClass $trait): void
-    {
-        if ($schema->properties === null) {
-            return;
-        }
-
-        $traitPropertyNames = array_map(
-            fn (\ReflectionProperty $p): string => $p->getName(),
-            $trait->getProperties(),
-        );
-
-        $schema->properties = array_values(array_filter(
-            $schema->properties,
-            fn (OA\Property $p): bool => !in_array($p->property, $traitPropertyNames, true),
-        ));
-
-        if ($schema->properties === []) {
-            $schema->properties = null;
         }
     }
 
@@ -221,21 +196,18 @@ class Inheritance implements PipeInterface
      */
     protected function getDirectTraits(\ReflectionClass $class): array
     {
-        $traits = $class->getTraits();
-        // Exclude traits inherited from parent
-        $parent = $class->getParentClass();
-        if ($parent !== false) {
-            $parentTraitNames = array_map(
-                fn (\ReflectionClass $t): string => $t->getName(),
-                $parent->getTraits(),
-            );
-            $traits = array_filter(
-                $traits,
-                fn (\ReflectionClass $t): bool => !in_array($t->getName(), $parentTraitNames, true),
+        $scannerDetails = $this->tokenScanner->detailsFor($class);
+
+        if ($scannerDetails !== null) {
+            return array_filter(
+                array_map(
+                    fn (string $name): ?\ReflectionClass => class_exists($name) || trait_exists($name) ? new \ReflectionClass($name) : null,
+                    $scannerDetails['traits'],
+                ),
             );
         }
 
-        return array_values($traits);
+        return [];
     }
 
     /**

--- a/src/Augmenter/Inheritance.php
+++ b/src/Augmenter/Inheritance.php
@@ -32,14 +32,18 @@ class Inheritance implements PipeInterface
     ) {
     }
 
-    public function setAttributeFactory(AttributeFactory $attributeFactory): void
+    public function setAttributeFactory(AttributeFactory $attributeFactory): static
     {
         $this->attributeFactory = $attributeFactory;
+
+        return $this;
     }
 
-    public function setTokenScanner(TokenScanner $tokenScanner): void
+    public function setTokenScanner(TokenScanner $tokenScanner): static
     {
         $this->tokenScanner = $tokenScanner;
+
+        return $this;
     }
 
     public function group(): string|\BackedEnum

--- a/src/Augmenter/Inheritance.php
+++ b/src/Augmenter/Inheritance.php
@@ -57,7 +57,7 @@ class Inheritance implements PipeInterface
                 continue;
             }
 
-            $existingProperties = array_map(fn (OA\Property $p): ?string => $p->property, $schema->properties ?? []);
+            $existingProperties = array_map(fn (OA\Property $property): ?string => $property->property, $schema->properties ?? []);
             $this->expandParents($schema, $reflector, $schemaMap, $existingProperties);
             $this->expandTraits($schema, $reflector, $schemaMap, $existingProperties);
             $this->expandInterfaces($schema, $reflector, $schemaMap, $existingProperties);
@@ -94,6 +94,7 @@ class Inheritance implements PipeInterface
         while ($parent !== false) {
             if (isset($schemaMap[$parent->getName()])) {
                 $this->addAllOfRef($schema, $schemaMap[$parent->getName()]);
+                // stop on first schema ancestor
                 break;
             }
 
@@ -161,9 +162,13 @@ class Inheritance implements PipeInterface
         $members = $this->attributeFactory->membersOf($class);
         $merged = [];
         foreach ($members as $member) {
-            if ($member instanceof OA\Property && !in_array($member->property, $existingProperties, true)) {
-                $existingProperties[] = $member->property;
-                $merged[] = $member;
+            if ($member instanceof OA\Property) {
+                // fallback to reflector if name not (yet) set
+                $propertyName = $member->property ?? ($member->getReflector() instanceof \ReflectionProperty ? $member->getReflector()->name : null);
+                if (!in_array($propertyName, $existingProperties, true)) {
+                    $existingProperties[] = $propertyName;
+                    $merged[] = $member;
+                }
             }
         }
 

--- a/src/Augmenter/Refs.php
+++ b/src/Augmenter/Refs.php
@@ -39,6 +39,7 @@ class Refs implements PipeInterface, LoggerAwareInterface
 
         $this->resolveFQCNRefs($payload, $refMap);
         $this->resolveDiscriminatorMappings($payload, $refMap);
+        $this->resolveAllOfPropertyRefs($payload);
 
         return null;
     }
@@ -138,5 +139,39 @@ class Refs implements PipeInterface, LoggerAwareInterface
                 }
             }
         }
+    }
+
+    /**
+     * Adjust refs pointing to schema properties that got merged into `allOf` during inheritance processing.
+     */
+    protected function resolveAllOfPropertyRefs(Specification $specification): void
+    {
+        $candidates = [];
+
+        $specification->getWalker()->visit(OA\Schema::class, function (OA\Schema $schema) use (&$candidates): void {
+            if ($schema->allOf !== null && $schema->properties === null) {
+                foreach ($schema->allOf as $index => $allOf) {
+                    if ($allOf instanceof OA\Schema && $allOf->properties !== null) {
+                        $name = $schema->schema ?? $schema->title;
+                        $candidates[$name] = $index;
+                    }
+                }
+            }
+        });
+
+        $specification->getWalker()->eachRef(function (OA\Schema|OA\Parameter|OA\Response|OA\Header|OA\RequestBody|OA\Link|OA\Example|OA\Security\Scheme $attribute) use (&$candidates): void {
+            preg_match('/#\/components\/schemas\/([^\/]+)\/(properties\/.+)/', (string) $attribute->ref, $matches);
+
+            if (count($matches) !== 3) {
+                return;
+            }
+
+            $name = $matches[1];
+            $path = $matches[2];
+            if (array_key_exists($name, $candidates)) {
+                $index = $candidates[$name];
+                $attribute->ref = "#/components/schemas/{$name}/allOf/{$index}/{$path}";
+            }
+        });
     }
 }

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -43,8 +43,6 @@ class Builder
 
     protected ?CompilerInterface $compiler = null;
 
-    protected ?AttributeFactory $attributeFactory = null;
-
     /**
      * @var Utils\Pipeline<Specification>|null
      */
@@ -94,32 +92,6 @@ class Builder
     public function setCompiler(CompilerInterface $compiler): static
     {
         $this->compiler = $compiler;
-
-        return $this;
-    }
-
-    public function getAttributeFactory(): AttributeFactory
-    {
-        $this->attributeFactory ??= new AttributeFactory();
-
-        return $this->attributeFactory;
-    }
-
-    public function setAttributeFactory(AttributeFactory $attributeFactory): static
-    {
-        $this->attributeFactory = $attributeFactory;
-
-        return $this;
-    }
-
-    /**
-     * Configure the attribute factory via callable.
-     *
-     * @param callable(AttributeFactory): void $hook
-     */
-    public function withAttributeFactory(callable $hook): static
-    {
-        $hook($this->getAttributeFactory());
 
         return $this;
     }
@@ -213,9 +185,11 @@ class Builder
     protected function doBuildSpec(): Result
     {
         $files = $this->resolveFiles();
+
         $tokenScanner = new TokenScanner();
+        $attributeFactory = new AttributeFactory($tokenScanner);
         $assembler = new Assembler(
-            attributeFactory: $this->getAttributeFactory(),
+            attributeFactory: $attributeFactory,
             tokenScanner: $tokenScanner,
         );
 
@@ -234,6 +208,7 @@ class Builder
         $this->getAugmenters()->get(Augmenter\Inheritance::class)
             ?->setTokenScanner($tokenScanner)
             ->setAttributeFactory($attributeFactory);
+
         $this->getAugmenters()->process($specification);
 
         $version = $this->version ?? $specification->openapi->version ?? '3.1.0';
@@ -308,7 +283,7 @@ class Builder
     protected function getDefaultAugmenters(): array
     {
         return [
-            new Augmenter\Inheritance(attributeFactory: $this->getAttributeFactory()),
+            new Augmenter\Inheritance(),
             new Augmenter\Names(),
             new Augmenter\Enums(),
             new Augmenter\PathItems(),

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -214,7 +214,6 @@ class Builder
     {
         $files = $this->resolveFiles();
         $tokenScanner = new TokenScanner();
-        $assembler = new Assembler(attributeFactory: $this->getAttributeFactory());
         $assembler = new Assembler(
             attributeFactory: $this->getAttributeFactory(),
             tokenScanner: $tokenScanner,
@@ -232,7 +231,9 @@ class Builder
         $specification = $assembler->getSpecification();
 
         // share the token scanner cache ...
-        $this->getAugmenters()->get(Augmenter\Inheritance::class)?->setTokenScanner($tokenScanner);
+        $this->getAugmenters()->get(Augmenter\Inheritance::class)
+            ?->setTokenScanner($tokenScanner)
+            ->setAttributeFactory($attributeFactory);
         $this->getAugmenters()->process($specification);
 
         $version = $this->version ?? $specification->openapi->version ?? '3.1.0';

--- a/src/Utils/AttributeFactory.php
+++ b/src/Utils/AttributeFactory.php
@@ -94,14 +94,18 @@ class AttributeFactory
      *
      * @return list<AttributeInterface>
      */
-    public function membersOf(\ReflectionClass $class): array
+    public function membersOf(\ReflectionClass $class, ?array $scannerDetails = null): array
     {
         $inner = [];
 
         foreach ($class->getProperties() as $property) {
-            if ($property->isPromoted() || $property->getDeclaringClass()->getName() !== $class->getName()) {
+            if ($property->isPromoted()
+                || $property->getDeclaringClass()->getName() !== $class->getName()
+                || ($scannerDetails && !in_array($property->getName(), $scannerDetails['properties']))
+            ) {
                 continue;
             }
+
             array_push($inner, ...$this->resolveNesting($this->readAttributes($property)));
         }
 
@@ -113,16 +117,23 @@ class AttributeFactory
         }
 
         foreach ($class->getReflectionConstants() as $constant) {
-            if ($constant->getDeclaringClass()->getName() !== $class->getName()) {
+            if ($constant->getDeclaringClass()->getName() !== $class->getName()
+                || ($scannerDetails && !in_array($constant->getName(), $scannerDetails['consts']))
+            ) {
                 continue;
             }
+
             array_push($inner, ...$this->resolveNesting($this->readAttributes($constant)));
         }
 
         foreach ($class->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
-            if ($method->isConstructor() || $method->getDeclaringClass()->getName() !== $class->getName()) {
+            if ($method->isConstructor()
+                || $method->getDeclaringClass()->getName() !== $class->getName()
+                || ($scannerDetails && !in_array($method->getName(), $scannerDetails['methods']))
+            ) {
                 continue;
             }
+
             $resolved = $this->resolveNesting($this->readAttributes($method));
             foreach ($resolved as $attribute) {
                 if ($attribute instanceof OA\Property) {

--- a/src/Utils/AttributeFactory.php
+++ b/src/Utils/AttributeFactory.php
@@ -27,12 +27,13 @@ class AttributeFactory
      */
     protected TypedList $translators;
 
-    public function __construct()
+    public function __construct(protected TokenScanner $tokenScanner = new TokenScanner())
     {
         /** @var list<AttributeTranslatorInterface> $translators */
         $translators = [
             new DefaultAttributeTranslator(),
         ];
+
         $this->translators = new TypedList($translators);
     }
 
@@ -94,14 +95,15 @@ class AttributeFactory
      *
      * @return list<AttributeInterface>
      */
-    public function membersOf(\ReflectionClass $class, ?array $scannerDetails = null): array
+    public function membersOf(\ReflectionClass $class): array
     {
         $inner = [];
+        $scannerDetails = $this->tokenScanner->detailsFor($class);
 
         foreach ($class->getProperties() as $property) {
             if ($property->isPromoted()
                 || $property->getDeclaringClass()->getName() !== $class->getName()
-                || ($scannerDetails && !in_array($property->getName(), $scannerDetails['properties']))
+                || ($scannerDetails && !in_array($property->getName(), $scannerDetails['properties'], true))
             ) {
                 continue;
             }
@@ -118,7 +120,7 @@ class AttributeFactory
 
         foreach ($class->getReflectionConstants() as $constant) {
             if ($constant->getDeclaringClass()->getName() !== $class->getName()
-                || ($scannerDetails && !in_array($constant->getName(), $scannerDetails['consts']))
+                || ($scannerDetails && !in_array($constant->getName(), $scannerDetails['consts'], true))
             ) {
                 continue;
             }
@@ -129,7 +131,7 @@ class AttributeFactory
         foreach ($class->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
             if ($method->isConstructor()
                 || $method->getDeclaringClass()->getName() !== $class->getName()
-                || ($scannerDetails && !in_array($method->getName(), $scannerDetails['methods']))
+                || ($scannerDetails && !in_array($method->getName(), $scannerDetails['methods'], true))
             ) {
                 continue;
             }

--- a/src/Utils/TokenScanner.php
+++ b/src/Utils/TokenScanner.php
@@ -22,7 +22,7 @@ use PhpParser\ParserFactory;
  */
 class TokenScanner
 {
-    /** @var array<string, array<class-string, array{uses: array<string, class-string>, interfaces: list<class-string>, traits: list<class-string>, enums: list<class-string>, methods: list<string>, properties: list<string>}>> */
+    /** @var array<string, array<class-string, array{uses: array<string, class-string>, interfaces: list<class-string>, traits: list<class-string>, enums: list<class-string>, methods: list<string>, properties: list<string>, consts: list<string>}>> */
     protected array $cache = [];
 
     /**
@@ -37,6 +37,7 @@ class TokenScanner
      *     enums: list<class-string>,
      *     methods: list<string>,
      *     properties: list<string>,
+     *     consts: list<string>,
      * }>
      */
     public function scanFile(string $filename): array
@@ -72,7 +73,7 @@ class TokenScanner
      *
      * Scans the file on demand if not already cached.
      *
-     * @return array{uses: array<string, class-string>, interfaces: list<class-string>, traits: list<class-string>, enums: list<class-string>, methods: list<string>, properties: list<string>}|null
+     * @return array{uses: array<string, class-string>, interfaces: list<class-string>, traits: list<class-string>, enums: list<class-string>, methods: list<string>, properties: list<string>,consts: list<string>}|null
      */
     public function detailsFor(\ReflectionClass $class): ?array
     {

--- a/src/Utils/TokenScanner.php
+++ b/src/Utils/TokenScanner.php
@@ -19,10 +19,20 @@ use PhpParser\ParserFactory;
 
 /**
  * High-level, PHP-token-based, scanner.
+ *
+ * @phpstan-type ScannerDetails array{
+ *     uses: array<string, class-string>,
+ *     interfaces: list<class-string>,
+ *     traits: list<class-string>,
+ *     enums: list<class-string>,
+ *     methods: list<string>,
+ *     properties: list<string>,
+ *     consts: list<string>,
+ * }
  */
 class TokenScanner
 {
-    /** @var array<string, array<class-string, array{uses: array<string, class-string>, interfaces: list<class-string>, traits: list<class-string>, enums: list<class-string>, methods: list<string>, properties: list<string>, consts: list<string>}>> */
+    /** @var array<string, array<class-string, ScannerDetails>> */
     protected array $cache = [];
 
     /**
@@ -30,15 +40,7 @@ class TokenScanner
      *
      * Results are cached by filename — repeated calls with the same path return the cached result.
      *
-     * @return array<class-string, array{
-     *     uses: array<string, class-string>,
-     *     interfaces: list<class-string>,
-     *     traits: list<class-string>,
-     *     enums: list<class-string>,
-     *     methods: list<string>,
-     *     properties: list<string>,
-     *     consts: list<string>,
-     * }>
+     * @return array<class-string, ScannerDetails>
      */
     public function scanFile(string $filename): array
     {
@@ -73,7 +75,7 @@ class TokenScanner
      *
      * Scans the file on demand if not already cached.
      *
-     * @return array{uses: array<string, class-string>, interfaces: list<class-string>, traits: list<class-string>, enums: list<class-string>, methods: list<string>, properties: list<string>,consts: list<string>}|null
+     * @return ScannerDetails|null
      */
     public function detailsFor(\ReflectionClass $class): ?array
     {

--- a/src/Utils/TokenScanner.php
+++ b/src/Utils/TokenScanner.php
@@ -105,6 +105,7 @@ class TokenScanner
                 'enums' => [],
                 'methods' => [],
                 'properties' => [],
+                'consts' => [],
             ];
         };
         $result = [];
@@ -155,6 +156,12 @@ class TokenScanner
         foreach ($stmt->getTraitUses() as $traitUse) {
             foreach ($traitUse->traits as $trait) {
                 $details['traits'][] = $resolve((string) $trait);
+            }
+        }
+
+        foreach ($stmt->getConstants() as $const) {
+            foreach ($const->consts as $c) {
+                $details['consts'][] = (string) $c->name;
             }
         }
 

--- a/tests/ExamplesTest.php
+++ b/tests/ExamplesTest.php
@@ -61,13 +61,13 @@ final class ExamplesTest extends OpenApiTestCase
 
                     foreach ($versions as $version) {
                         foreach ($modes as $mode) {
-                             if (
+                            if (
                                 ($implementation === 'spec' && in_array($mode, [Mode::CLASSIC, Mode::HYBRID], true))
                                 || ($implementation !== 'spec' && $mode === Mode::SPEC)
                                 || ($typeResolver instanceof LegacyTypeResolver && $mode !== Mode::CLASSIC)
-                             ) {
+                            ) {
                                 continue;
-                             }
+                            }
 
                             if (!file_exists(self::getSpecFilename($example, $implementation, $version, $mode))) {
                                 continue;

--- a/tests/ExamplesTest.php
+++ b/tests/ExamplesTest.php
@@ -39,7 +39,7 @@ final class ExamplesTest extends OpenApiTestCase
             'annotations',
             'attributes',
             'mixed', // classic annotations + attributes
-//            'spec',
+            'spec',
         ];
         $versions = [
             '3.0.0',
@@ -48,8 +48,8 @@ final class ExamplesTest extends OpenApiTestCase
         ];
         $modes = [
             Mode::CLASSIC,
-            // Mode::HYBRID,
-            // Mode::SPEC,
+            Mode::HYBRID,
+            Mode::SPEC,
         ];
 
         foreach (self::getTypeResolvers() as $resolverName => $typeResolver) {
@@ -61,13 +61,13 @@ final class ExamplesTest extends OpenApiTestCase
 
                     foreach ($versions as $version) {
                         foreach ($modes as $mode) {
-                            // if (
-                            //    ($implementation === 'spec' && in_array($mode, [Mode::CLASSIC, Mode::HYBRID], true))
-                            //    || ($implementation !== 'spec' && $mode === Mode::SPEC)
-                            //    || ($typeResolver instanceof LegacyTypeResolver && $mode !== Mode::CLASSIC)
-                            // ) {
-                            //    continue;
-                            // }
+                             if (
+                                ($implementation === 'spec' && in_array($mode, [Mode::CLASSIC, Mode::HYBRID], true))
+                                || ($implementation !== 'spec' && $mode === Mode::SPEC)
+                                || ($typeResolver instanceof LegacyTypeResolver && $mode !== Mode::CLASSIC)
+                             ) {
+                                continue;
+                             }
 
                             if (!file_exists(self::getSpecFilename($example, $implementation, $version, $mode))) {
                                 continue;

--- a/tests/Utils/TokenScannerTest.php
+++ b/tests/Utils/TokenScannerTest.php
@@ -26,6 +26,7 @@ final class TokenScannerTest extends OpenApiTestCase
                     'enums' => [],
                     'methods' => ['stuff', 'other', 'another'],
                     'properties' => [],
+                    'consts' => [],
                 ],
             ],
         ];
@@ -44,6 +45,7 @@ final class TokenScannerTest extends OpenApiTestCase
                         'return_ref',
                     ],
                     'properties' => [],
+                    'consts' => [],
                 ],
             ],
         ];
@@ -63,6 +65,7 @@ final class TokenScannerTest extends OpenApiTestCase
                     'enums' => [],
                     'methods' => [],
                     'properties' => [],
+                    'consts' => [],
                 ],
                 'OpenApi\Tests\Fixtures\PHP\GenericAttr' => [
                     'uses' => [],
@@ -71,6 +74,7 @@ final class TokenScannerTest extends OpenApiTestCase
                     'enums' => [],
                     'methods' => ['__construct'],
                     'properties' => [],
+                    'consts' => [],
                 ],
                 'OpenApi\Tests\Fixtures\PHP\Decorated' => [
                     'uses' => [],
@@ -79,6 +83,7 @@ final class TokenScannerTest extends OpenApiTestCase
                     'enums' => [],
                     'methods' => ['foo', 'bar'],
                     'properties' => [],
+                    'consts' => [],
                 ],
             ],
         ];
@@ -93,6 +98,7 @@ final class TokenScannerTest extends OpenApiTestCase
                     'enums' => [],
                     'methods' => ['extendsClassFunc'],
                     'properties' => ['extendsClassProp'],
+                    'consts' => [],
                 ],
             ],
         ];
@@ -107,6 +113,7 @@ final class TokenScannerTest extends OpenApiTestCase
                     'enums' => [],
                     'methods' => [],
                     'properties' => [],
+                    'consts' => [],
                 ],
             ],
         ];
@@ -121,6 +128,7 @@ final class TokenScannerTest extends OpenApiTestCase
                     'enums' => [],
                     'methods' => ['firstname', 'secondname', 'thirdname', 'fourthname', 'lastname', 'tags', 'submittedBy', 'friends', 'bestFriend'],
                     'properties' => [],
+                    'consts' => [],
                 ],
             ],
         ];
@@ -138,6 +146,7 @@ final class TokenScannerTest extends OpenApiTestCase
                     'enums' => [],
                     'methods' => [],
                     'properties' => [],
+                    'consts' => [],
                 ],
             ],
         ];
@@ -156,6 +165,9 @@ final class TokenScannerTest extends OpenApiTestCase
                     'enums' => [],
                     'methods' => ['getFirstName'],
                     'properties' => [],
+                    'consts' => [
+                        'CONSTANT',
+                    ],
                 ],
             ],
         ];
@@ -176,6 +188,7 @@ final class TokenScannerTest extends OpenApiTestCase
                     'enums' => [],
                     'methods' => [],
                     'properties' => ['greet'],
+                    'consts' => [],
                 ],
             ],
         ];
@@ -193,6 +206,7 @@ final class TokenScannerTest extends OpenApiTestCase
                     'enums' => [],
                     'methods' => ['__construct'],
                     'properties' => ['labels', 'tags', 'id'],
+                    'consts' => [],
                 ],
             ],
         ];
@@ -209,6 +223,7 @@ final class TokenScannerTest extends OpenApiTestCase
                     'enums' => [],
                     'methods' => ['useFoo', 'foo'],
                     'properties' => [],
+                    'consts' => [],
                 ],
                 'OpenApi\Tests\Fixtures\PHP\ReservedWordsAttr' => [
                     'uses' => [
@@ -219,6 +234,7 @@ final class TokenScannerTest extends OpenApiTestCase
                     'enums' => [],
                     'methods' => ['__construct'],
                     'properties' => [],
+                    'consts' => [],
                 ],
                 'OpenApi\Tests\Fixtures\PHP\UserlandClass' => [
                     'uses' => [
@@ -228,6 +244,7 @@ final class TokenScannerTest extends OpenApiTestCase
                     'traits' => [],
                     'enums' => [],
                     'methods' => [],
+                    'consts' => [],
                     'properties' => [],
                 ],
             ],
@@ -253,6 +270,7 @@ final class TokenScannerTest extends OpenApiTestCase
                         'curlyOpen',
                     ],
                     'properties' => [],
+                    'consts' => [],
                 ],
             ],
         ];
@@ -272,6 +290,7 @@ final class TokenScannerTest extends OpenApiTestCase
                         'second',
                     ],
                     'properties' => [],
+                    'consts' => [],
                 ],
             ],
         ];
@@ -286,6 +305,7 @@ final class TokenScannerTest extends OpenApiTestCase
                     'enums' => [],
                     'methods' => [],
                     'properties' => [],
+                    'consts' => [],
                 ],
                 'Bar\BarClass' => [
                     'uses' => [],
@@ -294,6 +314,7 @@ final class TokenScannerTest extends OpenApiTestCase
                     'enums' => [],
                     'methods' => [],
                     'properties' => [],
+                    'consts' => [],
                 ],
             ],
         ];
@@ -308,6 +329,7 @@ final class TokenScannerTest extends OpenApiTestCase
                     'traits' => [],
                     'methods' => [],
                     'properties' => [],
+                    'consts' => [],
                 ],
                 'Bar\BarClass' => [
                     'uses' => [],
@@ -316,6 +338,7 @@ final class TokenScannerTest extends OpenApiTestCase
                     'enums' => [],
                     'methods' => [],
                     'properties' => [],
+                    'consts' => [],
                 ],
             ],
         ];
@@ -330,6 +353,7 @@ final class TokenScannerTest extends OpenApiTestCase
                     'enums' => [],
                     'methods' => [],
                     'properties' => [],
+                    'consts' => [],
                 ],
             ],
         ];
@@ -344,6 +368,7 @@ final class TokenScannerTest extends OpenApiTestCase
                     'enums' => [],
                     'methods' => [],
                     'properties' => [],
+                    'consts' => [],
                 ],
                 'OpenApi\Tests\Fixtures\PHP\MultiNamespace' => [
                     'uses' => [],
@@ -352,6 +377,7 @@ final class TokenScannerTest extends OpenApiTestCase
                     'enums' => [],
                     'methods' => [],
                     'properties' => [],
+                    'consts' => [],
                 ],
             ],
         ];
@@ -368,6 +394,7 @@ final class TokenScannerTest extends OpenApiTestCase
                     'traits' => [],
                     'methods' => [],
                     'properties' => [],
+                    'consts' => [],
                 ],
             ],
         ];
@@ -384,6 +411,7 @@ final class TokenScannerTest extends OpenApiTestCase
                     'traits' => [],
                     'methods' => [],
                     'properties' => [],
+                    'consts' => [],
                 ],
             ],
         ];


### PR DESCRIPTION
## Summary

* Use TokenScanner details to complement reflection data to accurately resolve and merge inheritance.
* Handle schema property refs needing rewrite due to properties moved into `allOf`