### PR TITLE
feat(Spec): add shortcut to omit `OA\Property` when stacking witbh `OA\Schema`

### DIFF
--- a/docs/examples/specs/api/spec/Product.php
+++ b/docs/examples/specs/api/spec/Product.php
@@ -22,7 +22,7 @@ class Product
     #[OA\Property(property: 'kind')]
     public const KIND = 'Virtual';
 
-    #[OA\Property(schema: new OA\Schema(format: 'int64'))]
+    #[OA\Schema(format: 'int64')]
     /**
      * The id.
      *
@@ -37,7 +37,6 @@ class Product
         #[OA\Property]
         #[OA\Schema(example: null, default: null)]
         public ?string $brand,
-        #[OA\Property]
         #[OA\Schema(description: 'The colour')]
         public Colour $colour,
         #[OA\Property]

--- a/docs/guide/shortcuts.md
+++ b/docs/guide/shortcuts.md
@@ -53,6 +53,22 @@ and will generate the same output.
 
 The same applies to `OA\XmlContent`.
 
+## `OA\Property` (spec only)
+
+When using the `OA\Spec` namespace, class properties and promoted constructor parameters that have an `OA\Schema`
+attribute do not need an explicit `OA\Property` attribute — it will be added automatically.
+
+**Verbose:**
+
+<<< @/snippets/guide/shortcuts/optional_property_verbose_spec.php
+
+**Shortcut:**
+
+<<< @/snippets/guide/shortcuts/optional_property_short_spec.php
+
+Both produce the same output. The implicit `OA\Property` is inferred from the context (class property or promoted
+constructor parameter with an `OA\Schema`).
+
 ## `OA\Parameter`
 
 The `OA\Parameter` annotation requires specifying the `in` property to indicate where in the request the parameter is located.

--- a/docs/snippets/guide/shortcuts/optional_property_short_spec.php
+++ b/docs/snippets/guide/shortcuts/optional_property_short_spec.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Openapi\Snippets\Shortcuts\OptionalProperty;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema]
+class Product
+{
+    #[OA\Schema(format: 'int64')]
+    public int $id;
+}

--- a/docs/snippets/guide/shortcuts/optional_property_verbose_spec.php
+++ b/docs/snippets/guide/shortcuts/optional_property_verbose_spec.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Openapi\Snippets\Shortcuts\OptionalProperty;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema]
+class Product
+{
+    #[OA\Property]
+    #[OA\Schema(format: 'int64')]
+    public int $id;
+}

--- a/src/Assembler/DefaultAttributeTranslator.php
+++ b/src/Assembler/DefaultAttributeTranslator.php
@@ -9,7 +9,7 @@ namespace OpenApi\Assembler;
 use OpenApi\AttributeInterface;
 
 /**
- * Default implementation dealing with native attributes.
+ * Default implementation handling native (OpenApi) attributes.
  */
 class DefaultAttributeTranslator extends AbstractAttributeTranslator
 {

--- a/src/Assembler/OptionalPropertyAttributeTranslator.php
+++ b/src/Assembler/OptionalPropertyAttributeTranslator.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Assembler;
+
+use OpenApi\Spec as OA;
+
+/**
+ * Add the required `OA\Property` on schema properties that only have an `OA\Schema` attribute.
+ */
+class OptionalPropertyAttributeTranslator extends AbstractAttributeTranslator
+{
+    public function translate(array $attributes, array $created, \ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector): array
+    {
+        $hasInstance = fn (array $list, string $class): bool => array_reduce(
+            $list,
+            static fn (bool $found, object $attribute): bool =>
+                $found || $attribute instanceof $class,
+            false
+        );
+
+        $translated = [...$attributes, ...$created];
+
+        $hasSchema = $hasInstance($translated, OA\Schema::class);
+
+        if ($reflector instanceof \ReflectionProperty
+        || ($reflector instanceof \ReflectionParameter && $reflector->getDeclaringFunction()->getName() === '__construct')
+        ) {
+            $hasProperty = $hasInstance($translated, OA\Property::class);
+
+            if ($hasSchema && !$hasProperty) {
+                $translated = [new OA\Property(), ...$translated];
+            }
+        }
+
+        return $translated;
+    }
+}

--- a/src/Utils/AttributeFactory.php
+++ b/src/Utils/AttributeFactory.php
@@ -7,6 +7,7 @@
 namespace OpenApi\Utils;
 
 use OpenApi\Assembler\DefaultAttributeTranslator;
+use OpenApi\Assembler\OptionalPropertyAttributeTranslator;
 use OpenApi\AttributeInterface;
 use OpenApi\AttributeTranslatorInterface;
 use OpenApi\OpenApiException;
@@ -31,6 +32,7 @@ class AttributeFactory
         /** @var list<AttributeTranslatorInterface> $translators */
         $translators = [
             new DefaultAttributeTranslator(),
+            new OptionalPropertyAttributeTranslator(),
         ];
 
         $this->translators = new TypedList($translators);

--- a/tests/Fixtures/Assembler/ImplicitPropertyProduct.php
+++ b/tests/Fixtures/Assembler/ImplicitPropertyProduct.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Assembler;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema(schema: 'ImplicitPropertyProduct')]
+class ImplicitPropertyProduct
+{
+    #[OA\Schema(format: 'int64')]
+    public int $id;
+
+    public function __construct(
+        #[OA\Schema(description: 'The colour')]
+        public string $colour,
+    ) {
+    }
+}

--- a/tests/Fixtures/Assembler/SimpleProduct.php
+++ b/tests/Fixtures/Assembler/SimpleProduct.php
@@ -15,7 +15,7 @@ class SimpleProduct
     #[OA\Schema(description: 'The name.')]
     public string $name;
 
-    #[OA\Property(property: 'price')]
+    // omitting OA\Proeprtyy
     #[OA\Schema(type: 'number', format: 'float')]
     public float $price;
 }

--- a/tests/Utils/AttributeFactoryTest.php
+++ b/tests/Utils/AttributeFactoryTest.php
@@ -13,6 +13,7 @@ use OpenApi\OpenApiException;
 use OpenApi\Spec as OA;
 use OpenApi\Tests\Fixtures\Assembler\AmbiguousMerge;
 use OpenApi\Tests\Fixtures\Assembler\Attachable\RequestPayload;
+use OpenApi\Tests\Fixtures\Assembler\ImplicitPropertyProduct;
 use OpenApi\Tests\Fixtures\Assembler\SimpleController;
 use OpenApi\Tests\Fixtures\Assembler\SimpleProduct;
 use OpenApi\Utils\AttributeFactory;
@@ -31,6 +32,31 @@ final class AttributeFactoryTest extends TestCase
         $this->assertSame('name', $result[0]->property);
         $this->assertInstanceOf(OA\Schema::class, $result[0]->schema);
         $this->assertSame('The name.', $result[0]->schema->description);
+    }
+
+    public function testImplicitPropertyOnProperty(): void
+    {
+        $factory = new AttributeFactory();
+        $result = $factory->fromReflector(new \ReflectionProperty(ImplicitPropertyProduct::class, 'id'));
+
+        $this->assertCount(1, $result);
+        $this->assertInstanceOf(OA\Property::class, $result[0]);
+        $this->assertInstanceOf(OA\Schema::class, $result[0]->schema);
+        $this->assertSame('int64', $result[0]->schema->format);
+    }
+
+    public function testImplicitPropertyOnPromotedParameter(): void
+    {
+        $factory = new AttributeFactory();
+        $result = $factory->fromReflector(new \ReflectionParameter(
+            [ImplicitPropertyProduct::class, '__construct'],
+            'colour',
+        ));
+
+        $this->assertCount(1, $result);
+        $this->assertInstanceOf(OA\Property::class, $result[0]);
+        $this->assertInstanceOf(OA\Schema::class, $result[0]->schema);
+        $this->assertSame('The colour', $result[0]->schema->description);
     }
 
     public function testFromReflectorParameter(): void


### PR DESCRIPTION
## Summary

Add a new shortcut that allows to omit a `OA\Property` attribute if the property (regular/promoted) already has an `OA\Schema` attribute.

This simplifies the case where the property name is the default and there are only schema customizations.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Enhancement (improvement to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional changes)
- [ ] Chore (maintenance, dependencies, CI)

## Related Issues

<!-- Link related issues: Fixes #123, Closes #456 -->

## Test Plan

<!-- Describe the tests you ran or plan to run to verify the changes. -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass locally
- [ ] Any dependent changes have been merged and published
