### PR TITLE
Introduce `ComponentIndex` for lazy resolution of `$ref` values and component lookups

### DIFF
--- a/src/Augmenter/Inheritance/Schemas.php
+++ b/src/Augmenter/Inheritance/Schemas.php
@@ -6,9 +6,11 @@
 
 namespace OpenApi\Augmenter\Inheritance;
 
+use OpenApi\ComponentIndex;
 use OpenApi\Spec as OA;
 use OpenApi\Specification;
 use OpenApi\Utils\AttributeFactory;
+
 
 /**
  * Expands PHP class hierarchy into OpenAPI composition (allOf).
@@ -26,7 +28,7 @@ class Schemas
 
     public function resolve(Specification $payload): mixed
     {
-        $schemaMap = $this->buildSchemaMap($payload);
+        $index = $payload->buildComponentIndex();
 
         foreach ($payload->schemas as $schema) {
             $reflector = $schema->getClassReflector();
@@ -36,42 +38,21 @@ class Schemas
 
             $existingProperties = array_map(fn (OA\Property $property): ?string => $property->property, $schema->properties ?? []);
 
-            $this->expandParents($schema, $reflector, $schemaMap, $existingProperties);
-            $this->expandTraits($schema, $reflector, $schemaMap, $existingProperties);
-            $this->expandInterfaces($schema, $reflector, $schemaMap, $existingProperties);
+            $this->expandParents($schema, $reflector, $index, $existingProperties);
+            $this->expandTraits($schema, $reflector, $index, $existingProperties);
+            $this->expandInterfaces($schema, $reflector, $index, $existingProperties);
         }
 
         return null;
     }
 
-    /**
-     * @return array<string, OA\Schema> class name → schema
-     */
-    protected function buildSchemaMap(Specification $specification): array
+    protected function expandParents(OA\Schema $schema, \ReflectionClass $reflector, ComponentIndex $index, array &$existingProperties): void
     {
-        $map = [];
-        foreach ($specification->schemas as $schema) {
-            $className = $schema->getClassName();
-            if ($className !== null) {
-                $map[$className] = $schema;
-            }
-        }
-
-        return $map;
-    }
-
-    /**
-     * @param array<string, OA\Schema> $schemaMap
-     */
-    protected function expandParents(OA\Schema $schema, \ReflectionClass $reflector, array $schemaMap, array &$existingProperties): void
-    {
-        // Walk up the inheritance chain; stop at the first ancestor that has its own schema
-        // (it becomes a $ref). Non-schema ancestors have their members inlined.
         $parent = $reflector->getParentClass();
         while ($parent !== false) {
-            if (isset($schemaMap[$parent->getName()])) {
-                $this->addAllOfRef($schema, $schemaMap[$parent->getName()]);
-                // stop on first schema ancestor
+            $parentSchema = $index->findSchema($parent->getName());
+            if ($parentSchema instanceof OA\Schema) {
+                $this->addAllOfRef($schema, $parentSchema);
                 break;
             }
 
@@ -80,14 +61,12 @@ class Schemas
         }
     }
 
-    /**
-     * @param array<string, OA\Schema> $schemaMap
-     */
-    protected function expandTraits(OA\Schema $schema, \ReflectionClass $reflector, array $schemaMap, array &$existingProperties): void
+    protected function expandTraits(OA\Schema $schema, \ReflectionClass $reflector, ComponentIndex $index, array &$existingProperties): void
     {
         foreach ($this->attributeFactory->getDirectTraits($reflector) as $trait) {
-            if (isset($schemaMap[$trait->getName()])) {
-                $this->addAllOfRef($schema, $schemaMap[$trait->getName()]);
+            $traitSchema = $index->findSchema($trait->getName());
+            if ($traitSchema instanceof OA\Schema) {
+                $this->addAllOfRef($schema, $traitSchema);
             } else {
                 $this->mergeMembers($schema, $trait, $existingProperties);
             }
@@ -95,13 +74,14 @@ class Schemas
 
         $parent = $reflector->getParentClass();
         while ($parent !== false) {
-            if (isset($schemaMap[$parent->getName()])) {
+            if ($index->findSchema($parent->getName()) instanceof OA\Schema) {
                 break;
             }
 
             foreach ($this->attributeFactory->getDirectTraits($parent) as $trait) {
-                if (isset($schemaMap[$trait->getName()])) {
-                    $this->addAllOfRef($schema, $schemaMap[$trait->getName()]);
+                $traitSchema = $index->findSchema($trait->getName());
+                if ($traitSchema instanceof OA\Schema) {
+                    $this->addAllOfRef($schema, $traitSchema);
                 } else {
                     $this->mergeMembers($schema, $trait, $existingProperties);
                 }
@@ -111,16 +91,14 @@ class Schemas
         }
     }
 
-    /**
-     * @param array<string, OA\Schema> $schemaMap
-     */
-    protected function expandInterfaces(OA\Schema $schema, \ReflectionClass $reflector, array $schemaMap, array &$existingProperties): void
+    protected function expandInterfaces(OA\Schema $schema, \ReflectionClass $reflector, ComponentIndex $index, array &$existingProperties): void
     {
         $ownInterfaces = $this->attributeFactory->getDirectInterfaces($reflector);
 
         foreach ($ownInterfaces as $interface) {
-            if (isset($schemaMap[$interface->getName()])) {
-                $this->addAllOfRef($schema, $schemaMap[$interface->getName()]);
+            $interfaceSchema = $index->findSchema($interface->getName());
+            if ($interfaceSchema instanceof OA\Schema) {
+                $this->addAllOfRef($schema, $interfaceSchema);
             } else {
                 $this->mergeMembers($schema, $interface, $existingProperties);
             }

--- a/src/Augmenter/Inheritance/Schemas.php
+++ b/src/Augmenter/Inheritance/Schemas.php
@@ -11,7 +11,6 @@ use OpenApi\Spec as OA;
 use OpenApi\Specification;
 use OpenApi\Utils\AttributeFactory;
 
-
 /**
  * Expands PHP class hierarchy into OpenAPI composition (allOf).
  *

--- a/src/Augmenter/Refs.php
+++ b/src/Augmenter/Refs.php
@@ -36,7 +36,8 @@ class Refs implements PipeInterface, LoggerAwareInterface
             $this->dedupAllOfRefs($schema);
         }
 
-        $refMap = $this->buildRefMap($payload);
+        $index = $payload->buildComponentIndex();
+        $refMap = $index->buildRefMap();
 
         if ($refMap === []) {
             return null;
@@ -82,58 +83,6 @@ class Refs implements PipeInterface, LoggerAwareInterface
         foreach (array_keys($unresolved) as $ref) {
             $this->logger?->warning("Ref: unresolved reference '{$ref}' — no matching component found");
         }
-    }
-
-    /**
-     * Build a map of FQCN → #/components/{type}/{name}.
-     *
-     * @return array<string, string>
-     */
-    protected function buildRefMap(Specification $specification): array
-    {
-        $map = [];
-
-        $specification->getWalker()->eachSchema(function (OA\Schema $schema) use (&$map): void {
-            $name = $schema->schema ?? $schema->title;
-            $fqcn = $schema->getClassName();
-            if ($name !== null && $fqcn !== null) {
-                $map[$fqcn] = '#/components/schemas/' . $name;
-            }
-        });
-
-        foreach ($specification->responses as $response) {
-            $name = $response->response;
-            $fqcn = $response->getClassName();
-            if ($name !== null && $fqcn !== null) {
-                $map[$fqcn] = '#/components/responses/' . $name;
-            }
-        }
-
-        foreach ($specification->requestBodies as $body) {
-            $name = $body->request;
-            $fqcn = $body->getClassName();
-            if ($name !== null && $fqcn !== null) {
-                $map[$fqcn] = '#/components/requestBodies/' . $name;
-            }
-        }
-
-        foreach ($specification->headers as $header) {
-            $name = $header->header;
-            $fqcn = $header->getClassName();
-            if ($name !== null && $fqcn !== null) {
-                $map[$fqcn] = '#/components/headers/' . $name;
-            }
-        }
-
-        foreach ($specification->parameters as $parameter) {
-            $name = $parameter->parameter ?? $parameter->name;
-            $fqcn = $parameter->getClassName();
-            if ($name !== null && $fqcn !== null) {
-                $map[$fqcn] = '#/components/parameters/' . $name;
-            }
-        }
-
-        return $map;
     }
 
     /**

--- a/src/ComponentIndex.php
+++ b/src/ComponentIndex.php
@@ -1,0 +1,188 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi;
+
+use OpenApi\Spec as OA;
+
+/**
+ * Resolves `$ref` values to their corresponding component objects.
+ *
+ * Handles both canonical JSON Reference paths (`#/components/schemas/Foo`)
+ * and FQCN refs (`App\Models\Foo`) that haven't been rewritten yet.
+ *
+ * Indexes are built lazily per bucket on first access.
+ */
+class ComponentIndex
+{
+    protected const COMPONENTS_PREFIX = '#/components/';
+
+    protected const BUCKET_MAP = [
+        'schemas' => 'schemas',
+        'responses' => 'responses',
+        'parameters' => 'parameters',
+        'requestBodies' => 'requestBodies',
+        'headers' => 'headers',
+        'securitySchemes' => 'securitySchemes',
+        'links' => 'links',
+        'examples' => 'examples',
+    ];
+
+    /** @var array<string, array<string, AttributeInterface>|null> */
+    protected array $indexes = [];
+
+    public function __construct(
+        protected Specification $specification,
+    ) {
+    }
+
+    public function find(string $ref): ?AttributeInterface
+    {
+        if (str_starts_with($ref, self::COMPONENTS_PREFIX)) {
+            $path = substr($ref, strlen(self::COMPONENTS_PREFIX));
+            $slash = strpos($path, '/');
+            if ($slash === false) {
+                return null;
+            }
+
+            $bucket = substr($path, 0, $slash);
+            $name = substr($path, $slash + 1);
+
+            return $this->getIndex($bucket)[$name] ?? null;
+        }
+
+        foreach (array_keys(self::BUCKET_MAP) as $bucket) {
+            $found = $this->getIndex($bucket)[$ref] ?? null;
+            if ($found !== null) {
+                return $found;
+            }
+        }
+
+        return null;
+    }
+
+    public function findSchema(string $ref): ?OA\Schema
+    {
+        $result = str_starts_with($ref, self::COMPONENTS_PREFIX)
+            ? $this->find($ref)
+            : ($this->getIndex('schemas')[$ref] ?? null);
+
+        return $result instanceof OA\Schema ? $result : null;
+    }
+
+    public function findResponse(string $ref): ?OA\Response
+    {
+        $result = str_starts_with($ref, self::COMPONENTS_PREFIX)
+            ? $this->find($ref)
+            : ($this->getIndex('responses')[$ref] ?? null);
+
+        return $result instanceof OA\Response ? $result : null;
+    }
+
+    public function findRequestBody(string $ref): ?OA\RequestBody
+    {
+        $result = str_starts_with($ref, self::COMPONENTS_PREFIX)
+            ? $this->find($ref)
+            : ($this->getIndex('requestBodies')[$ref] ?? null);
+
+        return $result instanceof OA\RequestBody ? $result : null;
+    }
+
+    public function findParameter(string $ref): ?OA\Parameter
+    {
+        $result = str_starts_with($ref, self::COMPONENTS_PREFIX)
+            ? $this->find($ref)
+            : ($this->getIndex('parameters')[$ref] ?? null);
+
+        return $result instanceof OA\Parameter ? $result : null;
+    }
+
+    public function findHeader(string $ref): ?OA\Header
+    {
+        $result = str_starts_with($ref, self::COMPONENTS_PREFIX)
+            ? $this->find($ref)
+            : ($this->getIndex('headers')[$ref] ?? null);
+
+        return $result instanceof OA\Header ? $result : null;
+    }
+
+    /**
+     * @return array<string, string> FQCN → #/components/{type}/{name}
+     */
+    public function buildRefMap(): array
+    {
+        $map = [];
+
+        foreach (self::BUCKET_MAP as $bucket => $property) {
+            $items = $this->specification->{$property};
+
+            foreach ($items as $item) {
+                $name = $this->getComponentName($item, $bucket);
+                $fqcn = $item->getClassName();
+                if ($name !== null && $fqcn !== null) {
+                    $map[$fqcn] = self::COMPONENTS_PREFIX . $bucket . '/' . $name;
+                }
+            }
+        }
+
+        return $map;
+    }
+
+    /**
+     * @return array<string, AttributeInterface>
+     */
+    protected function getIndex(string $bucket): array
+    {
+        if (!isset(self::BUCKET_MAP[$bucket])) {
+            return [];
+        }
+
+        if (!array_key_exists($bucket, $this->indexes)) {
+            $this->indexes[$bucket] = $this->buildIndex($bucket);
+        }
+
+        return $this->indexes[$bucket];
+    }
+
+    /**
+     * @return array<string, AttributeInterface>
+     */
+    protected function buildIndex(string $bucket): array
+    {
+        $property = self::BUCKET_MAP[$bucket];
+        $items = $this->specification->{$property};
+        $index = [];
+
+        foreach ($items as $item) {
+            $name = $this->getComponentName($item, $bucket);
+            if ($name !== null) {
+                $index[$name] = $item;
+            }
+
+            $fqcn = $item->getClassName();
+            if ($fqcn !== null) {
+                $index[$fqcn] = $item;
+            }
+        }
+
+        return $index;
+    }
+
+    protected function getComponentName(AttributeInterface $item, string $bucket): ?string
+    {
+        return match ($bucket) {
+            'schemas' => $item instanceof OA\Schema ? ($item->schema ?? $item->title) : null,
+            'responses' => $item instanceof OA\Response ? ($item->response !== null ? (string) $item->response : null) : null,
+            'requestBodies' => $item instanceof OA\RequestBody ? $item->request : null,
+            'headers' => $item instanceof OA\Header ? $item->header : null,
+            'parameters' => $item instanceof OA\Parameter ? ($item->parameter ?? $item->name) : null,
+            'securitySchemes' => $item instanceof OA\Security\Scheme ? $item->securityScheme : null,
+            'links' => $item instanceof OA\Link ? $item->link : null,
+            'examples' => $item instanceof OA\Example ? $item->example : null,
+            default => null,
+        };
+    }
+}

--- a/src/Specification.php
+++ b/src/Specification.php
@@ -101,6 +101,11 @@ class Specification
         return new SpecificationWalker($this);
     }
 
+    public function buildComponentIndex(): ComponentIndex
+    {
+        return new ComponentIndex($this);
+    }
+
     protected function addComponentsChildren(OA\Components $components): void
     {
         foreach ((new \ReflectionClass($components))->getProperties(\ReflectionProperty::IS_PUBLIC) as $rp) {


### PR DESCRIPTION
## Summary

New class `ComponentIndex` wraps some lookup methods for components (related to refs)


## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Enhancement (improvement to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactor (no functional changes)
- [ ] Chore (maintenance, dependencies, CI)

## Related Issues

<!-- Link related issues: Fixes #123, Closes #456 -->

## Test Plan

<!-- Describe the tests you ran or plan to run to verify the changes. -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass locally
- [ ] Any dependent changes have been merged and published
