### PR TITLE
feat(Spec): clarify attribute translator lifecycle and add tests

### DIFF
--- a/src/Assembler.php
+++ b/src/Assembler.php
@@ -59,6 +59,8 @@ class Assembler
 
     protected function collectFromReflector(\ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector): void
     {
+        $this->attributeFactory->resetTranslators();
+
         if ($reflector instanceof \ReflectionClass) {
             $this->collectFromClass($reflector);
 

--- a/src/Assembler/AbstractAttributeTranslator.php
+++ b/src/Assembler/AbstractAttributeTranslator.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Assembler;
+
+use OpenApi\AttributeTranslatorInterface;
+
+/**
+ * Convenience empty/noop base imlementation of the `AttributeTranslatorInterface`.
+ */
+class AbstractAttributeTranslator implements AttributeTranslatorInterface
+{
+    public function reset(): void
+    {
+    }
+
+    public function getAttributes(\ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector): array
+    {
+        return [];
+    }
+
+    public function translate(array $attributes, array $created, \ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector): array
+    {
+        return [...$attributes, ...$created];
+    }
+}

--- a/src/Assembler/DefaultAttributeTranslator.php
+++ b/src/Assembler/DefaultAttributeTranslator.php
@@ -7,12 +7,11 @@
 namespace OpenApi\Assembler;
 
 use OpenApi\AttributeInterface;
-use OpenApi\AttributeTranslatorInterface;
 
 /**
  * Default implementation dealing with native attributes.
  */
-class DefaultAttributeTranslator implements AttributeTranslatorInterface
+class DefaultAttributeTranslator extends AbstractAttributeTranslator
 {
     public function getAttributes(\ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector): array
     {
@@ -20,10 +19,5 @@ class DefaultAttributeTranslator implements AttributeTranslatorInterface
             AttributeInterface::class,
             \ReflectionAttribute::IS_INSTANCEOF,
         );
-    }
-
-    public function translate(array $attributes, array $created, \ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector): array
-    {
-        return [...$attributes, ...$created];
     }
 }

--- a/src/AttributeTranslatorInterface.php
+++ b/src/AttributeTranslatorInterface.php
@@ -8,9 +8,25 @@ namespace OpenApi;
 
 /**
  * Contract for creating raw attributes and translating them into `AttributeInterface` instances.
+ *
+ * Translator instances are long-lived (one per factory) and shared across all
+ * `readAttributes()` calls within a collection pass. This means translators
+ * can accumulate state across structural levels — e.g. tracking the current
+ * `Operation` at method level and injecting into it at parameter level.
+ *
+ * Processing order within the Assembler is guaranteed structural:
+ * class → method → parameters (outer before inner).
  */
 interface AttributeTranslatorInterface
 {
+    /**
+     * Reset any accumulated state between collection boundaries.
+     *
+     * Called by the assembler at the start of each top-level collection unit
+     * (e.g. per class).
+     */
+    public function reset(): void;
+
     /**
      * Get attributes to load from the given reflector.
      *

--- a/src/Utils/AttributeFactory.php
+++ b/src/Utils/AttributeFactory.php
@@ -71,6 +71,18 @@ class AttributeFactory
     }
 
     /**
+     * Reset all translators.
+     *
+     * Called at the start of each top-level collection unit.
+     */
+    public function resetTranslators(): void
+    {
+        foreach ($this->translators as $translator) {
+            $translator->reset();
+        }
+    }
+
+    /**
      * Read and resolve attributes from a single member reflector.
      *
      * For methods, also resolves parameter-level attributes into the method-level ones.

--- a/tests/Fixtures/Assembler/Attachable/RequestPayload.php
+++ b/tests/Fixtures/Assembler/Attachable/RequestPayload.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Assembler\Attachable;
+
+use OpenApi\Spec as OA;
+
+#[\Attribute(\Attribute::TARGET_ALL | \Attribute::IS_REPEATABLE)]
+ class RequestPayload extends OA\Attachable
+{
+}

--- a/tests/Fixtures/Assembler/Attachable/RequestPayload.php
+++ b/tests/Fixtures/Assembler/Attachable/RequestPayload.php
@@ -6,9 +6,7 @@
 
 namespace OpenApi\Tests\Fixtures\Assembler\Attachable;
 
-use OpenApi\Spec as OA;
-
 #[\Attribute(\Attribute::TARGET_ALL | \Attribute::IS_REPEATABLE)]
- class RequestPayload extends OA\Attachable
+class RequestPayload
 {
 }

--- a/tests/Fixtures/Assembler/SimpleController.php
+++ b/tests/Fixtures/Assembler/SimpleController.php
@@ -7,15 +7,18 @@
 namespace OpenApi\Tests\Fixtures\Assembler;
 
 use OpenApi\Spec as OA;
+use OpenApi\Tests\Fixtures\Assembler\Attachable\RequestPayload;
 
 class SimpleController
 {
-    #[OA\Operation(path: '/products/{product_id}', method: 'get')]
+    #[OA\Operation\Post(path: '/products/{product_id}')]
     #[OA\Response(response: 200, description: 'OK')]
-    public function getProduct(
+    public function addProduct(
         #[OA\Parameter(name: 'product_id', in: 'path', required: true)]
         #[OA\Schema(format: 'int64')]
         ?int $product_id,
+        #[RequestPayload]
+        SimpleProduct $product,
     ) {
     }
 }

--- a/tests/Utils/AttributeFactoryTest.php
+++ b/tests/Utils/AttributeFactoryTest.php
@@ -6,13 +6,17 @@
 
 namespace OpenApi\Tests\Utils;
 
+use OpenApi\Assembler;
 use OpenApi\AttributeInterface;
+use OpenApi\AttributeTranslatorInterface;
 use OpenApi\OpenApiException;
 use OpenApi\Spec as OA;
 use OpenApi\Tests\Fixtures\Assembler\AmbiguousMerge;
+use OpenApi\Tests\Fixtures\Assembler\Attachable\RequestPayload;
 use OpenApi\Tests\Fixtures\Assembler\SimpleController;
 use OpenApi\Tests\Fixtures\Assembler\SimpleProduct;
 use OpenApi\Utils\AttributeFactory;
+use OpenApi\Utils\TypedList;
 use PHPUnit\Framework\TestCase;
 
 final class AttributeFactoryTest extends TestCase
@@ -92,5 +96,118 @@ final class AttributeFactoryTest extends TestCase
         $this->assertCount(1, $roots);
         $this->assertInstanceOf(OA\Schema::class, $roots[0]);
         $this->assertNotEmpty($roots[0]->properties);
+    }
+
+    public function testAttributeTranslatorModifies(): void
+    {
+        $factory = (new AttributeFactory())
+            ->withTranslators(
+                fn (TypedList $translators): TypedList => $translators->add(
+                    new class () implements AttributeTranslatorInterface {
+                        public function getAttributes(\ReflectionClassConstant|\ReflectionParameter|\ReflectionMethod|\ReflectionClass|\ReflectionProperty $reflector): array
+                        {
+                            return [];
+                        }
+
+                        public function translate(array $attributes, array $created, \ReflectionClassConstant|\ReflectionParameter|\ReflectionMethod|\ReflectionClass|\ReflectionProperty $reflector): array
+                        {
+                            $property = $attributes[0];
+                            if ($property instanceof OA\Property && $property->property === 'name') {
+                                $property->property = 'other';
+                            }
+
+                            return [...$attributes, ...$created];
+                        }
+                    }
+                )
+            );
+
+        $inner = $factory->membersOf(new \ReflectionClass(SimpleProduct::class));
+
+        $this->assertCount(2, $inner);
+        $this->assertInstanceOf(OA\Property::class, $inner[0]);
+        $this->assertSame('other', $inner[0]->property);
+    }
+
+    public function testAttributeTranslatorAdds(): void
+    {
+        $factory = (new AttributeFactory())
+            ->withTranslators(
+                fn (TypedList $translators): TypedList => $translators->add(
+                    new class () implements AttributeTranslatorInterface {
+                        public function getAttributes(\ReflectionClassConstant|\ReflectionParameter|\ReflectionMethod|\ReflectionClass|\ReflectionProperty $reflector): array
+                        {
+                            return [];
+                        }
+
+                        public function translate(array $attributes, array $created, \ReflectionClassConstant|\ReflectionParameter|\ReflectionMethod|\ReflectionClass|\ReflectionProperty $reflector): array
+                        {
+                            if ($attributes[0] instanceof OA\Schema && $attributes[0]->schema === 'SimpleProduct') {
+                                $property = new OA\Property(
+                                    property: 'extra',
+                                    schema: new OA\Schema(type: 'bool'),
+                                );
+                                $attributes[0]->properties[] = $property;
+                            }
+
+                            return [...$attributes, ...$created];
+                        }
+                    }
+                )
+            );
+
+        $assembler = new Assembler(attributeFactory: $factory);
+        $spec = $assembler->collect(new \ReflectionClass(SimpleProduct::class))
+            ->getSpecification();
+
+        $this->assertCount(1, $spec->schemas);
+        $schema = $spec->schemas[0];
+        $this->assertCount(3, $schema->properties);
+        $this->assertSame('extra', $schema->properties[0]->property);
+    }
+
+    public function testCustomTranslateMerge()
+    {
+        $factory = (new AttributeFactory())
+            ->withTranslators(
+                fn (TypedList $translators): TypedList => $translators->add(
+                    new class () implements AttributeTranslatorInterface {
+                        public function getAttributes(\ReflectionClassConstant|\ReflectionParameter|\ReflectionMethod|\ReflectionClass|\ReflectionProperty $reflector): array
+                        {
+                            if ($reflector instanceof \ReflectionParameter) {
+                                return $reflector->getAttributes(
+                                    RequestPayload::class,
+                                    \ReflectionAttribute::IS_INSTANCEOF,
+                                );
+                            };
+
+                            return [];
+                        }
+
+                        public function translate(array $attributes, array $created, \ReflectionClassConstant|\ReflectionParameter|\ReflectionMethod|\ReflectionClass|\ReflectionProperty $reflector): array
+                        {
+                            foreach ($created as $attribute) {
+                                if ($attribute instanceof RequestPayload) {
+                                    $created[] = new OA\RequestBody(
+                                        content: new OA\MediaType\Json(ref: $reflector->getName()),
+                                    );
+                                }
+                        }
+                            return [...$attributes, ...$created];
+                        }
+                    }
+                )
+            );
+
+        $assembler = new Assembler(attributeFactory: $factory);
+        $spec = $assembler->collect(
+            new \ReflectionClass(SimpleController::class),
+            new \ReflectionClass(SimpleProduct::class),
+        )
+            ->getSpecification();
+
+        $this->assertCount(1, $spec->operations);
+        $operation = $spec->operations[0];
+        $this->assertInstanceOf(OA\RequestBody::class, $operation->requestBody);
     }
 }

--- a/tests/Utils/AttributeFactoryTest.php
+++ b/tests/Utils/AttributeFactoryTest.php
@@ -7,6 +7,7 @@
 namespace OpenApi\Tests\Utils;
 
 use OpenApi\Assembler;
+use OpenApi\Assembler\AbstractAttributeTranslator;
 use OpenApi\AttributeInterface;
 use OpenApi\AttributeTranslatorInterface;
 use OpenApi\OpenApiException;
@@ -103,7 +104,7 @@ final class AttributeFactoryTest extends TestCase
         $factory = (new AttributeFactory())
             ->withTranslators(
                 fn (TypedList $translators): TypedList => $translators->add(
-                    new class () implements AttributeTranslatorInterface {
+                    new class () extends AbstractAttributeTranslator {
                         public function getAttributes(\ReflectionClassConstant|\ReflectionParameter|\ReflectionMethod|\ReflectionClass|\ReflectionProperty $reflector): array
                         {
                             return [];
@@ -134,7 +135,7 @@ final class AttributeFactoryTest extends TestCase
         $factory = (new AttributeFactory())
             ->withTranslators(
                 fn (TypedList $translators): TypedList => $translators->add(
-                    new class () implements AttributeTranslatorInterface {
+                    new class () extends AbstractAttributeTranslator {
                         public function getAttributes(\ReflectionClassConstant|\ReflectionParameter|\ReflectionMethod|\ReflectionClass|\ReflectionProperty $reflector): array
                         {
                             return [];
@@ -173,6 +174,11 @@ final class AttributeFactoryTest extends TestCase
                 fn (TypedList $translators): TypedList => $translators->add(
                     new class () implements AttributeTranslatorInterface {
                         protected OA\Operation|null $operation = null;
+
+                        public function reset(): void
+                        {
+                            $this->operation = null;
+                        }
 
                         public function getAttributes(\ReflectionClassConstant|\ReflectionParameter|\ReflectionMethod|\ReflectionClass|\ReflectionProperty $reflector): array
                         {

--- a/tests/Utils/AttributeFactoryTest.php
+++ b/tests/Utils/AttributeFactoryTest.php
@@ -37,7 +37,7 @@ final class AttributeFactoryTest extends TestCase
     {
         $factory = new AttributeFactory();
         $result = $factory->fromReflector(new \ReflectionParameter(
-            [SimpleController::class, 'getProduct'],
+            [SimpleController::class, 'addProduct'],
             'product_id',
         ));
 
@@ -63,7 +63,7 @@ final class AttributeFactoryTest extends TestCase
         $members = $factory->membersOf(new \ReflectionClass(SimpleProduct::class));
 
         $propertyNames = array_map(
-            fn(AttributeInterface $attr): ?string => $attr instanceof OA\Property ? $attr->property : null,
+            fn (AttributeInterface $attr): ?string => $attr instanceof OA\Property ? $attr->property : null,
             $members,
         );
 
@@ -102,7 +102,7 @@ final class AttributeFactoryTest extends TestCase
     {
         $factory = (new AttributeFactory())
             ->withTranslators(
-                fn(TypedList $translators): TypedList => $translators->add(
+                fn (TypedList $translators): TypedList => $translators->add(
                     new class () implements AttributeTranslatorInterface {
                         public function getAttributes(\ReflectionClassConstant|\ReflectionParameter|\ReflectionMethod|\ReflectionClass|\ReflectionProperty $reflector): array
                         {
@@ -133,7 +133,7 @@ final class AttributeFactoryTest extends TestCase
     {
         $factory = (new AttributeFactory())
             ->withTranslators(
-                fn(TypedList $translators): TypedList => $translators->add(
+                fn (TypedList $translators): TypedList => $translators->add(
                     new class () implements AttributeTranslatorInterface {
                         public function getAttributes(\ReflectionClassConstant|\ReflectionParameter|\ReflectionMethod|\ReflectionClass|\ReflectionProperty $reflector): array
                         {
@@ -166,11 +166,11 @@ final class AttributeFactoryTest extends TestCase
         $this->assertSame('extra', $schema->properties[0]->property);
     }
 
-    public function testCustomTranslateMerge()
+    public function testCustomTranslateMerge(): void
     {
         $factory = (new AttributeFactory())
             ->withTranslators(
-                fn(TypedList $translators): TypedList => $translators->add(
+                fn (TypedList $translators): TypedList => $translators->add(
                     new class () implements AttributeTranslatorInterface {
                         protected OA\Operation|null $operation = null;
 
@@ -206,7 +206,7 @@ final class AttributeFactoryTest extends TestCase
                                 }
                             }
 
-                            return array_filter([...$attributes, ...$created], fn($attribute) => !($attribute instanceof RequestPayload));
+                            return array_filter([...$attributes, ...$created], fn (object $attribute): bool => !($attribute instanceof RequestPayload));
                         }
                     }
                 )

--- a/tests/Utils/AttributeFactoryTest.php
+++ b/tests/Utils/AttributeFactoryTest.php
@@ -63,7 +63,7 @@ final class AttributeFactoryTest extends TestCase
         $members = $factory->membersOf(new \ReflectionClass(SimpleProduct::class));
 
         $propertyNames = array_map(
-            fn (AttributeInterface $attr): ?string => $attr instanceof OA\Property ? $attr->property : null,
+            fn(AttributeInterface $attr): ?string => $attr instanceof OA\Property ? $attr->property : null,
             $members,
         );
 
@@ -102,7 +102,7 @@ final class AttributeFactoryTest extends TestCase
     {
         $factory = (new AttributeFactory())
             ->withTranslators(
-                fn (TypedList $translators): TypedList => $translators->add(
+                fn(TypedList $translators): TypedList => $translators->add(
                     new class () implements AttributeTranslatorInterface {
                         public function getAttributes(\ReflectionClassConstant|\ReflectionParameter|\ReflectionMethod|\ReflectionClass|\ReflectionProperty $reflector): array
                         {
@@ -133,7 +133,7 @@ final class AttributeFactoryTest extends TestCase
     {
         $factory = (new AttributeFactory())
             ->withTranslators(
-                fn (TypedList $translators): TypedList => $translators->add(
+                fn(TypedList $translators): TypedList => $translators->add(
                     new class () implements AttributeTranslatorInterface {
                         public function getAttributes(\ReflectionClassConstant|\ReflectionParameter|\ReflectionMethod|\ReflectionClass|\ReflectionProperty $reflector): array
                         {
@@ -170,8 +170,10 @@ final class AttributeFactoryTest extends TestCase
     {
         $factory = (new AttributeFactory())
             ->withTranslators(
-                fn (TypedList $translators): TypedList => $translators->add(
+                fn(TypedList $translators): TypedList => $translators->add(
                     new class () implements AttributeTranslatorInterface {
+                        protected OA\Operation|null $operation = null;
+
                         public function getAttributes(\ReflectionClassConstant|\ReflectionParameter|\ReflectionMethod|\ReflectionClass|\ReflectionProperty $reflector): array
                         {
                             if ($reflector instanceof \ReflectionParameter) {
@@ -186,14 +188,25 @@ final class AttributeFactoryTest extends TestCase
 
                         public function translate(array $attributes, array $created, \ReflectionClassConstant|\ReflectionParameter|\ReflectionMethod|\ReflectionClass|\ReflectionProperty $reflector): array
                         {
+                            foreach ($attributes as $attribute) {
+                                if ($attribute instanceof OA\Operation) {
+                                    $this->operation = $attribute;
+                                }
+                            }
+
                             foreach ($created as $attribute) {
                                 if ($attribute instanceof RequestPayload) {
-                                    $created[] = new OA\RequestBody(
+                                    $requestBody = new OA\RequestBody(
                                         content: new OA\MediaType\Json(ref: $reflector->getName()),
                                     );
+
+                                    if ($this->operation) {
+                                        $this->operation->requestBody = $requestBody;
+                                    }
                                 }
-                        }
-                            return [...$attributes, ...$created];
+                            }
+
+                            return array_filter([...$attributes, ...$created], fn($attribute) => !($attribute instanceof RequestPayload));
                         }
                     }
                 )


### PR DESCRIPTION
## Summary

* Clarifies/documents the translator life-cycle
* Adds a `reset()` method to the `AttributeTranslatorInterface`
* Adds `AbstractAttributeTranslator` convenience class
* Adds translator tests