### PR TITLE
Exclude empty tags array from serialization

### DIFF
--- a/src/Annotations/OpenApi.php
+++ b/src/Annotations/OpenApi.php
@@ -296,6 +296,10 @@ class OpenApi extends AbstractAnnotation
 
     public function jsonSerialize(): \stdClass
     {
+        if ($this->tags === []) {
+            $this->tags = Undefined::UNDEFINED;
+        }
+
         $data = parent::jsonSerialize();
 
         if ($this->_context->isVersion('3.0.x')) {

--- a/src/Annotations/OpenApi.php
+++ b/src/Annotations/OpenApi.php
@@ -296,14 +296,14 @@ class OpenApi extends AbstractAnnotation
 
     public function jsonSerialize(): \stdClass
     {
-        if ($this->tags === []) {
-            $this->tags = Undefined::UNDEFINED;
-        }
-
         $data = parent::jsonSerialize();
 
         if ($this->_context->isVersion('3.0.x')) {
             unset($data->webhooks);
+        }
+
+        if (isset($data->tags) && $data->tags === []) {
+            unset($data->tags);
         }
 
         return $data;

--- a/src/Processors/AugmentTags.php
+++ b/src/Processors/AugmentTags.php
@@ -108,7 +108,9 @@ class AugmentTags
                 if (false !== $index = array_search($tag, $analysis->openapi->tags, true)) {
                     $analysis->removeAnnotation($tag);
                     unset($analysis->openapi->tags[$index]);
-                    $analysis->openapi->tags = array_values($analysis->openapi->tags);
+                    if ($analysis->openapi->tags !== []) {
+                        $analysis->openapi->tags = array_values($analysis->openapi->tags);
+                    }
                 }
             }
         }

--- a/tests/Fixtures/Scratch/VendorExtensions3.0.0.yaml
+++ b/tests/Fixtures/Scratch/VendorExtensions3.0.0.yaml
@@ -10,4 +10,3 @@ paths:
       responses:
         '200':
           description: OK
-tags: []

--- a/tests/Fixtures/Scratch/VendorExtensions3.1.0.yaml
+++ b/tests/Fixtures/Scratch/VendorExtensions3.1.0.yaml
@@ -10,4 +10,3 @@ paths:
       responses:
         '200':
           description: OK
-tags: []

--- a/tests/Fixtures/Scratch/VendorExtensions3.2.0.yaml
+++ b/tests/Fixtures/Scratch/VendorExtensions3.2.0.yaml
@@ -10,4 +10,3 @@ paths:
       responses:
         '200':
           description: OK
-tags: []


### PR DESCRIPTION
## Summary

Avoid generating empty tags element.
```
    tags: []
```