### PR TITLE
Explicitely allow additional CLI args for phpunit (only)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -100,8 +100,8 @@
             "@rector --dry-run"
         ],
         "test": [
-            "export XDEBUG_MODE=off && phpunit --display-all-issues",
-            "@lint"
+            "export XDEBUG_MODE=off && phpunit --display-all-issues @additional_args",
+            "@lint @no_additional_args"
         ],
         "performance": "export XDEBUG_MODE=off && phpunit --group performance",
         "analyse": [


### PR DESCRIPTION
## Summary

Explicitely allow extra CLI args on the composer `test` script

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Enhancement (improvement to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional changes)
- [x] Chore (maintenance, dependencies, CI)

## Related Issues

<!-- Link related issues: Fixes #123, Closes #456 -->

## Test Plan

<!-- Describe the tests you ran or plan to run to verify the changes. -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass locally
- [ ] Any dependent changes have been merged and published
