### PR TITLE
Improve handling of empty schemas and type consistency

### DIFF
--- a/src/Compiler/OpenApi30Compiler.php
+++ b/src/Compiler/OpenApi30Compiler.php
@@ -96,7 +96,7 @@ class OpenApi30Compiler extends OpenApi31Compiler
      * Compile schema using OAS 3.0 / JSON Schema draft-04 semantics.
      */
     #[\Override]
-    protected function compileSchema(OA\Schema|string $schema): array
+    protected function compileSchema(OA\Schema|string $schema): array|\stdClass
     {
         if (is_string($schema)) {
             return ['$ref' => $schema];
@@ -214,7 +214,7 @@ class OpenApi30Compiler extends OpenApi31Compiler
             $result['enum'] = [$schema->const];
         }
 
-        return $result;
+        return $result ?: new \stdClass();
     }
 
     #[\Override]

--- a/src/Compiler/OpenApi31Compiler.php
+++ b/src/Compiler/OpenApi31Compiler.php
@@ -406,7 +406,7 @@ class OpenApi31Compiler implements CompilerInterface
         ], $link);
     }
 
-    protected function compileSchema(OA\Schema|string $schema): array
+    protected function compileSchema(OA\Schema|string $schema): array|\stdClass
     {
         if (is_string($schema)) {
             return ['$ref' => $schema];
@@ -521,7 +521,7 @@ class OpenApi31Compiler implements CompilerInterface
             $result['example'] = $schema->example;
         }
 
-        return $result;
+        return $result ?: new \stdClass();
     }
 
     /**

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -245,7 +245,7 @@ final class CompilerTest extends TestCase
             ),
         );
 
-        $this->assertSame([], $result);
+        $this->assertEquals(new \stdClass(), $result);
     }
 
     public function test31IncludesIfThenElse(): void

--- a/tests/DocSnippetsTest.php
+++ b/tests/DocSnippetsTest.php
@@ -87,6 +87,6 @@ final class DocSnippetsTest extends OpenApiTestCase
             ->build();
 
         // file_put_contents($spec, $result->toYaml());
-        $this->assertSpecEquals(file_get_contents($spec), $result->toArray());
+        $this->assertSpecEquals(file_get_contents($spec), $result->toYaml());
     }
 }

--- a/tests/OpenApiTestCase.php
+++ b/tests/OpenApiTestCase.php
@@ -172,7 +172,7 @@ class OpenApiTestCase extends TestCase
             if (is_string($in)) {
                 // assume YAML
                 try {
-                    $in = Yaml::parse($in);
+                    $in = Yaml::parse($in, Yaml::PARSE_OBJECT_FOR_MAP);
                 } catch (ParseException $e) {
                     $this->fail('Invalid YAML: ' . $e->getMessage() . PHP_EOL . $in);
                 }
@@ -187,22 +187,23 @@ class OpenApiTestCase extends TestCase
         }
 
         if ($actual instanceof \stdClass && $expected === []) {
-            $this->assertEmpty((array) $actual, $message . PHP_EOL . '[] does not match expected type "object".');
-
-            return;
+            $this->fail($message . PHP_EOL . 'Expected array ([]), got object ({}).');
         }
         if ($expected instanceof \stdClass && $actual === []) {
-            $this->assertEmpty((array) $expected, $message . PHP_EOL . '[] does not match expected type "object".');
-
+            $this->fail($message . PHP_EOL . 'Expected object ({}), got array ([]).');
+        }
+        if ($actual === [] && $expected === []) {
             return;
         }
 
-        if (is_iterable($actual) && is_iterable($expected)) {
-            foreach ($actual as $key => $value) {
+        $isComposite = fn ($v): bool => is_iterable($v) || $v instanceof \stdClass;
+
+        if ($isComposite($actual) && $isComposite($expected)) {
+            foreach ((array) $actual as $key => $value) {
                 $this->assertArrayHasKey($key, (array) $expected, $message . ': property: "' . $key . '" should be absent, but has value: ' . $formattedValue($value));
                 $this->assertSpecEquals($value, ((array) $expected)[$key], $message . ' > ' . $key, true);
             }
-            foreach ($expected as $key => $value) {
+            foreach ((array) $expected as $key => $value) {
                 $this->assertArrayHasKey($key, (array) $actual, $message . ': property: "' . $key . '" is missing');
                 $this->assertSpecEquals(((array) $actual)[$key], $value, $message . ' > ' . $key, true);
             }

--- a/tests/Type/TypeResolverTest.php
+++ b/tests/Type/TypeResolverTest.php
@@ -149,6 +149,8 @@ final class TypeResolverTest extends OpenApiTestCase
             ],
         ];
 
+        $expectations[OA\OpenApi::VERSION_3_2_0] = $expectations[OA\OpenApi::VERSION_3_1_0];
+
         $rc = new \ReflectionClass(DocblockAndTypehintTypes::class);
         $fixtureFolder = dirname($rc->getFileName());
         $sources = [
@@ -158,7 +160,7 @@ final class TypeResolverTest extends OpenApiTestCase
         ];
 
         foreach (self::getTypeResolvers() as $key => $typeResolver) {
-            foreach ([OA\OpenApi::VERSION_3_0_0, OA\OpenApi::VERSION_3_1_0] as $version) {
+            foreach ([OA\OpenApi::VERSION_3_0_0, OA\OpenApi::VERSION_3_1_0, OA\OpenApi::VERSION_3_2_0] as $version) {
                 $analysis = (new Generator())
                     ->setVersion($version)
                     ->setProcessorPipeline(new Pipeline([new MergeIntoOpenApi(), new AugmentSchemas()]))

--- a/tests/Type/TypeResolverTest.php
+++ b/tests/Type/TypeResolverTest.php
@@ -186,7 +186,7 @@ final class TypeResolverTest extends OpenApiTestCase
                             $typeResolver,
                             $analysis,
                             $property,
-                            json_decode($json, true),
+                            json_decode($json),
                         ];
                     }
                 }
@@ -195,7 +195,7 @@ final class TypeResolverTest extends OpenApiTestCase
     }
 
     #[DataProvider('resolverAugmentCases')]
-    public function testAugmentSchemaType(TypeResolverInterface $typeResolver, Analysis $analysis, OA\Schema $schema, array $expected): void
+    public function testAugmentSchemaType(TypeResolverInterface $typeResolver, Analysis $analysis, OA\Schema $schema, \stdClass $expected): void
     {
         $typeResolver->augmentSchemaType($analysis, $schema);
 


### PR DESCRIPTION
## Summary

Fix serialization of empty schema as `{}` instead of `[]`. Also improve the test harness to properly detect these differences.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Enhancement (improvement to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional changes)
- [ ] Chore (maintenance, dependencies, CI)

## Related Issues

<!-- Link related issues: Fixes #123, Closes #456 -->

## Test Plan

<!-- Describe the tests you ran or plan to run to verify the changes. -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass locally
- [ ] Any dependent changes have been merged and published
