### PR TITLE
feat(BETA): apply CLI config to augmenters pipeline when mode is `SPEC`

### DIFF
--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -9,6 +9,7 @@ namespace OpenApi\Console;
 use OpenApi\Builder;
 use OpenApi\Builder\Result;
 use OpenApi\Generator;
+use OpenApi\Utils\Pipeline;
 use OpenApi\Utils\SourceFinder;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Attribute\MapInput;
@@ -79,7 +80,7 @@ class GenerateCommand
 
         if ($input->config || $input->addProcessor || $input->removeProcessor) {
             $builder->withGenerator(function (Generator $generator) use ($input): void {
-                if ($input->config) {
+                if ($input->config && $input->mode !== Builder\Mode::SPEC) {
                     $generator->setConfig($input->config);
                 }
 
@@ -99,6 +100,12 @@ class GenerateCommand
                         : '\OpenApi\Processors\\' . ucfirst((string) $processor);
                     $generator->getProcessorPipeline()->remove($class);
                 }
+            });
+        }
+
+        if ($input->config && $input->mode === Builder\Mode::SPEC) {
+            $builder->withAugmenters(function (Pipeline $augmenters) use ($input): void {
+                $augmenters->configure($input->config);
             });
         }
 

--- a/src/Console/GenerateInput.php
+++ b/src/Console/GenerateInput.php
@@ -16,7 +16,7 @@ class GenerateInput
     #[Argument('Source path(s) to scan')]
     public array $paths;
 
-    #[Option('Generator config (e.g. -c operationId.hash=false)', shortcut: 'c')]
+    #[Option('Generator/Augmenter config (e.g. -c operationId.hash=false)', shortcut: 'c')]
     public array $config = [];
 
     #[Option('Show default config', shortcut: 'D')]

--- a/src/Utils/Pipeline.php
+++ b/src/Utils/Pipeline.php
@@ -80,6 +80,28 @@ class Pipeline extends TypedList
         return $payload;
     }
 
+    public function configure(array $config): void
+    {
+        $config = $this->normaliseConfig($config);
+
+        $walker = function (callable $pipe) use ($config): void {
+            $rc = new \ReflectionClass($pipe);
+
+            // apply config
+            $pipeKey = lcfirst($rc->getShortName());
+            if (array_key_exists($pipeKey, $config)) {
+                foreach ($config[$pipeKey] as $name => $value) {
+                    $setter = 'set' . ucfirst($name);
+                    if (method_exists($pipe, $setter)) {
+                        $pipe->{$setter}($value);
+                    }
+                }
+            }
+        };
+
+        $this->walk($walker);
+    }
+
     /**
      * Return pipes in execution order: grouped if groups are configured, otherwise insertion order.
      *
@@ -113,5 +135,45 @@ class Pipeline extends TypedList
         return $group instanceof \BackedEnum
             ? (string) $group->value
             : $group;
+    }
+
+    protected function normaliseConfig(array $config): array
+    {
+        $normalised = [];
+        foreach ($config as $key => $value) {
+            if (is_numeric($key)) {
+                $token = explode('=', (string) $value);
+                if (2 === count($token)) {
+                    // 'operationId.hash=false'
+                    [$key, $value] = $token;
+                }
+            }
+
+            if (in_array($value, ['true', 'false'])) {
+                $value = 'true' == $value;
+            }
+
+            if ($isList = (str_ends_with((string) $key, '[]'))) {
+                $key = substr((string) $key, 0, -2);
+            }
+            $token = explode('.', (string) $key);
+            if (2 === count($token)) {
+                // 'operationId.hash' => false
+                // namespaced / pipe
+                if ($isList) {
+                    $normalised[$token[0]][$token[1]][] = $value;
+                } else {
+                    $normalised[$token[0]][$token[1]] = $value;
+                }
+            } else {
+                if ($isList) {
+                    $normalised[$key][] = $value;
+                } else {
+                    $normalised[$key] = $value;
+                }
+            }
+        }
+
+        return $normalised;
     }
 }

--- a/tests/Utils/PipelineTest.php
+++ b/tests/Utils/PipelineTest.php
@@ -6,8 +6,10 @@
 
 namespace OpenApi\Tests\Utils;
 
+use OpenApi\Augmenter\OperationIds;
 use OpenApi\Utils\PipeInterface;
 use OpenApi\Utils\Pipeline;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class PipelineTest extends TestCase
@@ -142,6 +144,27 @@ final class PipelineTest extends TestCase
         });
 
         $this->assertSame(['a', 'b'], $names);
+    }
+
+    public static function configCases(): \Iterator
+    {
+        yield 'default' => [[], true];
+        yield 'nested' => [['operationIds' => ['hash' => false]], false];
+        yield 'dots-kv' => [['operationIds.hash' => false], false];
+        yield 'dots-string' => [['operationIds.hash=false'], false];
+    }
+
+    #[DataProvider('configCases')]
+    public function testConfigure(array $config, bool $expected): void
+    {
+        $pipeline = new Pipeline([new OperationIds(hash: true)]);
+
+        $pipeline->configure($config);
+
+        $operationIds = $pipeline->get(OperationIds::class);
+        $rp = new \ReflectionProperty(OperationIds::class, 'hash');
+        $this->assertInstanceOf(OperationIds::class, $operationIds);
+        $this->assertEquals($expected, $rp->getValue($operationIds));
     }
 
     // --- Grouping ---


### PR DESCRIPTION
## Summary

When passing configuration options on the command line distinguish between `Generator` and augmentor pipeline (mode === spec).