### PR TITLE
fix(Spec): update remaining `$ref` type-hints to accept `OA\Schema\Ref`

### DIFF
--- a/src/Spec/Header.php
+++ b/src/Spec/Header.php
@@ -26,7 +26,7 @@ class Header extends AbstractAttribute
      * @param string|null                    $description A brief description of the header (CommonMark syntax)
      * @param bool|null                      $required    Whether the header is mandatory
      * @param bool|null                      $deprecated  Whether the header is deprecated
-     * @param string|null                    $ref         A JSON Reference to a reusable header
+     * @param string|Schema\Ref|null         $ref         A JSON Reference to a reusable header
      * @param string|ParameterStyle|null     $style       How the header value is serialized
      * @param bool|null                      $explode     Whether arrays/objects generate separate parameters
      * @param Schema|null                    $schema      The schema defining the type for the header

--- a/src/Spec/MediaType/Json.php
+++ b/src/Spec/MediaType/Json.php
@@ -51,7 +51,7 @@ class Json extends OA\MediaType
      */
     public function __construct(
         // schema shortcuts
-        public ?string $ref = null,
+        public string|Schema\Ref|null $ref = null,
         public string|array|null $type = null,
         public Schema|string|null $items = null,
         public ?array $properties = null,

--- a/src/Spec/MediaType/Xml.php
+++ b/src/Spec/MediaType/Xml.php
@@ -51,7 +51,7 @@ class Xml extends OA\MediaType
      */
     public function __construct(
         // schema shortcuts
-        public ?string $ref = null,
+        public string|Schema\Ref|null $ref = null,
         public string|array|null $type = null,
         public Schema|string|null $items = null,
         public ?array $properties = null,

--- a/src/Spec/Parameter.php
+++ b/src/Spec/Parameter.php
@@ -57,7 +57,7 @@ class Parameter extends AbstractAttribute
      * @param bool|null                      $required        Whether the parameter is mandatory
      * @param bool|null                      $deprecated      Whether the parameter is deprecated
      * @param bool|null                      $allowEmptyValue Whether empty-valued parameters are allowed
-     * @param string|null                    $ref             A JSON Reference to a reusable parameter
+     * @param string|Schema\Ref|null         $ref             A JSON Reference to a reusable parameter
      * @param string|ParameterStyle|null     $style           How the parameter value is serialized
      * @param bool|null                      $explode         Whether arrays/objects generate separate parameters
      * @param bool|null                      $allowReserved   Whether reserved characters are allowed without encoding

--- a/src/Spec/Parameter/Cookie.php
+++ b/src/Spec/Parameter/Cookie.php
@@ -29,7 +29,7 @@ class Cookie extends OA\Parameter
         ?string $description = Undefined::UNDEFINED,
         ?bool $required = null,
         ?bool $deprecated = null,
-        ?string $ref = null,
+        string|OA\Schema\Ref|null $ref = null,
         ?bool $explode = null,
         ?OA\Schema $schema = null,
         mixed $example = Undefined::UNDEFINED,

--- a/src/Spec/Parameter/Header.php
+++ b/src/Spec/Parameter/Header.php
@@ -29,7 +29,7 @@ class Header extends OA\Parameter
         ?string $description = Undefined::UNDEFINED,
         ?bool $required = null,
         ?bool $deprecated = null,
-        ?string $ref = null,
+        string|OA\Schema\Ref|null $ref = null,
         ?bool $explode = null,
         ?OA\Schema $schema = null,
         mixed $example = Undefined::UNDEFINED,

--- a/src/Spec/Parameter/Path.php
+++ b/src/Spec/Parameter/Path.php
@@ -29,7 +29,7 @@ class Path extends OA\Parameter
         ?string $description = Undefined::UNDEFINED,
         ?bool $required = true,
         ?bool $deprecated = null,
-        ?string $ref = null,
+        string|OA\Schema\Ref|null $ref = null,
         string|OA\ParameterStyle|null $style = null,
         ?bool $explode = null,
         ?OA\Schema $schema = null,

--- a/src/Spec/Parameter/Query.php
+++ b/src/Spec/Parameter/Query.php
@@ -30,7 +30,7 @@ class Query extends OA\Parameter
         ?bool $required = null,
         ?bool $deprecated = null,
         ?bool $allowEmptyValue = null,
-        ?string $ref = null,
+        string|OA\Schema\Ref|null $ref = null,
         string|OA\ParameterStyle|null $style = null,
         ?bool $explode = null,
         ?bool $allowReserved = null,

--- a/src/Spec/RequestBody.php
+++ b/src/Spec/RequestBody.php
@@ -21,7 +21,7 @@ class RequestBody extends AbstractAttribute
      * @param string|null                    $request     Reusable request body identifier (component key)
      * @param string|null                    $description A brief description of the request body (CommonMark syntax)
      * @param bool|null                      $required    Whether the request body is required
-     * @param string|null                    $ref         A JSON Reference to a reusable request body
+     * @param string|Schema\Ref|null         $ref         A JSON Reference to a reusable request body
      * @param MediaType|list<MediaType>|null $content     The content of the request body
      * @param array<string,mixed>|null       $x           Vendor extensions (x-* properties)
      * @param list<Attachable>|null          $attachables Reusable custom attachable attributes

--- a/src/Spec/Response.php
+++ b/src/Spec/Response.php
@@ -20,7 +20,7 @@ class Response extends AbstractAttribute
     /**
      * @param string|int|null                $response    The HTTP status code or 'default'
      * @param string|null                    $description A description of the response (CommonMark syntax)
-     * @param string|null                    $ref         A JSON Reference to a reusable response
+     * @param string|Schema\Ref|null         $ref         A JSON Reference to a reusable response
      * @param list<Header>|null              $headers     Headers sent with the response
      * @param MediaType|list<MediaType>|null $content     Possible response payloads
      * @param list<Link>|null                $links       Design-time links for the response

--- a/tests/Fixtures/Scratch/MergeTraits-spec.php
+++ b/tests/Fixtures/Scratch/MergeTraits-spec.php
@@ -52,7 +52,7 @@ class AddressSpec extends ModelSpec
 #[OA\Response(
     response: 200,
     description: 'successful operation',
-    content: new OA\MediaType\Json(ref: AddressSpec::class)
+    content: new OA\MediaType\Json(ref: new OA\Schema\Ref(AddressSpec::class))
 )]
 class MergeTraitsEndpointSpec
 {


### PR DESCRIPTION
## Summary

Add missing `OA\Schema\Ref` type-hint to `$ref` parameters that still needed it.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Enhancement (improvement to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactor (no functional changes)
- [ ] Chore (maintenance, dependencies, CI)

## Related Issues

<!-- Link related issues: Fixes #123, Closes #456 -->

## Test Plan

<!-- Describe the tests you ran or plan to run to verify the changes. -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass locally
- [ ] Any dependent changes have been merged and published
