### PR TITLE
feat(BETA): align callable signatures and drop `SpecificationWalker::eacheSchema()`

### DIFF
--- a/src/Augmenter/Enums.php
+++ b/src/Augmenter/Enums.php
@@ -109,7 +109,7 @@ class Enums implements PipeInterface
 
     protected function resolveEnumValues(Specification $specification): void
     {
-        $specification->getWalker()->eachSchema(function (OA\Schema $schema): void {
+        $specification->getWalker()->visit(OA\Schema::class, function (OA\Schema $schema): void {
             if ($schema->enum === null) {
                 return;
             }

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -115,7 +115,7 @@ class Builder
     /**
      * Configure the augmenter pipeline via callable.
      *
-     * @param callable(Utils\Pipeline<Specification>): void $hook
+     * @param callable(Utils\Pipeline<Specification>): (Utils\Pipeline<Specification>|void) $hook
      */
     public function withAugmenters(callable $hook): static
     {
@@ -132,7 +132,7 @@ class Builder
     }
 
     /**
-     * @param callable(AttributeFactory):void $hook
+     * @param callable(AttributeFactory): (AttributeFactory|void) $hook
      */
     public function withAttributeFactory(callable $hook): static
     {

--- a/src/Compiler/OpenApi31Compiler.php
+++ b/src/Compiler/OpenApi31Compiler.php
@@ -809,7 +809,7 @@ class OpenApi31Compiler implements CompilerInterface
     protected function collectSchemas(Specification $specification): array
     {
         $schemas = [];
-        $specification->getWalker()->eachSchema(function (OA\Schema $schema) use (&$schemas): void {
+        $specification->getWalker()->visit(OA\Schema::class, function (OA\Schema $schema) use (&$schemas): void {
             $schemas[] = $schema;
         });
 

--- a/src/Utils/AttributeFactory.php
+++ b/src/Utils/AttributeFactory.php
@@ -61,7 +61,7 @@ class AttributeFactory
     }
 
     /**
-     * @param callable(TypedList<AttributeTranslatorInterface>): void $hook
+     * @param callable(TypedList<AttributeTranslatorInterface>): (TypedList<AttributeTranslatorInterface>|void) $hook
      */
     public function withTranslators(callable $hook): static
     {

--- a/tests/Augmenter/CleanupPerformanceTest.php
+++ b/tests/Augmenter/CleanupPerformanceTest.php
@@ -34,7 +34,6 @@ final class CleanupPerformanceTest extends TestCase
 
         $withPipeline = (new Builder())->getAugmenters();
         $withoutPipeline = (new Builder())
-            /* @phpstan-ignore argument.type */
             ->withAugmenters(fn (Pipeline $pipeline): Pipeline => $pipeline->remove(Augmenter\Cleanup::class))
             ->getAugmenters();
 


### PR DESCRIPTION
## Summary

Align callable return types so short functions do not cause type issues.

Also remove a specail case method `SpecificationWalker::eachSchema()`