### PR TITLE
refactor(Spec): refactor attribute `contains()` method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,9 @@ docs/.vitepress/dist/
 docs/node_modules/
 docs/package-lock.json
 node_modules/
-/scratch/
+scratch/
 vendor/
 .idea/
 .phpstan/
-/.phpunit.cache/test-results
-/.claude/settings.local.json
+.phpunit.cache/
+.claude/settings.local.json

--- a/docs/guide/modes.md
+++ b/docs/guide/modes.md
@@ -36,7 +36,7 @@ Classic mode gives you access to the full `Generator` API including custom proce
 Spec mode is a ground-up reimplementation of the pipeline using pure PHP 8.1+ attributes from the `OpenApi\Spec` namespace. It introduces:
 
 - **Typed DTOs** — attributes are simple data containers with constructor-promoted properties
-- **Slot-map nesting** — explicit `merge()`/`contained()` maps replace reflection-based nesting resolution
+- **Slot-map nesting** — explicit `merge()`/`contained()` maps replace reflection-based nesting
 - **Grouped augmenters** — a three-phase pipeline (resolve → reduce → augment) that's easy to extend and configure
 - **Version-aware compilers** — separate compilers for OpenAPI 3.0, 3.1, and 3.2
 
@@ -55,7 +55,7 @@ $result->toYaml();
 Spec mode uses the `OpenApi\Spec` namespace (`use OpenApi\Spec as OA;`) with a cleaner attribute API. See [Using Spec Attributes](/guide/spec-attributes) for a full guide.
 
 ::: warning Beta
-Spec mode is feature-complete but still beta. The attribute API may evolve based on feedback before being promoted to default in a future major version.
+Spec mode is mostly feature-complete but still beta. The attribute API may evolve based on feedback before being promoted to default in a future major version.
 :::
 
 ## Hybrid (beta) {#hybrid}
@@ -77,6 +77,10 @@ $result->toYaml();
 ```
 
 Hybrid mode is the recommended transition path for existing projects that want to benefit from the new pipeline incrementally.
+
+::: warning Disclaimer
+Hybrid mode will not work in heavily customized projects like `NelmioApiDocBundle or projects adding custom processors.
+:::
 
 ## Switching modes
 

--- a/docs/guide/modes.md
+++ b/docs/guide/modes.md
@@ -36,7 +36,7 @@ Classic mode gives you access to the full `Generator` API including custom proce
 Spec mode is a ground-up reimplementation of the pipeline using pure PHP 8.1+ attributes from the `OpenApi\Spec` namespace. It introduces:
 
 - **Typed DTOs** — attributes are simple data containers with constructor-promoted properties
-- **Slot-map nesting** — explicit `merge()`/`contains()` maps replace reflection-based nesting resolution
+- **Slot-map nesting** — explicit `merge()`/`contained()` maps replace reflection-based nesting resolution
 - **Grouped augmenters** — a three-phase pipeline (resolve → reduce → augment) that's easy to extend and configure
 - **Version-aware compilers** — separate compilers for OpenAPI 3.0, 3.1, and 3.2
 

--- a/docs/guide/spec-attributes.md
+++ b/docs/guide/spec-attributes.md
@@ -537,7 +537,7 @@ In spec mode, the typed operation subclasses `OA\Operation\Get`, `OA\Operation\H
 Classic mode accepts `requestBody` on all operations (with a comment noting it should be ignored by validators for methods that don't support it).
 
 ```php
-// This works in classic mode but is a compile error in spec mode:
+// This works in classic mode but is a compile warning in spec mode:
 #[OA\Operation\Get(path: '/pets', requestBody: new OA\RequestBody(...))]
 
 // Use Post, Put, Patch, or Delete for request bodies:

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,8 +31,8 @@ Add `swagger-php` attributes (or legacy annotations) to your source code.
 possible attributes should be used.
 
 ::: info `spec` [mode](guide/modes)
-As of version 6.5.0 an new, improved set of attributes has beend introduced - the `spec` attributes.
-When using those the mode needs to be set to `spec` in order to generate OpenAPI documents.
+As of version 6.5.0, a new, improved set of attributes has beend introduced - the `spec` attributes.
+When using those, the mode needs to be set to `spec` in order to generate OpenAPI documents.
 ```shell
 > ./vendor/bin/openapi -m spec ...
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,15 @@ Add `swagger-php` attributes (or legacy annotations) to your source code.
 ⚠️ The `doctrine/annotations` library used to parse annotation is going to be deprecated, so wherever
 possible attributes should be used.
 
+::: info `spec` [mode](guide/modes)
+As of version 6.5.0 an new, improved set of attributes has beend introduced - the `spec` attributes.
+When using those the mode needs to be set to `spec` in order to generate OpenAPI documents.
+```shell
+> ./vendor/bin/openapi -m spec ...
+```
+:::
+
+
 <codeblock id="minimal">
   <template v-slot:at>
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -22,17 +22,19 @@ The Assembler collects spec attributes from source files and resolves their nest
 
 Each attribute declares its relationships via two methods:
 
-- `merge()` returns `[ParentClass => 'slot']` — how this attribute composes into siblings on the same reflector
-- `contains()` returns `[ChildClass => 'slot']` — which child attributes from inner reflectors this attribute absorbs
+- `merge()` returns `[TargetClass => 'slot']` — how this attribute composes into siblings on the same reflector
+- `contained()` returns `[ParentClass => 'slot']` — which outer-level attribute types can absorb this attribute from inner reflector levels
 
 Slots use `[]` suffix for collection append (`'parameters[]'`), bare name for scalar assignment (`'requestBody'`).
+
+Both methods are child-driven: the attribute itself declares where it can go, whether same-level (merge) or cross-level (contained). This makes the system fully extensible by downstream code — custom attachables can declare their own nesting targets without modifying native attributes.
 
 ### Level-by-level resolution
 
 Assembler resolution itself is purely attribute-relationship driven — no PHP structural semantics:
 
 1. **Sibling merge** — attributes on the same reflector compose via `merge()` maps
-2. **Hierarchical absorb** — resolved attributes flow upward level by level via `contains()` maps (first match wins). If a level has containers, unmatched non-roots are errors. If a level has no containers, unmatched attributes pass through to the next level up.
+2. **Hierarchical absorb** — resolved attributes flow upward level by level via `contained()` maps (first match wins). If a level has containers, unmatched non-roots are errors. If a level has no containers, unmatched attributes pass through to the next level up.
 
 After resolution, only root attributes (should) remain and are added to the Specification.
 

--- a/docs/reference/augmenters.md
+++ b/docs/reference/augmenters.md
@@ -38,14 +38,7 @@ and configure individual augmenters via `Pipeline::get()`.
 
 ### [Inheritance](https://github.com/zircote/swagger-php/tree/master/src/Augmenter/Inheritance.php)
 
-Expands PHP class hierarchy into OpenAPI composition (allOf).
-
-For each schema backed by a class reflector, walks parents, traits, and interfaces:
-- Ancestor with #[Schema] → adds $ref to allOf, stops walking up (parents only)
-- Ancestor without #[Schema] → merges its own members into the current schema
-
-After expansion, if a schema has both allOf and properties, the properties are
-moved into a dedicated allOf entry (anonymous schema with type: object).
+Handle all scenarios related to PHP inheritance.
 
 #### Config settings
 - **inheritance.attributeFactory** : `OpenApi\Utils\AttributeFactory` · default: `OpenApi\Utils\AttributeFactory`  

--- a/docs/reference/augmenters.md
+++ b/docs/reference/augmenters.md
@@ -140,7 +140,7 @@ referenced by another unused schema should also be removed).
 
 Re-keys MediaType encoding lists by property name.
 
-The assembler collects Encoding objects as a flat list via contains().
+The assembler collects Encoding objects as a flat list via contained().
 The compiler expects them as an associative array keyed by the property name
 the encoding applies to.
 

--- a/docs/reference/spec-attributes.md
+++ b/docs/reference/spec-attributes.md
@@ -52,7 +52,7 @@ can be declared directly on a class without needing a Components wrapper.
 
 #### Nested elements
 ---
-<a href="#schema">Schema</a>, <a href="#parameter">Parameter</a>, <a href="#response">Response</a>, <a href="#requestbody">RequestBody</a>, <a href="#header">Header</a>, <a href="#security-scheme">Security\Scheme</a>, <a href="#link">Link</a>, <a href="#example">Example</a>, <a href="#pathitem">PathItem</a>
+<a href="#security-scheme">Security\Scheme</a>, <a href="#security-scheme-apikey">Security\Scheme\ApiKey</a>, <a href="#security-scheme-http">Security\Scheme\Http</a>, <a href="#security-scheme-mutualtls">Security\Scheme\MutualTls</a>, <a href="#security-scheme-oauth2">Security\Scheme\OAuth2</a>, <a href="#security-scheme-openidconnect">Security\Scheme\OpenIdConnect</a>
 
 #### Parameters
 ---
@@ -120,7 +120,7 @@ Describes the encoding for a single property in a media type.
 
 #### Allowed in
 ---
-<a href="#mediatype">MediaType</a>, <a href="#mediatype-json">MediaType\Json</a>, <a href="#mediatype-xml">MediaType\Xml</a>
+<a href="#mediatype">MediaType</a>
 
 #### Parameters
 ---
@@ -147,7 +147,7 @@ Describes an example value for a parameter, media type, or schema.
 
 #### Allowed in
 ---
-<a href="#components">Components</a>, <a href="#header">Header</a>, <a href="#mediatype">MediaType</a>, <a href="#mediatype-json">MediaType\Json</a>, <a href="#mediatype-xml">MediaType\Xml</a>, <a href="#parameter">Parameter</a>, <a href="#parameter-cookie">Parameter\Cookie</a>, <a href="#parameter-header">Parameter\Header</a>, <a href="#parameter-path">Parameter\Path</a>, <a href="#parameter-query">Parameter\Query</a>
+<a href="#mediatype">MediaType</a>, <a href="#parameter">Parameter</a>, <a href="#header">Header</a>
 
 #### Parameters
 ---
@@ -220,7 +220,7 @@ Produces:
 
 #### Allowed in
 ---
-<a href="#security-scheme">Security\Scheme</a>, <a href="#security-scheme-apikey">Security\Scheme\ApiKey</a>, <a href="#security-scheme-http">Security\Scheme\Http</a>, <a href="#security-scheme-mutualtls">Security\Scheme\MutualTls</a>, <a href="#security-scheme-oauth2">Security\Scheme\OAuth2</a>, <a href="#security-scheme-openidconnect">Security\Scheme\OpenIdConnect</a>
+<a href="#security-scheme">Security\Scheme</a>
 
 #### Parameters
 ---
@@ -332,11 +332,11 @@ Describes a single HTTP header.
 
 #### Allowed in
 ---
-<a href="#components">Components</a>, <a href="#response">Response</a>
+<a href="#response">Response</a>
 
 #### Nested elements
 ---
-<a href="#mediatype">MediaType</a>, <a href="#example">Example</a>
+<a href="#example">Example</a>, <a href="#mediatype">MediaType</a>, <a href="#mediatype-json">MediaType\Json</a>, <a href="#mediatype-xml">MediaType\Xml</a>
 
 #### Parameters
 ---
@@ -348,7 +348,7 @@ Describes a single HTTP header.
   Whether the header is mandatory
 - **deprecated** : `bool|null`
   Whether the header is deprecated
-- **ref** : `string|null`
+- **ref** : `string|Schema\Ref|null`
   A JSON Reference to a reusable header
 - **style** : `string|ParameterStyle|null`
   How the header value is serialized
@@ -423,7 +423,7 @@ Describes a possible design-time link for a response.
 
 #### Allowed in
 ---
-<a href="#components">Components</a>, <a href="#response">Response</a>
+<a href="#response">Response</a>
 
 #### Parameters
 ---
@@ -454,7 +454,7 @@ Describes the content payload for a specific media type.
 
 #### Allowed in
 ---
-<a href="#header">Header</a>, <a href="#parameter">Parameter</a>, <a href="#parameter-cookie">Parameter\Cookie</a>, <a href="#parameter-header">Parameter\Header</a>, <a href="#parameter-path">Parameter\Path</a>, <a href="#parameter-query">Parameter\Query</a>, <a href="#requestbody">RequestBody</a>, <a href="#response">Response</a>
+<a href="#response">Response</a>, <a href="#requestbody">RequestBody</a>, <a href="#parameter">Parameter</a>, <a href="#header">Header</a>
 
 #### Nested elements
 ---
@@ -500,11 +500,7 @@ The `Shortcuts` augmenter expands the schema properties into a nested `OA\Schema
 
 #### Allowed in
 ---
-<a href="#response">Response</a>, <a href="#requestbody">RequestBody</a>, <a href="#parameter">Parameter</a>
-
-#### Nested elements
----
-<a href="#encoding">Encoding</a>, <a href="#example">Example</a>
+<a href="#response">Response</a>, <a href="#requestbody">RequestBody</a>, <a href="#parameter">Parameter</a>, <a href="#header">Header</a>
 
 #### Parameters
 ---
@@ -554,11 +550,7 @@ The `Shortcuts` augmenter expands the schema properties into a nested `OA\Schema
 
 #### Allowed in
 ---
-<a href="#response">Response</a>, <a href="#requestbody">RequestBody</a>, <a href="#parameter">Parameter</a>
-
-#### Nested elements
----
-<a href="#encoding">Encoding</a>, <a href="#example">Example</a>
+<a href="#response">Response</a>, <a href="#requestbody">RequestBody</a>, <a href="#parameter">Parameter</a>, <a href="#header">Header</a>
 
 #### Parameters
 ---
@@ -636,7 +628,7 @@ For webhooks, use `webhook` instead of `path`:
 
 #### Nested elements
 ---
-<a href="#parameter">Parameter</a>, <a href="#response">Response</a>, <a href="#requestbody">RequestBody</a>, <a href="#server">Server</a>, <a href="#security-requirement">Security\Requirement</a>
+<a href="#parameter">Parameter</a>, <a href="#parameter-cookie">Parameter\Cookie</a>, <a href="#parameter-header">Parameter\Header</a>, <a href="#parameter-path">Parameter\Path</a>, <a href="#parameter-query">Parameter\Query</a>, <a href="#requestbody">RequestBody</a>, <a href="#response">Response</a>, <a href="#security-requirement">Security\Requirement</a>, <a href="#server">Server</a>
 
 #### Parameters
 ---
@@ -680,10 +672,6 @@ For webhooks, use `webhook` instead of `path`:
 
 Shorthand for an HTTP DELETE operation.
 
-#### Nested elements
----
-<a href="#parameter">Parameter</a>, <a href="#response">Response</a>, <a href="#requestbody">RequestBody</a>, <a href="#server">Server</a>, <a href="#security-requirement">Security\Requirement</a>
-
 #### Parameters
 ---
 - **path** : `string|null`
@@ -723,10 +711,6 @@ Shorthand for an HTTP DELETE operation.
 
 Shorthand for an HTTP GET operation.
 
-#### Nested elements
----
-<a href="#parameter">Parameter</a>, <a href="#response">Response</a>, <a href="#server">Server</a>, <a href="#security-requirement">Security\Requirement</a>
-
 #### Parameters
 ---
 - **path** : `string|null`
@@ -763,10 +747,6 @@ Shorthand for an HTTP GET operation.
 ### [Operation\Head](https://github.com/zircote/swagger-php/tree/master/src/Spec/Operation/Head.php)
 
 Shorthand for an HTTP HEAD operation.
-
-#### Nested elements
----
-<a href="#parameter">Parameter</a>, <a href="#response">Response</a>, <a href="#server">Server</a>, <a href="#security-requirement">Security\Requirement</a>
 
 #### Parameters
 ---
@@ -805,10 +785,6 @@ Shorthand for an HTTP HEAD operation.
 
 Shorthand for an HTTP OPTIONS operation.
 
-#### Nested elements
----
-<a href="#parameter">Parameter</a>, <a href="#response">Response</a>, <a href="#server">Server</a>, <a href="#security-requirement">Security\Requirement</a>
-
 #### Parameters
 ---
 - **path** : `string|null`
@@ -845,10 +821,6 @@ Shorthand for an HTTP OPTIONS operation.
 ### [Operation\Patch](https://github.com/zircote/swagger-php/tree/master/src/Spec/Operation/Patch.php)
 
 Shorthand for an HTTP PATCH operation.
-
-#### Nested elements
----
-<a href="#parameter">Parameter</a>, <a href="#response">Response</a>, <a href="#requestbody">RequestBody</a>, <a href="#server">Server</a>, <a href="#security-requirement">Security\Requirement</a>
 
 #### Parameters
 ---
@@ -889,10 +861,6 @@ Shorthand for an HTTP PATCH operation.
 
 Shorthand for an HTTP POST operation.
 
-#### Nested elements
----
-<a href="#parameter">Parameter</a>, <a href="#response">Response</a>, <a href="#requestbody">RequestBody</a>, <a href="#server">Server</a>, <a href="#security-requirement">Security\Requirement</a>
-
 #### Parameters
 ---
 - **path** : `string|null`
@@ -932,10 +900,6 @@ Shorthand for an HTTP POST operation.
 
 Shorthand for an HTTP PUT operation.
 
-#### Nested elements
----
-<a href="#parameter">Parameter</a>, <a href="#response">Response</a>, <a href="#requestbody">RequestBody</a>, <a href="#server">Server</a>, <a href="#security-requirement">Security\Requirement</a>
-
 #### Parameters
 ---
 - **path** : `string|null`
@@ -974,10 +938,6 @@ Shorthand for an HTTP PUT operation.
 ### [Operation\Trace](https://github.com/zircote/swagger-php/tree/master/src/Spec/Operation/Trace.php)
 
 Shorthand for an HTTP TRACE operation.
-
-#### Nested elements
----
-<a href="#parameter">Parameter</a>, <a href="#response">Response</a>, <a href="#server">Server</a>, <a href="#security-requirement">Security\Requirement</a>
 
 #### Parameters
 ---
@@ -1044,11 +1004,11 @@ Produces:
 
 #### Allowed in
 ---
-<a href="#components">Components</a>, <a href="#operation">Operation</a>, <a href="#operation-delete">Operation\Delete</a>, <a href="#operation-get">Operation\Get</a>, <a href="#operation-head">Operation\Head</a>, <a href="#operation-options">Operation\Options</a>, <a href="#operation-patch">Operation\Patch</a>, <a href="#operation-post">Operation\Post</a>, <a href="#operation-put">Operation\Put</a>, <a href="#operation-trace">Operation\Trace</a>, <a href="#pathitem">PathItem</a>
+<a href="#operation">Operation</a>, <a href="#pathitem">PathItem</a>
 
 #### Nested elements
 ---
-<a href="#mediatype">MediaType</a>, <a href="#example">Example</a>
+<a href="#example">Example</a>, <a href="#mediatype">MediaType</a>, <a href="#mediatype-json">MediaType\Json</a>, <a href="#mediatype-xml">MediaType\Xml</a>
 
 #### Parameters
 ---
@@ -1066,7 +1026,7 @@ Produces:
   Whether the parameter is deprecated
 - **allowEmptyValue** : `bool|null`
   Whether empty-valued parameters are allowed
-- **ref** : `string|null`
+- **ref** : `string|Schema\Ref|null`
   A JSON Reference to a reusable parameter
 - **style** : `string|ParameterStyle|null`
   How the parameter value is serialized
@@ -1093,11 +1053,7 @@ A parameter passed via an HTTP cookie.
 
 #### Allowed in
 ---
-<a href="#components">Components</a>, <a href="#operation">Operation</a>, <a href="#pathitem">PathItem</a>
-
-#### Nested elements
----
-<a href="#mediatype">MediaType</a>, <a href="#example">Example</a>
+<a href="#operation">Operation</a>, <a href="#pathitem">PathItem</a>
 
 #### Parameters
 ---
@@ -1111,7 +1067,7 @@ A parameter passed via an HTTP cookie.
   No details available.
 - **deprecated** : `bool|null`
   No details available.
-- **ref** : `string|null`
+- **ref** : `OpenApi\Spec\Schema\Ref|string|null`
   No details available.
 - **explode** : `bool|null`
   No details available.
@@ -1134,11 +1090,7 @@ A parameter passed via an HTTP header.
 
 #### Allowed in
 ---
-<a href="#components">Components</a>, <a href="#operation">Operation</a>, <a href="#pathitem">PathItem</a>
-
-#### Nested elements
----
-<a href="#mediatype">MediaType</a>, <a href="#example">Example</a>
+<a href="#operation">Operation</a>, <a href="#pathitem">PathItem</a>
 
 #### Parameters
 ---
@@ -1152,7 +1104,7 @@ A parameter passed via an HTTP header.
   No details available.
 - **deprecated** : `bool|null`
   No details available.
-- **ref** : `string|null`
+- **ref** : `OpenApi\Spec\Schema\Ref|string|null`
   No details available.
 - **explode** : `bool|null`
   No details available.
@@ -1175,11 +1127,7 @@ A parameter passed via the URL path (always required).
 
 #### Allowed in
 ---
-<a href="#components">Components</a>, <a href="#operation">Operation</a>, <a href="#pathitem">PathItem</a>
-
-#### Nested elements
----
-<a href="#mediatype">MediaType</a>, <a href="#example">Example</a>
+<a href="#operation">Operation</a>, <a href="#pathitem">PathItem</a>
 
 #### Parameters
 ---
@@ -1193,7 +1141,7 @@ A parameter passed via the URL path (always required).
   No details available.
 - **deprecated** : `bool|null`
   No details available.
-- **ref** : `string|null`
+- **ref** : `OpenApi\Spec\Schema\Ref|string|null`
   No details available.
 - **style** : `OpenApi\Spec\ParameterStyle|string|null`
   No details available.
@@ -1218,11 +1166,7 @@ A parameter passed via the URL query string.
 
 #### Allowed in
 ---
-<a href="#components">Components</a>, <a href="#operation">Operation</a>, <a href="#pathitem">PathItem</a>
-
-#### Nested elements
----
-<a href="#mediatype">MediaType</a>, <a href="#example">Example</a>
+<a href="#operation">Operation</a>, <a href="#pathitem">PathItem</a>
 
 #### Parameters
 ---
@@ -1238,7 +1182,7 @@ A parameter passed via the URL query string.
   No details available.
 - **allowEmptyValue** : `bool|null`
   No details available.
-- **ref** : `string|null`
+- **ref** : `OpenApi\Spec\Schema\Ref|string|null`
   No details available.
 - **style** : `OpenApi\Spec\ParameterStyle|string|null`
   No details available.
@@ -1301,13 +1245,9 @@ responses, and parameters accumulate from the full ancestor chain. Deduplication
 is by value (tags), by scheme (security), by status code (responses), and by
 name+in (parameters).
 
-#### Allowed in
----
-<a href="#components">Components</a>
-
 #### Nested elements
 ---
-<a href="#parameter">Parameter</a>, <a href="#server">Server</a>, <a href="#response">Response</a>, <a href="#security-requirement">Security\Requirement</a>
+<a href="#parameter">Parameter</a>, <a href="#parameter-cookie">Parameter\Cookie</a>, <a href="#parameter-header">Parameter\Header</a>, <a href="#parameter-path">Parameter\Path</a>, <a href="#parameter-query">Parameter\Query</a>, <a href="#response">Response</a>, <a href="#security-requirement">Security\Requirement</a>, <a href="#server">Server</a>
 
 #### Parameters
 ---
@@ -1340,7 +1280,7 @@ Defines a single property within a Schema object.
 
 #### Allowed in
 ---
-<a href="#schema">Schema</a>, <a href="#schema-additionalproperties">Schema\AdditionalProperties</a>, <a href="#schema-items">Schema\Items</a>, <a href="#schema-ref">Schema\Ref</a>
+<a href="#schema">Schema</a>
 
 #### Parameters
 ---
@@ -1359,11 +1299,11 @@ Describes a single request body.
 
 #### Allowed in
 ---
-<a href="#components">Components</a>, <a href="#operation">Operation</a>, <a href="#operation-delete">Operation\Delete</a>, <a href="#operation-patch">Operation\Patch</a>, <a href="#operation-post">Operation\Post</a>, <a href="#operation-put">Operation\Put</a>
+<a href="#operation">Operation</a>
 
 #### Nested elements
 ---
-<a href="#mediatype">MediaType</a>
+<a href="#mediatype">MediaType</a>, <a href="#mediatype-json">MediaType\Json</a>, <a href="#mediatype-xml">MediaType\Xml</a>
 
 #### Parameters
 ---
@@ -1373,7 +1313,7 @@ Describes a single request body.
   A brief description of the request body (CommonMark syntax)
 - **required** : `bool|null`
   Whether the request body is required
-- **ref** : `string|null`
+- **ref** : `string|Schema\Ref|null`
   A JSON Reference to a reusable request body
 - **content** : `MediaType|list&lt;MediaType&gt;|null`
   The content of the request body
@@ -1388,11 +1328,11 @@ Describes a single response from an API operation.
 
 #### Allowed in
 ---
-<a href="#components">Components</a>, <a href="#operation">Operation</a>, <a href="#operation-delete">Operation\Delete</a>, <a href="#operation-get">Operation\Get</a>, <a href="#operation-head">Operation\Head</a>, <a href="#operation-options">Operation\Options</a>, <a href="#operation-patch">Operation\Patch</a>, <a href="#operation-post">Operation\Post</a>, <a href="#operation-put">Operation\Put</a>, <a href="#operation-trace">Operation\Trace</a>, <a href="#pathitem">PathItem</a>
+<a href="#operation">Operation</a>, <a href="#pathitem">PathItem</a>
 
 #### Nested elements
 ---
-<a href="#header">Header</a>, <a href="#mediatype">MediaType</a>, <a href="#link">Link</a>
+<a href="#header">Header</a>, <a href="#link">Link</a>, <a href="#mediatype">MediaType</a>, <a href="#mediatype-json">MediaType\Json</a>, <a href="#mediatype-xml">MediaType\Xml</a>
 
 #### Parameters
 ---
@@ -1400,7 +1340,7 @@ Describes a single response from an API operation.
   The HTTP status code or 'default'
 - **description** : `string|null`
   A description of the response (CommonMark syntax)
-- **ref** : `string|null`
+- **ref** : `string|Schema\Ref|null`
   A JSON Reference to a reusable response
 - **headers** : `list&lt;Header&gt;|null`
   Headers sent with the response
@@ -1442,11 +1382,11 @@ Inline — used within parameters, responses, or other schemas:
 
 #### Allowed in
 ---
-<a href="#components">Components</a>, <a href="#schema">Schema</a>, <a href="#schema-additionalproperties">Schema\AdditionalProperties</a>, <a href="#schema-items">Schema\Items</a>, <a href="#schema-ref">Schema\Ref</a>
+<a href="#schema">Schema</a>
 
 #### Nested elements
 ---
-<a href="#property">Property</a>, <a href="#schema">Schema</a>
+<a href="#property">Property</a>, <a href="#schema">Schema</a>, <a href="#schema-additionalproperties">Schema\AdditionalProperties</a>, <a href="#schema-items">Schema\Items</a>, <a href="#schema-ref">Schema\Ref</a>
 
 #### Parameters
 ---
@@ -1578,11 +1518,7 @@ schemas with constrained additional properties:
 
 #### Allowed in
 ---
-<a href="#components">Components</a>, <a href="#property">Property</a>, <a href="#parameter">Parameter</a>, <a href="#header">Header</a>, <a href="#mediatype">MediaType</a>
-
-#### Nested elements
----
-<a href="#property">Property</a>, <a href="#schema">Schema</a>
+<a href="#schema">Schema</a>
 
 #### Parameters
 ---
@@ -1721,11 +1657,7 @@ The `Shortcuts` augmenter wraps this into `OA\Schema(type: 'array', items: ...)`
 
 #### Allowed in
 ---
-<a href="#components">Components</a>, <a href="#property">Property</a>, <a href="#parameter">Parameter</a>, <a href="#header">Header</a>, <a href="#mediatype">MediaType</a>
-
-#### Nested elements
----
-<a href="#property">Property</a>, <a href="#schema">Schema</a>
+<a href="#schema">Schema</a>
 
 #### Parameters
 ---
@@ -1858,11 +1790,7 @@ If used on a `$ref` directly, only the ref value is used.
 
 #### Allowed in
 ---
-<a href="#components">Components</a>, <a href="#property">Property</a>, <a href="#parameter">Parameter</a>, <a href="#header">Header</a>, <a href="#mediatype">MediaType</a>
-
-#### Nested elements
----
-<a href="#property">Property</a>, <a href="#schema">Schema</a>
+<a href="#schema">Schema</a>
 
 #### Parameters
 ---
@@ -1882,7 +1810,7 @@ Multiple schemes within a single requirement represent AND logic.
 
 #### Allowed in
 ---
-<a href="#openapi">OpenApi</a>, <a href="#operation">Operation</a>, <a href="#operation-delete">Operation\Delete</a>, <a href="#operation-get">Operation\Get</a>, <a href="#operation-head">Operation\Head</a>, <a href="#operation-options">Operation\Options</a>, <a href="#operation-patch">Operation\Patch</a>, <a href="#operation-post">Operation\Post</a>, <a href="#operation-put">Operation\Put</a>, <a href="#operation-trace">Operation\Trace</a>, <a href="#pathitem">PathItem</a>
+<a href="#openapi">OpenApi</a>, <a href="#operation">Operation</a>, <a href="#pathitem">PathItem</a>
 
 #### Parameters
 ---
@@ -1914,7 +1842,7 @@ Typed subtypes are available for each security scheme type:
 
 #### Nested elements
 ---
-<a href="#flow">Flow</a>
+<a href="#flow">Flow</a>, <a href="#flow-authorizationcode">Flow\AuthorizationCode</a>, <a href="#flow-clientcredentials">Flow\ClientCredentials</a>, <a href="#flow-implicit">Flow\Implicit</a>, <a href="#flow-password">Flow\Password</a>
 
 #### Parameters
 ---
@@ -1951,10 +1879,6 @@ An API key security scheme (header, query, or cookie).
 ---
 <a href="#components">Components</a>
 
-#### Nested elements
----
-<a href="#flow">Flow</a>
-
 #### Parameters
 ---
 - **securityScheme** : `string|null`
@@ -1977,10 +1901,6 @@ An HTTP authentication security scheme (Basic, Bearer, etc.).
 #### Allowed in
 ---
 <a href="#components">Components</a>
-
-#### Nested elements
----
-<a href="#flow">Flow</a>
 
 #### Parameters
 ---
@@ -2005,10 +1925,6 @@ A Mutual TLS security scheme.
 ---
 <a href="#components">Components</a>
 
-#### Nested elements
----
-<a href="#flow">Flow</a>
-
 #### Parameters
 ---
 - **securityScheme** : `string|null`
@@ -2027,10 +1943,6 @@ An OAuth2 security scheme with one or more flows.
 #### Allowed in
 ---
 <a href="#components">Components</a>
-
-#### Nested elements
----
-<a href="#flow">Flow</a>
 
 #### Parameters
 ---
@@ -2053,10 +1965,6 @@ An OpenID Connect Discovery security scheme.
 ---
 <a href="#components">Components</a>
 
-#### Nested elements
----
-<a href="#flow">Flow</a>
-
 #### Parameters
 ---
 - **securityScheme** : `string|null`
@@ -2076,7 +1984,7 @@ Represents a Server.
 
 #### Allowed in
 ---
-<a href="#operation">Operation</a>, <a href="#operation-delete">Operation\Delete</a>, <a href="#operation-get">Operation\Get</a>, <a href="#operation-head">Operation\Head</a>, <a href="#operation-options">Operation\Options</a>, <a href="#operation-patch">Operation\Patch</a>, <a href="#operation-post">Operation\Post</a>, <a href="#operation-put">Operation\Put</a>, <a href="#operation-trace">Operation\Trace</a>, <a href="#pathitem">PathItem</a>
+<a href="#operation">Operation</a>, <a href="#pathitem">PathItem</a>
 
 #### Nested elements
 ---

--- a/docs/reference/spec-attributes.md
+++ b/docs/reference/spec-attributes.md
@@ -9,9 +9,9 @@ Spec attributes are typed PHP 8.1+ attributes in the `OpenApi\Spec` namespace â€
 spec-attributes pipeline (`--mode spec` or `--mode hybrid`).
 
 They are immutable data containers with no serialization logic. Relationships between attributes are
-declared via `contains()` (what children an attribute absorbs) and `merge()` (what parent an attribute
-composes into). The [Assembler](/reference/builder.md) resolves nesting, and [Augmenters](/reference/augmenters.md)
-enrich the collected specification before compilation.
+declared via `merge()` (what sibling an attribute composes into on the same reflector) and `contained()`
+(what parent types can absorb this attribute from inner reflector levels). The [Assembler](/reference/builder.md)
+resolves nesting, and [Augmenters](/reference/augmenters.md) enrich the collected specification before compilation.
 
 Typed subclasses (e.g. `Operation\Get`, `Parameter\Path`, `Flow\AuthorizationCode`) pre-fill common
 fields to reduce boilerplate â€” the base class can always be used directly.

--- a/docs/snippets/preamble_spec-attributes.md
+++ b/docs/snippets/preamble_spec-attributes.md
@@ -3,9 +3,9 @@ Spec attributes are typed PHP 8.1+ attributes in the `OpenApi\Spec` namespace â€
 spec-attributes pipeline (`--mode spec` or `--mode hybrid`).
 
 They are immutable data containers with no serialization logic. Relationships between attributes are
-declared via `contains()` (what children an attribute absorbs) and `merge()` (what parent an attribute
-composes into). The [Assembler](/reference/builder.md) resolves nesting, and [Augmenters](/reference/augmenters.md)
-enrich the collected specification before compilation.
+declared via `merge()` (what sibling an attribute composes into on the same reflector) and `contained()`
+(what parent types can absorb this attribute from inner reflector levels). The [Assembler](/reference/builder.md)
+resolves nesting, and [Augmenters](/reference/augmenters.md) enrich the collected specification before compilation.
 
 Typed subclasses (e.g. `Operation\Get`, `Parameter\Path`, `Flow\AuthorizationCode`) pre-fill common
 fields to reduce boilerplate â€” the base class can always be used directly.

--- a/src/Assembler.php
+++ b/src/Assembler.php
@@ -17,7 +17,7 @@ use OpenApi\Utils\AttributeFactory;
  *    using merge() — e.g., a Schema adjacent to a Property fills the Property's $schema slot.
  *
  * 2. Absorb (resolveHierarchy): resolved attributes flow upward level by level using
- *    contains() (first match wins). Roots that aren't absorbed pass through to the spec.
+ *    contained() (first match wins). Roots that aren't absorbed pass through to the spec.
  */
 class Assembler
 {

--- a/src/AttributeInterface.php
+++ b/src/AttributeInterface.php
@@ -22,10 +22,9 @@ use OpenApi\Utils\SourceLocation;
  *   types this attribute can be nested into. E.g., Schema merges into Property,
  *   filling its $schema slot.
  *
- * - contains(): defines hierarchical absorption. Attributes from inner reflectors
- *   flow up into enclosing-level attributes. contains() declares which types a
- *   container can absorb from the level below. E.g., Operation on a method contains
- *   RequestBody from a parameter; Schema on a class contains Property from members.
+ * - contained(): defines hierarchical absorption. An inner-level attribute declares
+ *   which outer-level types can absorb it. E.g., RequestBody on a parameter declares
+ *   Operation as its container; Property on a class member declares Schema as its container.
  */
 interface AttributeInterface
 {
@@ -51,21 +50,21 @@ interface AttributeInterface
     public function merge(): array;
 
     /**
-     * Types this attribute can absorb from inner reflector levels.
+     * Attribute types that can absorb this attribute from inner reflector levels.
      *
      * During hierarchical resolution (class absorbs members, method absorbs parameters),
-     * the assembler uses contains() to determine which inner-level attributes flow into
-     * this container. Keys are the child class, values are the property name on this
+     * the assembler uses contained() to determine which outer-level attributes can contain
+     * this container. Keys are the parent class, values are the property name on this
      * attribute where the child will be placed.
      *
      * Use '[]' suffix for collection slots (append): 'properties[]'
      * Omit suffix for scalar slots (set): 'requestBody'
      *
-     * Return an empty array if this attribute does not absorb children.
+     * Return an empty array if this attribute does not have parents.
      *
      * @return array<class-string<AttributeInterface>, string>
      */
-    public function contains(): array;
+    public function contained(): array;
 
     public function getReflector(): ?\Reflector;
 

--- a/src/Augmenter/Inheritance.php
+++ b/src/Augmenter/Inheritance.php
@@ -13,6 +13,10 @@ use OpenApi\Utils\PipeInterface;
 /**
  * Handle all scenarios related to PHP inheritance.
  *
+ * Delegates to:
+ * - Inheritance\Schemas
+ * - Inheritance\Operations
+ *
  * @implements PipeInterface<Specification>
  */
 class Inheritance implements PipeInterface

--- a/src/Augmenter/MediaTypes.php
+++ b/src/Augmenter/MediaTypes.php
@@ -13,7 +13,7 @@ use OpenApi\Utils\PipeInterface;
 /**
  * Re-keys MediaType encoding lists by property name.
  *
- * The assembler collects Encoding objects as a flat list via contains().
+ * The assembler collects Encoding objects as a flat list via contained().
  * The compiler expects them as an associative array keyed by the property name
  * the encoding applies to.
  *

--- a/src/Compiler/OpenApi31Compiler.php
+++ b/src/Compiler/OpenApi31Compiler.php
@@ -20,6 +20,8 @@ class OpenApi31Compiler implements CompilerInterface
 {
     protected const VERSIONS = ['3.1.0', '3.1.1', '3.1.2'];
 
+    protected const OPERATION_REQUEST_BODY_METHODS = ['put', 'post', 'delete', 'patch'];
+
     protected CollectingLogger $logger;
 
     public function __construct(?LoggerInterface $logger = null)
@@ -229,10 +231,14 @@ class OpenApi31Compiler implements CompilerInterface
             'tags' => $operation->tags,
             'summary' => $operation->summary,
             'description' => $operation->description,
-            'externalDocs' => $operation->externalDocs instanceof OA\ExternalDocumentation ? $this->compileExternalDocs($operation->externalDocs) : null,
+            'externalDocs' => $operation->externalDocs instanceof OA\ExternalDocumentation
+                ? $this->compileExternalDocs($operation->externalDocs)
+                : null,
             'operationId' => $operation->operationId,
             'parameters' => array_map($this->compileParameter(...), $operation->parameters ?? []),
-            'requestBody' => $operation->requestBody instanceof OA\RequestBody ? $this->compileRequestBody($operation->requestBody) : null,
+            'requestBody' => $operation->requestBody instanceof OA\RequestBody
+                ? $this->compileRequestBody($operation->requestBody, $operation->method)
+                : null,
             'responses' => $this->compileResponses($operation->responses ?? []),
             'callbacks' => $this->compileCallbacks($operation->callbacks ?? []),
             'deprecated' => $operation->deprecated,
@@ -293,8 +299,12 @@ class OpenApi31Compiler implements CompilerInterface
         ], $parameter);
     }
 
-    protected function compileRequestBody(OA\RequestBody $body): array|\stdClass
+    protected function compileRequestBody(OA\RequestBody $body, ?string $method = null): array|\stdClass|null
     {
+        if ($method && !in_array($method, static::OPERATION_REQUEST_BODY_METHODS)) {
+            return null;
+        }
+
         if ($body->ref !== null) {
             return ['$ref' => $body->ref];
         }
@@ -654,6 +664,11 @@ class OpenApi31Compiler implements CompilerInterface
 
     protected function validateOperations(Specification $specification): void
     {
+        $specification->getWalker()->visit(OA\Operation::class, function (OA\Operation $operation): void {
+            if ($operation->requestBody instanceof OA\RequestBody && !in_array($operation->method, static::OPERATION_REQUEST_BODY_METHODS)) {
+                $this->logger->warning("Request body not supported for method {$operation->method} in " . $operation->getSourceLocation());
+            }
+        });
     }
 
     /**

--- a/src/Compiler/OpenApi31Compiler.php
+++ b/src/Compiler/OpenApi31Compiler.php
@@ -42,7 +42,7 @@ class OpenApi31Compiler implements CompilerInterface
         if (!$specification->info instanceof OA\Info) {
             $this->logger->error('info is required');
         } elseif ($specification->info->title === null) {
-            $this->logger->error('info.title is required');
+            $this->logger->error('info.title is required in ' . $specification->info->getSourceLocation());
         }
 
         $hasPaths = (bool) array_filter($specification->operations, fn (OA\Operation $op): bool => $op->path !== null);
@@ -59,11 +59,13 @@ class OpenApi31Compiler implements CompilerInterface
         if ($specification->info?->license instanceof OA\License) {
             $license = $specification->info->license;
             if ($license->url !== null && $license->identifier !== null) {
-                $this->logger->warning('License url and identifier are mutually exclusive');
+                $this->logger->warning('License url and identifier are mutually exclusive in ' . $license->getSourceLocation());
             }
         }
 
         $this->validateSchemas($specification);
+
+        $this->validateOperations($specification);
 
         return $this->logger->entries();
     }
@@ -644,10 +646,14 @@ class OpenApi31Compiler implements CompilerInterface
         foreach ($allSchemas as $schema) {
             if ($schema->type !== null && (is_array($schema->type) ? in_array('array', $schema->type, true) : $schema->type === 'array')) {
                 if ($schema->items === null) {
-                    $this->logger->warning('Schema' . ($schema->schema ? " \"$schema->schema\"" : '') . ' has type "array" but no items');
+                    $this->logger->warning('Schema' . ($schema->schema ? " \"$schema->schema\"" : '') . ' has type "array" but no items in ' . $schema->getSourceLocation());
                 }
             }
         }
+    }
+
+    protected function validateOperations(Specification $specification): void
+    {
     }
 
     /**

--- a/src/Spec/AbstractAttribute.php
+++ b/src/Spec/AbstractAttribute.php
@@ -35,7 +35,7 @@ abstract class AbstractAttribute implements AttributeInterface
         return [];
     }
 
-    public function contains(): array
+    public function contained(): array
     {
         return [];
     }

--- a/src/Spec/Components.php
+++ b/src/Spec/Components.php
@@ -64,19 +64,4 @@ class Components extends AbstractAttribute
     {
         return true;
     }
-
-    public function contains(): array
-    {
-        return [
-            Schema::class => 'schemas[]',
-            Parameter::class => 'parameters[]',
-            Response::class => 'responses[]',
-            RequestBody::class => 'requestBodies[]',
-            Header::class => 'headers[]',
-            Security\Scheme::class => 'securitySchemes[]',
-            Link::class => 'links[]',
-            Example::class => 'examples[]',
-            PathItem::class => 'pathItems[]',
-        ];
-    }
 }

--- a/src/Spec/Contact.php
+++ b/src/Spec/Contact.php
@@ -35,4 +35,9 @@ class Contact extends AbstractAttribute
     {
         return [Info::class => 'contact'];
     }
+
+    public function contained(): array
+    {
+        return [Info::class => 'contact'];
+    }
 }

--- a/src/Spec/Encoding.php
+++ b/src/Spec/Encoding.php
@@ -44,4 +44,9 @@ class Encoding extends AbstractAttribute
     {
         return [MediaType::class => 'encoding[]'];
     }
+
+    public function contained(): array
+    {
+        return [MediaType::class => 'encoding[]'];
+    }
 }

--- a/src/Spec/Example.php
+++ b/src/Spec/Example.php
@@ -46,4 +46,13 @@ class Example extends AbstractAttribute
             Header::class => 'examples[]',
         ];
     }
+
+    public function contained(): array
+    {
+        return [
+            MediaType::class => 'examples[]',
+            Parameter::class => 'examples[]',
+            Header::class => 'examples[]',
+        ];
+    }
 }

--- a/src/Spec/ExternalDocumentation.php
+++ b/src/Spec/ExternalDocumentation.php
@@ -41,4 +41,11 @@ class ExternalDocumentation extends AbstractAttribute
             Schema::class => 'externalDocs',
         ];
     }
+
+    public function contained(): array
+    {
+        return [
+            Tag::class => 'externalDocs',
+        ];
+    }
 }

--- a/src/Spec/Flow.php
+++ b/src/Spec/Flow.php
@@ -70,4 +70,9 @@ class Flow extends AbstractAttribute
     {
         return [Security\Scheme::class => 'flows[]'];
     }
+
+    public function contained(): array
+    {
+        return [Security\Scheme::class => 'flows[]'];
+    }
 }

--- a/src/Spec/Header.php
+++ b/src/Spec/Header.php
@@ -65,11 +65,10 @@ class Header extends AbstractAttribute
         ];
     }
 
-    public function contains(): array
+    public function contained(): array
     {
         return [
-            MediaType::class => 'content[]',
-            Example::class => 'examples[]',
+            Response::class => 'headers[]',
         ];
     }
 }

--- a/src/Spec/Info.php
+++ b/src/Spec/Info.php
@@ -43,12 +43,4 @@ class Info extends AbstractAttribute
     {
         return true;
     }
-
-    public function contains(): array
-    {
-        return [
-            Contact::class => 'contact',
-            License::class => 'license',
-        ];
-    }
 }

--- a/src/Spec/License.php
+++ b/src/Spec/License.php
@@ -35,4 +35,9 @@ class License extends AbstractAttribute
     {
         return [Info::class => 'license'];
     }
+
+    public function contained(): array
+    {
+        return [Info::class => 'license'];
+    }
 }

--- a/src/Spec/Link.php
+++ b/src/Spec/Link.php
@@ -53,4 +53,11 @@ class Link extends AbstractAttribute
             Response::class => 'links[]',
         ];
     }
+
+    public function contained(): array
+    {
+        return [
+            Response::class => 'links[]',
+        ];
+    }
 }

--- a/src/Spec/MediaType.php
+++ b/src/Spec/MediaType.php
@@ -46,11 +46,13 @@ class MediaType extends AbstractAttribute
         ];
     }
 
-    public function contains(): array
+    public function contained(): array
     {
         return [
-            Encoding::class => 'encoding[]',
-            Example::class => 'examples[]',
+            Response::class => 'content[]',
+            RequestBody::class => 'content[]',
+            Parameter::class => 'content[]',
+            Header::class => 'content[]',
         ];
     }
 }

--- a/src/Spec/OpenApi.php
+++ b/src/Spec/OpenApi.php
@@ -36,9 +36,4 @@ class OpenApi extends AbstractAttribute
     {
         return true;
     }
-
-    public function contains(): array
-    {
-        return [Security\Requirement::class => 'security[]'];
-    }
 }

--- a/src/Spec/Operation.php
+++ b/src/Spec/Operation.php
@@ -84,7 +84,7 @@ class Operation extends AbstractAttribute
         ?array $attachables = null,
     ) {
         parent::__construct(x: $x, attachables: $attachables);
-        $this->method = $method instanceof \BackedEnum ? $method->value : $method;
+        $this->method = $method instanceof \BackedEnum ? $method->value : strtolower($method);
     }
 
     public function isRoot(): bool

--- a/src/Spec/Operation.php
+++ b/src/Spec/Operation.php
@@ -91,15 +91,4 @@ class Operation extends AbstractAttribute
     {
         return true;
     }
-
-    public function contains(): array
-    {
-        return [
-            Parameter::class => 'parameters[]',
-            Response::class => 'responses[]',
-            RequestBody::class => 'requestBody',
-            Server::class => 'servers[]',
-            Security\Requirement::class => 'security[]',
-        ];
-    }
 }

--- a/src/Spec/Operation/Get.php
+++ b/src/Spec/Operation/Get.php
@@ -8,7 +8,6 @@ namespace OpenApi\Spec\Operation;
 
 use OpenApi\Spec as OA;
 use OpenApi\Spec\Parameter;
-use OpenApi\Spec\RequestBody;
 use OpenApi\Spec\Response;
 use OpenApi\Spec\Server;
 use OpenApi\Undefined;
@@ -66,13 +65,5 @@ class Get extends OA\Operation
             x: $x,
             attachables: $attachables,
         );
-    }
-
-    public function contains(): array
-    {
-        $result = parent::contains();
-        unset($result[RequestBody::class]);
-
-        return $result;
     }
 }

--- a/src/Spec/Operation/Head.php
+++ b/src/Spec/Operation/Head.php
@@ -7,7 +7,6 @@
 namespace OpenApi\Spec\Operation;
 
 use OpenApi\Spec as OA;
-use OpenApi\Spec\RequestBody;
 use OpenApi\Undefined;
 
 /**
@@ -63,13 +62,5 @@ class Head extends OA\Operation
             x: $x,
             attachables: $attachables,
         );
-    }
-
-    public function contains(): array
-    {
-        $result = parent::contains();
-        unset($result[RequestBody::class]);
-
-        return $result;
     }
 }

--- a/src/Spec/Operation/Options.php
+++ b/src/Spec/Operation/Options.php
@@ -7,7 +7,6 @@
 namespace OpenApi\Spec\Operation;
 
 use OpenApi\Spec as OA;
-use OpenApi\Spec\RequestBody;
 use OpenApi\Undefined;
 
 /**
@@ -63,13 +62,5 @@ class Options extends OA\Operation
             x: $x,
             attachables: $attachables,
         );
-    }
-
-    public function contains(): array
-    {
-        $result = parent::contains();
-        unset($result[RequestBody::class]);
-
-        return $result;
     }
 }

--- a/src/Spec/Operation/Trace.php
+++ b/src/Spec/Operation/Trace.php
@@ -7,7 +7,6 @@
 namespace OpenApi\Spec\Operation;
 
 use OpenApi\Spec as OA;
-use OpenApi\Spec\RequestBody;
 use OpenApi\Undefined;
 
 /**
@@ -63,13 +62,5 @@ class Trace extends OA\Operation
             x: $x,
             attachables: $attachables,
         );
-    }
-
-    public function contains(): array
-    {
-        $result = parent::contains();
-        unset($result[RequestBody::class]);
-
-        return $result;
     }
 }

--- a/src/Spec/Parameter.php
+++ b/src/Spec/Parameter.php
@@ -107,11 +107,11 @@ class Parameter extends AbstractAttribute
         ];
     }
 
-    public function contains(): array
+    public function contained(): array
     {
         return [
-            MediaType::class => 'content[]',
-            Example::class => 'examples[]',
+            Operation::class => 'parameters[]',
+            PathItem::class => 'parameters[]',
         ];
     }
 }

--- a/src/Spec/PathItem.php
+++ b/src/Spec/PathItem.php
@@ -88,14 +88,4 @@ class PathItem extends AbstractAttribute
     {
         return true;
     }
-
-    public function contains(): array
-    {
-        return [
-            Parameter::class => 'parameters[]',
-            Server::class => 'servers[]',
-            Response::class => 'responses[]',
-            Security\Requirement::class => 'security[]',
-        ];
-    }
 }

--- a/src/Spec/Property.php
+++ b/src/Spec/Property.php
@@ -33,4 +33,11 @@ class Property extends AbstractAttribute
     {
         return [];
     }
+
+    public function contained(): array
+    {
+        return [
+            Schema::class => 'properties[]',
+        ];
+    }
 }

--- a/src/Spec/RequestBody.php
+++ b/src/Spec/RequestBody.php
@@ -52,8 +52,10 @@ class RequestBody extends AbstractAttribute
         ];
     }
 
-    public function contains(): array
+    public function contained(): array
     {
-        return [MediaType::class => 'content[]'];
+        return [
+            Operation::class => 'requestBody',
+        ];
     }
 }

--- a/src/Spec/Response.php
+++ b/src/Spec/Response.php
@@ -55,12 +55,11 @@ class Response extends AbstractAttribute
         ];
     }
 
-    public function contains(): array
+    public function contained(): array
     {
         return [
-            Header::class => 'headers[]',
-            MediaType::class => 'content[]',
-            Link::class => 'links[]',
+            Operation::class => 'responses[]',
+            PathItem::class => 'responses[]',
         ];
     }
 }

--- a/src/Spec/Schema.php
+++ b/src/Spec/Schema.php
@@ -212,11 +212,10 @@ class Schema extends AbstractAttribute
         ];
     }
 
-    public function contains(): array
+    public function contained(): array
     {
         return [
-            Property::class => 'properties[]',
-            self::class => 'properties[]',
+            Schema::class => 'properties[]',
         ];
     }
 }

--- a/src/Spec/Security/Requirement.php
+++ b/src/Spec/Security/Requirement.php
@@ -41,6 +41,11 @@ class Requirement extends OA\AbstractAttribute
         return [OA\OpenApi::class => 'security[]', OA\Operation::class => 'security[]', OA\PathItem::class => 'security[]'];
     }
 
+    public function contained(): array
+    {
+        return [OA\OpenApi::class => 'security[]', OA\Operation::class => 'security[]', OA\PathItem::class => 'security[]'];
+    }
+
     /**
      * Resolve to the normalized map format: ['schemeName' => [...scopes]].
      *

--- a/src/Spec/Security/Scheme.php
+++ b/src/Spec/Security/Scheme.php
@@ -75,10 +75,10 @@ class Scheme extends OA\AbstractAttribute
         ];
     }
 
-    public function contains(): array
+    public function contained(): array
     {
         return [
-            OA\Flow::class => 'flows[]',
+            Components::class => 'securitySchemes[]',
         ];
     }
 }

--- a/src/Spec/Server.php
+++ b/src/Spec/Server.php
@@ -41,8 +41,11 @@ class Server extends AbstractAttribute
         return [PathItem::class => 'servers[]', Operation::class => 'servers[]'];
     }
 
-    public function contains(): array
+    public function contained(): array
     {
-        return [ServerVariable::class => 'variables[]'];
+        return [
+            Operation::class => 'servers[]',
+            PathItem::class => 'servers[]',
+        ];
     }
 }

--- a/src/Spec/ServerVariable.php
+++ b/src/Spec/ServerVariable.php
@@ -37,4 +37,9 @@ class ServerVariable extends AbstractAttribute
     {
         return [Server::class => 'variables[]'];
     }
+
+    public function contained(): array
+    {
+        return [Server::class => 'variables[]'];
+    }
 }

--- a/src/Spec/Tag.php
+++ b/src/Spec/Tag.php
@@ -41,9 +41,4 @@ class Tag extends AbstractAttribute
     {
         return true;
     }
-
-    public function contains(): array
-    {
-        return [ExternalDocumentation::class => 'externalDocs'];
-    }
 }

--- a/src/Specification.php
+++ b/src/Specification.php
@@ -103,9 +103,9 @@ class Specification
 
     protected function addComponentsChildren(OA\Components $components): void
     {
-        foreach ($components->contains() as $slot) {
-            $property = rtrim($slot, '[]');
-            if (property_exists($this, $property) && property_exists($components, $property)) {
+        foreach ((new \ReflectionClass($components))->getProperties(\ReflectionProperty::IS_PUBLIC) as $rp) {
+            $property = $rp->getName();
+            if (property_exists($this, $property) && is_array($components->{$property})) {
                 array_push($this->{$property}, ...$components->{$property});
             }
         }

--- a/src/Utils/AttributeFactory.php
+++ b/src/Utils/AttributeFactory.php
@@ -247,9 +247,9 @@ class AttributeFactory
     }
 
     /**
-     * Hierarchical absorb: outer-level attributes absorb inner-level attributes using contains().
+     * Hierarchical absorb: inner-level attributes declare which outer-level types can contain them.
      *
-     * Inner attributes that match a container's contains() are nested into it (first match wins).
+     * Inner attributes that match an outer attribute via contained() are nested into it (first match wins).
      * Inner attributes that find no container pass through alongside outer.
      *
      * @param  list<AttributeInterface> $outer
@@ -260,18 +260,16 @@ class AttributeFactory
     {
         foreach ($inner as $innerAttribute) {
             $absorbed = false;
+            $containedTargets = $innerAttribute->contained();
 
-            foreach ($outer as $outerAttribute) {
-                $containsTypes = $outerAttribute->contains();
-                if ($containsTypes === []) {
-                    continue;
-                }
-
-                foreach ($containsTypes as $childClass => $slot) {
-                    if ($innerAttribute instanceof $childClass) {
-                        $this->nestChild($outerAttribute, $innerAttribute, $slot);
-                        $absorbed = true;
-                        break 2;
+            if ($containedTargets !== []) {
+                foreach ($outer as $outerAttribute) {
+                    foreach ($containedTargets as $parentClass => $slot) {
+                        if ($outerAttribute instanceof $parentClass) {
+                            $this->nestChild($outerAttribute, $innerAttribute, $slot);
+                            $absorbed = true;
+                            break 2;
+                        }
                     }
                 }
             }

--- a/tests/Concerns/CollectsSpecClasses.php
+++ b/tests/Concerns/CollectsSpecClasses.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Concerns;
+
+use OpenApi\AttributeInterface;
+
+trait CollectsSpecClasses
+{
+    /**
+     * @return list<class-string<AttributeInterface>>
+     */
+    private static function allSpecClasses(): array
+    {
+        $classes = [];
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator(dirname(__DIR__, 2) . '/src/Spec', \FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $file) {
+            if ($file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $class = 'OpenApi\\Spec\\' . str_replace(
+                ['/', '.php'],
+                ['\\', ''],
+                substr($file->getPathname(), strlen(dirname(__DIR__, 2) . '/src/Spec/'))
+            );
+
+            if (!class_exists($class) || !(new \ReflectionClass($class))->isInstantiable()) {
+                continue;
+            }
+
+            if (!is_subclass_of($class, AttributeInterface::class)) {
+                continue;
+            }
+
+            $classes[] = $class;
+        }
+
+        sort($classes);
+
+        return $classes;
+    }
+}

--- a/tests/Spec/SlotMapConsistencyTest.php
+++ b/tests/Spec/SlotMapConsistencyTest.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Spec;
+
+use OpenApi\Tests\Concerns\CollectsSpecClasses;
+use PHPUnit\Framework\TestCase;
+
+final class SlotMapConsistencyTest extends TestCase
+{
+    use CollectsSpecClasses;
+
+    public function testMergeAndContainedSlotsAreConsistentWhenBothDeclared(): void
+    {
+        $failures = [];
+
+        foreach (self::allSpecClasses() as $class) {
+            $instance = (new \ReflectionClass($class))->newInstanceWithoutConstructor();
+            $merge = $instance->merge();
+            $contained = $instance->contained();
+
+            foreach ($contained as $parentClass => $slot) {
+                if (isset($merge[$parentClass]) && $merge[$parentClass] !== $slot) {
+                    $failures[] = sprintf(
+                        '%s declares %s in both merge() and contained() but with different slots: merge="%s", contained="%s"',
+                        $class,
+                        $parentClass,
+                        $merge[$parentClass],
+                        $slot
+                    );
+                }
+            }
+        }
+
+        $this->assertEmpty($failures, implode("\n", $failures));
+    }
+}

--- a/tools/src/Docs/Reference/SpecAttributeGenerator.php
+++ b/tools/src/Docs/Reference/SpecAttributeGenerator.php
@@ -41,7 +41,7 @@ class SpecAttributeGenerator extends DocGenerator
     public function generate(): array
     {
         $classes = $this->discoverClasses();
-        $parentMap = $this->buildParentMap($classes);
+        [$parentMap, $nestedMap] = $this->buildMaps($classes);
 
         $content = $this->renderer->preamble(
             'Spec Attribute',
@@ -52,7 +52,7 @@ class SpecAttributeGenerator extends DocGenerator
 
         foreach ($classes as $shortName => $fqdn) {
             $content .= "\n" . $this->renderClassLink($shortName, $fqdn);
-            $data = $this->collectClassData($shortName, $fqdn, $parentMap);
+            $data = $this->collectClassData($shortName, $fqdn, $parentMap, $nestedMap);
 
             foreach ($this->sections as $section) {
                 $rendered = $section->render($data);
@@ -120,32 +120,36 @@ class SpecAttributeGenerator extends DocGenerator
     }
 
     /**
-     * Build a map: child FQDN => list of parent short names (who can contain this class).
+     * Build maps from contained(): parentMap (child FQDN => parents) and nestedMap (parent FQDN => children).
      *
      * @param array<string,class-string<AbstractAttribute>> $classes
      *
-     * @return array<string,list<array{name: string, anchor: string}>>
+     * @return array{array<string,list<array{name: string, anchor: string}>>, array<string,list<array{name: string, anchor: string}>>}
      */
-    protected function buildParentMap(array $classes): array
+    protected function buildMaps(array $classes): array
     {
-        $map = [];
+        $parentMap = [];
+        $nestedMap = [];
 
         foreach ($classes as $shortName => $fqdn) {
             $instance = (new \ReflectionClass($fqdn))->newInstanceWithoutConstructor();
-            foreach ($instance->contains() as $childClass => $prop) {
-                $map[$childClass][] = ['name' => $shortName, 'anchor' => $this->anchor($shortName)];
+            foreach ($instance->contained() as $parentClass => $prop) {
+                $parentShortName = $this->shortName($parentClass);
+                $parentMap[$fqdn][] = ['name' => $parentShortName, 'anchor' => $this->anchor($parentShortName)];
+                $nestedMap[$parentClass][] = ['name' => $shortName, 'anchor' => $this->anchor($shortName)];
             }
         }
 
-        return $map;
+        return [$parentMap, $nestedMap];
     }
 
     /**
      * @param array<string,list<array{name: string, anchor: string}>> $parentMap
+     * @param array<string,list<array{name: string, anchor: string}>> $nestedMap
      *
      * @return array<string,mixed>
      */
-    protected function collectClassData(string $shortName, string $fqdn, array $parentMap): array
+    protected function collectClassData(string $shortName, string $fqdn, array $parentMap, array $nestedMap): array
     {
         $rc = new \ReflectionClass($fqdn);
         $classDoc = $this->parseDocblock($rc->getDocComment());
@@ -154,7 +158,7 @@ class SpecAttributeGenerator extends DocGenerator
             : ['content' => '', 'see' => [], 'var' => '', 'params' => []];
 
         $instance = $rc->newInstanceWithoutConstructor();
-        $nested = $this->collectNested($instance);
+        $nested = $nestedMap[$fqdn] ?? [];
         $parents = $parentMap[$fqdn] ?? $this->collectMergeParents($instance);
         $parameters = $this->collectParameters($rc, $ctorDoc);
 
@@ -200,21 +204,6 @@ class SpecAttributeGenerator extends DocGenerator
         }
 
         return $parameters;
-    }
-
-    /**
-     * @return list<array{name: string, anchor: string}>
-     */
-    protected function collectNested(OA\AbstractAttribute $instance): array
-    {
-        $nested = [];
-
-        foreach ($instance->contains() as $childClass => $prop) {
-            $shortName = $this->shortName($childClass);
-            $nested[] = ['name' => $shortName, 'anchor' => $this->anchor($shortName)];
-        }
-
-        return $nested;
     }
 
     /**


### PR DESCRIPTION
## Summary

Move `contains()` method from attribute parent to `contained()` in the child.
Ths is closer to how the current attachables work and also moves all merge knowledge into the actual attribute, so attachables make more sense.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Enhancement (improvement to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactor (no functional changes)
- [ ] Chore (maintenance, dependencies, CI)

## Related Issues

<!-- Link related issues: Fixes #123, Closes #456 -->

## Test Plan

<!-- Describe the tests you ran or plan to run to verify the changes. -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass locally
- [ ] Any dependent changes have been merged and published
