### PR TITLE
feat(Spec): introduce `OA\Schema\Ref` which can be used as schema and on `ref: ` direct

### DIFF
--- a/docs/examples/specs/using-refs/spec/ProductController.php
+++ b/docs/examples/specs/using-refs/spec/ProductController.php
@@ -18,7 +18,7 @@ class ProductController
         operationId: 'getProduct',
         tags: ['Products'],
         responses: [
-            new OA\Response(response: 'default', ref: '#/components/responses/product'),
+            new OA\Response(response: 'default', ref: new OA\Schema\Ref(ref: '#/components/responses/product')),
         ],
     )]
     public function getProduct($id)

--- a/src/Augmenter/Refs.php
+++ b/src/Augmenter/Refs.php
@@ -37,6 +37,7 @@ class Refs implements PipeInterface, LoggerAwareInterface
             return null;
         }
 
+        $this->resolveRefRefs($payload);
         $this->resolveFQCNRefs($payload, $refMap);
         $this->resolveDiscriminatorMappings($payload, $refMap);
         $this->resolveAllOfPropertyRefs($payload);
@@ -44,7 +45,16 @@ class Refs implements PipeInterface, LoggerAwareInterface
         return null;
     }
 
-    protected function resolveFQCNRefs(Specification $specification, array &$refMap): array
+    protected function resolveRefRefs(Specification $specification): void
+    {
+        $specification->getWalker()->eachRef(function (OA\AbstractAttribute $attribute): void {
+            if ($attribute->ref instanceof OA\Schema\Ref) {
+                $attribute->ref = $attribute->ref->ref;
+            }
+        });
+    }
+
+    protected function resolveFQCNRefs(Specification $specification, array &$refMap): void
     {
         $unresolved = [];
 
@@ -64,8 +74,6 @@ class Refs implements PipeInterface, LoggerAwareInterface
                 'ref' => $ref,
             ]);
         }
-
-        return $refMap;
     }
 
     /**

--- a/src/Spec/Example.php
+++ b/src/Spec/Example.php
@@ -30,7 +30,7 @@ class Example extends AbstractAttribute
         public ?string $description = null,
         public mixed $value = null,
         public ?string $externalValue = null,
-        public ?string $ref = null,
+        public string|Schema\Ref|null $ref = null,
         ?array $x = null,
         ?array $attachables = null,
     ) {

--- a/src/Spec/Header.php
+++ b/src/Spec/Header.php
@@ -41,7 +41,7 @@ class Header extends AbstractAttribute
         public ?string $description = null,
         public ?bool $required = null,
         public ?bool $deprecated = null,
-        public ?string $ref = null,
+        public string|Schema\Ref|null $ref = null,
         string|ParameterStyle|null $style = null,
         public ?bool $explode = null,
         public ?Schema $schema = null,

--- a/src/Spec/Link.php
+++ b/src/Spec/Link.php
@@ -33,7 +33,7 @@ class Link extends AbstractAttribute
         public ?array $parameters = null,
         public mixed $requestBody = null,
         public ?string $description = null,
-        public ?string $ref = null,
+        public string|Schema\Ref|null $ref = null,
         public ?Server $server = null,
         ?array $x = null,
         ?array $attachables = null,

--- a/src/Spec/Parameter.php
+++ b/src/Spec/Parameter.php
@@ -76,7 +76,7 @@ class Parameter extends AbstractAttribute
         public ?bool $required = null,
         public ?bool $deprecated = null,
         public ?bool $allowEmptyValue = null,
-        public ?string $ref = null,
+        public string|Schema\Ref|null $ref = null,
         string|ParameterStyle|null $style = null,
         public ?bool $explode = null,
         public ?bool $allowReserved = null,

--- a/src/Spec/PathItem.php
+++ b/src/Spec/PathItem.php
@@ -66,7 +66,7 @@ class PathItem extends AbstractAttribute
      * @param list<Attachable>|null           $attachables Reusable custom attachable attributes
      */
     public function __construct(
-        public ?string $ref = null,
+        public string|Schema\Ref|null $ref = null,
         public ?string $prefix = null,
         public ?string $summary = null,
         public ?string $description = null,

--- a/src/Spec/RequestBody.php
+++ b/src/Spec/RequestBody.php
@@ -30,7 +30,7 @@ class RequestBody extends AbstractAttribute
         public ?string $request = null,
         public ?string $description = null,
         public ?bool $required = null,
-        public ?string $ref = null,
+        public string|Schema\Ref|null $ref = null,
         MediaType|array|null $content = null,
         ?array $x = null,
         ?array $attachables = null,

--- a/src/Spec/Response.php
+++ b/src/Spec/Response.php
@@ -30,7 +30,7 @@ class Response extends AbstractAttribute
     public function __construct(
         public string|int|null $response = null,
         public ?string $description = null,
-        public ?string $ref = null,
+        public string|Schema\Ref|null $ref = null,
         public ?array $headers = null,
         MediaType|array|null $content = null,
         public ?array $links = null,

--- a/src/Spec/Schema.php
+++ b/src/Spec/Schema.php
@@ -105,7 +105,7 @@ class Schema extends AbstractAttribute
         public ?string $description = null,
 
         // Reference
-        public ?string $ref = null,
+        public string|Schema\Ref|null $ref = null,
 
         // Core type
         public string|array|null $type = null,

--- a/src/Spec/Schema/Ref.php
+++ b/src/Spec/Schema/Ref.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec\Schema;
+
+use OpenApi\Spec as OA;
+
+/**
+ * A reference-only schema — $ref is required, most other Schema properties are unavailable.
+ *
+ * In OpenAPI 3.1+, $ref can be combined with title and description to override
+ * the referenced schema's metadata without duplicating the definition.
+ *
+ * Usage:
+ *   #[OA\Property(schema: new OA\Schema\Ref(ref: Pet::class))]
+ *   #[OA\Property(schema: new OA\Schema\Ref(ref: '#/components/schemas/Pet', title: 'The pet'))]
+ *   #[OA\Property(schema: new OA\Schema\Ref(ref: Pet::class, description: 'Override desc'))]
+ */
+#[\Attribute(\Attribute::TARGET_ALL | \Attribute::IS_REPEATABLE)]
+class Ref extends OA\Schema
+{
+    public function __construct(
+        string $ref,
+        ?string $title = null,
+        ?string $description = null,
+        ?array $x = null,
+        ?array $attachables = null,
+    ) {
+        parent::__construct(
+            title: $title,
+            description: $description,
+            ref: $ref,
+            x: $x,
+            attachables: $attachables,
+        );
+    }
+}

--- a/src/Spec/Security/Scheme.php
+++ b/src/Spec/Security/Scheme.php
@@ -50,7 +50,7 @@ class Scheme extends OA\AbstractAttribute
         public ?string $bearerFormat = null,
         public ?string $openIdConnectUrl = null,
         public ?array $flows = null,
-        public ?string $ref = null,
+        public string|OA\Schema\Ref|null $ref = null,
         ?array $x = null,
         ?array $attachables = null,
     ) {

--- a/tests/Augmenter/RefsTest.php
+++ b/tests/Augmenter/RefsTest.php
@@ -13,6 +13,7 @@ use OpenApi\Tests\Concerns\AssemblesSpecification;
 use OpenApi\Tests\Fixtures;
 use PHPUnit\Framework\TestCase;
 
+
 final class RefsTest extends TestCase
 {
     use AssemblesSpecification;
@@ -47,6 +48,53 @@ final class RefsTest extends TestCase
         (new Augmenter\Refs())($spec);
 
         $this->assertSame('#/components/schemas/Foo', $response->content[0]->schema->ref);
+    }
+
+    public function testResolvesRefInstanceOnSchema(): void
+    {
+        $spec = $this->assemble(
+            Fixtures\Augmenter\RefTarget::class,
+            Fixtures\Augmenter\RefInstanceController::class,
+        );
+
+        (new Augmenter\Refs())($spec);
+
+        $operation = null;
+        foreach ($spec->operations as $op) {
+            if ($op->path === '/ref-instance-schema') {
+                $operation = $op;
+                break;
+            }
+        }
+
+        $this->assertInstanceOf(OA\Operation::class, $operation);
+        $schema = $operation->responses[0]->content[0]->schema;
+        $this->assertSame('#/components/schemas/RefTarget', $schema->ref);
+    }
+
+    public function testResolvesRefInstanceOnResponse(): void
+    {
+        $spec = $this->assemble(
+            Fixtures\Augmenter\RefTarget::class,
+            Fixtures\Augmenter\RefInstanceController::class,
+        );
+
+        $sharedResponse = new OA\Response(response: 'SharedResponse', description: 'Shared');
+        $sharedResponse->setReflector(new \ReflectionClass(Fixtures\Augmenter\RefTarget::class));
+        $spec->responses[] = $sharedResponse;
+
+        (new Augmenter\Refs())($spec);
+
+        $operation = null;
+        foreach ($spec->operations as $op) {
+            if ($op->path === '/ref-instance-response') {
+                $operation = $op;
+                break;
+            }
+        }
+
+        $this->assertInstanceOf(OA\Operation::class, $operation);
+        $this->assertSame('#/components/responses/SharedResponse', $operation->responses[0]->ref);
     }
 
     public function testResolvesDiscriminatorMapping(): void

--- a/tests/Augmenter/RefsTest.php
+++ b/tests/Augmenter/RefsTest.php
@@ -13,7 +13,6 @@ use OpenApi\Tests\Concerns\AssemblesSpecification;
 use OpenApi\Tests\Fixtures;
 use PHPUnit\Framework\TestCase;
 
-
 final class RefsTest extends TestCase
 {
     use AssemblesSpecification;

--- a/tests/Fixtures/Augmenter/RefInstanceController.php
+++ b/tests/Fixtures/Augmenter/RefInstanceController.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter;
+
+use OpenApi\Spec as OA;
+
+class RefInstanceController
+{
+    #[OA\Operation\Get(path: '/ref-instance-schema')]
+    #[OA\Response(response: 200, description: 'OK', content: [
+        new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: new OA\Schema\Ref(ref: RefTarget::class))),
+    ])]
+    public function schemaRef()
+    {
+    }
+
+    #[OA\Operation\Get(path: '/ref-instance-response')]
+    #[OA\Response(ref: new OA\Schema\Ref(ref: '#/components/responses/SharedResponse'), response: 200)]
+    public function responseRef()
+    {
+    }
+}


### PR DESCRIPTION
## Summary

Allow to set a `ref` via attribute `OA\Schema\Ref`. This is just designed to help downstream users that might want to add extra metadata to refs.