### PR TITLE
feat(Spec): widen the type of the `content` parameter (`MediaType`) to accept `MediaType|array|null`

### DIFF
--- a/src/Spec/AbstractAttribute.php
+++ b/src/Spec/AbstractAttribute.php
@@ -94,4 +94,20 @@ abstract class AbstractAttribute implements AttributeInterface
 
         return $this->sourceLocation;
     }
+
+    /**
+     * @template T
+     *
+     * @param T|list<T>|null $value
+     *
+     * @return list<T>|null
+     */
+    protected static function wrapList(mixed $value): ?array
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return is_array($value) ? $value : [$value];
+    }
 }

--- a/src/Spec/Header.php
+++ b/src/Spec/Header.php
@@ -16,20 +16,23 @@ use OpenApi\Undefined;
 #[\Attribute(\Attribute::IS_REPEATABLE)]
 class Header extends AbstractAttribute
 {
+    /** @var list<MediaType>|null */
+    public ?array $content = null;
+
     /**
-     * @param string|null              $header      The header name (component key)
-     * @param string|null              $description A brief description of the header (CommonMark syntax)
-     * @param bool|null                $required    Whether the header is mandatory
-     * @param bool|null                $deprecated  Whether the header is deprecated
-     * @param string|null              $ref         A JSON Reference to a reusable header
-     * @param string|null              $style       How the header value is serialized
-     * @param bool|null                $explode     Whether arrays/objects generate separate parameters
-     * @param Schema|null              $schema      The schema defining the type for the header
-     * @param mixed                    $example     Example of the header's value
-     * @param list<Example>|null       $examples    Examples of the header's value
-     * @param list<MediaType>|null     $content     Content-type based header serialization
-     * @param array<string,mixed>|null $x           Vendor extensions (x-* properties)
-     * @param list<Attachable>|null    $attachables Reusable custom attachable attributes
+     * @param string|null                    $header      The header name (component key)
+     * @param string|null                    $description A brief description of the header (CommonMark syntax)
+     * @param bool|null                      $required    Whether the header is mandatory
+     * @param bool|null                      $deprecated  Whether the header is deprecated
+     * @param string|null                    $ref         A JSON Reference to a reusable header
+     * @param string|null                    $style       How the header value is serialized
+     * @param bool|null                      $explode     Whether arrays/objects generate separate parameters
+     * @param Schema|null                    $schema      The schema defining the type for the header
+     * @param mixed                          $example     Example of the header's value
+     * @param list<Example>|null             $examples    Examples of the header's value
+     * @param MediaType|list<MediaType>|null $content     Content-type based header serialization
+     * @param array<string,mixed>|null       $x           Vendor extensions (x-* properties)
+     * @param list<Attachable>|null          $attachables Reusable custom attachable attributes
      */
     public function __construct(
         public ?string $header = null,
@@ -42,11 +45,12 @@ class Header extends AbstractAttribute
         public ?Schema $schema = null,
         public mixed $example = Undefined::UNDEFINED,
         public ?array $examples = null,
-        public ?array $content = null,
+        MediaType|array|null $content = null,
         ?array $x = null,
         ?array $attachables = null,
     ) {
         parent::__construct(x: $x, attachables: $attachables);
+        $this->content = self::wrapList($content);
     }
 
     public function merge(): array

--- a/src/Spec/Parameter.php
+++ b/src/Spec/Parameter.php
@@ -42,24 +42,27 @@ use OpenApi\Undefined;
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY | \Attribute::TARGET_PARAMETER | \Attribute::IS_REPEATABLE)]
 class Parameter extends AbstractAttribute
 {
+    /** @var list<MediaType>|null */
+    public ?array $content = null;
+
     /**
-     * @param string|null              $parameter       Reusable parameter identifier (component key)
-     * @param string|null              $name            The name of the parameter
-     * @param string|null              $in              The location of the parameter (query, header, path, cookie)
-     * @param string|null              $description     A brief description of the parameter (CommonMark syntax)
-     * @param bool|null                $required        Whether the parameter is mandatory
-     * @param bool|null                $deprecated      Whether the parameter is deprecated
-     * @param bool|null                $allowEmptyValue Whether empty-valued parameters are allowed
-     * @param string|null              $ref             A JSON Reference to a reusable parameter
-     * @param string|null              $style           How the parameter value is serialized
-     * @param bool|null                $explode         Whether arrays/objects generate separate parameters
-     * @param bool|null                $allowReserved   Whether reserved characters are allowed without encoding
-     * @param Schema|null              $schema          The schema defining the type for the parameter
-     * @param mixed                    $example         Example of the parameter's value
-     * @param list<Example>|null       $examples        Examples of the parameter's value
-     * @param list<MediaType>|null     $content         Content-type based parameter serialization
-     * @param array<string,mixed>|null $x               Vendor extensions (x-* properties)
-     * @param list<Attachable>|null    $attachables     Reusable custom attachable attributes
+     * @param string|null                    $parameter       Reusable parameter identifier (component key)
+     * @param string|null                    $name            The name of the parameter
+     * @param string|null                    $in              The location of the parameter (query, header, path, cookie)
+     * @param string|null                    $description     A brief description of the parameter (CommonMark syntax)
+     * @param bool|null                      $required        Whether the parameter is mandatory
+     * @param bool|null                      $deprecated      Whether the parameter is deprecated
+     * @param bool|null                      $allowEmptyValue Whether empty-valued parameters are allowed
+     * @param string|null                    $ref             A JSON Reference to a reusable parameter
+     * @param string|null                    $style           How the parameter value is serialized
+     * @param bool|null                      $explode         Whether arrays/objects generate separate parameters
+     * @param bool|null                      $allowReserved   Whether reserved characters are allowed without encoding
+     * @param Schema|null                    $schema          The schema defining the type for the parameter
+     * @param mixed                          $example         Example of the parameter's value
+     * @param list<Example>|null             $examples        Examples of the parameter's value
+     * @param MediaType|list<MediaType>|null $content         Content-type based parameter serialization
+     * @param array<string,mixed>|null       $x               Vendor extensions (x-* properties)
+     * @param list<Attachable>|null          $attachables     Reusable custom attachable attributes
      */
     public function __construct(
         public ?string $parameter = null,
@@ -76,11 +79,12 @@ class Parameter extends AbstractAttribute
         public ?Schema $schema = null,
         public mixed $example = Undefined::UNDEFINED,
         public ?array $examples = null,
-        public ?array $content = null,
+        MediaType|array|null $content = null,
         ?array $x = null,
         ?array $attachables = null,
     ) {
         parent::__construct(x: $x, attachables: $attachables);
+        $this->content = self::wrapList($content);
     }
 
     public function isRoot(): bool

--- a/src/Spec/Parameter/Cookie.php
+++ b/src/Spec/Parameter/Cookie.php
@@ -18,10 +18,10 @@ use OpenApi\Undefined;
 class Cookie extends OA\Parameter
 {
     /**
-     * @param list<OA\Example>|null    $examples
-     * @param list<OA\MediaType>|null  $content
-     * @param array<string,mixed>|null $x
-     * @param list<OA\Attachable>|null $attachables
+     * @param list<OA\Example>|null                $examples
+     * @param OA\MediaType|list<OA\MediaType>|null $content
+     * @param array<string,mixed>|null             $x
+     * @param list<OA\Attachable>|null             $attachables
      */
     public function __construct(
         ?string $parameter = null,
@@ -34,7 +34,7 @@ class Cookie extends OA\Parameter
         ?OA\Schema $schema = null,
         mixed $example = Undefined::UNDEFINED,
         ?array $examples = null,
-        ?array $content = null,
+        OA\MediaType|array|null $content = null,
         ?array $x = null,
         ?array $attachables = null,
     ) {

--- a/src/Spec/Parameter/Header.php
+++ b/src/Spec/Parameter/Header.php
@@ -18,10 +18,10 @@ use OpenApi\Undefined;
 class Header extends OA\Parameter
 {
     /**
-     * @param list<OA\Example>|null    $examples
-     * @param list<OA\MediaType>|null  $content
-     * @param array<string,mixed>|null $x
-     * @param list<OA\Attachable>|null $attachables
+     * @param list<OA\Example>|null                $examples
+     * @param OA\MediaType|list<OA\MediaType>|null $content
+     * @param array<string,mixed>|null             $x
+     * @param list<OA\Attachable>|null             $attachables
      */
     public function __construct(
         ?string $parameter = null,
@@ -34,7 +34,7 @@ class Header extends OA\Parameter
         ?OA\Schema $schema = null,
         mixed $example = Undefined::UNDEFINED,
         ?array $examples = null,
-        ?array $content = null,
+        OA\MediaType|array|null $content = null,
         ?array $x = null,
         ?array $attachables = null,
     ) {

--- a/src/Spec/Parameter/Path.php
+++ b/src/Spec/Parameter/Path.php
@@ -18,10 +18,10 @@ use OpenApi\Undefined;
 class Path extends OA\Parameter
 {
     /**
-     * @param list<OA\Example>|null    $examples
-     * @param list<OA\MediaType>|null  $content
-     * @param array<string,mixed>|null $x
-     * @param list<OA\Attachable>|null $attachables
+     * @param list<OA\Example>|null                $examples
+     * @param OA\MediaType|list<OA\MediaType>|null $content
+     * @param array<string,mixed>|null             $x
+     * @param list<OA\Attachable>|null             $attachables
      */
     public function __construct(
         ?string $parameter = null,
@@ -34,7 +34,7 @@ class Path extends OA\Parameter
         ?OA\Schema $schema = null,
         mixed $example = Undefined::UNDEFINED,
         ?array $examples = null,
-        ?array $content = null,
+        OA\MediaType|array|null $content = null,
         ?array $x = null,
         ?array $attachables = null,
     ) {

--- a/src/Spec/Parameter/Query.php
+++ b/src/Spec/Parameter/Query.php
@@ -18,10 +18,10 @@ use OpenApi\Undefined;
 class Query extends OA\Parameter
 {
     /**
-     * @param list<OA\Example>|null    $examples
-     * @param list<OA\MediaType>|null  $content
-     * @param array<string,mixed>|null $x
-     * @param list<OA\Attachable>|null $attachables
+     * @param list<OA\Example>|null                $examples
+     * @param OA\MediaType|list<OA\MediaType>|null $content
+     * @param array<string,mixed>|null             $x
+     * @param list<OA\Attachable>|null             $attachables
      */
     public function __construct(
         ?string $parameter = null,
@@ -37,7 +37,7 @@ class Query extends OA\Parameter
         ?OA\Schema $schema = null,
         mixed $example = Undefined::UNDEFINED,
         ?array $examples = null,
-        ?array $content = null,
+        OA\MediaType|array|null $content = null,
         ?array $x = null,
         ?array $attachables = null,
     ) {

--- a/src/Spec/RequestBody.php
+++ b/src/Spec/RequestBody.php
@@ -14,25 +14,29 @@ namespace OpenApi\Spec;
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class RequestBody extends AbstractAttribute
 {
+    /** @var list<MediaType>|null */
+    public ?array $content = null;
+
     /**
-     * @param string|null              $request     Reusable request body identifier (component key)
-     * @param string|null              $description A brief description of the request body (CommonMark syntax)
-     * @param bool|null                $required    Whether the request body is required
-     * @param string|null              $ref         A JSON Reference to a reusable request body
-     * @param list<MediaType>|null     $content     The content of the request body
-     * @param array<string,mixed>|null $x           Vendor extensions (x-* properties)
-     * @param list<Attachable>|null    $attachables Reusable custom attachable attributes
+     * @param string|null                    $request     Reusable request body identifier (component key)
+     * @param string|null                    $description A brief description of the request body (CommonMark syntax)
+     * @param bool|null                      $required    Whether the request body is required
+     * @param string|null                    $ref         A JSON Reference to a reusable request body
+     * @param MediaType|list<MediaType>|null $content     The content of the request body
+     * @param array<string,mixed>|null       $x           Vendor extensions (x-* properties)
+     * @param list<Attachable>|null          $attachables Reusable custom attachable attributes
      */
     public function __construct(
         public ?string $request = null,
         public ?string $description = null,
         public ?bool $required = null,
         public ?string $ref = null,
-        public ?array $content = null,
+        MediaType|array|null $content = null,
         ?array $x = null,
         ?array $attachables = null,
     ) {
         parent::__construct(x: $x, attachables: $attachables);
+        $this->content = self::wrapList($content);
     }
 
     public function isRoot(): bool

--- a/src/Spec/Response.php
+++ b/src/Spec/Response.php
@@ -14,27 +14,31 @@ namespace OpenApi\Spec;
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class Response extends AbstractAttribute
 {
+    /** @var list<MediaType>|null */
+    public ?array $content = null;
+
     /**
-     * @param string|int|null          $response    The HTTP status code or 'default'
-     * @param string|null              $description A description of the response (CommonMark syntax)
-     * @param string|null              $ref         A JSON Reference to a reusable response
-     * @param list<Header>|null        $headers     Headers sent with the response
-     * @param list<MediaType>|null     $content     Possible response payloads
-     * @param list<Link>|null          $links       Design-time links for the response
-     * @param array<string,mixed>|null $x           Vendor extensions (x-* properties)
-     * @param list<Attachable>|null    $attachables Reusable custom attachable attributes
+     * @param string|int|null                $response    The HTTP status code or 'default'
+     * @param string|null                    $description A description of the response (CommonMark syntax)
+     * @param string|null                    $ref         A JSON Reference to a reusable response
+     * @param list<Header>|null              $headers     Headers sent with the response
+     * @param MediaType|list<MediaType>|null $content     Possible response payloads
+     * @param list<Link>|null                $links       Design-time links for the response
+     * @param array<string,mixed>|null       $x           Vendor extensions (x-* properties)
+     * @param list<Attachable>|null          $attachables Reusable custom attachable attributes
      */
     public function __construct(
         public string|int|null $response = null,
         public ?string $description = null,
         public ?string $ref = null,
         public ?array $headers = null,
-        public ?array $content = null,
+        MediaType|array|null $content = null,
         public ?array $links = null,
         ?array $x = null,
         ?array $attachables = null,
     ) {
         parent::__construct(x: $x, attachables: $attachables);
+        $this->content = self::wrapList($content);
     }
 
     public function isRoot(): bool


### PR DESCRIPTION
## Summary

Updates all `spec` attributes with a `content` attribute, wideing the type to accept both a single `MediaType` instance or a `list`.