### PR TITLE
feat(Spec): add string-backed enums for fixed OpenAPI spec values

### DIFF
--- a/docs/examples/specs/misc/spec/MultiValueQueryParamEndpoint.php
+++ b/docs/examples/specs/misc/spec/MultiValueQueryParamEndpoint.php
@@ -24,7 +24,7 @@ class MultiValueQueryParamEndpoint
         parameters: [
             new OA\Parameter(
                 name: 'things[]',
-                in: 'query',
+                in: OA\ParameterIn::Query,
                 description: 'A list of things.',
                 required: false,
                 schema: new OA\Schema(type: 'array', items: new OA\Schema(type: 'integer')),

--- a/docs/examples/specs/petstore/spec/Controllers/PetController.php
+++ b/docs/examples/specs/petstore/spec/Controllers/PetController.php
@@ -45,7 +45,7 @@ class PetController
     #[OA\Operation\Get(path: '/pet/findByStatus', operationId: 'findPetsByStatus', summary: 'Finds Pets by status', description: 'Multiple status values can be provided with comma separated string', tags: ['pet'], parameters: [
         new OA\Parameter(
             name: 'status',
-            in: 'query',
+            in: OA\ParameterIn::Query,
             description: 'Status values that needed to be considered for filter',
             required: true,
             explode: true,
@@ -97,7 +97,7 @@ class PetController
     #[OA\Operation\Get(path: '/pet/{petId}', operationId: 'getPetById', summary: 'Find pet by ID', description: 'Returns a single pet', tags: ['pet'], parameters: [
         new OA\Parameter(
             name: 'petId',
-            in: 'path',
+            in: OA\ParameterIn::Path,
             description: 'ID of pet to return',
             required: true,
             schema: new OA\Schema(type: 'integer', format: 'int64'),

--- a/docs/examples/specs/petstore/spec/Security.php
+++ b/docs/examples/specs/petstore/spec/Security.php
@@ -17,7 +17,7 @@ use OpenApi\Spec as OA;
         ],
     ),
 ])]
-#[OA\Security\Scheme\ApiKey(securityScheme: 'api_key', name: 'api_key', in: 'header')]
+#[OA\Security\Scheme\ApiKey(securityScheme: 'api_key', name: 'api_key', in: OA\SchemeIn::Header)]
 class Security
 {
 }

--- a/docs/examples/specs/using-refs/spec/ProductParameter.php
+++ b/docs/examples/specs/using-refs/spec/ProductParameter.php
@@ -14,7 +14,7 @@ class ProductParameter
     #[OA\Parameter(
         parameter: 'product_id_in_path_required',
         name: 'product_id',
-        in: 'path',
+        in: OA\ParameterIn::Path,
         description: 'The ID of the product',
         required: true,
         schema: new OA\Schema(type: 'integer', format: 'int64'),

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -117,6 +117,21 @@ class CustomAugmenter implements PipeInterface
 }
 ```
 
+## Design principles
+
+### Normalise early, store simple
+
+When a property has both a rich input type (e.g. a PHP enum) and a plain serialization type (e.g. string), accept both on input but normalise to the plain type immediately in the constructor. Properties always store the simple form — enums, objects, and convenience types are input sugar only. This keeps downstream code (augmenters, compilers, serialization) free of type-checking branches.
+
+```php
+// Example: FlowType enum accepted on input, stored as string
+public function __construct(string|FlowType|null $flow = null) {
+    parent::__construct([
+        'flow' => $flow instanceof \BackedEnum ? $flow->value : $flow,
+    ]);
+}
+```
+
 ## Compilers
 
 Each OpenAPI version has its own compiler that handles version-specific output differences:

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -117,6 +117,18 @@ class CustomAugmenter implements PipeInterface
 }
 ```
 
+## Compilers
+
+Each OpenAPI version has its own compiler that handles version-specific output differences:
+
+| Compiler | Version | Key differences                                                   |
+|---|---|-------------------------------------------------------------------|
+| `Compiler30` | 3.0.x | `nullable` as property, `exclusiveMinimum` as boolean             |
+| `Compiler31` | 3.1.x | `nullable` via type array, `exclusiveMinimum` as number, webhooks |
+| `Compiler32` | 3.2.x | Extends 3.1 (currently without additional features)               |
+
+The compiler transforms a Specification into a plain PHP array representing the OpenAPI document. Version selection is automatic based on `Builder::setVersion()` or the `#[OA\OpenApi(version: '...')]` attribute.
+
 ## Design principles
 
 ### Normalise early, store simple
@@ -132,19 +144,7 @@ public function __construct(string|FlowType|null $flow = null) {
 }
 ```
 
-## Compilers
-
-Each OpenAPI version has its own compiler that handles version-specific output differences:
-
-| Compiler | Version | Key differences                                                   |
-|---|---|-------------------------------------------------------------------|
-| `Compiler30` | 3.0.x | `nullable` as property, `exclusiveMinimum` as boolean             |
-| `Compiler31` | 3.1.x | `nullable` via type array, `exclusiveMinimum` as number, webhooks |
-| `Compiler32` | 3.2.x | Extends 3.1 (currently without additional features)               |
-
-The compiler transforms a Specification into a plain PHP array representing the OpenAPI document. Version selection is automatic based on `Builder::setVersion()` or the `#[OA\OpenApi(version: '...')]` attribute.
-
-## Reflectors as glue
+### Reflectors as glue
 
 Every root DTO carries its originating reflector (`ReflectionClass`, `ReflectionMethod`, etc.). This is the fundamental mechanism for resolving cross-bucket relationships at augmentation time.
 
@@ -157,7 +157,7 @@ Key applications:
 
 This design keeps the Assembler simple (just collect into buckets) and makes cross-cutting relationships resolvable without coupling DTOs to each other.
 
-## DTO class tree
+### DTO class tree
 
 All spec attributes extend `AbstractAttribute` and live in the `OpenApi\Spec` namespace:
 

--- a/docs/spec-attributes.md
+++ b/docs/spec-attributes.md
@@ -412,4 +412,4 @@ Re-evaluate support for convenience attributes that reduce boilerplate in common
 - test to verify merges()/contains() consistency (with property type checks)
 - attachable example/test
 - review [] property types that could also accept a single: type|list<type>
-.- enums for fixed strings, like flows->implicit, etc
+~~- enums for fixed strings, like flows->implicit, etc~~

--- a/src/Spec/Encoding.php
+++ b/src/Spec/Encoding.php
@@ -14,27 +14,30 @@ namespace OpenApi\Spec;
 #[\Attribute(\Attribute::IS_REPEATABLE)]
 class Encoding extends AbstractAttribute
 {
+    public ?string $style = null;
+
     /**
-     * @param string|null              $encoding      The property name this encoding applies to
-     * @param string|null              $contentType   The Content-Type for encoding a specific property
-     * @param list<Header>|null        $headers       Additional headers for multipart media types
-     * @param string|null              $style         How the property value is serialized
-     * @param bool|null                $explode       Whether arrays/objects generate separate parameters
-     * @param bool|null                $allowReserved Whether reserved characters are allowed without encoding
-     * @param array<string,mixed>|null $x             Vendor extensions (x-* properties)
-     * @param list<Attachable>|null    $attachables   Reusable custom attachable attributes
+     * @param string|null                $encoding      The property name this encoding applies to
+     * @param string|null                $contentType   The Content-Type for encoding a specific property
+     * @param list<Header>|null          $headers       Additional headers for multipart media types
+     * @param string|ParameterStyle|null $style         How the property value is serialized
+     * @param bool|null                  $explode       Whether arrays/objects generate separate parameters
+     * @param bool|null                  $allowReserved Whether reserved characters are allowed without encoding
+     * @param array<string,mixed>|null   $x             Vendor extensions (x-* properties)
+     * @param list<Attachable>|null      $attachables   Reusable custom attachable attributes
      */
     public function __construct(
         public ?string $encoding = null,
         public ?string $contentType = null,
         public ?array $headers = null,
-        public ?string $style = null,
+        string|ParameterStyle|null $style = null,
         public ?bool $explode = null,
         public ?bool $allowReserved = null,
         ?array $x = null,
         ?array $attachables = null,
     ) {
         parent::__construct(x: $x, attachables: $attachables);
+        $this->style = $style instanceof \BackedEnum ? $style->value : $style;
     }
 
     public function merge(): array

--- a/src/Spec/Flow.php
+++ b/src/Spec/Flow.php
@@ -42,8 +42,10 @@ namespace OpenApi\Spec;
 #[\Attribute(\Attribute::IS_REPEATABLE)]
 class Flow extends AbstractAttribute
 {
+    public ?string $flow = null;
+
     /**
-     * @param string|null               $flow             The OAuth2 flow type (implicit, password, clientCredentials, authorizationCode)
+     * @param string|FlowType|null      $flow             The OAuth2 flow type (implicit, password, clientCredentials, authorizationCode)
      * @param string|null               $authorizationUrl The authorization URL for this flow
      * @param string|null               $tokenUrl         The token URL for this flow
      * @param string|null               $refreshUrl       The URL for obtaining refresh tokens
@@ -52,7 +54,7 @@ class Flow extends AbstractAttribute
      * @param list<Attachable>|null     $attachables      Reusable custom attachable attributes
      */
     public function __construct(
-        public ?string $flow = null,
+        string|FlowType|null $flow = null,
         public ?string $authorizationUrl = null,
         public ?string $tokenUrl = null,
         public ?string $refreshUrl = null,
@@ -61,6 +63,7 @@ class Flow extends AbstractAttribute
         ?array $attachables = null,
     ) {
         parent::__construct(x: $x, attachables: $attachables);
+        $this->flow = $flow instanceof \BackedEnum ? $flow->value : $flow;
     }
 
     public function merge(): array

--- a/src/Spec/Flow/AuthorizationCode.php
+++ b/src/Spec/Flow/AuthorizationCode.php
@@ -30,7 +30,7 @@ class AuthorizationCode extends OA\Flow
         ?array $attachables = null,
     ) {
         parent::__construct(
-            flow: 'authorizationCode',
+            flow: OA\FlowType::AuthorizationCode,
             authorizationUrl: $authorizationUrl,
             tokenUrl: $tokenUrl,
             refreshUrl: $refreshUrl,

--- a/src/Spec/Flow/ClientCredentials.php
+++ b/src/Spec/Flow/ClientCredentials.php
@@ -29,7 +29,7 @@ class ClientCredentials extends OA\Flow
         ?array $attachables = null,
     ) {
         parent::__construct(
-            flow: 'clientCredentials',
+            flow: OA\FlowType::ClientCredentials,
             tokenUrl: $tokenUrl,
             refreshUrl: $refreshUrl,
             scopes: $scopes,

--- a/src/Spec/Flow/Implicit.php
+++ b/src/Spec/Flow/Implicit.php
@@ -29,7 +29,7 @@ class Implicit extends OA\Flow
         ?array $attachables = null,
     ) {
         parent::__construct(
-            flow: 'implicit',
+            flow: OA\FlowType::Implicit,
             authorizationUrl: $authorizationUrl,
             refreshUrl: $refreshUrl,
             scopes: $scopes,

--- a/src/Spec/Flow/Password.php
+++ b/src/Spec/Flow/Password.php
@@ -29,7 +29,7 @@ class Password extends OA\Flow
         ?array $attachables = null,
     ) {
         parent::__construct(
-            flow: 'password',
+            flow: OA\FlowType::Password,
             tokenUrl: $tokenUrl,
             refreshUrl: $refreshUrl,
             scopes: $scopes,

--- a/src/Spec/FlowType.php
+++ b/src/Spec/FlowType.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec;
+
+enum FlowType: string
+{
+    case Implicit = 'implicit';
+    case Password = 'password';
+    case ClientCredentials = 'clientCredentials';
+    case AuthorizationCode = 'authorizationCode';
+}

--- a/src/Spec/Header.php
+++ b/src/Spec/Header.php
@@ -16,6 +16,8 @@ use OpenApi\Undefined;
 #[\Attribute(\Attribute::IS_REPEATABLE)]
 class Header extends AbstractAttribute
 {
+    public ?string $style = null;
+
     /** @var list<MediaType>|null */
     public ?array $content = null;
 
@@ -25,7 +27,7 @@ class Header extends AbstractAttribute
      * @param bool|null                      $required    Whether the header is mandatory
      * @param bool|null                      $deprecated  Whether the header is deprecated
      * @param string|null                    $ref         A JSON Reference to a reusable header
-     * @param string|null                    $style       How the header value is serialized
+     * @param string|ParameterStyle|null     $style       How the header value is serialized
      * @param bool|null                      $explode     Whether arrays/objects generate separate parameters
      * @param Schema|null                    $schema      The schema defining the type for the header
      * @param mixed                          $example     Example of the header's value
@@ -40,7 +42,7 @@ class Header extends AbstractAttribute
         public ?bool $required = null,
         public ?bool $deprecated = null,
         public ?string $ref = null,
-        public ?string $style = null,
+        string|ParameterStyle|null $style = null,
         public ?bool $explode = null,
         public ?Schema $schema = null,
         public mixed $example = Undefined::UNDEFINED,
@@ -50,6 +52,7 @@ class Header extends AbstractAttribute
         ?array $attachables = null,
     ) {
         parent::__construct(x: $x, attachables: $attachables);
+        $this->style = $style instanceof \BackedEnum ? $style->value : $style;
         $this->content = self::wrapList($content);
     }
 

--- a/src/Spec/HttpMethod.php
+++ b/src/Spec/HttpMethod.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec;
+
+enum HttpMethod: string
+{
+    case Get = 'get';
+    case Put = 'put';
+    case Post = 'post';
+    case Delete = 'delete';
+    case Options = 'options';
+    case Head = 'head';
+    case Patch = 'patch';
+    case Trace = 'trace';
+}

--- a/src/Spec/Operation.php
+++ b/src/Spec/Operation.php
@@ -41,10 +41,12 @@ namespace OpenApi\Spec;
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class Operation extends AbstractAttribute
 {
+    public ?string $method = null;
+
     /**
      * @param string|null                     $path         The URL path for the operation
      * @param string|null                     $webhook      The webhook name (mutually exclusive with path)
-     * @param string|null                     $method       The HTTP method (get, post, put, delete, etc.)
+     * @param string|HttpMethod|null          $method       The HTTP method (get, post, put, delete, etc.)
      * @param string|null                     $operationId  Unique identifier for the operation
      * @param string|null                     $summary      A short summary of what the operation does
      * @param string|null                     $description  A verbose explanation of the operation (CommonMark syntax)
@@ -63,7 +65,7 @@ class Operation extends AbstractAttribute
     public function __construct(
         public ?string $path = null,
         public ?string $webhook = null,
-        public ?string $method = null,
+        string|HttpMethod|null $method = null,
         public ?string $operationId = null,
         public ?string $summary = null,
         public ?string $description = null,
@@ -80,6 +82,7 @@ class Operation extends AbstractAttribute
         ?array $attachables = null,
     ) {
         parent::__construct(x: $x, attachables: $attachables);
+        $this->method = $method instanceof \BackedEnum ? $method->value : $method;
     }
 
     public function isRoot(): bool

--- a/src/Spec/Operation/Delete.php
+++ b/src/Spec/Operation/Delete.php
@@ -47,7 +47,7 @@ class Delete extends OA\Operation
         parent::__construct(
             path: $path,
             webhook: $webhook,
-            method: 'delete',
+            method: OA\HttpMethod::Delete,
             operationId: $operationId,
             summary: $summary,
             description: $description,

--- a/src/Spec/Operation/Get.php
+++ b/src/Spec/Operation/Get.php
@@ -47,7 +47,7 @@ class Get extends OA\Operation
         parent::__construct(
             path: $path,
             webhook: $webhook,
-            method: 'get',
+            method: OA\HttpMethod::Get,
             operationId: $operationId,
             summary: $summary,
             description: $description,

--- a/src/Spec/Operation/Head.php
+++ b/src/Spec/Operation/Head.php
@@ -47,7 +47,7 @@ class Head extends OA\Operation
         parent::__construct(
             path: $path,
             webhook: $webhook,
-            method: 'head',
+            method: OA\HttpMethod::Head,
             operationId: $operationId,
             summary: $summary,
             description: $description,

--- a/src/Spec/Operation/Options.php
+++ b/src/Spec/Operation/Options.php
@@ -47,7 +47,7 @@ class Options extends OA\Operation
         parent::__construct(
             path: $path,
             webhook: $webhook,
-            method: 'options',
+            method: OA\HttpMethod::Options,
             operationId: $operationId,
             summary: $summary,
             description: $description,

--- a/src/Spec/Operation/Patch.php
+++ b/src/Spec/Operation/Patch.php
@@ -47,7 +47,7 @@ class Patch extends OA\Operation
         parent::__construct(
             path: $path,
             webhook: $webhook,
-            method: 'patch',
+            method: OA\HttpMethod::Patch,
             operationId: $operationId,
             summary: $summary,
             description: $description,

--- a/src/Spec/Operation/Post.php
+++ b/src/Spec/Operation/Post.php
@@ -47,7 +47,7 @@ class Post extends OA\Operation
         parent::__construct(
             path: $path,
             webhook: $webhook,
-            method: 'post',
+            method: OA\HttpMethod::Post,
             operationId: $operationId,
             summary: $summary,
             description: $description,

--- a/src/Spec/Operation/Put.php
+++ b/src/Spec/Operation/Put.php
@@ -47,7 +47,7 @@ class Put extends OA\Operation
         parent::__construct(
             path: $path,
             webhook: $webhook,
-            method: 'put',
+            method: OA\HttpMethod::Put,
             operationId: $operationId,
             summary: $summary,
             description: $description,

--- a/src/Spec/Operation/Trace.php
+++ b/src/Spec/Operation/Trace.php
@@ -47,7 +47,7 @@ class Trace extends OA\Operation
         parent::__construct(
             path: $path,
             webhook: $webhook,
-            method: 'trace',
+            method: OA\HttpMethod::Trace,
             operationId: $operationId,
             summary: $summary,
             description: $description,

--- a/src/Spec/Parameter.php
+++ b/src/Spec/Parameter.php
@@ -42,19 +42,23 @@ use OpenApi\Undefined;
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY | \Attribute::TARGET_PARAMETER | \Attribute::IS_REPEATABLE)]
 class Parameter extends AbstractAttribute
 {
+    public ?string $in = null;
+
+    public ?string $style = null;
+
     /** @var list<MediaType>|null */
     public ?array $content = null;
 
     /**
      * @param string|null                    $parameter       Reusable parameter identifier (component key)
      * @param string|null                    $name            The name of the parameter
-     * @param string|null                    $in              The location of the parameter (query, header, path, cookie)
+     * @param string|ParameterIn|null        $in              The location of the parameter (query, header, path, cookie)
      * @param string|null                    $description     A brief description of the parameter (CommonMark syntax)
      * @param bool|null                      $required        Whether the parameter is mandatory
      * @param bool|null                      $deprecated      Whether the parameter is deprecated
      * @param bool|null                      $allowEmptyValue Whether empty-valued parameters are allowed
      * @param string|null                    $ref             A JSON Reference to a reusable parameter
-     * @param string|null                    $style           How the parameter value is serialized
+     * @param string|ParameterStyle|null     $style           How the parameter value is serialized
      * @param bool|null                      $explode         Whether arrays/objects generate separate parameters
      * @param bool|null                      $allowReserved   Whether reserved characters are allowed without encoding
      * @param Schema|null                    $schema          The schema defining the type for the parameter
@@ -67,13 +71,13 @@ class Parameter extends AbstractAttribute
     public function __construct(
         public ?string $parameter = null,
         public ?string $name = null,
-        public ?string $in = null,
+        string|ParameterIn|null $in = null,
         public ?string $description = null,
         public ?bool $required = null,
         public ?bool $deprecated = null,
         public ?bool $allowEmptyValue = null,
         public ?string $ref = null,
-        public ?string $style = null,
+        string|ParameterStyle|null $style = null,
         public ?bool $explode = null,
         public ?bool $allowReserved = null,
         public ?Schema $schema = null,
@@ -84,6 +88,8 @@ class Parameter extends AbstractAttribute
         ?array $attachables = null,
     ) {
         parent::__construct(x: $x, attachables: $attachables);
+        $this->in = $in instanceof \BackedEnum ? $in->value : $in;
+        $this->style = $style instanceof \BackedEnum ? $style->value : $style;
         $this->content = self::wrapList($content);
     }
 

--- a/src/Spec/Parameter/Cookie.php
+++ b/src/Spec/Parameter/Cookie.php
@@ -41,7 +41,7 @@ class Cookie extends OA\Parameter
         parent::__construct(
             parameter: $parameter,
             name: $name,
-            in: 'cookie',
+            in: OA\ParameterIn::Cookie,
             description: $description,
             required: $required,
             deprecated: $deprecated,

--- a/src/Spec/Parameter/Header.php
+++ b/src/Spec/Parameter/Header.php
@@ -41,7 +41,7 @@ class Header extends OA\Parameter
         parent::__construct(
             parameter: $parameter,
             name: $name,
-            in: 'header',
+            in: OA\ParameterIn::Header,
             description: $description,
             required: $required,
             deprecated: $deprecated,

--- a/src/Spec/Parameter/Path.php
+++ b/src/Spec/Parameter/Path.php
@@ -29,7 +29,7 @@ class Path extends OA\Parameter
         ?string $description = null,
         ?bool $deprecated = null,
         ?string $ref = null,
-        ?string $style = null,
+        string|OA\ParameterStyle|null $style = null,
         ?bool $explode = null,
         ?OA\Schema $schema = null,
         mixed $example = Undefined::UNDEFINED,
@@ -41,7 +41,7 @@ class Path extends OA\Parameter
         parent::__construct(
             parameter: $parameter,
             name: $name,
-            in: 'path',
+            in: OA\ParameterIn::Path,
             description: $description,
             required: true,
             deprecated: $deprecated,

--- a/src/Spec/Parameter/Query.php
+++ b/src/Spec/Parameter/Query.php
@@ -31,7 +31,7 @@ class Query extends OA\Parameter
         ?bool $deprecated = null,
         ?bool $allowEmptyValue = null,
         ?string $ref = null,
-        ?string $style = null,
+        string|OA\ParameterStyle|null $style = null,
         ?bool $explode = null,
         ?bool $allowReserved = null,
         ?OA\Schema $schema = null,
@@ -44,7 +44,7 @@ class Query extends OA\Parameter
         parent::__construct(
             parameter: $parameter,
             name: $name,
-            in: 'query',
+            in: OA\ParameterIn::Query,
             description: $description,
             required: $required,
             deprecated: $deprecated,

--- a/src/Spec/ParameterIn.php
+++ b/src/Spec/ParameterIn.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec;
+
+enum ParameterIn: string
+{
+    case Query = 'query';
+    case Header = 'header';
+    case Path = 'path';
+    case Cookie = 'cookie';
+}

--- a/src/Spec/ParameterStyle.php
+++ b/src/Spec/ParameterStyle.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec;
+
+enum ParameterStyle: string
+{
+    case Matrix = 'matrix';
+    case Label = 'label';
+    case Form = 'form';
+    case Simple = 'simple';
+    case SpaceDelimited = 'spaceDelimited';
+    case PipeDelimited = 'pipeDelimited';
+    case DeepObject = 'deepObject';
+}

--- a/src/Spec/SchemeIn.php
+++ b/src/Spec/SchemeIn.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec;
+
+enum SchemeIn: string
+{
+    case Query = 'query';
+    case Header = 'header';
+    case Cookie = 'cookie';
+}

--- a/src/Spec/SchemeType.php
+++ b/src/Spec/SchemeType.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec;
+
+enum SchemeType: string
+{
+    case ApiKey = 'apiKey';
+    case Http = 'http';
+    case MutualTLS = 'mutualTLS';
+    case OAuth2 = 'oauth2';
+    case OpenIdConnect = 'openIdConnect';
+}

--- a/src/Spec/Security/Scheme.php
+++ b/src/Spec/Security/Scheme.php
@@ -22,26 +22,30 @@ use OpenApi\Spec as OA;
  */
 class Scheme extends OA\AbstractAttribute
 {
+    public ?string $type = null;
+
+    public ?string $in = null;
+
     /**
-     * @param string|null              $securityScheme   Reusable security scheme identifier (component key)
-     * @param string|null              $type             The type of the security scheme (apiKey, http, mutualTLS, oauth2, openIdConnect)
-     * @param string|null              $description      A description of the security scheme (CommonMark syntax)
-     * @param string|null              $name             The name of the header, query, or cookie parameter (apiKey)
-     * @param string|null              $in               The location of the API key (query, header, cookie)
-     * @param string|null              $scheme           The HTTP authorization scheme (http)
-     * @param string|null              $bearerFormat     A hint about the format of the bearer token (http/bearer)
-     * @param string|null              $openIdConnectUrl The OpenID Connect URL to discover configuration (openIdConnect)
-     * @param list<OA\Flow>|null       $flows            The available OAuth2 flows (oauth2)
-     * @param string|null              $ref              A JSON Reference to a reusable security scheme
-     * @param array<string,mixed>|null $x                Vendor extensions (x-* properties)
-     * @param list<OA\Attachable>|null $attachables      Reusable custom attachable attributes
+     * @param string|null               $securityScheme   Reusable security scheme identifier (component key)
+     * @param string|OA\SchemeType|null $type             The type of the security scheme (apiKey, http, mutualTLS, oauth2, openIdConnect)
+     * @param string|null               $description      A description of the security scheme (CommonMark syntax)
+     * @param string|null               $name             The name of the header, query, or cookie parameter (apiKey)
+     * @param string|OA\SchemeIn|null   $in               The location of the API key (query, header, cookie)
+     * @param string|null               $scheme           The HTTP authorization scheme (http)
+     * @param string|null               $bearerFormat     A hint about the format of the bearer token (http/bearer)
+     * @param string|null               $openIdConnectUrl The OpenID Connect URL to discover configuration (openIdConnect)
+     * @param list<OA\Flow>|null        $flows            The available OAuth2 flows (oauth2)
+     * @param string|null               $ref              A JSON Reference to a reusable security scheme
+     * @param array<string,mixed>|null  $x                Vendor extensions (x-* properties)
+     * @param list<OA\Attachable>|null  $attachables      Reusable custom attachable attributes
      */
     public function __construct(
         public ?string $securityScheme = null,
-        public ?string $type = null,
+        string|OA\SchemeType|null $type = null,
         public ?string $description = null,
         public ?string $name = null,
-        public ?string $in = null,
+        string|OA\SchemeIn|null $in = null,
         public ?string $scheme = null,
         public ?string $bearerFormat = null,
         public ?string $openIdConnectUrl = null,
@@ -51,6 +55,8 @@ class Scheme extends OA\AbstractAttribute
         ?array $attachables = null,
     ) {
         parent::__construct(x: $x, attachables: $attachables);
+        $this->type = $type instanceof \BackedEnum ? $type->value : $type;
+        $this->in = $in instanceof \BackedEnum ? $in->value : $in;
     }
 
     public function isRoot(): bool

--- a/src/Spec/Security/Scheme/ApiKey.php
+++ b/src/Spec/Security/Scheme/ApiKey.php
@@ -24,13 +24,13 @@ class ApiKey extends OA\Security\Scheme
         ?string $securityScheme = null,
         ?string $description = null,
         ?string $name = null,
-        ?string $in = null,
+        string|OA\SchemeIn|null $in = null,
         ?array $x = null,
         ?array $attachables = null,
     ) {
         parent::__construct(
             securityScheme: $securityScheme,
-            type: 'apiKey',
+            type: OA\SchemeType::ApiKey,
             description: $description,
             name: $name,
             in: $in,

--- a/src/Spec/Security/Scheme/Http.php
+++ b/src/Spec/Security/Scheme/Http.php
@@ -30,7 +30,7 @@ class Http extends OA\Security\Scheme
     ) {
         parent::__construct(
             securityScheme: $securityScheme,
-            type: 'http',
+            type: OA\SchemeType::Http,
             description: $description,
             scheme: $scheme,
             bearerFormat: $bearerFormat,

--- a/src/Spec/Security/Scheme/MutualTls.php
+++ b/src/Spec/Security/Scheme/MutualTls.php
@@ -28,7 +28,7 @@ class MutualTls extends OA\Security\Scheme
     ) {
         parent::__construct(
             securityScheme: $securityScheme,
-            type: 'mutualTLS',
+            type: OA\SchemeType::MutualTLS,
             description: $description,
             x: $x,
             attachables: $attachables,

--- a/src/Spec/Security/Scheme/OAuth2.php
+++ b/src/Spec/Security/Scheme/OAuth2.php
@@ -30,7 +30,7 @@ class OAuth2 extends OA\Security\Scheme
     ) {
         parent::__construct(
             securityScheme: $securityScheme,
-            type: 'oauth2',
+            type: OA\SchemeType::OAuth2,
             description: $description,
             flows: $flows,
             x: $x,

--- a/src/Spec/Security/Scheme/OpenIdConnect.php
+++ b/src/Spec/Security/Scheme/OpenIdConnect.php
@@ -29,7 +29,7 @@ class OpenIdConnect extends OA\Security\Scheme
     ) {
         parent::__construct(
             securityScheme: $securityScheme,
-            type: 'openIdConnect',
+            type: OA\SchemeType::OpenIdConnect,
             description: $description,
             openIdConnectUrl: $openIdConnectUrl,
             x: $x,


### PR DESCRIPTION
## Summary

Add string-backed enums for fixed OpenAPI spec values. Allows for both plain strings or backed enum values.