### PR TITLE
feat(SPEC): add shortcut attribute `Items`

### DIFF
--- a/docs/examples/specs/petstore/spec/Controllers/PetController.php
+++ b/docs/examples/specs/petstore/spec/Controllers/PetController.php
@@ -56,7 +56,7 @@ class PetController
             response: 200,
             description: 'successful operation',
             content: [
-                new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(type: 'array', items: new OA\Schema(ref: Pet::class))),
+                new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema\Items(ref: Pet::class)),
                 new OA\MediaType(mediaType: 'application/xml', schema: new OA\Schema(type: 'array', items: new OA\Schema(ref: Pet::class))),
             ],
         ),

--- a/docs/guide/spec-attributes.md
+++ b/docs/guide/spec-attributes.md
@@ -225,7 +225,8 @@ This produces paths `/api/v1/users/` and `/api/v1/users/{id}`, both tagged with 
 | `summary` / `description` | Emitted at path level |
 | `servers` | Emitted at path level |
 
-## MediaType
+## Shortcuts
+### MediaType
 
 `OA\MediaType\Json` and `OA\MediaType\Xml` are the corresponding versions of the classic `OA\JsonContent` and `OA\XmlContent`, respectively.
 
@@ -233,6 +234,11 @@ They do work pretty much the same, however since they are not inheriting from `O
 Still useful even when nesting `OA\Schema` as the media type is prefilled either way.
 
 **If a nested `OA\Schema` is set, the custom attributes are ignored.**
+
+### Items
+`#[OA\Schema\Items]` is the equivalent to the classic `OA\Items` attribute. Similar to `OA\MediaType\Json` and `Xml` it is a shortcut that allows to skip the outer `OA\Schema(type: 'array')`.
+
+Both the `MediaType` and `Items` shortcut are resolved by the `Shortcuts` augmenter.
 
 ## Components
 
@@ -385,15 +391,16 @@ Or apply globally via the OpenApi attribute or via PathItem (cloned to all opera
 
 ## Differences from classic attributes
 
-| Classic (`OpenApi\Attributes`) | Spec (`OpenApi\Spec`)                                                              |
-|---|------------------------------------------------------------------------------------|
-| `use OpenApi\Attributes as OA;` | `use OpenApi\Spec as OA;`                                                          |
-| `#[OA\Get(path: '/pets')]` | `#[OA\Operation\Get(path: '/pets')]`                                               |
-| `#[OA\JsonContent(...)]` | `new OA\MediaType\Json(...)` - but with limited set of (OA\Schema) attributes only |
-| `#[OA\PathParameter(...)]` | `#[OA\Parameter\Path(...)]`                                                        |
-| Schema inherits from annotation base | Schema is standalone, stackable                                                    |
+| Classic (`OpenApi\Attributes`)            | Spec (`OpenApi\Spec`)                                                              |
+|-------------------------------------------|------------------------------------------------------------------------------------|
+| `use OpenApi\Attributes as OA;`           | `use OpenApi\Spec as OA;`                                                          |
+| `#[OA\Get(path: '/pets')]`                | `#[OA\Operation\Get(path: '/pets')]`                                               |
+| `#[OA\JsonContent(...)]`                  | `new OA\MediaType\Json(...)` - but with limited set of (OA\Schema) attributes only |
+| `#[OA\PathParameter(...)]`                | `#[OA\Parameter\Path(...)]`                                                        |
+| `#[OA\Items(...)]`                        | `#[OA\Schema\Items(...)]`                                                          |
+| Schema inherits from annotation base      | Schema is standalone, stackable                                                    |
 | Processors modify mutable annotation tree | Augmenters enrich immutable DTOs                                                   |
-| Single serializer with version branches | Dedicated compiler per OpenAPI version                                             |
+| Single serializer with version branches   | Dedicated compiler per OpenAPI version                                             |
 
 ## References
 

--- a/docs/guide/spec-attributes.md
+++ b/docs/guide/spec-attributes.md
@@ -235,10 +235,32 @@ Still useful even when nesting `OA\Schema` as the media type is prefilled either
 
 **If a nested `OA\Schema` is set, the custom attributes are ignored.**
 
-### Items
-`#[OA\Schema\Items]` is the equivalent to the classic `OA\Items` attribute. Similar to `OA\MediaType\Json` and `Xml` it is a shortcut that allows to skip the outer `OA\Schema(type: 'array')`.
+```php
+// Without shortcut
+#[OA\Response(response: 200, content: [
+    new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(type: 'array', items: new OA\Schema(ref: Pet::class))),
+])]
 
-Both the `MediaType` and `Items` shortcut are resolved by the `Shortcuts` augmenter.
+// With shortcut
+#[OA\Response(response: 200, content: [new OA\MediaType\Json(type: 'array', items: new OA\Schema(ref: Pet::class))])]
+```
+
+### Items
+`#[OA\Schema\Items]` is the equivalent to the classic `OA\Items` attribute. Similar to `OA\MediaType\Json` and `Xml` it is a shortcut that allows to skip the outer `OA\Schema(type: 'array')`. The `Shortcuts` augmenter wraps it into `OA\Schema(type: 'array', items: ...)` automatically.
+
+```php
+// Without shortcut
+#[OA\Property]
+#[OA\Schema(type: 'array', items: new OA\Schema(ref: Tag::class))]
+public array $tags;
+
+// With shortcut
+#[OA\Property]
+#[OA\Schema\Items(ref: Tag::class)]
+public array $tags;
+```
+
+Both the `MediaType` and `Items` shortcuts are resolved by the `Shortcuts` augmenter.
 
 ## Components
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -183,6 +183,7 @@ OA\AbstractAttribute
 │   └── OA\Operation\Trace
 ├── OA\PathItem
 ├── OA\Schema
+│   ├── OA\Schema\Items
 │   └── OA\Property
 ├── OA\Parameter
 │   ├── OA\Parameter\Path

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -60,9 +60,9 @@ Augmenters form a grouped pipeline that enriches the Specification in three orde
 
 | Phase | Purpose | Examples |
 |---|---|---|
-| **Resolve** | Infer data from PHP reflection and cross-bucket relationships | `Types`, `Refs`, `PathItems` |
+| **Resolve** | Infer data from PHP reflection and cross-bucket relationships | `Inheritance`, `Names`, `Enums`, `PathItems`, `Types`, `Refs`, `Shortcuts` |
 | **Reduce** | Filter or remove entries | `PathFilter`, `Cleanup` |
-| **Augment** | Add derived metadata | `Docblocks`, `OperationIds`, `Tags`, `Inheritance`, `Names` |
+| **Augment** | Add derived metadata | `MediaTypes`, `Docblocks`, `OperationIds`, `Tags`, `EnumDescriptions` |
 
 Each augmenter implements `PipeInterface` and receives the full Specification. Augmenters within a phase run in registration order.
 
@@ -89,30 +89,36 @@ $builder->withAugmenters(function (\OpenApi\Utils\Pipeline $pipeline) {
 A custom augmenter implements `PipeInterface`:
 
 ```php
-use OpenApi\Augmenter\PipeInterface;
-use OpenApi\Spec\Specification;
+use OpenApi\Utils\PipeInterface;
+use OpenApi\Specification;
+use OpenApi\Spec as OA;
 
 class CustomAugmenter implements PipeInterface
 {
-    public function pipe(Specification $specification): Specification
+    public function group(): string|\BackedEnum
     {
-        foreach ($specification->schemas as $schema) {
+        return \OpenApi\Augmenter\Group::Augment;
+    }
+
+    public function __invoke(mixed $payload): mixed
+    {
+        foreach ($payload->schemas as $schema) {
             // enrich schemas...
         }
 
         // or
 
         // the walker will walk all attributes (including nested) of the specification
-        $specification->getWalker()->visit(OA\Property::class, function (OA\Property $property) {
+        $payload->getWalker()->visit(OA\Property::class, function (OA\Property $property) {
             // ...
         });
 
         // or walk all attributes with $ref set
-        $specification->getWalker()->eachRef(funtion () {
+        $payload->getWalker()->eachRef(function () {
             // $attribute->ref = ...
         });
 
-        return $specification;
+        return $payload;
     }
 }
 ```
@@ -123,9 +129,9 @@ Each OpenAPI version has its own compiler that handles version-specific output d
 
 | Compiler | Version | Key differences                                                   |
 |---|---|-------------------------------------------------------------------|
-| `Compiler30` | 3.0.x | `nullable` as property, `exclusiveMinimum` as boolean             |
-| `Compiler31` | 3.1.x | `nullable` via type array, `exclusiveMinimum` as number, webhooks |
-| `Compiler32` | 3.2.x | Extends 3.1 (currently without additional features)               |
+| `OpenApi30Compiler` | 3.0.x | `nullable` as property, `exclusiveMinimum` as boolean             |
+| `OpenApi31Compiler` | 3.1.x | `nullable` via type array, `exclusiveMinimum` as number, webhooks |
+| `OpenApi32Compiler` | 3.2.x | Extends 3.1 (currently without additional features)               |
 
 The compiler transforms a Specification into a plain PHP array representing the OpenAPI document. Version selection is automatic based on `Builder::setVersion()` or the `#[OA\OpenApi(version: '...')]` attribute.
 

--- a/docs/reference/augmenters.md
+++ b/docs/reference/augmenters.md
@@ -85,6 +85,7 @@ Resolves shortcut attributes.
 Handles:
 * `OA\MediaType\Json`
 * `OA\MediaType\Xml`
+* `OA\Schema\Items`
 
 ### [PathItems](https://github.com/zircote/swagger-php/tree/master/src/Augmenter/PathItems.php)
 

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -97,7 +97,7 @@ $builder->setVersion('3.1.0');
 Sets the target OpenAPI version. Version resolution order:
 1. Explicit `setVersion()` call (highest priority)
 2. Version declared in the source `#[OA\OpenApi(version: '...')]` attribute
-3. Falls back to `3.0.0`
+3. Falls back to `3.0.0` (classic) or `3.1.0` (spec/hybrid)
 
 ### Logger
 

--- a/docs/reference/spec-attributes.md
+++ b/docs/reference/spec-attributes.md
@@ -111,7 +111,7 @@ Describes the encoding for a single property in a media type.
   The Content-Type for encoding a specific property
 - **headers** : `list&lt;Header&gt;|null`
   Additional headers for multipart media types
-- **style** : `string|null`
+- **style** : `string|ParameterStyle|null`
   How the property value is serialized
 - **explode** : `bool|null`
   Whether arrays/objects generate separate parameters
@@ -205,7 +205,7 @@ Produces:
 
 #### Parameters
 ---
-- **flow** : `string|null`
+- **flow** : `string|FlowType|null`
   The OAuth2 flow type (implicit, password, clientCredentials, authorizationCode)
 - **authorizationUrl** : `string|null`
   The authorization URL for this flow
@@ -331,7 +331,7 @@ Describes a single HTTP header.
   Whether the header is deprecated
 - **ref** : `string|null`
   A JSON Reference to a reusable header
-- **style** : `string|null`
+- **style** : `string|ParameterStyle|null`
   How the header value is serialized
 - **explode** : `bool|null`
   Whether arrays/objects generate separate parameters
@@ -341,7 +341,7 @@ Describes a single HTTP header.
   Example of the header's value
 - **examples** : `list&lt;Example&gt;|null`
   Examples of the header's value
-- **content** : `list&lt;MediaType&gt;|null`
+- **content** : `MediaType|list&lt;MediaType&gt;|null`
   Content-type based header serialization
 
 #### Reference
@@ -467,6 +467,18 @@ A shortcut version of `OA\MediaType` with some of the more common `OA\Schema` pr
 * `ref`, `type`, `items`, `properties` and `required` may be used and will be expanded into a nested `OA\Schema` automatically.
 * If `schema` is explicitly set, the custom `OA\Schema` properties will be ignored.
 
+Allows to shorten this:
+
+  #[OA\Response(response: 200, content: [
+      new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(type: 'array', items: new OA\Schema(ref: Pet::class))),
+  ])]
+
+to this:
+
+  #[OA\Response(response: 200, content: [new OA\MediaType\Json(type: 'array', items: new OA\Schema(ref: Pet::class))])]
+
+The `Shortcuts` augmenter expands the schema properties into a nested `OA\Schema` automatically.
+
 #### Allowed in
 ---
 <a href="#response">Response</a>, <a href="#requestbody">RequestBody</a>, <a href="#parameter">Parameter</a>
@@ -508,6 +520,18 @@ A shortcut version of `OA\MediaType` with some of the more common `OA\Schema` pr
 * `mediaType` is set to `application/xml` by default.
 * `ref`, `type`, `items`, `properties` and `required` may be used and will be expanded into a nested `OA\Schema` automatically.
 * If `schema` is explicitly set, the custom `OA\Schema` properties will be ignored.
+
+Allows to shorten this:
+
+  #[OA\Response(response: 200, content: [
+      new OA\MediaType(mediaType: 'application/xml', schema: new OA\Schema(type: 'array', items: new OA\Schema(ref: Pet::class))),
+  ])]
+
+to this:
+
+  #[OA\Response(response: 200, content: [new OA\MediaType\Xml(type: 'array', items: new OA\Schema(ref: Pet::class))])]
+
+The `Shortcuts` augmenter expands the schema properties into a nested `OA\Schema` automatically.
 
 #### Allowed in
 ---
@@ -601,7 +625,7 @@ For webhooks, use `webhook` instead of `path`:
   The URL path for the operation
 - **webhook** : `string|null`
   The webhook name (mutually exclusive with path)
-- **method** : `string|null`
+- **method** : `string|HttpMethod|null`
   The HTTP method (get, post, put, delete, etc.)
 - **operationId** : `string|null`
   Unique identifier for the operation
@@ -1021,7 +1045,7 @@ Produces:
   Reusable parameter identifier (component key)
 - **name** : `string|null`
   The name of the parameter
-- **in** : `string|null`
+- **in** : `string|ParameterIn|null`
   The location of the parameter (query, header, path, cookie)
 - **description** : `string|null`
   A brief description of the parameter (CommonMark syntax)
@@ -1033,7 +1057,7 @@ Produces:
   Whether empty-valued parameters are allowed
 - **ref** : `string|null`
   A JSON Reference to a reusable parameter
-- **style** : `string|null`
+- **style** : `string|ParameterStyle|null`
   How the parameter value is serialized
 - **explode** : `bool|null`
   Whether arrays/objects generate separate parameters
@@ -1045,7 +1069,7 @@ Produces:
   Example of the parameter's value
 - **examples** : `list&lt;Example&gt;|null`
   Examples of the parameter's value
-- **content** : `list&lt;MediaType&gt;|null`
+- **content** : `MediaType|list&lt;MediaType&gt;|null`
   Content-type based parameter serialization
 
 #### Reference
@@ -1086,7 +1110,7 @@ A parameter passed via an HTTP cookie.
   No details available.
 - **examples** : `list&lt;OA\Example&gt;|null`
   No details available.
-- **content** : `list&lt;OA\MediaType&gt;|null`
+- **content** : `OA\MediaType|list&lt;OA\MediaType&gt;|null`
   No details available.
 
 #### Reference
@@ -1127,7 +1151,7 @@ A parameter passed via an HTTP header.
   No details available.
 - **examples** : `list&lt;OA\Example&gt;|null`
   No details available.
-- **content** : `list&lt;OA\MediaType&gt;|null`
+- **content** : `OA\MediaType|list&lt;OA\MediaType&gt;|null`
   No details available.
 
 #### Reference
@@ -1158,7 +1182,7 @@ A parameter passed via the URL path (always required).
   No details available.
 - **ref** : `string|null`
   No details available.
-- **style** : `string|null`
+- **style** : `OpenApi\Spec\ParameterStyle|string|null`
   No details available.
 - **explode** : `bool|null`
   No details available.
@@ -1168,7 +1192,7 @@ A parameter passed via the URL path (always required).
   No details available.
 - **examples** : `list&lt;OA\Example&gt;|null`
   No details available.
-- **content** : `list&lt;OA\MediaType&gt;|null`
+- **content** : `OA\MediaType|list&lt;OA\MediaType&gt;|null`
   No details available.
 
 #### Reference
@@ -1203,7 +1227,7 @@ A parameter passed via the URL query string.
   No details available.
 - **ref** : `string|null`
   No details available.
-- **style** : `string|null`
+- **style** : `OpenApi\Spec\ParameterStyle|string|null`
   No details available.
 - **explode** : `bool|null`
   No details available.
@@ -1215,7 +1239,7 @@ A parameter passed via the URL query string.
   No details available.
 - **examples** : `list&lt;OA\Example&gt;|null`
   No details available.
-- **content** : `list&lt;OA\MediaType&gt;|null`
+- **content** : `OA\MediaType|list&lt;OA\MediaType&gt;|null`
   No details available.
 
 #### Reference
@@ -1303,7 +1327,7 @@ Defines a single property within a Schema object.
 
 #### Allowed in
 ---
-<a href="#schema">Schema</a>
+<a href="#schema">Schema</a>, <a href="#schema-items">Schema\Items</a>
 
 #### Parameters
 ---
@@ -1338,7 +1362,7 @@ Describes a single request body.
   Whether the request body is required
 - **ref** : `string|null`
   A JSON Reference to a reusable request body
-- **content** : `list&lt;MediaType&gt;|null`
+- **content** : `MediaType|list&lt;MediaType&gt;|null`
   The content of the request body
 
 #### Reference
@@ -1367,7 +1391,7 @@ Describes a single response from an API operation.
   A JSON Reference to a reusable response
 - **headers** : `list&lt;Header&gt;|null`
   Headers sent with the response
-- **content** : `list&lt;MediaType&gt;|null`
+- **content** : `MediaType|list&lt;MediaType&gt;|null`
   Possible response payloads
 - **links** : `list&lt;Link&gt;|null`
   Design-time links for the response
@@ -1405,7 +1429,7 @@ Inline — used within parameters, responses, or other schemas:
 
 #### Allowed in
 ---
-<a href="#components">Components</a>, <a href="#schema">Schema</a>
+<a href="#components">Components</a>, <a href="#schema">Schema</a>, <a href="#schema-items">Schema\Items</a>
 
 #### Nested elements
 ---
@@ -1527,6 +1551,153 @@ Inline — used within parameters, responses, or other schemas:
 - [Schema Object](https://spec.openapis.org/oas/v3.1.1.html#schema-object) ↗
 - [JSON Schema](https://json-schema.org/draft/2020-12/json-schema-validation) ↗
 
+### [Schema\Items](https://github.com/zircote/swagger-php/tree/master/src/Spec/Schema/Items.php)
+
+Shortcut for `OA\Schema` with type `array` and `items`.
+
+Allows to shorten this:
+
+  #[OA\Schema]
+  class Pet {
+      #[OA\Property]
+      #[OA\Schema(type: 'array', items: new OA\Schema(ref: MyModel::class))]
+      public array $names;
+  }
+
+to this:
+
+  #[OA\Schema]
+  class Pet {
+      #[OA\Property]
+      #[OA\Schema\Items(ref: MyModel::class)]
+      public array $names;
+  }
+
+The `Shortcuts` augmenter wraps this into `OA\Schema(type: 'array', items: ...)` automatically.
+
+#### Allowed in
+---
+<a href="#property">Property</a>, <a href="#parameter">Parameter</a>, <a href="#header">Header</a>, <a href="#mediatype">MediaType</a>
+
+#### Nested elements
+---
+<a href="#property">Property</a>, <a href="#schema">Schema</a>
+
+#### Parameters
+---
+- **schema** : `string|null`
+  Reusable schema identifier (component key)
+- **title** : `string|null`
+  A title for the schema
+- **description** : `string|null`
+  A description of the schema (CommonMark syntax)
+- **ref** : `string|null`
+  A JSON Reference to a reusable schema
+- **type** : `string|list&lt;string&gt;|null`
+  The value type(s) (string, number, integer, boolean, array, object, null)
+- **format** : `string|null`
+  Further refines the type (e.g. int32, int64, float, double, date-time, email)
+- **nullable** : `bool|null`
+  Whether the value can be null (OAS 3.0 only; use type array in 3.1+)
+- **minLength** : `int|null`
+  Minimum string length
+- **maxLength** : `int|null`
+  Maximum string length
+- **pattern** : `string|null`
+  Regular expression pattern the string must match
+- **contentMediaType** : `string|null`
+  The media type of string content encoding
+- **contentEncoding** : `string|null`
+  The encoding used for string content (e.g. base64)
+- **minimum** : `int|float|null`
+  Minimum numeric value (inclusive)
+- **maximum** : `int|float|null`
+  Maximum numeric value (inclusive)
+- **exclusiveMinimum** : `int|float|bool|null`
+  Exclusive minimum value
+- **exclusiveMaximum** : `int|float|bool|null`
+  Exclusive maximum value
+- **multipleOf** : `int|float|null`
+  The value must be a multiple of this number
+- **items** : `Schema|string|null`
+  Schema for array items
+- **minItems** : `int|null`
+  Minimum number of array items
+- **maxItems** : `int|null`
+  Maximum number of array items
+- **uniqueItems** : `bool|null`
+  Whether array items must be unique
+- **prefixItems** : `list&lt;Schema&gt;|null`
+  Schemas for positional array items (tuple validation)
+- **contains** : `Schema|bool|null`
+  Schema that at least one array item must match
+- **minContains** : `int|null`
+  Minimum number of items matching contains
+- **maxContains** : `int|null`
+  Maximum number of items matching contains
+- **unevaluatedItems** : `Schema|bool|null`
+  Schema for items not covered by other keywords
+- **properties** : `list&lt;Property|Schema&gt;|null`
+  Object property definitions
+- **required** : `list&lt;string&gt;|null`
+  List of required property names
+- **additionalProperties** : `Schema|bool|null`
+  Schema or boolean for additional properties
+- **patternProperties** : `array&lt;string,Schema&gt;|null`
+  Schemas for properties matching regex patterns
+- **minProperties** : `int|null`
+  Minimum number of properties
+- **maxProperties** : `int|null`
+  Maximum number of properties
+- **unevaluatedProperties** : `Schema|bool|null`
+  Schema for properties not covered by other keywords
+- **propertyNames** : `Schema|null`
+  Schema that property names must validate against
+- **dependentRequired** : `array&lt;string,list&lt;string&gt;&gt;|null`
+  Property-level required dependencies
+- **dependentSchemas** : `array&lt;string,Schema&gt;|null`
+  Property-level schema dependencies
+- **allOf** : `list&lt;Schema&gt;|null`
+  All schemas must match (AND composition)
+- **anyOf** : `list&lt;Schema&gt;|null`
+  At least one schema must match (OR composition)
+- **oneOf** : `list&lt;Schema&gt;|null`
+  Exactly one schema must match (XOR composition)
+- **not** : `Schema|null`
+  The schema must NOT match
+- **if** : `Schema|null`
+  Conditional schema (if-then-else)
+- **then** : `Schema|null`
+  Applied when 'if' succeeds
+- **else** : `Schema|null`
+  Applied when 'if' fails
+- **enum** : `list&lt;string|int|float|bool|\UnitEnum|class-string&lt;\UnitEnum&gt;|null&gt;|null`
+  Allowed values
+- **const** : `mixed`
+  A single allowed value
+- **example** : `mixed`
+  An example value
+- **examples** : `list&lt;mixed&gt;|null`
+  A list of example values
+- **deprecated** : `bool|null`
+  Whether the schema is deprecated
+- **readOnly** : `bool|null`
+  Whether the value is read-only
+- **writeOnly** : `bool|null`
+  Whether the value is write-only
+- **default** : `mixed`
+  The default value
+- **discriminator** : `Discriminator|null`
+  Discriminator for polymorphism
+- **externalDocs** : `ExternalDocumentation|null`
+  Additional external documentation
+- **xml** : `Xml|null`
+  XML representation metadata
+
+#### Reference
+---
+- [Schema Object](https://spec.openapis.org/oas/v3.1.1.html#schema-object) ↗
+
 ### [Security\Requirement](https://github.com/zircote/swagger-php/tree/master/src/Spec/Security/Requirement.php)
 
 A security requirement declaring which security schemes apply.
@@ -1574,13 +1745,13 @@ Typed subtypes are available for each security scheme type:
 ---
 - **securityScheme** : `string|null`
   Reusable security scheme identifier (component key)
-- **type** : `string|null`
+- **type** : `string|OA\SchemeType|null`
   The type of the security scheme (apiKey, http, mutualTLS, oauth2, openIdConnect)
 - **description** : `string|null`
   A description of the security scheme (CommonMark syntax)
 - **name** : `string|null`
   The name of the header, query, or cookie parameter (apiKey)
-- **in** : `string|null`
+- **in** : `string|OA\SchemeIn|null`
   The location of the API key (query, header, cookie)
 - **scheme** : `string|null`
   The HTTP authorization scheme (http)
@@ -1613,7 +1784,7 @@ An API key security scheme (header, query, or cookie).
   No details available.
 - **name** : `string|null`
   No details available.
-- **in** : `string|null`
+- **in** : `OpenApi\Spec\SchemeIn|string|null`
   No details available.
 
 #### Reference

--- a/docs/reference/spec-attributes.md
+++ b/docs/reference/spec-attributes.md
@@ -64,11 +64,11 @@ Contact information for the exposed API.
 
 #### Parameters
 ---
-- **name** : `string|null`  
+- **name** : `string|null`
   The identifying name of the contact person/organization
-- **url** : `string|null`  
+- **url** : `string|null`
   A URL pointing to the contact information
-- **email** : `string|null`  
+- **email** : `string|null`
   The email address of the contact person/organization
 
 #### Reference
@@ -86,9 +86,9 @@ can be one of several schemas (used with oneOf, anyOf, allOf).
 
 #### Parameters
 ---
-- **propertyName** : `string|null`  
+- **propertyName** : `string|null`
   The name of the property in the payload that distinguishes types
-- **mapping** : `array&lt;string,string&gt;|null`  
+- **mapping** : `array&lt;string,string&gt;|null`
   Maps payload values to schema names or references
 
 #### Reference
@@ -105,17 +105,17 @@ Describes the encoding for a single property in a media type.
 
 #### Parameters
 ---
-- **encoding** : `string|null`  
+- **encoding** : `string|null`
   The property name this encoding applies to
-- **contentType** : `string|null`  
+- **contentType** : `string|null`
   The Content-Type for encoding a specific property
-- **headers** : `list&lt;Header&gt;|null`  
+- **headers** : `list&lt;Header&gt;|null`
   Additional headers for multipart media types
-- **style** : `string|null`  
+- **style** : `string|null`
   How the property value is serialized
-- **explode** : `bool|null`  
+- **explode** : `bool|null`
   Whether arrays/objects generate separate parameters
-- **allowReserved** : `bool|null`  
+- **allowReserved** : `bool|null`
   Whether reserved characters are allowed without encoding
 
 #### Reference
@@ -132,17 +132,17 @@ Describes an example value for a parameter, media type, or schema.
 
 #### Parameters
 ---
-- **example** : `string|null`  
+- **example** : `string|null`
   Reusable example identifier (component key)
-- **summary** : `string|null`  
+- **summary** : `string|null`
   Short description of the example
-- **description** : `string|null`  
+- **description** : `string|null`
   Long description of the example (CommonMark syntax)
-- **value** : `mixed`  
+- **value** : `mixed`
   Embedded literal example value
-- **externalValue** : `string|null`  
+- **externalValue** : `string|null`
   A URI pointing to the literal example
-- **ref** : `string|null`  
+- **ref** : `string|null`
   A JSON Reference to a reusable example
 
 #### Reference
@@ -159,9 +159,9 @@ Allows referencing an external resource for extended documentation.
 
 #### Parameters
 ---
-- **url** : `string|null`  
+- **url** : `string|null`
   The URL for the target documentation
-- **description** : `string|null`  
+- **description** : `string|null`
   A description of the target documentation (CommonMark syntax)
 
 #### Reference
@@ -205,15 +205,15 @@ Produces:
 
 #### Parameters
 ---
-- **flow** : `string|null`  
+- **flow** : `string|null`
   The OAuth2 flow type (implicit, password, clientCredentials, authorizationCode)
-- **authorizationUrl** : `string|null`  
+- **authorizationUrl** : `string|null`
   The authorization URL for this flow
-- **tokenUrl** : `string|null`  
+- **tokenUrl** : `string|null`
   The token URL for this flow
-- **refreshUrl** : `string|null`  
+- **refreshUrl** : `string|null`
   The URL for obtaining refresh tokens
-- **scopes** : `array&lt;string,string&gt;|null`  
+- **scopes** : `array&lt;string,string&gt;|null`
   The available scopes for the OAuth2 security scheme
 
 #### Reference
@@ -231,13 +231,13 @@ Configuration for the OAuth2 Authorization Code flow.
 
 #### Parameters
 ---
-- **authorizationUrl** : `string|null`  
+- **authorizationUrl** : `string|null`
   No details available.
-- **tokenUrl** : `string|null`  
+- **tokenUrl** : `string|null`
   No details available.
-- **refreshUrl** : `string|null`  
+- **refreshUrl** : `string|null`
   No details available.
-- **scopes** : `array&lt;string,string&gt;|null`  
+- **scopes** : `array&lt;string,string&gt;|null`
   No details available.
 
 #### Reference
@@ -254,11 +254,11 @@ Configuration for the OAuth2 Client Credentials flow.
 
 #### Parameters
 ---
-- **tokenUrl** : `string|null`  
+- **tokenUrl** : `string|null`
   No details available.
-- **refreshUrl** : `string|null`  
+- **refreshUrl** : `string|null`
   No details available.
-- **scopes** : `array&lt;string,string&gt;|null`  
+- **scopes** : `array&lt;string,string&gt;|null`
   No details available.
 
 #### Reference
@@ -275,11 +275,11 @@ Configuration for the OAuth2 Implicit flow.
 
 #### Parameters
 ---
-- **authorizationUrl** : `string|null`  
+- **authorizationUrl** : `string|null`
   No details available.
-- **refreshUrl** : `string|null`  
+- **refreshUrl** : `string|null`
   No details available.
-- **scopes** : `array&lt;string,string&gt;|null`  
+- **scopes** : `array&lt;string,string&gt;|null`
   No details available.
 
 #### Reference
@@ -296,11 +296,11 @@ Configuration for the OAuth2 Resource Owner Password flow.
 
 #### Parameters
 ---
-- **tokenUrl** : `string|null`  
+- **tokenUrl** : `string|null`
   No details available.
-- **refreshUrl** : `string|null`  
+- **refreshUrl** : `string|null`
   No details available.
-- **scopes** : `array&lt;string,string&gt;|null`  
+- **scopes** : `array&lt;string,string&gt;|null`
   No details available.
 
 #### Reference
@@ -321,27 +321,27 @@ Describes a single HTTP header.
 
 #### Parameters
 ---
-- **header** : `string|null`  
+- **header** : `string|null`
   The header name (component key)
-- **description** : `string|null`  
+- **description** : `string|null`
   A brief description of the header (CommonMark syntax)
-- **required** : `bool|null`  
+- **required** : `bool|null`
   Whether the header is mandatory
-- **deprecated** : `bool|null`  
+- **deprecated** : `bool|null`
   Whether the header is deprecated
-- **ref** : `string|null`  
+- **ref** : `string|null`
   A JSON Reference to a reusable header
-- **style** : `string|null`  
+- **style** : `string|null`
   How the header value is serialized
-- **explode** : `bool|null`  
+- **explode** : `bool|null`
   Whether arrays/objects generate separate parameters
-- **schema** : `Schema|null`  
+- **schema** : `Schema|null`
   The schema defining the type for the header
-- **example** : `mixed`  
+- **example** : `mixed`
   Example of the header's value
-- **examples** : `list&lt;Example&gt;|null`  
+- **examples** : `list&lt;Example&gt;|null`
   Examples of the header's value
-- **content** : `list&lt;MediaType&gt;|null`  
+- **content** : `list&lt;MediaType&gt;|null`
   Content-type based header serialization
 
 #### Reference
@@ -358,19 +358,19 @@ Metadata about the API.
 
 #### Parameters
 ---
-- **title** : `string|null`  
+- **title** : `string|null`
   The title of the API
-- **description** : `string|null`  
+- **description** : `string|null`
   A description of the API (CommonMark syntax)
-- **termsOfService** : `string|null`  
+- **termsOfService** : `string|null`
   A URL to the Terms of Service for the API
-- **version** : `string|null`  
+- **version** : `string|null`
   The version of the API document
-- **contact** : `Contact|null`  
+- **contact** : `Contact|null`
   Contact information for the API
-- **license** : `License|null`  
+- **license** : `License|null`
   License information for the API
-- **summary** : `string|null`  
+- **summary** : `string|null`
   A short summary of the API
 
 #### Reference
@@ -387,11 +387,11 @@ License information for the exposed API.
 
 #### Parameters
 ---
-- **name** : `string|null`  
+- **name** : `string|null`
   The license name used for the API
-- **identifier** : `string|null`  
+- **identifier** : `string|null`
   An SPDX license expression for the API
-- **url** : `string|null`  
+- **url** : `string|null`
   A URL to the license used for the API
 
 #### Reference
@@ -408,21 +408,21 @@ Describes a possible design-time link for a response.
 
 #### Parameters
 ---
-- **link** : `string|null`  
+- **link** : `string|null`
   Reusable link identifier (component key)
-- **operationRef** : `string|null`  
+- **operationRef** : `string|null`
   A relative or absolute URI reference to a linked operation
-- **operationId** : `string|null`  
+- **operationId** : `string|null`
   The name of an existing operation (mutually exclusive with operationRef)
-- **parameters** : `array&lt;string,mixed&gt;|null`  
+- **parameters** : `array&lt;string,mixed&gt;|null`
   Values to pass to the linked operation's parameters
-- **requestBody** : `mixed`  
+- **requestBody** : `mixed`
   A value to use as the request body for the linked operation
-- **description** : `string|null`  
+- **description** : `string|null`
   A description of the link (CommonMark syntax)
-- **ref** : `string|null`  
+- **ref** : `string|null`
   A JSON Reference to a reusable link
-- **server** : `Server|null`  
+- **server** : `Server|null`
   A server object to be used by the target operation
 
 #### Reference
@@ -443,15 +443,15 @@ Describes the content payload for a specific media type.
 
 #### Parameters
 ---
-- **mediaType** : `string|null`  
+- **mediaType** : `string|null`
   The media type identifier (e.g. 'application/json')
-- **schema** : `Schema|null`  
+- **schema** : `Schema|null`
   The schema defining the content
-- **example** : `mixed`  
+- **example** : `mixed`
   Example of the media type content
-- **examples** : `list&lt;Example&gt;|null`  
+- **examples** : `list&lt;Example&gt;|null`
   Examples of the media type content
-- **encoding** : `list&lt;Encoding&gt;|array&lt;string,Encoding&gt;|null`  
+- **encoding** : `list&lt;Encoding&gt;|array&lt;string,Encoding&gt;|null`
   Encoding information for specific properties
 
 #### Reference
@@ -477,23 +477,23 @@ A shortcut version of `OA\MediaType` with some of the more common `OA\Schema` pr
 
 #### Parameters
 ---
-- **ref** : `string|null`  
+- **ref** : `string|null`
   A JSON Reference to a reusable schema
-- **type** : `string|list&lt;string&gt;|null`  
+- **type** : `string|list&lt;string&gt;|null`
   The value type(s) (string, number, integer, boolean, array, object, null)
-- **items** : `Schema|string|null`  
+- **items** : `Schema|string|null`
   Schema for array items
-- **properties** : `list&lt;Property|Schema&gt;|null`  
+- **properties** : `list&lt;Property|Schema&gt;|null`
   Object property definitions
-- **required** : `list&lt;string&gt;|null`  
+- **required** : `list&lt;string&gt;|null`
   List of required property names
-- **schema** : `Schema|null`  
+- **schema** : `Schema|null`
   The schema defining the content
-- **example** : `mixed`  
+- **example** : `mixed`
   Example of the media type content
-- **examples** : `list&lt;OA\Example&gt;|null`  
+- **examples** : `list&lt;OA\Example&gt;|null`
   Examples of the media type content
-- **encoding** : `list&lt;OA\Encoding&gt;|array&lt;string,OA\Encoding&gt;|null`  
+- **encoding** : `list&lt;OA\Encoding&gt;|array&lt;string,OA\Encoding&gt;|null`
   Encoding information for specific properties
 
 #### Reference
@@ -519,23 +519,23 @@ A shortcut version of `OA\MediaType` with some of the more common `OA\Schema` pr
 
 #### Parameters
 ---
-- **ref** : `string|null`  
+- **ref** : `string|null`
   A JSON Reference to a reusable schema
-- **type** : `string|list&lt;string&gt;|null`  
+- **type** : `string|list&lt;string&gt;|null`
   The value type(s) (string, number, integer, boolean, array, object, null)
-- **items** : `Schema|string|null`  
+- **items** : `Schema|string|null`
   Schema for array items
-- **properties** : `list&lt;Property|Schema&gt;|null`  
+- **properties** : `list&lt;Property|Schema&gt;|null`
   Object property definitions
-- **required** : `list&lt;string&gt;|null`  
+- **required** : `list&lt;string&gt;|null`
   List of required property names
-- **schema** : `Schema|null`  
+- **schema** : `Schema|null`
   The schema defining the content
-- **example** : `mixed`  
+- **example** : `mixed`
   Example of the media type content
-- **examples** : `list&lt;OA\Example&gt;|null`  
+- **examples** : `list&lt;OA\Example&gt;|null`
   Examples of the media type content
-- **encoding** : `list&lt;OA\Encoding&gt;|array&lt;string,OA\Encoding&gt;|null`  
+- **encoding** : `list&lt;OA\Encoding&gt;|array&lt;string,OA\Encoding&gt;|null`
   Encoding information for specific properties
 
 #### Reference
@@ -552,9 +552,9 @@ The root element of an OpenAPI definition.
 
 #### Parameters
 ---
-- **version** : `string|null`  
+- **version** : `string|null`
   The OpenAPI specification version (e.g. '3.1.0')
-- **security** : `list&lt;Security\Requirement&gt;|null`  
+- **security** : `list&lt;Security\Requirement&gt;|null`
   Default security requirements for the API
 
 #### Reference
@@ -597,35 +597,35 @@ For webhooks, use `webhook` instead of `path`:
 
 #### Parameters
 ---
-- **path** : `string|null`  
+- **path** : `string|null`
   The URL path for the operation
-- **webhook** : `string|null`  
+- **webhook** : `string|null`
   The webhook name (mutually exclusive with path)
-- **method** : `string|null`  
+- **method** : `string|null`
   The HTTP method (get, post, put, delete, etc.)
-- **operationId** : `string|null`  
+- **operationId** : `string|null`
   Unique identifier for the operation
-- **summary** : `string|null`  
+- **summary** : `string|null`
   A short summary of what the operation does
-- **description** : `string|null`  
+- **description** : `string|null`
   A verbose explanation of the operation (CommonMark syntax)
-- **tags** : `list&lt;string&gt;|null`  
+- **tags** : `list&lt;string&gt;|null`
   Tags for API documentation grouping
-- **parameters** : `list&lt;Parameter&gt;|null`  
+- **parameters** : `list&lt;Parameter&gt;|null`
   Parameters applicable to this operation
-- **requestBody** : `RequestBody|null`  
+- **requestBody** : `RequestBody|null`
   The request body applicable to this operation
-- **responses** : `list&lt;Response&gt;|null`  
+- **responses** : `list&lt;Response&gt;|null`
   The list of possible responses
-- **callbacks** : `array&lt;string,mixed&gt;|null`  
+- **callbacks** : `array&lt;string,mixed&gt;|null`
   Possible out-of-band callbacks related to the operation
-- **deprecated** : `bool|null`  
+- **deprecated** : `bool|null`
   Whether the operation is deprecated
-- **security** : `list&lt;Security\Requirement&gt;|null`  
+- **security** : `list&lt;Security\Requirement&gt;|null`
   Security mechanisms that can be used for this operation
-- **servers** : `list&lt;Server&gt;|null`  
+- **servers** : `list&lt;Server&gt;|null`
   Alternative servers for this operation
-- **externalDocs** : `ExternalDocumentation|null`  
+- **externalDocs** : `ExternalDocumentation|null`
   Additional external documentation
 
 #### Reference
@@ -643,33 +643,33 @@ Shorthand for an HTTP DELETE operation.
 
 #### Parameters
 ---
-- **path** : `string|null`  
+- **path** : `string|null`
   No details available.
-- **webhook** : `string|null`  
+- **webhook** : `string|null`
   No details available.
-- **operationId** : `string|null`  
+- **operationId** : `string|null`
   No details available.
-- **summary** : `string|null`  
+- **summary** : `string|null`
   No details available.
-- **description** : `string|null`  
+- **description** : `string|null`
   No details available.
-- **tags** : `list&lt;string&gt;|null`  
+- **tags** : `list&lt;string&gt;|null`
   No details available.
-- **parameters** : `list&lt;OA\Parameter&gt;|null`  
+- **parameters** : `list&lt;OA\Parameter&gt;|null`
   No details available.
-- **requestBody** : `OpenApi\Spec\RequestBody|null`  
+- **requestBody** : `OpenApi\Spec\RequestBody|null`
   No details available.
-- **responses** : `list&lt;OA\Response&gt;|null`  
+- **responses** : `list&lt;OA\Response&gt;|null`
   No details available.
-- **callbacks** : `array&lt;string,mixed&gt;|null`  
+- **callbacks** : `array&lt;string,mixed&gt;|null`
   No details available.
-- **deprecated** : `bool|null`  
+- **deprecated** : `bool|null`
   No details available.
-- **security** : `list&lt;OA\Security\Requirement&gt;|null`  
+- **security** : `list&lt;OA\Security\Requirement&gt;|null`
   No details available.
-- **servers** : `list&lt;OA\Server&gt;|null`  
+- **servers** : `list&lt;OA\Server&gt;|null`
   No details available.
-- **externalDocs** : `OpenApi\Spec\ExternalDocumentation|null`  
+- **externalDocs** : `OpenApi\Spec\ExternalDocumentation|null`
   No details available.
 
 #### Reference
@@ -686,33 +686,33 @@ Shorthand for an HTTP GET operation.
 
 #### Parameters
 ---
-- **path** : `string|null`  
+- **path** : `string|null`
   No details available.
-- **webhook** : `string|null`  
+- **webhook** : `string|null`
   No details available.
-- **operationId** : `string|null`  
+- **operationId** : `string|null`
   No details available.
-- **summary** : `string|null`  
+- **summary** : `string|null`
   No details available.
-- **description** : `string|null`  
+- **description** : `string|null`
   No details available.
-- **tags** : `list&lt;string&gt;|null`  
+- **tags** : `list&lt;string&gt;|null`
   No details available.
-- **parameters** : `list&lt;OA\Parameter&gt;|null`  
+- **parameters** : `list&lt;OA\Parameter&gt;|null`
   No details available.
-- **requestBody** : `OpenApi\Spec\RequestBody|null`  
+- **requestBody** : `OpenApi\Spec\RequestBody|null`
   No details available.
-- **responses** : `list&lt;OA\Response&gt;|null`  
+- **responses** : `list&lt;OA\Response&gt;|null`
   No details available.
-- **callbacks** : `array&lt;string,mixed&gt;|null`  
+- **callbacks** : `array&lt;string,mixed&gt;|null`
   No details available.
-- **deprecated** : `bool|null`  
+- **deprecated** : `bool|null`
   No details available.
-- **security** : `list&lt;OA\Security\Requirement&gt;|null`  
+- **security** : `list&lt;OA\Security\Requirement&gt;|null`
   No details available.
-- **servers** : `list&lt;OA\Server&gt;|null`  
+- **servers** : `list&lt;OA\Server&gt;|null`
   No details available.
-- **externalDocs** : `OpenApi\Spec\ExternalDocumentation|null`  
+- **externalDocs** : `OpenApi\Spec\ExternalDocumentation|null`
   No details available.
 
 #### Reference
@@ -729,33 +729,33 @@ Shorthand for an HTTP HEAD operation.
 
 #### Parameters
 ---
-- **path** : `string|null`  
+- **path** : `string|null`
   No details available.
-- **webhook** : `string|null`  
+- **webhook** : `string|null`
   No details available.
-- **operationId** : `string|null`  
+- **operationId** : `string|null`
   No details available.
-- **summary** : `string|null`  
+- **summary** : `string|null`
   No details available.
-- **description** : `string|null`  
+- **description** : `string|null`
   No details available.
-- **tags** : `list&lt;string&gt;|null`  
+- **tags** : `list&lt;string&gt;|null`
   No details available.
-- **parameters** : `list&lt;OA\Parameter&gt;|null`  
+- **parameters** : `list&lt;OA\Parameter&gt;|null`
   No details available.
-- **requestBody** : `OpenApi\Spec\RequestBody|null`  
+- **requestBody** : `OpenApi\Spec\RequestBody|null`
   No details available.
-- **responses** : `list&lt;OA\Response&gt;|null`  
+- **responses** : `list&lt;OA\Response&gt;|null`
   No details available.
-- **callbacks** : `array&lt;string,mixed&gt;|null`  
+- **callbacks** : `array&lt;string,mixed&gt;|null`
   No details available.
-- **deprecated** : `bool|null`  
+- **deprecated** : `bool|null`
   No details available.
-- **security** : `list&lt;OA\Security\Requirement&gt;|null`  
+- **security** : `list&lt;OA\Security\Requirement&gt;|null`
   No details available.
-- **servers** : `list&lt;OA\Server&gt;|null`  
+- **servers** : `list&lt;OA\Server&gt;|null`
   No details available.
-- **externalDocs** : `OpenApi\Spec\ExternalDocumentation|null`  
+- **externalDocs** : `OpenApi\Spec\ExternalDocumentation|null`
   No details available.
 
 #### Reference
@@ -772,33 +772,33 @@ Shorthand for an HTTP OPTIONS operation.
 
 #### Parameters
 ---
-- **path** : `string|null`  
+- **path** : `string|null`
   No details available.
-- **webhook** : `string|null`  
+- **webhook** : `string|null`
   No details available.
-- **operationId** : `string|null`  
+- **operationId** : `string|null`
   No details available.
-- **summary** : `string|null`  
+- **summary** : `string|null`
   No details available.
-- **description** : `string|null`  
+- **description** : `string|null`
   No details available.
-- **tags** : `list&lt;string&gt;|null`  
+- **tags** : `list&lt;string&gt;|null`
   No details available.
-- **parameters** : `list&lt;OA\Parameter&gt;|null`  
+- **parameters** : `list&lt;OA\Parameter&gt;|null`
   No details available.
-- **requestBody** : `OpenApi\Spec\RequestBody|null`  
+- **requestBody** : `OpenApi\Spec\RequestBody|null`
   No details available.
-- **responses** : `list&lt;OA\Response&gt;|null`  
+- **responses** : `list&lt;OA\Response&gt;|null`
   No details available.
-- **callbacks** : `array&lt;string,mixed&gt;|null`  
+- **callbacks** : `array&lt;string,mixed&gt;|null`
   No details available.
-- **deprecated** : `bool|null`  
+- **deprecated** : `bool|null`
   No details available.
-- **security** : `list&lt;OA\Security\Requirement&gt;|null`  
+- **security** : `list&lt;OA\Security\Requirement&gt;|null`
   No details available.
-- **servers** : `list&lt;OA\Server&gt;|null`  
+- **servers** : `list&lt;OA\Server&gt;|null`
   No details available.
-- **externalDocs** : `OpenApi\Spec\ExternalDocumentation|null`  
+- **externalDocs** : `OpenApi\Spec\ExternalDocumentation|null`
   No details available.
 
 #### Reference
@@ -815,33 +815,33 @@ Shorthand for an HTTP PATCH operation.
 
 #### Parameters
 ---
-- **path** : `string|null`  
+- **path** : `string|null`
   No details available.
-- **webhook** : `string|null`  
+- **webhook** : `string|null`
   No details available.
-- **operationId** : `string|null`  
+- **operationId** : `string|null`
   No details available.
-- **summary** : `string|null`  
+- **summary** : `string|null`
   No details available.
-- **description** : `string|null`  
+- **description** : `string|null`
   No details available.
-- **tags** : `list&lt;string&gt;|null`  
+- **tags** : `list&lt;string&gt;|null`
   No details available.
-- **parameters** : `list&lt;OA\Parameter&gt;|null`  
+- **parameters** : `list&lt;OA\Parameter&gt;|null`
   No details available.
-- **requestBody** : `OpenApi\Spec\RequestBody|null`  
+- **requestBody** : `OpenApi\Spec\RequestBody|null`
   No details available.
-- **responses** : `list&lt;OA\Response&gt;|null`  
+- **responses** : `list&lt;OA\Response&gt;|null`
   No details available.
-- **callbacks** : `array&lt;string,mixed&gt;|null`  
+- **callbacks** : `array&lt;string,mixed&gt;|null`
   No details available.
-- **deprecated** : `bool|null`  
+- **deprecated** : `bool|null`
   No details available.
-- **security** : `list&lt;OA\Security\Requirement&gt;|null`  
+- **security** : `list&lt;OA\Security\Requirement&gt;|null`
   No details available.
-- **servers** : `list&lt;OA\Server&gt;|null`  
+- **servers** : `list&lt;OA\Server&gt;|null`
   No details available.
-- **externalDocs** : `OpenApi\Spec\ExternalDocumentation|null`  
+- **externalDocs** : `OpenApi\Spec\ExternalDocumentation|null`
   No details available.
 
 #### Reference
@@ -858,33 +858,33 @@ Shorthand for an HTTP POST operation.
 
 #### Parameters
 ---
-- **path** : `string|null`  
+- **path** : `string|null`
   No details available.
-- **webhook** : `string|null`  
+- **webhook** : `string|null`
   No details available.
-- **operationId** : `string|null`  
+- **operationId** : `string|null`
   No details available.
-- **summary** : `string|null`  
+- **summary** : `string|null`
   No details available.
-- **description** : `string|null`  
+- **description** : `string|null`
   No details available.
-- **tags** : `list&lt;string&gt;|null`  
+- **tags** : `list&lt;string&gt;|null`
   No details available.
-- **parameters** : `list&lt;OA\Parameter&gt;|null`  
+- **parameters** : `list&lt;OA\Parameter&gt;|null`
   No details available.
-- **requestBody** : `OpenApi\Spec\RequestBody|null`  
+- **requestBody** : `OpenApi\Spec\RequestBody|null`
   No details available.
-- **responses** : `list&lt;OA\Response&gt;|null`  
+- **responses** : `list&lt;OA\Response&gt;|null`
   No details available.
-- **callbacks** : `array&lt;string,mixed&gt;|null`  
+- **callbacks** : `array&lt;string,mixed&gt;|null`
   No details available.
-- **deprecated** : `bool|null`  
+- **deprecated** : `bool|null`
   No details available.
-- **security** : `list&lt;OA\Security\Requirement&gt;|null`  
+- **security** : `list&lt;OA\Security\Requirement&gt;|null`
   No details available.
-- **servers** : `list&lt;OA\Server&gt;|null`  
+- **servers** : `list&lt;OA\Server&gt;|null`
   No details available.
-- **externalDocs** : `OpenApi\Spec\ExternalDocumentation|null`  
+- **externalDocs** : `OpenApi\Spec\ExternalDocumentation|null`
   No details available.
 
 #### Reference
@@ -901,33 +901,33 @@ Shorthand for an HTTP PUT operation.
 
 #### Parameters
 ---
-- **path** : `string|null`  
+- **path** : `string|null`
   No details available.
-- **webhook** : `string|null`  
+- **webhook** : `string|null`
   No details available.
-- **operationId** : `string|null`  
+- **operationId** : `string|null`
   No details available.
-- **summary** : `string|null`  
+- **summary** : `string|null`
   No details available.
-- **description** : `string|null`  
+- **description** : `string|null`
   No details available.
-- **tags** : `list&lt;string&gt;|null`  
+- **tags** : `list&lt;string&gt;|null`
   No details available.
-- **parameters** : `list&lt;OA\Parameter&gt;|null`  
+- **parameters** : `list&lt;OA\Parameter&gt;|null`
   No details available.
-- **requestBody** : `OpenApi\Spec\RequestBody|null`  
+- **requestBody** : `OpenApi\Spec\RequestBody|null`
   No details available.
-- **responses** : `list&lt;OA\Response&gt;|null`  
+- **responses** : `list&lt;OA\Response&gt;|null`
   No details available.
-- **callbacks** : `array&lt;string,mixed&gt;|null`  
+- **callbacks** : `array&lt;string,mixed&gt;|null`
   No details available.
-- **deprecated** : `bool|null`  
+- **deprecated** : `bool|null`
   No details available.
-- **security** : `list&lt;OA\Security\Requirement&gt;|null`  
+- **security** : `list&lt;OA\Security\Requirement&gt;|null`
   No details available.
-- **servers** : `list&lt;OA\Server&gt;|null`  
+- **servers** : `list&lt;OA\Server&gt;|null`
   No details available.
-- **externalDocs** : `OpenApi\Spec\ExternalDocumentation|null`  
+- **externalDocs** : `OpenApi\Spec\ExternalDocumentation|null`
   No details available.
 
 #### Reference
@@ -944,33 +944,33 @@ Shorthand for an HTTP TRACE operation.
 
 #### Parameters
 ---
-- **path** : `string|null`  
+- **path** : `string|null`
   No details available.
-- **webhook** : `string|null`  
+- **webhook** : `string|null`
   No details available.
-- **operationId** : `string|null`  
+- **operationId** : `string|null`
   No details available.
-- **summary** : `string|null`  
+- **summary** : `string|null`
   No details available.
-- **description** : `string|null`  
+- **description** : `string|null`
   No details available.
-- **tags** : `list&lt;string&gt;|null`  
+- **tags** : `list&lt;string&gt;|null`
   No details available.
-- **parameters** : `list&lt;OA\Parameter&gt;|null`  
+- **parameters** : `list&lt;OA\Parameter&gt;|null`
   No details available.
-- **requestBody** : `OpenApi\Spec\RequestBody|null`  
+- **requestBody** : `OpenApi\Spec\RequestBody|null`
   No details available.
-- **responses** : `list&lt;OA\Response&gt;|null`  
+- **responses** : `list&lt;OA\Response&gt;|null`
   No details available.
-- **callbacks** : `array&lt;string,mixed&gt;|null`  
+- **callbacks** : `array&lt;string,mixed&gt;|null`
   No details available.
-- **deprecated** : `bool|null`  
+- **deprecated** : `bool|null`
   No details available.
-- **security** : `list&lt;OA\Security\Requirement&gt;|null`  
+- **security** : `list&lt;OA\Security\Requirement&gt;|null`
   No details available.
-- **servers** : `list&lt;OA\Server&gt;|null`  
+- **servers** : `list&lt;OA\Server&gt;|null`
   No details available.
-- **externalDocs** : `OpenApi\Spec\ExternalDocumentation|null`  
+- **externalDocs** : `OpenApi\Spec\ExternalDocumentation|null`
   No details available.
 
 #### Reference
@@ -1017,35 +1017,35 @@ Produces:
 
 #### Parameters
 ---
-- **parameter** : `string|null`  
+- **parameter** : `string|null`
   Reusable parameter identifier (component key)
-- **name** : `string|null`  
+- **name** : `string|null`
   The name of the parameter
-- **in** : `string|null`  
+- **in** : `string|null`
   The location of the parameter (query, header, path, cookie)
-- **description** : `string|null`  
+- **description** : `string|null`
   A brief description of the parameter (CommonMark syntax)
-- **required** : `bool|null`  
+- **required** : `bool|null`
   Whether the parameter is mandatory
-- **deprecated** : `bool|null`  
+- **deprecated** : `bool|null`
   Whether the parameter is deprecated
-- **allowEmptyValue** : `bool|null`  
+- **allowEmptyValue** : `bool|null`
   Whether empty-valued parameters are allowed
-- **ref** : `string|null`  
+- **ref** : `string|null`
   A JSON Reference to a reusable parameter
-- **style** : `string|null`  
+- **style** : `string|null`
   How the parameter value is serialized
-- **explode** : `bool|null`  
+- **explode** : `bool|null`
   Whether arrays/objects generate separate parameters
-- **allowReserved** : `bool|null`  
+- **allowReserved** : `bool|null`
   Whether reserved characters are allowed without encoding
-- **schema** : `Schema|null`  
+- **schema** : `Schema|null`
   The schema defining the type for the parameter
-- **example** : `mixed`  
+- **example** : `mixed`
   Example of the parameter's value
-- **examples** : `list&lt;Example&gt;|null`  
+- **examples** : `list&lt;Example&gt;|null`
   Examples of the parameter's value
-- **content** : `list&lt;MediaType&gt;|null`  
+- **content** : `list&lt;MediaType&gt;|null`
   Content-type based parameter serialization
 
 #### Reference
@@ -1066,27 +1066,27 @@ A parameter passed via an HTTP cookie.
 
 #### Parameters
 ---
-- **parameter** : `string|null`  
+- **parameter** : `string|null`
   No details available.
-- **name** : `string|null`  
+- **name** : `string|null`
   No details available.
-- **description** : `string|null`  
+- **description** : `string|null`
   No details available.
-- **required** : `bool|null`  
+- **required** : `bool|null`
   No details available.
-- **deprecated** : `bool|null`  
+- **deprecated** : `bool|null`
   No details available.
-- **ref** : `string|null`  
+- **ref** : `string|null`
   No details available.
-- **explode** : `bool|null`  
+- **explode** : `bool|null`
   No details available.
-- **schema** : `OpenApi\Spec\Schema|null`  
+- **schema** : `OpenApi\Spec\Schema|null`
   No details available.
-- **example** : `mixed|null`  
+- **example** : `mixed|null`
   No details available.
-- **examples** : `list&lt;OA\Example&gt;|null`  
+- **examples** : `list&lt;OA\Example&gt;|null`
   No details available.
-- **content** : `list&lt;OA\MediaType&gt;|null`  
+- **content** : `list&lt;OA\MediaType&gt;|null`
   No details available.
 
 #### Reference
@@ -1107,27 +1107,27 @@ A parameter passed via an HTTP header.
 
 #### Parameters
 ---
-- **parameter** : `string|null`  
+- **parameter** : `string|null`
   No details available.
-- **name** : `string|null`  
+- **name** : `string|null`
   No details available.
-- **description** : `string|null`  
+- **description** : `string|null`
   No details available.
-- **required** : `bool|null`  
+- **required** : `bool|null`
   No details available.
-- **deprecated** : `bool|null`  
+- **deprecated** : `bool|null`
   No details available.
-- **ref** : `string|null`  
+- **ref** : `string|null`
   No details available.
-- **explode** : `bool|null`  
+- **explode** : `bool|null`
   No details available.
-- **schema** : `OpenApi\Spec\Schema|null`  
+- **schema** : `OpenApi\Spec\Schema|null`
   No details available.
-- **example** : `mixed|null`  
+- **example** : `mixed|null`
   No details available.
-- **examples** : `list&lt;OA\Example&gt;|null`  
+- **examples** : `list&lt;OA\Example&gt;|null`
   No details available.
-- **content** : `list&lt;OA\MediaType&gt;|null`  
+- **content** : `list&lt;OA\MediaType&gt;|null`
   No details available.
 
 #### Reference
@@ -1148,27 +1148,27 @@ A parameter passed via the URL path (always required).
 
 #### Parameters
 ---
-- **parameter** : `string|null`  
+- **parameter** : `string|null`
   No details available.
-- **name** : `string|null`  
+- **name** : `string|null`
   No details available.
-- **description** : `string|null`  
+- **description** : `string|null`
   No details available.
-- **deprecated** : `bool|null`  
+- **deprecated** : `bool|null`
   No details available.
-- **ref** : `string|null`  
+- **ref** : `string|null`
   No details available.
-- **style** : `string|null`  
+- **style** : `string|null`
   No details available.
-- **explode** : `bool|null`  
+- **explode** : `bool|null`
   No details available.
-- **schema** : `OpenApi\Spec\Schema|null`  
+- **schema** : `OpenApi\Spec\Schema|null`
   No details available.
-- **example** : `mixed|null`  
+- **example** : `mixed|null`
   No details available.
-- **examples** : `list&lt;OA\Example&gt;|null`  
+- **examples** : `list&lt;OA\Example&gt;|null`
   No details available.
-- **content** : `list&lt;OA\MediaType&gt;|null`  
+- **content** : `list&lt;OA\MediaType&gt;|null`
   No details available.
 
 #### Reference
@@ -1189,33 +1189,33 @@ A parameter passed via the URL query string.
 
 #### Parameters
 ---
-- **parameter** : `string|null`  
+- **parameter** : `string|null`
   No details available.
-- **name** : `string|null`  
+- **name** : `string|null`
   No details available.
-- **description** : `string|null`  
+- **description** : `string|null`
   No details available.
-- **required** : `bool|null`  
+- **required** : `bool|null`
   No details available.
-- **deprecated** : `bool|null`  
+- **deprecated** : `bool|null`
   No details available.
-- **allowEmptyValue** : `bool|null`  
+- **allowEmptyValue** : `bool|null`
   No details available.
-- **ref** : `string|null`  
+- **ref** : `string|null`
   No details available.
-- **style** : `string|null`  
+- **style** : `string|null`
   No details available.
-- **explode** : `bool|null`  
+- **explode** : `bool|null`
   No details available.
-- **allowReserved** : `bool|null`  
+- **allowReserved** : `bool|null`
   No details available.
-- **schema** : `OpenApi\Spec\Schema|null`  
+- **schema** : `OpenApi\Spec\Schema|null`
   No details available.
-- **example** : `mixed|null`  
+- **example** : `mixed|null`
   No details available.
-- **examples** : `list&lt;OA\Example&gt;|null`  
+- **examples** : `list&lt;OA\Example&gt;|null`
   No details available.
-- **content** : `list&lt;OA\MediaType&gt;|null`  
+- **content** : `list&lt;OA\MediaType&gt;|null`
   No details available.
 
 #### Reference
@@ -1274,23 +1274,23 @@ name+in (parameters).
 
 #### Parameters
 ---
-- **ref** : `string|null`  
+- **ref** : `string|null`
   A JSON Reference to a reusable path item
-- **prefix** : `string|null`  
+- **prefix** : `string|null`
   Path prefix — composable via class hierarchy
-- **summary** : `string|null`  
+- **summary** : `string|null`
   An optional summary, intended to apply to all operations in this path
-- **description** : `string|null`  
+- **description** : `string|null`
   An optional description, intended to apply to all operations in this path
-- **parameters** : `list&lt;Parameter&gt;|null`  
+- **parameters** : `list&lt;Parameter&gt;|null`
   Parameters applicable to all operations under this path
-- **servers** : `list&lt;Server&gt;|null`  
+- **servers** : `list&lt;Server&gt;|null`
   Alternative servers for all operations under this path
-- **tags** : `list&lt;string&gt;|null`  
+- **tags** : `list&lt;string&gt;|null`
   Tags to clone to contained operations
-- **security** : `list&lt;Security\Requirement&gt;|null`  
+- **security** : `list&lt;Security\Requirement&gt;|null`
   Security requirements to clone to contained operations
-- **responses** : `list&lt;Response&gt;|null`  
+- **responses** : `list&lt;Response&gt;|null`
   Shared responses to clone to contained operations
 
 #### Reference
@@ -1307,9 +1307,9 @@ Defines a single property within a Schema object.
 
 #### Parameters
 ---
-- **property** : `string|null`  
+- **property** : `string|null`
   The property name
-- **schema** : `Schema|null`  
+- **schema** : `Schema|null`
   The schema defining the property type and constraints
 
 #### Reference
@@ -1330,15 +1330,15 @@ Describes a single request body.
 
 #### Parameters
 ---
-- **request** : `string|null`  
+- **request** : `string|null`
   Reusable request body identifier (component key)
-- **description** : `string|null`  
+- **description** : `string|null`
   A brief description of the request body (CommonMark syntax)
-- **required** : `bool|null`  
+- **required** : `bool|null`
   Whether the request body is required
-- **ref** : `string|null`  
+- **ref** : `string|null`
   A JSON Reference to a reusable request body
-- **content** : `list&lt;MediaType&gt;|null`  
+- **content** : `list&lt;MediaType&gt;|null`
   The content of the request body
 
 #### Reference
@@ -1359,17 +1359,17 @@ Describes a single response from an API operation.
 
 #### Parameters
 ---
-- **response** : `string|int|null`  
+- **response** : `string|int|null`
   The HTTP status code or 'default'
-- **description** : `string|null`  
+- **description** : `string|null`
   A description of the response (CommonMark syntax)
-- **ref** : `string|null`  
+- **ref** : `string|null`
   A JSON Reference to a reusable response
-- **headers** : `list&lt;Header&gt;|null`  
+- **headers** : `list&lt;Header&gt;|null`
   Headers sent with the response
-- **content** : `list&lt;MediaType&gt;|null`  
+- **content** : `list&lt;MediaType&gt;|null`
   Possible response payloads
-- **links** : `list&lt;Link&gt;|null`  
+- **links** : `list&lt;Link&gt;|null`
   Design-time links for the response
 
 #### Reference
@@ -1413,113 +1413,113 @@ Inline — used within parameters, responses, or other schemas:
 
 #### Parameters
 ---
-- **schema** : `string|null`  
+- **schema** : `string|null`
   Reusable schema identifier (component key)
-- **title** : `string|null`  
+- **title** : `string|null`
   A title for the schema
-- **description** : `string|null`  
+- **description** : `string|null`
   A description of the schema (CommonMark syntax)
-- **ref** : `string|null`  
+- **ref** : `string|null`
   A JSON Reference to a reusable schema
-- **type** : `string|list&lt;string&gt;|null`  
+- **type** : `string|list&lt;string&gt;|null`
   The value type(s) (string, number, integer, boolean, array, object, null)
-- **format** : `string|null`  
+- **format** : `string|null`
   Further refines the type (e.g. int32, int64, float, double, date-time, email)
-- **nullable** : `bool|null`  
+- **nullable** : `bool|null`
   Whether the value can be null (OAS 3.0 only; use type array in 3.1+)
-- **minLength** : `int|null`  
+- **minLength** : `int|null`
   Minimum string length
-- **maxLength** : `int|null`  
+- **maxLength** : `int|null`
   Maximum string length
-- **pattern** : `string|null`  
+- **pattern** : `string|null`
   Regular expression pattern the string must match
-- **contentMediaType** : `string|null`  
+- **contentMediaType** : `string|null`
   The media type of string content encoding
-- **contentEncoding** : `string|null`  
+- **contentEncoding** : `string|null`
   The encoding used for string content (e.g. base64)
-- **minimum** : `int|float|null`  
+- **minimum** : `int|float|null`
   Minimum numeric value (inclusive)
-- **maximum** : `int|float|null`  
+- **maximum** : `int|float|null`
   Maximum numeric value (inclusive)
-- **exclusiveMinimum** : `int|float|bool|null`  
+- **exclusiveMinimum** : `int|float|bool|null`
   Exclusive minimum value
-- **exclusiveMaximum** : `int|float|bool|null`  
+- **exclusiveMaximum** : `int|float|bool|null`
   Exclusive maximum value
-- **multipleOf** : `int|float|null`  
+- **multipleOf** : `int|float|null`
   The value must be a multiple of this number
-- **items** : `Schema|string|null`  
+- **items** : `Schema|string|null`
   Schema for array items
-- **minItems** : `int|null`  
+- **minItems** : `int|null`
   Minimum number of array items
-- **maxItems** : `int|null`  
+- **maxItems** : `int|null`
   Maximum number of array items
-- **uniqueItems** : `bool|null`  
+- **uniqueItems** : `bool|null`
   Whether array items must be unique
-- **prefixItems** : `list&lt;Schema&gt;|null`  
+- **prefixItems** : `list&lt;Schema&gt;|null`
   Schemas for positional array items (tuple validation)
-- **contains** : `Schema|bool|null`  
+- **contains** : `Schema|bool|null`
   Schema that at least one array item must match
-- **minContains** : `int|null`  
+- **minContains** : `int|null`
   Minimum number of items matching contains
-- **maxContains** : `int|null`  
+- **maxContains** : `int|null`
   Maximum number of items matching contains
-- **unevaluatedItems** : `Schema|bool|null`  
+- **unevaluatedItems** : `Schema|bool|null`
   Schema for items not covered by other keywords
-- **properties** : `list&lt;Property|Schema&gt;|null`  
+- **properties** : `list&lt;Property|Schema&gt;|null`
   Object property definitions
-- **required** : `list&lt;string&gt;|null`  
+- **required** : `list&lt;string&gt;|null`
   List of required property names
-- **additionalProperties** : `Schema|bool|null`  
+- **additionalProperties** : `Schema|bool|null`
   Schema or boolean for additional properties
-- **patternProperties** : `array&lt;string,Schema&gt;|null`  
+- **patternProperties** : `array&lt;string,Schema&gt;|null`
   Schemas for properties matching regex patterns
-- **minProperties** : `int|null`  
+- **minProperties** : `int|null`
   Minimum number of properties
-- **maxProperties** : `int|null`  
+- **maxProperties** : `int|null`
   Maximum number of properties
-- **unevaluatedProperties** : `Schema|bool|null`  
+- **unevaluatedProperties** : `Schema|bool|null`
   Schema for properties not covered by other keywords
-- **propertyNames** : `Schema|null`  
+- **propertyNames** : `Schema|null`
   Schema that property names must validate against
-- **dependentRequired** : `array&lt;string,list&lt;string&gt;&gt;|null`  
+- **dependentRequired** : `array&lt;string,list&lt;string&gt;&gt;|null`
   Property-level required dependencies
-- **dependentSchemas** : `array&lt;string,Schema&gt;|null`  
+- **dependentSchemas** : `array&lt;string,Schema&gt;|null`
   Property-level schema dependencies
-- **allOf** : `list&lt;Schema&gt;|null`  
+- **allOf** : `list&lt;Schema&gt;|null`
   All schemas must match (AND composition)
-- **anyOf** : `list&lt;Schema&gt;|null`  
+- **anyOf** : `list&lt;Schema&gt;|null`
   At least one schema must match (OR composition)
-- **oneOf** : `list&lt;Schema&gt;|null`  
+- **oneOf** : `list&lt;Schema&gt;|null`
   Exactly one schema must match (XOR composition)
-- **not** : `Schema|null`  
+- **not** : `Schema|null`
   The schema must NOT match
-- **if** : `Schema|null`  
+- **if** : `Schema|null`
   Conditional schema (if-then-else)
-- **then** : `Schema|null`  
+- **then** : `Schema|null`
   Applied when 'if' succeeds
-- **else** : `Schema|null`  
+- **else** : `Schema|null`
   Applied when 'if' fails
-- **enum** : `list&lt;string|int|float|bool|\UnitEnum|class-string&lt;\UnitEnum&gt;|null&gt;|null`  
+- **enum** : `list&lt;string|int|float|bool|\UnitEnum|class-string&lt;\UnitEnum&gt;|null&gt;|null`
   Allowed values
-- **const** : `mixed`  
+- **const** : `mixed`
   A single allowed value
-- **example** : `mixed`  
+- **example** : `mixed`
   An example value
-- **examples** : `list&lt;mixed&gt;|null`  
+- **examples** : `list&lt;mixed&gt;|null`
   A list of example values
-- **deprecated** : `bool|null`  
+- **deprecated** : `bool|null`
   Whether the schema is deprecated
-- **readOnly** : `bool|null`  
+- **readOnly** : `bool|null`
   Whether the value is read-only
-- **writeOnly** : `bool|null`  
+- **writeOnly** : `bool|null`
   Whether the value is write-only
-- **default** : `mixed`  
+- **default** : `mixed`
   The default value
-- **discriminator** : `Discriminator|null`  
+- **discriminator** : `Discriminator|null`
   Discriminator for polymorphism
-- **externalDocs** : `ExternalDocumentation|null`  
+- **externalDocs** : `ExternalDocumentation|null`
   Additional external documentation
-- **xml** : `Xml|null`  
+- **xml** : `Xml|null`
   XML representation metadata
 
 #### Reference
@@ -1540,11 +1540,11 @@ Multiple schemes within a single requirement represent AND logic.
 
 #### Parameters
 ---
-- **scheme** : `string|null`  
+- **scheme** : `string|null`
   Single scheme name (shorthand for simple requirements)
-- **scopes** : `list&lt;string&gt;|null`  
+- **scopes** : `list&lt;string&gt;|null`
   Scopes for the single scheme (OAuth2/OpenIdConnect)
-- **schemes** : `array&lt;string,list&lt;string&gt;&gt;|null`  
+- **schemes** : `array&lt;string,list&lt;string&gt;&gt;|null`
   Map of scheme names to scopes (for AND logic with multiple schemes)
 
 #### Reference
@@ -1572,25 +1572,25 @@ Typed subtypes are available for each security scheme type:
 
 #### Parameters
 ---
-- **securityScheme** : `string|null`  
+- **securityScheme** : `string|null`
   Reusable security scheme identifier (component key)
-- **type** : `string|null`  
+- **type** : `string|null`
   The type of the security scheme (apiKey, http, mutualTLS, oauth2, openIdConnect)
-- **description** : `string|null`  
+- **description** : `string|null`
   A description of the security scheme (CommonMark syntax)
-- **name** : `string|null`  
+- **name** : `string|null`
   The name of the header, query, or cookie parameter (apiKey)
-- **in** : `string|null`  
+- **in** : `string|null`
   The location of the API key (query, header, cookie)
-- **scheme** : `string|null`  
+- **scheme** : `string|null`
   The HTTP authorization scheme (http)
-- **bearerFormat** : `string|null`  
+- **bearerFormat** : `string|null`
   A hint about the format of the bearer token (http/bearer)
-- **openIdConnectUrl** : `string|null`  
+- **openIdConnectUrl** : `string|null`
   The OpenID Connect URL to discover configuration (openIdConnect)
-- **flows** : `list&lt;OA\Flow&gt;|null`  
+- **flows** : `list&lt;OA\Flow&gt;|null`
   The available OAuth2 flows (oauth2)
-- **ref** : `string|null`  
+- **ref** : `string|null`
   A JSON Reference to a reusable security scheme
 
 #### Reference
@@ -1607,13 +1607,13 @@ An API key security scheme (header, query, or cookie).
 
 #### Parameters
 ---
-- **securityScheme** : `string|null`  
+- **securityScheme** : `string|null`
   No details available.
-- **description** : `string|null`  
+- **description** : `string|null`
   No details available.
-- **name** : `string|null`  
+- **name** : `string|null`
   No details available.
-- **in** : `string|null`  
+- **in** : `string|null`
   No details available.
 
 #### Reference
@@ -1630,13 +1630,13 @@ An HTTP authentication security scheme (Basic, Bearer, etc.).
 
 #### Parameters
 ---
-- **securityScheme** : `string|null`  
+- **securityScheme** : `string|null`
   No details available.
-- **description** : `string|null`  
+- **description** : `string|null`
   No details available.
-- **scheme** : `string|null`  
+- **scheme** : `string|null`
   No details available.
-- **bearerFormat** : `string|null`  
+- **bearerFormat** : `string|null`
   No details available.
 
 #### Reference
@@ -1653,9 +1653,9 @@ A Mutual TLS security scheme.
 
 #### Parameters
 ---
-- **securityScheme** : `string|null`  
+- **securityScheme** : `string|null`
   No details available.
-- **description** : `string|null`  
+- **description** : `string|null`
   No details available.
 
 #### Reference
@@ -1672,11 +1672,11 @@ An OAuth2 security scheme with one or more flows.
 
 #### Parameters
 ---
-- **securityScheme** : `string|null`  
+- **securityScheme** : `string|null`
   No details available.
-- **description** : `string|null`  
+- **description** : `string|null`
   No details available.
-- **flows** : `list&lt;OA\Flow&gt;|null`  
+- **flows** : `list&lt;OA\Flow&gt;|null`
   No details available.
 
 #### Reference
@@ -1693,11 +1693,11 @@ An OpenID Connect Discovery security scheme.
 
 #### Parameters
 ---
-- **securityScheme** : `string|null`  
+- **securityScheme** : `string|null`
   No details available.
-- **description** : `string|null`  
+- **description** : `string|null`
   No details available.
-- **openIdConnectUrl** : `string|null`  
+- **openIdConnectUrl** : `string|null`
   No details available.
 
 #### Reference
@@ -1718,11 +1718,11 @@ Represents a Server.
 
 #### Parameters
 ---
-- **url** : `string|null`  
+- **url** : `string|null`
   A URL to the target host
-- **description** : `string|null`  
+- **description** : `string|null`
   A description of the host (CommonMark syntax)
-- **variables** : `list&lt;ServerVariable&gt;|null`  
+- **variables** : `list&lt;ServerVariable&gt;|null`
   Variables for server URL template substitution
 
 #### Reference
@@ -1739,13 +1739,13 @@ Represents a Server Variable for server URL template substitution.
 
 #### Parameters
 ---
-- **serverVariable** : `string|null`  
+- **serverVariable** : `string|null`
   The variable name
-- **default** : `string|null`  
+- **default** : `string|null`
   The default value to use for substitution
-- **description** : `string|null`  
+- **description** : `string|null`
   A description of the server variable (CommonMark syntax)
-- **enum** : `list&lt;string&gt;|null`  
+- **enum** : `list&lt;string&gt;|null`
   Enumeration of allowed string values for substitution
 
 #### Reference
@@ -1762,11 +1762,11 @@ Adds metadata to a single tag used by the Operation Object.
 
 #### Parameters
 ---
-- **name** : `string|null`  
+- **name** : `string|null`
   The name of the tag
-- **description** : `string|null`  
+- **description** : `string|null`
   A description of the tag (CommonMark syntax)
-- **externalDocs** : `ExternalDocumentation|null`  
+- **externalDocs** : `ExternalDocumentation|null`
   Additional external documentation for this tag
 
 #### Reference
@@ -1783,15 +1783,15 @@ Metadata for XML representation of a schema property.
 
 #### Parameters
 ---
-- **name** : `string|null`  
+- **name** : `string|null`
   Replaces the name of the element/attribute
-- **namespace** : `string|null`  
+- **namespace** : `string|null`
   The URI of the XML namespace
-- **prefix** : `string|null`  
+- **prefix** : `string|null`
   The namespace prefix to use
-- **attribute** : `bool|null`  
+- **attribute** : `bool|null`
   Whether the property translates to an XML attribute
-- **wrapped** : `bool|null`  
+- **wrapped** : `bool|null`
   Whether array items are wrapped in an additional element
 
 #### Reference

--- a/docs/snippets/guide/shortcuts/response_json_content-3.1.0.yaml
+++ b/docs/snippets/guide/shortcuts/response_json_content-3.1.0.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 components:
   responses:
-    '200':
+    200:
       description: 'successful operation'
       content:
         application/json:

--- a/docs/snippets/guide/shortcuts/response_json_content_spec.php
+++ b/docs/snippets/guide/shortcuts/response_json_content_spec.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Openapi\Snippets\Shortcuts\ResponseJson;
+
+use OpenApi\Spec as OA;
+
+class ControllerSpec
+{
+    #[OA\Operation\Get(path: '/endpoint')]
+    #[OA\Response(
+        response: 200,
+        description: 'successful operation',
+        content: [new OA\MediaType\Json(
+            ref: '#/components/schemas/User',
+        )],
+    )]
+    public function endpoint()
+    {
+    }
+}

--- a/docs/snippets/guide/shortcuts/response_json_content_spec.php
+++ b/docs/snippets/guide/shortcuts/response_json_content_spec.php
@@ -4,9 +4,8 @@ namespace Openapi\Snippets\Shortcuts\ResponseJson;
 
 use OpenApi\Spec as OA;
 
-class ControllerSpec
+class Controller
 {
-    #[OA\Operation\Get(path: '/endpoint')]
     #[OA\Response(
         response: 200,
         description: 'successful operation',

--- a/docs/snippets/guide/shortcuts/response_media_type-3.1.0.yaml
+++ b/docs/snippets/guide/shortcuts/response_media_type-3.1.0.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 components:
   responses:
-    '200':
+    200:
       description: 'successful operation'
       content:
         application/json:

--- a/docs/snippets/guide/shortcuts/response_media_type_spec.php
+++ b/docs/snippets/guide/shortcuts/response_media_type_spec.php
@@ -4,9 +4,8 @@ namespace Openapi\Snippets\Shortcuts\MediaType;
 
 use OpenApi\Spec as OA;
 
-class ControllerSpec
+class Controller
 {
-    #[OA\Operation\Get(path: '/endpoint')]
     #[OA\Response(
         response: 200,
         description: 'successful operation',

--- a/docs/snippets/guide/shortcuts/response_media_type_spec.php
+++ b/docs/snippets/guide/shortcuts/response_media_type_spec.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Openapi\Snippets\Shortcuts\MediaType;
+
+use OpenApi\Spec as OA;
+
+class ControllerSpec
+{
+    #[OA\Operation\Get(path: '/endpoint')]
+    #[OA\Response(
+        response: 200,
+        description: 'successful operation',
+        content: [new OA\MediaType(
+            mediaType: 'application/json',
+            schema: new OA\Schema(ref: '#/components/schemas/User'),
+        )],
+    )]
+    public function endpoint()
+    {
+    }
+}

--- a/docs/spec-attributes.md
+++ b/docs/spec-attributes.md
@@ -16,7 +16,7 @@ The spec attributes pipeline introduces a clean separation of concerns with expl
 
 ### Additional augmenter pipes
 
-- **`EnumDescription`** — generate human-readable descriptions from PHP enum cases (ported from openapi-extras). Ships in the default pipeline but disabled by default; enable via `$builder->getAugmenters()->get(EnumDescription::class)->setEnabled(true)`.
+- **`EnumDescriptions`** — generate human-readable descriptions from PHP enum cases (ported from openapi-extras). Ships in the default pipeline but disabled by default; enable via `$builder->getAugmenters()->get(EnumDescriptions::class)->setEnabled(true)`.
 
 ### Shipping
 

--- a/docs/spec-attributes.md
+++ b/docs/spec-attributes.md
@@ -35,12 +35,12 @@ The spec attributes pipeline introduces a clean separation of concerns with expl
 
 Re-evaluate support for convenience attributes that reduce boilerplate in common patterns:
 
-- **`Items`** — shorthand for array item schema declaration; this probably should be extending `OA\Items` and get a dedicated `PipeInterface` augmenter.
+~~- **`Items`** — shorthand for array item schema declaration; this probably should be extending `OA\Items` and get a dedicated `PipeInterface` augmenter.~~
 ~~- **`JsonContent`** / **`XmlContent`** — shorthand for wrapping a schema in a media type with the appropriate content type; a new `AttributeTranslatorInterface` should be implemented to handle the translation of these attributes.~~
 - Optional `OA\Property` if `OA\Schema` present and the default property name is used (empty `#[OA\Property])`)
 - Adjust attribute parameter types to aid downstream projects?
 - A `OA\Schema\Ref` attribute (with title/description 3.1.0+), $ref required attribute - extends `OA\Schema`
 - test to verify merges()/contains() consistency (with property type checks)
-- attachable example/test
-- review [] property types that could also accept a single: type|list<type>
+~~- attachable example/test~~
+~~- review [] property types that could also accept a single: type|list<type>~~
 ~~- enums for fixed strings, like flows->implicit, etc~~

--- a/src/Augmenter/Shortcuts.php
+++ b/src/Augmenter/Shortcuts.php
@@ -30,6 +30,7 @@ class Shortcuts implements PipeInterface
     public function __invoke(mixed $payload): mixed
     {
         $this->processMediaTypes($payload);
+        $this->processSchemaItems($payload);
 
         return null;
     }
@@ -58,5 +59,46 @@ class Shortcuts implements PipeInterface
                 required: $mediaType->required,
             );
         }
+    }
+
+    protected function processSchemaItems(Specification $specification): void
+    {
+        $specification->getWalker()->visit(AttributeInterface::class, function (AttributeInterface $attribute): void {
+            if (property_exists($attribute, 'schema') && $attribute->schema instanceof OA\Schema\Items) {
+                $this->processSchemaItem($attribute);
+            }
+        });
+    }
+
+    protected function processSchemaItem(AttributeInterface $parent): void
+    {
+        if (!property_exists($parent, 'schema') || !$parent->schema instanceof OA\Schema\Items) {
+            return;
+        }
+
+        $arrayConstraints = [
+            'minItems',
+            'maxItems',
+            'uniqueItems',
+            'prefixItems',
+            'contains',
+            'minContains',
+            'maxContains',
+            'unevaluatedItems',
+        ];
+
+        $inner = $parent->schema;
+        $outer = new OA\Schema(
+            type: 'array',
+            items: $inner,
+        );
+        foreach ($arrayConstraints as $arrayConstraint) {
+            $outer->{$arrayConstraint} = $inner->{$arrayConstraint};
+        }
+        foreach ($arrayConstraints as $arrayConstraint) {
+            $inner->{$arrayConstraint} = null;
+        }
+
+        $parent->schema = $outer;
     }
 }

--- a/src/Augmenter/Shortcuts.php
+++ b/src/Augmenter/Shortcuts.php
@@ -18,11 +18,14 @@ use OpenApi\Utils\PipeInterface;
  * Handles:
  * * `OA\MediaType\Json`
  * * `OA\MediaType\Xml`
+ * * `OA\Schema\Items`
  *
  * @implements PipeInterface<Specification>
  */
 class Shortcuts implements PipeInterface
 {
+    private const MEDIA_TYPE_SCHEMA_PROPERTIES = ['ref', 'type', 'items', 'properties', 'required'];
+
     private const ITEMS_KEEP_PROPERTIES = ['schema', 'title', 'description', 'deprecated', 'readOnly', 'writeOnly', 'xml', 'externalDocs', 'x', 'attachables'];
 
     public function group(): string|\BackedEnum
@@ -54,13 +57,14 @@ class Shortcuts implements PipeInterface
     protected function processMediaType(OA\MediaType\Json|OA\MediaType\Xml $mediaType): void
     {
         if (!$mediaType->schema instanceof OA\Schema) {
-            $mediaType->schema = new OA\Schema(
-                ref: $mediaType->ref,
-                type: $mediaType->type,
-                items: $mediaType->items,
-                properties: $mediaType->properties,
-                required: $mediaType->required,
-            );
+            $args = [];
+            foreach (self::MEDIA_TYPE_SCHEMA_PROPERTIES as $prop) {
+                if ($mediaType->{$prop} !== null) {
+                    $args[$prop] = $mediaType->{$prop};
+                    $mediaType->{$prop} = null;
+                }
+            }
+            $mediaType->schema = new OA\Schema(...$args);
         }
     }
 

--- a/src/Augmenter/Shortcuts.php
+++ b/src/Augmenter/Shortcuts.php
@@ -9,6 +9,7 @@ namespace OpenApi\Augmenter;
 use OpenApi\AttributeInterface;
 use OpenApi\Spec as OA;
 use OpenApi\Specification;
+use OpenApi\Undefined;
 use OpenApi\Utils\PipeInterface;
 
 /**
@@ -22,6 +23,8 @@ use OpenApi\Utils\PipeInterface;
  */
 class Shortcuts implements PipeInterface
 {
+    private const ITEMS_KEEP_PROPERTIES = ['schema', 'title', 'description', 'deprecated', 'readOnly', 'writeOnly', 'xml', 'externalDocs', 'x', 'attachables'];
+
     public function group(): string|\BackedEnum
     {
         return Group::Resolve;
@@ -65,40 +68,35 @@ class Shortcuts implements PipeInterface
     {
         $specification->getWalker()->visit(AttributeInterface::class, function (AttributeInterface $attribute): void {
             if (property_exists($attribute, 'schema') && $attribute->schema instanceof OA\Schema\Items) {
-                $this->processSchemaItem($attribute);
+                $this->processSchemaItem($attribute->schema);
             }
         });
     }
 
-    protected function processSchemaItem(AttributeInterface $parent): void
+    protected function processSchemaItem(OA\Schema\Items $items): void
     {
-        if (!property_exists($parent, 'schema') || !$parent->schema instanceof OA\Schema\Items) {
-            return;
+        if ($items->items instanceof OA\Schema\Items) {
+            $this->processSchemaItem($items->items);
         }
 
-        $arrayConstraints = [
-            'minItems',
-            'maxItems',
-            'uniqueItems',
-            'prefixItems',
-            'contains',
-            'minContains',
-            'maxContains',
-            'unevaluatedItems',
-        ];
+        $itemKeep = [...OA\Schema::ARRAY_PROPERTIES, ...self::ITEMS_KEEP_PROPERTIES];
 
-        $inner = $parent->schema;
-        $outer = new OA\Schema(
-            type: 'array',
-            items: $inner,
-        );
-        foreach ($arrayConstraints as $arrayConstraint) {
-            $outer->{$arrayConstraint} = $inner->{$arrayConstraint};
-        }
-        foreach ($arrayConstraints as $arrayConstraint) {
-            $inner->{$arrayConstraint} = null;
+        $innerArgs = [];
+        foreach ((new \ReflectionClass(OA\Schema::class))->getConstructor()->getParameters() as $param) {
+            $prop = $param->getName();
+            if (in_array($prop, $itemKeep, true)) {
+                continue;
+            }
+            $value = $items->{$prop};
+            if ($value !== null && $value !== Undefined::UNDEFINED) {
+                $innerArgs[$prop] = $value;
+                $items->{$prop} = null;
+            }
         }
 
-        $parent->schema = $outer;
+        $items->type = 'array';
+        if ($innerArgs || $items->items === null) {
+            $items->items = new OA\Schema(...$innerArgs);
+        }
     }
 }

--- a/src/Spec/MediaType/Json.php
+++ b/src/Spec/MediaType/Json.php
@@ -19,6 +19,18 @@ use OpenApi\Undefined;
  * * `ref`, `type`, `items`, `properties` and `required` may be used and will be expanded into a nested `OA\Schema` automatically.
  * * If `schema` is explicitly set, the custom `OA\Schema` properties will be ignored.
  *
+ * Allows to shorten this:
+ *
+ *   #[OA\Response(response: 200, content: [
+ *       new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(type: 'array', items: new OA\Schema(ref: Pet::class))),
+ *   ])]
+ *
+ * to this:
+ *
+ *   #[OA\Response(response: 200, content: [new OA\MediaType\Json(type: 'array', items: new OA\Schema(ref: Pet::class))])]
+ *
+ * The `Shortcuts` augmenter expands the schema properties into a nested `OA\Schema` automatically.
+ *
  * @see [Media Type Object](https://spec.openapis.org/oas/v3.1.1.html#media-type-object)
  */
 #[\Attribute(\Attribute::IS_REPEATABLE)]

--- a/src/Spec/MediaType/Xml.php
+++ b/src/Spec/MediaType/Xml.php
@@ -19,6 +19,18 @@ use OpenApi\Undefined;
  * * `ref`, `type`, `items`, `properties` and `required` may be used and will be expanded into a nested `OA\Schema` automatically.
  * * If `schema` is explicitly set, the custom `OA\Schema` properties will be ignored.
  *
+ * Allows to shorten this:
+ *
+ *   #[OA\Response(response: 200, content: [
+ *       new OA\MediaType(mediaType: 'application/xml', schema: new OA\Schema(type: 'array', items: new OA\Schema(ref: Pet::class))),
+ *   ])]
+ *
+ * to this:
+ *
+ *   #[OA\Response(response: 200, content: [new OA\MediaType\Xml(type: 'array', items: new OA\Schema(ref: Pet::class))])]
+ *
+ * The `Shortcuts` augmenter expands the schema properties into a nested `OA\Schema` automatically.
+ *
  * @see [Media Type Object](https://spec.openapis.org/oas/v3.1.1.html#media-type-object)
  */
 #[\Attribute(\Attribute::IS_REPEATABLE)]

--- a/src/Spec/Schema.php
+++ b/src/Spec/Schema.php
@@ -40,6 +40,18 @@ use OpenApi\Undefined;
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY | \Attribute::TARGET_PARAMETER | \Attribute::IS_REPEATABLE)]
 class Schema extends AbstractAttribute
 {
+    public const ARRAY_PROPERTIES = [
+        'items',
+        'minItems',
+        'maxItems',
+        'uniqueItems',
+        'prefixItems',
+        'contains',
+        'minContains',
+        'maxContains',
+        'unevaluatedItems',
+    ];
+
     /**
      * @param string|null                                                             $schema                Reusable schema identifier (component key)
      * @param string|null                                                             $title                 A title for the schema

--- a/src/Spec/Schema/Items.php
+++ b/src/Spec/Schema/Items.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Spec\Schema;
+
+use OpenApi\Spec as OA;
+
+/**
+ * Shortcut for `OA\Schema` with type `array` and `items`.
+ *
+ * Allows to shorten this:
+ *
+ *   #[OA\Schema]
+ *   class Pet {
+ *       #[OA\Property]
+ *       #[OA\Schema(type: 'array', items: new OA\Schema(ref: MyModel::class))]
+ *       public array $names;
+ *   }
+ *
+ * to this:
+ *
+ *   #[OA\Schema]
+ *   class Pet {
+ *       #[OA\Property]
+ *       #[OA\Items(ref: MyModel::class)]
+ *       public array $names;
+ *   }
+ *
+ * @see [Schema Object](https://spec.openapis.org/oas/v3.1.1.html#schema-object)
+ */
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY | \Attribute::TARGET_PARAMETER | \Attribute::IS_REPEATABLE)]
+class Items extends OA\Schema
+{
+}

--- a/src/Spec/Schema/Items.php
+++ b/src/Spec/Schema/Items.php
@@ -25,9 +25,11 @@ use OpenApi\Spec as OA;
  *   #[OA\Schema]
  *   class Pet {
  *       #[OA\Property]
- *       #[OA\Items(ref: MyModel::class)]
+ *       #[OA\Schema\Items(ref: MyModel::class)]
  *       public array $names;
  *   }
+ *
+ * The `Shortcuts` augmenter wraps this into `OA\Schema(type: 'array', items: ...)` automatically.
  *
  * @see [Schema Object](https://spec.openapis.org/oas/v3.1.1.html#schema-object)
  */

--- a/tests/Augmenter/ShortcutsTest.php
+++ b/tests/Augmenter/ShortcutsTest.php
@@ -16,7 +16,7 @@ final class ShortcutsTest extends TestCase
 {
     use AssemblesSpecification;
 
-    public function testBasicEnumUsesNames(): void
+    public function testMediaTypeJson(): void
     {
         $spec = $this->assemble(Fixtures\Augmenter\JsonController::class);
 
@@ -36,8 +36,8 @@ final class ShortcutsTest extends TestCase
 
         $property = $spec->schemas[0]->properties[0];
         $this->assertInstanceOf(OA\Property::class, $property);
-        $this->assertInstanceOf(OA\Schema::class, $property->schema);
+        $this->assertInstanceOf(OA\Schema\Items::class, $property->schema);
         $this->assertSame('array', $property->schema->type);
-        $this->assertInstanceOf(OA\Schema\Items::class, $property->schema->items);
+        $this->assertInstanceOf(OA\Schema::class, $property->schema->items);
     }
 }

--- a/tests/Augmenter/ShortcutsTest.php
+++ b/tests/Augmenter/ShortcutsTest.php
@@ -27,4 +27,17 @@ final class ShortcutsTest extends TestCase
         $this->assertInstanceOf(OA\Schema::class, $json->schema);
         $this->assertSame('string', $json->schema->type);
     }
+
+    public function testItems(): void
+    {
+        $spec = $this->assemble(Fixtures\Augmenter\ItemsSchema::class);
+
+        (new Augmenter\Shortcuts())($spec);
+
+        $property = $spec->schemas[0]->properties[0];
+        $this->assertInstanceOf(OA\Property::class, $property);
+        $this->assertInstanceOf(OA\Schema::class, $property->schema);
+        $this->assertSame('array', $property->schema->type);
+        $this->assertInstanceOf(OA\Schema\Items::class, $property->schema->items);
+    }
 }

--- a/tests/Augmenter/ShortcutsTest.php
+++ b/tests/Augmenter/ShortcutsTest.php
@@ -22,6 +22,7 @@ final class ShortcutsTest extends TestCase
 
         (new Augmenter\Shortcuts())($spec);
 
+        /** @var OA\MediaType\Json $json */
         $json = $spec->operations[0]->requestBody->content[0];
         $this->assertSame('application/json', $json->mediaType);
         $this->assertInstanceOf(OA\Schema::class, $json->schema);

--- a/tests/Augmenter/ShortcutsTest.php
+++ b/tests/Augmenter/ShortcutsTest.php
@@ -26,6 +26,11 @@ final class ShortcutsTest extends TestCase
         $this->assertSame('application/json', $json->mediaType);
         $this->assertInstanceOf(OA\Schema::class, $json->schema);
         $this->assertSame('string', $json->schema->type);
+        $this->assertNull($json->ref);
+        $this->assertNull($json->type);
+        $this->assertNull($json->items);
+        $this->assertNull($json->properties);
+        $this->assertNull($json->required);
     }
 
     public function testItems(): void
@@ -39,5 +44,21 @@ final class ShortcutsTest extends TestCase
         $this->assertInstanceOf(OA\Schema\Items::class, $property->schema);
         $this->assertSame('array', $property->schema->type);
         $this->assertInstanceOf(OA\Schema::class, $property->schema->items);
+    }
+
+    public function testRecursiveItems(): void
+    {
+        $spec = $this->assemble(Fixtures\Augmenter\ItemsSchema::class);
+
+        (new Augmenter\Shortcuts())($spec);
+
+        $property = $spec->schemas[0]->properties[1];
+        $this->assertInstanceOf(OA\Property::class, $property);
+        $this->assertInstanceOf(OA\Schema\Items::class, $property->schema);
+        $this->assertSame('array', $property->schema->type);
+        $this->assertInstanceOf(OA\Schema\Items::class, $property->schema->items);
+        $this->assertSame('array', $property->schema->items->type);
+        $this->assertInstanceOf(OA\Schema::class, $property->schema->items->items);
+        $this->assertSame('string', $property->schema->items->items->type);
     }
 }

--- a/tests/Fixtures/Augmenter/ItemsSchema.php
+++ b/tests/Fixtures/Augmenter/ItemsSchema.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema]
+class ItemsSchema
+{
+    /** @var list<string> */
+    #[OA\Property]
+    #[OA\Schema\Items]
+    public array $tags;
+}

--- a/tests/Fixtures/Augmenter/ItemsSchema.php
+++ b/tests/Fixtures/Augmenter/ItemsSchema.php
@@ -15,4 +15,9 @@ class ItemsSchema
     #[OA\Property]
     #[OA\Schema\Items]
     public array $tags;
+
+    /** @var list<list<string>> */
+    #[OA\Property]
+    #[OA\Schema\Items(items: new OA\Schema\Items(type: 'string'))]
+    public array $matrix;
 }

--- a/tools/src/Docs/Sections/ParametersSection.php
+++ b/tools/src/Docs/Sections/ParametersSection.php
@@ -27,7 +27,7 @@ class ParametersSection implements SectionInterface
 
         foreach ($parameters as $param) {
             $type = ($param['type'] ?? '') !== '' ? ' : `' . $param['type'] . '`' : '';
-            $out .= '- **' . $param['name'] . '**' . $type . "  \n";
+            $out .= '- **' . $param['name'] . '**' . $type . "\n";
 
             $desc = ($param['description'] ?? '') ?: DocGenerator::NO_DETAILS_AVAILABLE;
             $out .= '  ' . $desc . "\n";


### PR DESCRIPTION
## Summary

Add the equivalent of the classic `OA\Items` to the spec attributes: `OA\Schema\Items`.

Handled by the `Shortcuts` augmenter, together with the media type shortcuts.