### PR TITLE
Remove redundant `description` attribute from `#[OA\Property]` annotation

### DIFF
--- a/docs/examples/specs/api/spec/NameTrait.php
+++ b/docs/examples/specs/api/spec/NameTrait.php
@@ -11,10 +11,10 @@ use OpenApi\Spec as OA;
 /**
  * A Name.
  */
-#[OA\Schema(schema: 'NameTrait')]
+#[OA\Schema]
 trait NameTrait
 {
-    #[OA\Property(property: 'name')]
+    #[OA\Property]
     #[OA\Schema(description: 'The name.')]
     public $name;
 }

--- a/docs/examples/specs/api/spec/Product.php
+++ b/docs/examples/specs/api/spec/Product.php
@@ -22,7 +22,7 @@ class Product
     #[OA\Property(property: 'kind')]
     public const KIND = 'Virtual';
 
-    #[OA\Property(property: 'id', schema: new OA\Schema(description: 'The id.', format: 'int64'))]
+    #[OA\Property(schema: new OA\Schema(format: 'int64'))]
     /**
      * The id.
      *
@@ -31,16 +31,16 @@ class Product
     public $id;
 
     public function __construct(
-        #[OA\Property(property: 'quantity')]
+        #[OA\Property]
         #[OA\Schema]
         public int $quantity,
-        #[OA\Property(property: 'brand')]
+        #[OA\Property]
         #[OA\Schema(example: null, default: null)]
         public ?string $brand,
-        #[OA\Property(property: 'colour')]
+        #[OA\Property]
         #[OA\Schema(description: 'The colour')]
         public Colour $colour,
-        #[OA\Property(property: 'releasedAt')]
+        #[OA\Property]
         #[OA\Schema(type: 'string')]
         public \DateTimeInterface $releasedAt,
     ) {

--- a/docs/examples/specs/misc/spec/ResultSchema.php
+++ b/docs/examples/specs/misc/spec/ResultSchema.php
@@ -11,11 +11,11 @@ use OpenApi\Spec as OA;
 #[OA\Schema(schema: 'Result', title: 'Sample schema for using references')]
 class ResultSchema
 {
-    #[OA\Property(property: 'status')]
+    #[OA\Property]
     #[OA\Schema(type: 'string')]
     public $status;
 
-    #[OA\Property(property: 'error')]
+    #[OA\Property]
     #[OA\Schema(type: 'string')]
     public $error;
 }

--- a/docs/examples/specs/petstore/spec/Models/ApiResponse.php
+++ b/docs/examples/specs/petstore/spec/Models/ApiResponse.php
@@ -14,15 +14,15 @@ use OpenApi\Spec as OA;
 #[OA\Schema(title: 'Api response', description: 'Api response')]
 class ApiResponse
 {
-    #[OA\Property(property: 'code')]
+    #[OA\Property]
     #[OA\Schema(title: 'Code', description: 'Code', format: 'int32')]
     private int $code;
 
-    #[OA\Property(property: 'type')]
+    #[OA\Property]
     #[OA\Schema(title: 'Type', description: 'Type')]
     private string $type;
 
-    #[OA\Property(property: 'message')]
+    #[OA\Property]
     #[OA\Schema(title: 'Message', description: 'Message')]
     private string $message;
 }

--- a/docs/examples/specs/petstore/spec/Models/Category.php
+++ b/docs/examples/specs/petstore/spec/Models/Category.php
@@ -17,11 +17,11 @@ use OpenApi\Spec as OA;
 )]
 class Category
 {
-    #[OA\Property(property: 'id')]
+    #[OA\Property]
     #[OA\Schema(title: 'ID', description: 'ID', format: 'int64')]
     private int $id;
 
-    #[OA\Property(property: 'name')]
+    #[OA\Property]
     #[OA\Schema(title: 'Category name', description: 'Category name')]
     private string $name;
 }

--- a/docs/examples/specs/petstore/spec/Models/Order.php
+++ b/docs/examples/specs/petstore/spec/Models/Order.php
@@ -20,23 +20,23 @@ class Order
     #[OA\Schema(title: 'ID', description: 'ID', format: 'int64', default: 1)]
     private int $id;
 
-    #[OA\Property(property: 'petId')]
+    #[OA\Property]
     #[OA\Schema(title: 'Pet ID', description: 'Pet ID', format: 'int64', default: 1)]
     private int $petId;
 
-    #[OA\Property(property: 'quantity')]
+    #[OA\Property]
     #[OA\Schema(title: 'Quantity', description: 'Quantity', format: 'int32', default: 12)]
     private int $quantity;
 
-    #[OA\Property(property: 'shipDate')]
-    #[OA\Schema(title: 'Shipping date', description: 'Shipping date', type: 'string', format: 'datetime', default: '2017-02-02 18:31:45')]
+    #[OA\Property]
+    #[OA\Schema(title: 'Shipping date', description: 'Shipping date', format: 'datetime', default: '2017-02-02 18:31:45')]
     private \DateTime $shipDate;
 
-    #[OA\Property(property: 'status')]
+    #[OA\Property]
     #[OA\Schema(title: 'Order status', description: 'Order status', enum: ['placed', 'approved', 'delivered'], default: 'placed')]
     private string $status;
 
-    #[OA\Property(property: 'complete')]
-    #[OA\Schema(title: 'Complete status', description: 'Complete status', type: 'boolean', default: false)]
+    #[OA\Property]
+    #[OA\Schema(title: 'Complete status', description: 'Complete status', default: false)]
     private bool $complete;
 }

--- a/docs/examples/specs/petstore/spec/Models/Pet.php
+++ b/docs/examples/specs/petstore/spec/Models/Pet.php
@@ -17,26 +17,25 @@ use OpenApi\Spec as OA;
 ], xml: new OA\Xml(name: 'Pet'))]
 class Pet
 {
-    #[OA\Property(property: 'id')]
+    #[OA\Property]
     #[OA\Schema(title: 'ID', description: 'ID', format: 'int64')]
     private int $id;
 
-    #[OA\Property(property: 'category')]
+    #[OA\Property]
     #[OA\Schema(title: 'Category', ref: Category::class)]
     private Category $category;
 
-    #[OA\Property(property: 'name')]
+    #[OA\Property]
     #[OA\Schema(title: 'Pet name', description: 'Pet name', format: 'int64')]
     private string $name;
 
     /**
      * @var array<string>
      */
-    #[OA\Property(property: 'photoUrls')]
+    #[OA\Property]
     #[OA\Schema(
         title: 'Photo urls',
         description: 'Photo urls',
-        type: 'array',
         items: new OA\Schema(type: 'string', default: 'images/image-1.png'),
         xml: new OA\Xml(name: 'photoUrl', wrapped: true),
     )]
@@ -45,11 +44,10 @@ class Pet
     /**
      * @var array<Tag>
      */
-    #[OA\Property(property: 'tags')]
+    #[OA\Property]
     #[OA\Schema(
         title: 'Pet tags',
         description: 'Pet tags',
-        type: 'array',
         items: new OA\Schema(ref: Tag::class),
         xml: new OA\Xml(name: 'tag', wrapped: true),
     )]

--- a/docs/examples/specs/petstore/spec/Models/Tag.php
+++ b/docs/examples/specs/petstore/spec/Models/Tag.php
@@ -17,11 +17,11 @@ use OpenApi\Spec as OA;
 )]
 class Tag
 {
-    #[OA\Property(property: 'id')]
+    #[OA\Property]
     #[OA\Schema(title: 'ID', description: 'ID', format: 'int64')]
     private int $id;
 
-    #[OA\Property(property: 'name')]
+    #[OA\Property]
     #[OA\Schema(title: 'Name', description: 'Name')]
     private string $name;
 }

--- a/docs/examples/specs/petstore/spec/Models/User.php
+++ b/docs/examples/specs/petstore/spec/Models/User.php
@@ -14,35 +14,35 @@ use OpenApi\Spec as OA;
 #[OA\Schema(title: 'User model', description: 'User model')]
 class User
 {
-    #[OA\Property(property: 'id')]
+    #[OA\Property]
     #[OA\Schema(title: 'ID', description: 'ID', format: 'int64')]
     private int $id;
 
-    #[OA\Property(property: 'username')]
+    #[OA\Property]
     #[OA\Schema(title: 'Username', description: 'Username')]
     private string $username;
 
-    #[OA\Property(property: 'firstName')]
+    #[OA\Property]
     #[OA\Schema(title: 'First name', description: 'First name')]
     private string $firstName;
 
-    #[OA\Property(property: 'lastName')]
+    #[OA\Property]
     #[OA\Schema(title: 'Last name', description: 'Last name')]
     private string $lastName;
 
-    #[OA\Property(property: 'email')]
+    #[OA\Property]
     #[OA\Schema(title: 'Email', description: 'Email', format: 'email')]
     private string $email;
 
-    #[OA\Property(property: 'password')]
+    #[OA\Property]
     #[OA\Schema(title: 'Password', description: 'Password', maximum: 255)]
     private string $password;
 
-    #[OA\Property(property: 'phone')]
+    #[OA\Property]
     #[OA\Schema(title: 'Phone', description: 'Phone', format: 'msisdn')]
     private string $phone;
 
-    #[OA\Property(property: 'userStatus')]
+    #[OA\Property]
     #[OA\Schema(title: 'User status', description: 'User status', format: 'int32')]
     private int $userStatus;
 }

--- a/docs/examples/specs/polymorphism/spec/AbstractResponsible.php
+++ b/docs/examples/specs/polymorphism/spec/AbstractResponsible.php
@@ -22,7 +22,7 @@ abstract class AbstractResponsible
 {
     protected const TYPE = null;
 
-    #[OA\Property(property: 'type')]
+    #[OA\Property]
     #[OA\Schema(nullable: false, enum: ['employee', 'assignee', 'fl'])]
     protected string $type;
 

--- a/docs/examples/specs/polymorphism/spec/Employee.php
+++ b/docs/examples/specs/polymorphism/spec/Employee.php
@@ -14,7 +14,7 @@ final class Employee extends AbstractResponsible
     #[OA\Property(property: 'type')]
     protected const TYPE = 'Virtual';
 
-    #[OA\Property(property: 'property2')]
+    #[OA\Property]
     #[OA\Schema(nullable: false)]
     public string $property2;
 }

--- a/docs/examples/specs/polymorphism/spec/Fl.php
+++ b/docs/examples/specs/polymorphism/spec/Fl.php
@@ -13,6 +13,6 @@ final class Fl extends AbstractResponsible
 {
     public const TYPE = 'fl';
 
-    #[OA\Property(property: 'property3')]
+    #[OA\Property]
     public ?string $property3 = null;
 }

--- a/docs/examples/specs/polymorphism/spec/Request.php
+++ b/docs/examples/specs/polymorphism/spec/Request.php
@@ -13,6 +13,6 @@ final class Request
 {
     protected const TYPE = 'employee';
 
-    #[OA\Property(property: 'payload')]
+    #[OA\Property]
     public AbstractResponsible $payload;
 }

--- a/docs/examples/specs/using-interfaces/spec/Product.php
+++ b/docs/examples/specs/using-interfaces/spec/Product.php
@@ -14,8 +14,8 @@ class Product implements ProductInterface
     /**
      * The unique identifier of a product in our catalog.
      */
-    #[OA\Property(property: 'id')]
-    #[OA\Schema(type: 'integer', format: 'int64', example: 1)]
+    #[OA\Property]
+    #[OA\Schema(format: 'int64', example: 1)]
     public int $id;
 
     public function getName(): string

--- a/docs/examples/specs/using-links/spec/PullRequest.php
+++ b/docs/examples/specs/using-links/spec/PullRequest.php
@@ -11,24 +11,24 @@ use OpenApi\Spec as OA;
 #[OA\Schema(schema: 'pullrequest')]
 class PullRequest
 {
-    #[OA\Property(property: 'id')]
+    #[OA\Property]
     #[OA\Schema(type: 'integer')]
     public $id;
 
-    #[OA\Property(property: 'title')]
+    #[OA\Property]
     #[OA\Schema(type: 'string')]
     public $title;
 
-    #[OA\Property(property: 'repository')]
+    #[OA\Property]
     #[OA\Schema(ref: Repository::class)]
     public $repository;
 
-    #[OA\Property(property: 'author')]
+    #[OA\Property]
     #[OA\Schema(ref: User::class)]
     public $author;
 
     public function __construct(
-        #[OA\Property(property: 'state')]
+        #[OA\Property]
         public State $state,
     ) {
     }

--- a/docs/examples/specs/using-links/spec/Repository.php
+++ b/docs/examples/specs/using-links/spec/Repository.php
@@ -11,10 +11,10 @@ use OpenApi\Spec as OA;
 #[OA\Schema(schema: 'repository')]
 class Repository
 {
-    #[OA\Property(property: 'slug')]
+    #[OA\Property]
     #[OA\Schema(type: 'string')]
     public $slug;
 
-    #[OA\Property(property: 'owner')]
+    #[OA\Property]
     public User $owner;
 }

--- a/docs/examples/specs/using-links/spec/User.php
+++ b/docs/examples/specs/using-links/spec/User.php
@@ -11,11 +11,11 @@ use OpenApi\Spec as OA;
 #[OA\Schema(schema: 'user')]
 class User
 {
-    #[OA\Property(property: 'username')]
+    #[OA\Property]
     #[OA\Schema(type: 'string')]
     public $username;
 
-    #[OA\Property(property: 'uuid')]
+    #[OA\Property]
     #[OA\Schema(type: 'string')]
     public $uuid;
 }

--- a/docs/examples/specs/using-refs/spec/Product.php
+++ b/docs/examples/specs/using-refs/spec/Product.php
@@ -8,14 +8,14 @@ namespace OpenApi\Examples\Specs\UsingRefs\Spec;
 
 use OpenApi\Spec as OA;
 
-#[OA\Schema(title: 'Product model', description: 'Product model', type: 'object')]
+#[OA\Schema(title: 'Product model', description: 'Product model')]
 class Product extends Model
 {
     /**
      * The unique identifier of a product in our catalog.
      */
     #[OA\Property]
-    #[OA\Schema(type: 'integer', format: 'int64', example: 1)]
+    #[OA\Schema(format: 'int64', example: 1)]
     public int $id;
 
     #[OA\Property(schema: new OA\Schema(ref: '#/components/schemas/product_status'))]

--- a/docs/examples/specs/using-traits/spec/Product.php
+++ b/docs/examples/specs/using-traits/spec/Product.php
@@ -18,7 +18,7 @@ class Product
      * The unique identifier of a product in our catalog.
      */
     #[OA\Property]
-    #[OA\Schema(type: 'integer', format: 'int64', example: 1)]
+    #[OA\Schema(format: 'int64', example: 1)]
     public int $id;
 
     /**

--- a/docs/examples/specs/using-traits/spec/SimpleProduct.php
+++ b/docs/examples/specs/using-traits/spec/SimpleProduct.php
@@ -18,6 +18,6 @@ class SimpleProduct
      * The unique identifier of a simple product in our catalog.
      */
     #[OA\Property]
-    #[OA\Schema(type: 'integer', format: 'int64', example: 1)]
+    #[OA\Schema(format: 'int64', example: 1)]
     public int $id;
 }

--- a/docs/examples/specs/webhooks/spec/Pet.php
+++ b/docs/examples/specs/webhooks/spec/Pet.php
@@ -11,13 +11,13 @@ use OpenApi\Spec as OA;
 #[OA\Schema(required: ['id', 'name'])]
 final class Pet
 {
-    #[OA\Property(property: 'id')]
+    #[OA\Property]
     #[OA\Schema(format: 'int64')]
     public int $id;
 
-    #[OA\Property(property: 'name')]
+    #[OA\Property]
     public string $name;
 
-    #[OA\Property(property: 'tag')]
+    #[OA\Property]
     public string $tag;
 }


### PR DESCRIPTION
## Summary

Remove redundant attributes that should be handled by augmenters