### PR TITLE
feat(Spec): widen `Builder` sources to accept `\Reflector` instances too (except in `CLASSIC` mode)

### DIFF
--- a/docs/guide/generating-openapi-documents.md
+++ b/docs/guide/generating-openapi-documents.md
@@ -131,6 +131,23 @@ echo $result->toYaml();
 
 Spec mode uses attributes from the `OpenApi\Spec` namespace. See [Using Spec Attributes](/guide/spec-attributes) for details on the attribute API and [Processing Modes](/guide/modes) for a comparison of all modes.
 
+In spec and hybrid mode, you can also pass `\ReflectionClass` instances directly instead of file paths:
+
+```php
+<?php
+require('vendor/autoload.php');
+
+$result = (new \OpenApi\Builder())
+    ->setMode(\OpenApi\Builder\Mode::SPEC)
+    ->addSource([
+        new \ReflectionClass(App\Controllers\PetController::class),
+        new \ReflectionClass(App\Models\Pet::class),
+    ])
+    ->build();
+
+echo $result->toYaml();
+```
+
 ### Using the Generator directly
 
 The `Generator` class can also be used directly (classic mode only):

--- a/docs/guide/generating-openapi-documents.md
+++ b/docs/guide/generating-openapi-documents.md
@@ -86,13 +86,14 @@ The result object provides access to the generated spec in multiple formats, the
 files, and any validation warnings or errors collected during generation.
 
 ```php
-$result->toYaml();      // YAML string
-$result->toJson();      // JSON string
-$result->toArray();     // PHP array
-$result->files();       // list of scanned files
-$result->warnings();    // validation warnings
-$result->errors();      // validation errors
-$result->isValid();     // true if spec was generated
+$result->toYaml();        // YAML string
+$result->toJson();        // JSON string
+$result->toArray();       // PHP array
+$result->files();         // list of scanned files
+$result->warnings();      // validation warnings
+$result->errors();        // validation errors
+$result->isValid();       // true if spec was generated
+$result->specification(); // the final `Specification` instance
 ```
 
 For advanced Generator configuration (custom analysers, processors, aliases, etc.), use the

--- a/docs/guide/modes.md
+++ b/docs/guide/modes.md
@@ -93,11 +93,8 @@ Hybrid mode is the recommended transition path for existing projects that want t
 use OpenApi\Builder;
 use OpenApi\Builder\Mode;
 
-// String value
-$builder->setMode('spec');
-
-// Or enum
 $builder->setMode(Mode::SPEC);
+// or: $builder->setMode('spec');
 ```
 
 ## Behavioral differences
@@ -116,11 +113,11 @@ The three modes produce equivalent OpenAPI output for the same logical API. Howe
 
 The recommended migration path is:
 
-1. **Classic → Hybrid** — change `setMode('hybrid')` and verify output is unchanged. No code changes needed. This gives you access to the augmenter pipeline.
+1. **Classic → Hybrid** — change `setMode(Mode::HYBRID)` and verify output is unchanged. No code changes needed. This gives you access to the augmenter pipeline.
 
 2. **Hybrid → Spec** — when starting new code, use `OpenApi\Spec` attributes. Existing `OpenApi\Attributes` code continues to work via hybrid mode.
 
-3. **Full Spec** — once all code uses `OpenApi\Spec` attributes, switch to `setMode('spec')` for the cleanest pipeline.
+3. **Full Spec** — once all code uses `OpenApi\Spec` attributes, switch to `setMode(Mode::SPEC)` for the cleanest pipeline.
 
 ::: tip Version timeline
 - **v6** — spec/hybrid ship as opt-in beta. Classic remains default.

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -17,14 +17,17 @@ echo $result->toYaml();
 
 ## Processing modes
 
-The Builder supports three processing modes via `setMode()`:
+The Builder supports three processing modes via `setMode(string|Mode $mode)`:
 
 ### Classic (default)
 
 Scans source files for annotations/attributes and assembles the OpenAPI document via the Generator pipeline. This is the stable, production-ready mode.
 
 ```php
-$builder->setMode('classic');
+use OpenApi\Builder\Mode;
+
+$builder->setMode(Mode::CLASSIC);
+// or: $builder->setMode('classic');
 ```
 
 ### Spec (beta) {#mode-spec}
@@ -32,7 +35,8 @@ $builder->setMode('classic');
 Runs the new spec attributes pipeline end-to-end: Assembler → Augmenters → Compiler. Uses pure PHP 8.1+ attributes from the `OpenApi\Spec` namespace with typed DTOs and version-aware compilers.
 
 ```php
-$builder->setMode('spec');
+$builder->setMode(Mode::SPEC);
+// or: $builder->setMode('spec');
 ```
 
 ### Hybrid (beta) {#mode-hybrid}
@@ -40,7 +44,8 @@ $builder->setMode('spec');
 Uses the classic Generator for scanning, then bridges the result into the spec pipeline's augmenters and compilers. A transition path for existing projects that want access to the new augmenter pipeline without rewriting all annotations.
 
 ```php
-$builder->setMode('hybrid');
+$builder->setMode(Mode::HYBRID);
+// or: $builder->setMode('hybrid');
 ```
 
 ::: tip Choosing a mode

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -147,14 +147,15 @@ The `build()` method returns a `\OpenApi\Builder\Result` instance:
 ```php
 $result = $builder->build();
 
-$result->isValid();     // bool — true if a spec was generated
-$result->toArray();     // array — the spec as a PHP array
-$result->toJson();      // string — JSON output
-$result->toYaml();      // string — YAML output
-$result->files();       // string[] — scanned source files
-$result->log();         // array — all log entries [{level, message}, ...]
-$result->warnings();    // string[] — warning messages
-$result->errors();      // string[] — error messages
+$result->isValid();      // bool — true if a spec was generated
+$result->toArray();       // array — the spec as a PHP array
+$result->toJson();        // string — JSON output
+$result->toYaml();        // string — YAML output
+$result->files();         // string[] — scanned source files
+$result->log();           // array — all log entries [{level, message}, ...]
+$result->warnings();      // string[] — warning messages
+$result->errors();        // string[] — error messages
+$result->specification(); // the final `Specification` instance
 ```
 
 ## Full example (spec mode)

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -67,6 +67,27 @@ $builder->setSources(['src/Controllers', 'src/Models']);
 
 Sources can be directory paths, file paths, `\SplFileInfo`, `\Symfony\Component\Finder\Finder` instances, or nested iterables of these.
 
+#### Reflector sources (spec/hybrid mode)
+
+In spec and hybrid mode, you can pass `\Reflector` instances (e.g. `\ReflectionClass`) directly instead of file paths. This is useful when you already have reflection objects available or want to build a spec from a specific set of classes without file scanning:
+
+```php
+use OpenApi\Builder;
+use OpenApi\Builder\Mode;
+
+$result = (new Builder())
+    ->setMode(Mode::SPEC)
+    ->addSource([
+        new \ReflectionClass(App\Controllers\PetController::class),
+        new \ReflectionClass(App\Models\Pet::class),
+    ])
+    ->build();
+```
+
+::: warning
+Reflector sources are not supported in classic mode — they require the spec or hybrid pipeline.
+:::
+
 ### Version
 
 ```php

--- a/docs/spec-attributes.md
+++ b/docs/spec-attributes.md
@@ -126,7 +126,7 @@ This design keeps the assembler simple and makes cross-cutting relationships res
 
 ### Tri-mode Builder
 
-The `Builder` class supports three modes via `setMode('classic'|'spec'|'hybrid')`:
+The `Builder` class supports three modes via `setMode(Mode::CLASSIC|Mode::SPEC|Mode::HYBRID)`:
 - **classic** — delegates to the existing `Generator` pipeline
 - **spec** — runs the new spec attributes pipeline end-to-end
 - **hybrid** — uses the classic `Generator` for scanning only (MergeJsonContent/MergeXmlContent), then iterates the `Analysis` annotations directly via `HybridBridge` into a `Specification` and runs it through the full spec augmenter chain and compilers
@@ -335,7 +335,7 @@ These components can then be referenced via `$ref` from operations, PathItems, o
 
 - Dedicated test coverage for `HybridBridge` (currently exercised only indirectly via examples)
 - Migrate scratch tests and doc snippet tests to run in spec and/or hybrid modes
-- Broad hybrid validation by forcing existing classic tests to use `setMode('hybrid')` on their Builder — most classic tests should pass through hybrid unchanged, exposing gaps
+- Broad hybrid validation by forcing existing classic tests to use `setMode(Mode::HYBRID)` on their Builder — most classic tests should pass through hybrid unchanged, exposing gaps
 
 ### Testing
 
@@ -388,8 +388,8 @@ Need to document the general pattern for shortcut attributes: how they participa
 
 ### Version timeline
 
-- **v6.x** — spec pipeline ships as opt-in (`setMode('spec')`). Classic remains default. Both modes available side-by-side.
-- **v7** — spec mode becomes default. Classic still available via `setMode('classic')`. Remove legacy namespaces (`Annotations\*`, `Attributes\*`), `Context`, `Analysis`, doctrine support. Introduce `ProcessorInterface::process(Specification)`.
+- **v6.x** — spec pipeline ships as opt-in (`setMode(Mode::SPEC)`). Classic remains default. Both modes available side-by-side.
+- **v7** — spec mode becomes default. Classic still available via `setMode(Mode::CLASSIC)`. Remove legacy namespaces (`Annotations\*`, `Attributes\*`), `Context`, `Analysis`, doctrine support. Introduce `ProcessorInterface::process(Specification)`.
 - **v8** — classic mode removed entirely. Builder is spec-only.
 
 ## Consequences

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -23,16 +23,23 @@ use Psr\Log\NullLogger;
  *   setMode(Builder\Mode::SPEC)    — spec attribute pipeline via Assembler + Compiler
  *   setMode(Builder\Mode::HYBRID)  — reduced classic pipeline → HybridBridge → spec Compiler
  *
+ * Set/add sources to process:
+ *   addSource() > can be file based (string, \SplFileInfo) or reflection (\ReflectionClass)
+ *
  * Version resolution (spec/hybrid pipeline):
  *   setVersion() > #[OpenApi(version: ...)] from source > '3.1.0' fallback
  *
  * Compiler resolution (spec/hybrid pipeline):
  *   setCompiler() explicit > auto-resolved from version
+ *
+ * @phpstan-type BuilderSource string|\SplFileInfo|\Reflector
  */
 class Builder
 {
-    /** @var list<string|iterable> */
-    protected array $sources = [];
+    /**
+     * @var list<BuilderSource|iterable<BuilderSource>>
+     */
+    protected string|\SplFileInfo|\Reflector|iterable $sources = [];
 
     protected Mode $mode = Mode::CLASSIC;
 
@@ -47,12 +54,17 @@ class Builder
      */
     protected ?Utils\Pipeline $augmenters = null;
 
-    /** @var callable|null */
+    /**
+     * @var callable|null
+     */
     protected $generatorHook;
 
     protected ?AttributeFactory $attributeFactory = null;
 
-    public function addSource(string|iterable $source): static
+    /**
+     * @param BuilderSource|iterable<BuilderSource> $source
+     */
+    public function addSource(string|\SplFileInfo|\Reflector|iterable $source): static
     {
         $this->sources[] = $source;
 
@@ -60,7 +72,7 @@ class Builder
     }
 
     /**
-     * @param list<string|iterable> $sources
+     * @param list<BuilderSource|iterable<BuilderSource>> $sources
      */
     public function setSources(array $sources): static
     {
@@ -184,14 +196,18 @@ class Builder
             $generator = ($this->generatorHook)($generator) ?? $generator;
         }
 
-        $openApi = $generator->generate($this->sources);
+        $sourceScanner = new SourceScanner($this->getLogger());
+        $files = $sourceScanner->scan($this->sources);
 
-        return Result::fromClassic($this->resolveFiles(), $openApi, $collecting->entries());
+        $openApi = $generator->generate($files);
+
+        return Result::fromClassic($files, $openApi, $collecting->entries());
     }
 
     protected function doBuildSpec(bool $hybrid = false): Result
     {
-        $files = $this->resolveFiles();
+        $sourceScanner = new SourceScanner($this->getLogger());
+        $sourceScanner->scan($this->sources);
 
         $attributeFactory = $this->getAttributeFactory();
         $tokenScanner = $attributeFactory->getTokenScanner();
@@ -200,11 +216,17 @@ class Builder
             tokenScanner: $tokenScanner,
         );
 
-        foreach ($files as $file) {
+        foreach ($sourceScanner->getFiles() as $file) {
             foreach (array_keys($tokenScanner->scanFile($file)) as $class) {
                 if (class_exists($class) || interface_exists($class) || enum_exists($class) || trait_exists($class)) {
                     $assembler->collect(new \ReflectionClass($class));
                 }
+            }
+        }
+
+        foreach ($sourceScanner->getReflectors() as $reflector) {
+            if ($reflector instanceof \ReflectionClass) {
+                $assembler->collect($reflector);
             }
         }
 
@@ -228,7 +250,7 @@ class Builder
         $diagnostics = $compiler->validate($specification);
         $output = $compiler->compile($specification);
 
-        return Result::fromSpec($files, $specification, $output, $diagnostics);
+        return Result::fromSpec($sourceScanner->getFiles(), $specification, $output, $diagnostics);
     }
 
     protected function doHybridAssemble(Specification $specification): void
@@ -296,15 +318,5 @@ class Builder
             new Augmenter\Tags(),
             new Augmenter\EnumDescriptions(),
         ];
-    }
-
-    /**
-     * @return list<string>
-     */
-    protected function resolveFiles(): array
-    {
-        $scanner = new SourceScanner($this->getLogger());
-
-        return $scanner->scan($this->sources);
     }
 }

--- a/src/Utils/SourceScanner.php
+++ b/src/Utils/SourceScanner.php
@@ -6,13 +6,22 @@
 
 namespace OpenApi\Utils;
 
+use OpenApi\Builder;
 use Psr\Log\LoggerInterface;
 
 /**
- * Resolves mixed source inputs into a flat list of resolved file paths.
+ * Resolves mixed source inputs into file paths and reflectors.
+ *
+ * @phpstan-import-type BuilderSource from Builder
  */
 class SourceScanner
 {
+    /** @var list<string> */
+    protected array $files = [];
+
+    /** @var list<\Reflector> */
+    protected array $reflectors = [];
+
     public function __construct(protected LoggerInterface $logger)
     {
     }
@@ -20,23 +29,46 @@ class SourceScanner
     /**
      * Scan sources and return resolved file paths.
      *
-     * @param iterable $sources file/directory paths, \SplFileInfo, \Symfony\Component\Finder\Finder instances, or nested iterables
+     * @param list<BuilderSource|iterable<BuilderSource>> $sources
      *
-     * @return string[] resolved absolute file paths
+     * @return list<string> resolved absolute file paths
      */
     public function scan(iterable $sources): array
     {
-        $files = [];
-        $this->collect($sources, $files);
+        $this->files = [];
+        $this->reflectors = [];
+        $this->collect($sources);
 
-        return $files;
+        return $this->files;
     }
 
-    protected function collect(iterable $sources, array &$files): void
+    /**
+     * Return files collected during the last scan().
+     *
+     * @return list<string>
+     */
+    public function getFiles(): array
+    {
+        return $this->files;
+    }
+
+    /**
+     * Return reflectors collected during the last scan().
+     *
+     * @return list<\Reflector>
+     */
+    public function getReflectors(): array
+    {
+        return $this->reflectors;
+    }
+
+    protected function collect(iterable $sources): void
     {
         foreach ($sources as $source) {
-            if (is_iterable($source)) {
-                $this->collect($source, $files);
+            if ($source instanceof \Reflector) {
+                $this->reflectors[] = $source;
+            } elseif (is_iterable($source)) {
+                $this->collect($source);
             } else {
                 $resolvedSource = $source instanceof \SplFileInfo ? $source->getPathname() : realpath($source);
                 if (!$resolvedSource) {
@@ -44,9 +76,9 @@ class SourceScanner
                     continue;
                 }
                 if (is_dir($resolvedSource)) {
-                    $this->collect(new SourceFinder($resolvedSource), $files);
+                    $this->collect(new SourceFinder($resolvedSource));
                 } else {
-                    $files[] = $resolvedSource;
+                    $this->files[] = $resolvedSource;
                 }
             }
         }

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -9,6 +9,7 @@ namespace OpenApi\Tests;
 use OpenApi\Augmenter\OperationIds;
 use OpenApi\Builder;
 use OpenApi\Builder\Mode;
+use OpenApi\Examples\Specs\Webhooks\Spec as WebhooksSpec;
 use OpenApi\Generator;
 use OpenApi\Tests\Concerns\UsesExamples;
 use OpenApi\Utils\SourceFinder;
@@ -108,6 +109,27 @@ final class BuilderTest extends OpenApiTestCase
         foreach ($result->files() as $file) {
             $this->assertFileExists($file);
         }
+    }
+
+    public function testBuildReflectors(): void
+    {
+        $this->registerExampleClassloader('webhooks', 'spec');
+
+        $reflectorResult = (new Builder())
+            ->setMode(Mode::SPEC)
+            ->addSource([
+                new \ReflectionClass(WebhooksSpec\NewPetWebhook::class),
+                new \ReflectionClass(WebhooksSpec\OpenApiSpec::class),
+                new \ReflectionClass(WebhooksSpec\Pet::class),
+            ])
+            ->build();
+
+        $fileResult = (new Builder())
+            ->setMode(Mode::SPEC)
+            ->addSource(new SourceFinder(self::examplePath('webhooks/spec')))
+            ->build();
+
+        $this->assertSpecEquals($fileResult->toArray(), $reflectorResult->toArray());
     }
 
     public function testBuildEmptySources(): void

--- a/tests/Utils/SourceScannerTest.php
+++ b/tests/Utils/SourceScannerTest.php
@@ -51,7 +51,7 @@ final class SourceScannerTest extends OpenApiTestCase
     public function testScanNestedIterables(): void
     {
         $sourceDir = self::examplePath('petstore/annotations');
-        $nested = [[new SourceFinder($sourceDir)]];
+        $nested = [new SourceFinder($sourceDir)];
 
         $scanner = new SourceScanner($this->getTrackingLogger());
         $files = $scanner->scan($nested);
@@ -71,5 +71,30 @@ final class SourceScannerTest extends OpenApiTestCase
 
         $this->assertCount(1, $files);
         $this->assertFileExists($files[0]);
+    }
+
+    public function testScanReflectors(): void
+    {
+        $reflector = new \ReflectionClass(self::class);
+
+        $scanner = new SourceScanner($this->getTrackingLogger());
+        $files = $scanner->scan([$reflector]);
+
+        $this->assertEmpty($files);
+        $this->assertCount(1, $scanner->getReflectors());
+        $this->assertSame($reflector, $scanner->getReflectors()[0]);
+    }
+
+    public function testScanMixed(): void
+    {
+        $sourceDir = self::examplePath('petstore/annotations');
+        $reflector = new \ReflectionClass(self::class);
+
+        $scanner = new SourceScanner($this->getTrackingLogger());
+        $files = $scanner->scan([$sourceDir, $reflector]);
+
+        $this->assertNotEmpty($files);
+        $this->assertCount(1, $scanner->getReflectors());
+        $this->assertSame($reflector, $scanner->getReflectors()[0]);
     }
 }


### PR DESCRIPTION
## Summary

Widen the scope of sources that the `Builder` accepts.

In `CLASSIC` this is stays limited to files as before, but in `HYBRID` and `SPEC` mode the builder will accept also `\ReflectionClass` instances that skip the scan step and get fed directly into the `Assembler`.