### PR TITLE
feat(Spec): add resolver step to spec pipeline

### DIFF
--- a/docs/dev/pipeline.md
+++ b/docs/dev/pipeline.md
@@ -119,6 +119,26 @@ public function __construct(
 
 Augmenters, compilers and serialization then never need to branch on type.
 
+## Why resolution is its own step
+
+Resolving unknown classes inside the augmenter pipeline would create an ordering problem: an
+augmenter that adds schemas runs after `Names` and `Types`, so it would have to re-invoke
+them on whatever it added. Running resolution between assembly and augmentation means every
+schema exists before the augmenters start their single pass.
+
+Discovery draws on two sources, both readable before any augmenter has run:
+
+- **Ref values** — raw FQCN strings in `$ref`, not yet rewritten to `#/components/...`, so
+  no dependency on `Names` or `Refs`
+- **Reflector types** — non-builtin types on properties and constructor parameters, read
+  straight off `\ReflectionProperty::getType()`, so no dependency on `Types`
+
+A `ComponentIndex` deduplicates against what the specification already holds.
+
+Resolution then runs as a convergence loop: discover, hand each FQCN to the chain until one
+claims it, re-discover. That is what handles transitive references — resolving class A can
+introduce a schema referencing class B, which the next pass picks up.
+
 ## Augmenter ordering lives in one place
 
 Registration order is `Builder::getDefaultAugmenters()`. The phase each augmenter runs in

--- a/docs/guide/modes.md
+++ b/docs/guide/modes.md
@@ -102,14 +102,14 @@ $builder->setMode(Mode::SPEC);
 
 The modes aim for equivalent output from the same source, but differ in what they accept and in how they can be configured:
 
-| Behavior                                | Classic                | Hybrid                                               | Spec                          |
-| --------------------------------------- | ---------------------- | ---------------------------------------------------- | ----------------------------- |
-| Annotation support (`/** @OA\... */`)   | Yes                    | Yes                                                  | No                            |
-| `MergeJsonContent` / `MergeXmlContent`  | Yes                    | Yes                                                  | Yes (via `OA\MediaType\Json`) |
-| Processor chain (`withGenerator()`)     | Yes                    | Scanning only (`MergeJsonContent`/`MergeXmlContent`) | No                            |
-| Resolver (`withResolver()`)             | No                     | Yes                                                  | Yes                           |
-| Augmenter pipeline (`withAugmenters()`) | No                     | Yes                                                  | Yes                           |
-| Version-aware compilation               | No (single serializer) | Yes                                                  | Yes                           |
+| Behavior                                | Classic                | Hybrid                                               | Spec                                   |
+| --------------------------------------- | ---------------------- | ---------------------------------------------------- | -------------------------------------- |
+| Annotation support (`/** @OA\... */`)   | Yes                    | Yes                                                  | No                                     |
+| `MergeJsonContent` / `MergeXmlContent`  | Yes                    | Yes                                                  | Yes (via `OA\MediaType\Json`)          |
+| Processor chain (`withGenerator()`)     | Yes                    | Scanning only (`MergeJsonContent`/`MergeXmlContent`) | No                                     |
+| Resolver (`withResolver()`)             | No                     | Yes (`Resolver\Reflection` by default)               | Yes (`Resolver\Reflection` by default) |
+| Augmenter pipeline (`withAugmenters()`) | No                     | Yes                                                  | Yes                                    |
+| Version-aware compilation               | No (single serializer) | Yes                                                  | Yes                                    |
 
 ## Migration path
 

--- a/docs/guide/modes.md
+++ b/docs/guide/modes.md
@@ -4,13 +4,13 @@ Swagger-php supports three processing modes that control how your source code is
 
 ## Overview
 
-|                 | Classic                | Hybrid                                           | Spec                              |
-| --------------- | ---------------------- | ------------------------------------------------ | --------------------------------- |
-| **Status**      | Stable                 | Beta                                             | Beta                              |
-| **Attributes**  | `OpenApi\Attributes`   | `OpenApi\Attributes`                             | `OpenApi\Spec`                    |
-| **Annotations** | Yes                    | Yes                                              | No                                |
-| **Pipeline**    | Generator → Processors | Generator → HybridBridge → Augmenters → Compiler | Assembler → Augmenters → Compiler |
-| **Best for**    | Existing projects      | Gradual migration                                | New projects                      |
+|                 | Classic                | Hybrid                                                       | Spec                                         |
+| --------------- | ---------------------- | ------------------------------------------------------------ | -------------------------------------------- |
+| **Status**      | Stable                 | Beta                                                         | Beta                                         |
+| **Attributes**  | `OpenApi\Attributes`   | `OpenApi\Attributes`                                         | `OpenApi\Spec`                               |
+| **Annotations** | Yes                    | Yes                                                          | No                                           |
+| **Pipeline**    | Generator → Processors | Generator → HybridBridge → Resolver → Augmenters → Compiler  | Assembler → Resolver → Augmenters → Compiler |
+| **Best for**    | Existing projects      | Gradual migration                                            | New projects                                 |
 
 ## Classic (default)
 
@@ -107,6 +107,7 @@ The modes aim for equivalent output from the same source, but differ in what the
 | Annotation support (`/** @OA\... */`)   | Yes                    | Yes                                                  | No                            |
 | `MergeJsonContent` / `MergeXmlContent`  | Yes                    | Yes                                                  | Yes (via `OA\MediaType\Json`) |
 | Processor chain (`withGenerator()`)     | Yes                    | Scanning only (`MergeJsonContent`/`MergeXmlContent`) | No                            |
+| Resolver (`withResolver()`)             | No                     | Yes                                                  | Yes                           |
 | Augmenter pipeline (`withAugmenters()`) | No                     | Yes                                                  | Yes                           |
 | Version-aware compilation               | No (single serializer) | Yes                                                  | Yes                           |
 

--- a/docs/guide/modes.md
+++ b/docs/guide/modes.md
@@ -9,7 +9,7 @@ Swagger-php supports three processing modes that control how your source code is
 | **Status**      | Stable                 | Beta                                                         | Beta                                         |
 | **Attributes**  | `OpenApi\Attributes`   | `OpenApi\Attributes`                                         | `OpenApi\Spec`                               |
 | **Annotations** | Yes                    | Yes                                                          | No                                           |
-| **Pipeline**    | Generator → Processors | Generator → HybridBridge → Resolver → Augmenters → Compiler  | Assembler → Resolver → Augmenters → Compiler |
+| **Pipeline**    | Generator → Processors | Assembler → Resolver → HybridBridge → Augmenters → Compiler  | Assembler → Resolver → Augmenters → Compiler |
 | **Best for**    | Existing projects      | Gradual migration                                            | New projects                                 |
 
 ## Classic (default)

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -9,14 +9,15 @@ see [Spec pipeline internals](/dev/pipeline).
 ## Pipeline overview
 
 ```
-Source files → Assembler → Specification → Augmenters → Compiler → OpenAPI document
+Source files → Assembler → Specification → Resolver → Augmenters → Compiler → OpenAPI document
 ```
 
 1. **Assembler** — scans source files, instantiates attributes from reflection, resolves nesting via slot maps (merge + hierarchical absorb)
 2. **Specification** — a flat, typed container holding all collected attributes in buckets
-3. **Augmenters** — enrich the specification with inferred data (types, refs, tags, etc.) via a grouped pipeline
-4. **Compiler** — transforms the specification into a versioned OpenAPI document array
-5. **Builder** — the unified entry point that orchestrates the pipeline
+3. **Resolver** — discovers and resolves unresolved FQCNs (e.g. unannotated model classes) before augmentation
+4. **Augmenters** — enrich the specification with inferred data (types, refs, tags, etc.) via a grouped pipeline
+5. **Compiler** — transforms the specification into a versioned OpenAPI document array
+6. **Builder** — the unified entry point that orchestrates the pipeline
 
 ## Assembler
 
@@ -37,6 +38,53 @@ Whatever is left once nesting is resolved is added to the Specification.
 The Specification is a flat, typed container with one bucket per root attribute type. It holds all attributes collected by the Assembler, organized by type (schemas, operations, pathItems, tags, etc.).
 
 Augmenters read from and write to the Specification's buckets. The container is deliberately simple — no tree structure, no parent pointers. Cross-bucket relationships are resolved by augmenters using reflectors.
+
+## Resolver
+
+The Resolver discovers FQCNs referenced by the specification that have no corresponding component (e.g. unannotated model classes used in `$ref` or typed properties) and delegates their handling to user-registered `ResolverInterface` implementations.
+
+### Why a separate step
+
+Solving this inside the augmenter pipeline creates ordering problems: an augmenter that adds new schemas runs after `Names` and `Types`, so it must re-invoke those augmenters on the newly added entries. The Resolver runs after assembly but before augmenters, so all schemas are present when augmenters start their single pass.
+
+### Discovery
+
+Two sources are inspected to find unresolved FQCNs:
+
+- **Ref values** — walks all `$ref` attributes for raw FQCN strings (not yet rewritten to `#/components/...` paths). These are discoverable without `Names` or `Refs` having run.
+- **Reflector types** — walks schema class reflectors for non-builtin typed properties and constructor parameters. This reads `\ReflectionProperty::getType()` directly, no `Types` augmenter needed.
+
+A `ComponentIndex` is used to deduplicate against components already present in the specification.
+
+### Resolution loop
+
+The Resolver iterates in a convergence loop: discover unresolved FQCNs, pass each to the resolver chain (first resolver to claim success wins), then re-discover. This handles transitive references — resolving class A may add a schema referencing class B, which the next iteration discovers. A `MAX_ITERATIONS` guard (default 50) protects against misbehaving resolvers.
+
+### ResolverInterface
+
+```php
+namespace OpenApi\Contracts;
+
+interface ResolverInterface
+{
+    public function resolve(string $fqcn, Specification $specification): bool;
+}
+```
+
+Each resolver is self-contained — it owns its internal assembler and attribute factory. It writes into the specification directly (e.g. via `Specification::add()`) and returns `true` if it handled the FQCN.
+
+### Configuring resolvers
+
+```php
+use OpenApi\Resolver;
+use OpenApi\Utils\TypedList;
+
+$builder->withResolver(function (Resolver $resolver) {
+    $resolver->withResolvers(fn (TypedList $resolvers) => $resolvers->add(new MyResolver()));
+});
+```
+
+When no resolvers are registered, the resolution step is skipped entirely.
 
 ## Augmenters
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -41,7 +41,7 @@ Augmenters read from and write to the Specification's buckets. The container is 
 
 ## Resolver
 
-The Resolver discovers FQCNs referenced by the specification that have no corresponding component (e.g. unannotated model classes used in `$ref` or typed properties) and delegates their handling to user-registered `ResolverInterface` implementations.
+The Resolver discovers FQCNs referenced by the specification that have no corresponding component (e.g. model classes used in `$ref` or typed properties that were never scanned) and delegates their handling to a chain of `ResolverInterface` implementations. `Resolver\Reflection` is registered by default; further resolvers can be added, and the chain can be cleared entirely.
 
 ### Why a separate step
 
@@ -58,7 +58,7 @@ A `ComponentIndex` is used to deduplicate against components already present in 
 
 ### Resolution loop
 
-The Resolver iterates in a convergence loop: discover unresolved FQCNs, pass each to the resolver chain (first resolver to claim success wins), then re-discover. This handles transitive references — resolving class A may add a schema referencing class B, which the next iteration discovers. A `MAX_ITERATIONS` guard (default 50) protects against misbehaving resolvers.
+The Resolver iterates in a convergence loop: discover unresolved FQCNs, pass each to the resolver chain (first resolver to claim success wins), then re-discover. This handles transitive references — resolving class A may add a schema referencing class B, which the next iteration discovers.
 
 ### ResolverInterface
 
@@ -67,13 +67,42 @@ namespace OpenApi\Contracts;
 
 interface ResolverInterface
 {
-    public function resolve(string $fqcn, Specification $specification): bool;
+    public function resolve(string $fqcn, Assembler $assembler): bool;
 }
 ```
 
-Each resolver is self-contained — it owns its internal assembler and attribute factory. It writes into the specification directly (e.g. via `Specification::add()`) and returns `true` if it handled the FQCN.
+Resolvers receive the `Assembler` that assembled the specification. Collecting a reflector with it adds the result straight into the specification being built; resolvers that assemble differently can use their own assembler and add to `$assembler->getSpecification()` directly. Returning `true` marks the FQCN as handled and stops the chain for it.
+
+### Resolver\Reflection
+
+The default resolver collects the referenced class with the assembler in use:
+
+```php
+class Reflection implements ResolverInterface
+{
+    public function resolve(string $fqcn, Assembler $assembler): bool
+    {
+        $assembler->collect(new \ReflectionClass($fqcn));
+
+        return $assembler->getSpecification()->buildComponentIndex()->find($fqcn) !== null;
+    }
+}
+```
+
+Because it is registered by default, **listing all related classes as builder sources is optional** — a single controller is enough as long as everything it references carries spec attributes:
+
+```php
+$result = (new Builder())
+    ->setMode(Mode::SPEC)
+    ->addSource(new \ReflectionClass(ProductController::class))
+    ->build();
+```
+
+Classes without spec attributes add nothing, so `resolve()` returns `false` and the next resolver in the chain gets a turn — that is where, for example, a resolver generating schemas for unannotated classes would slot in.
 
 ### Configuring resolvers
+
+The default chain contains `Resolver\Reflection` only. Add to it, or place a resolver ahead of it, via `withResolvers()`:
 
 ```php
 use OpenApi\Resolver;
@@ -84,7 +113,11 @@ $builder->withResolver(function (Resolver $resolver) {
 });
 ```
 
-When no resolvers are registered, the resolution step is skipped entirely.
+To opt out of resolution altogether, replace the chain with an empty list — the step is skipped when no resolvers are registered:
+
+```php
+$builder->withResolver(fn (Resolver $resolver) => $resolver->setResolvers(new TypedList()));
+```
 
 ## Augmenters
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -41,26 +41,20 @@ Augmenters read from and write to the Specification's buckets. The container is 
 
 ## Resolver
 
-The Resolver discovers FQCNs referenced by the specification that have no corresponding component (e.g. model classes used in `$ref` or typed properties that were never scanned) and delegates their handling to a chain of `ResolverInterface` implementations. `Resolver\Reflection` is registered by default; further resolvers can be added, and the chain can be cleared entirely.
+Between assembly and augmentation, the Resolver looks for classes the specification refers
+to but does not contain — a model used in a `$ref`, or the type of a property on a schema —
+and hands each one to a chain of `ResolverInterface` implementations.
 
-### Why a separate step
+`Resolver\Reflection` is registered by default: it reflects the class and collects it with
+the assembler already in use. A class carrying no spec attributes contributes nothing, so
+resolution reports failure and the next resolver in the chain gets a turn — which is where
+something generating schemas for unannotated classes would slot in.
 
-Solving this inside the augmenter pipeline creates ordering problems: an augmenter that adds new schemas runs after `Names` and `Types`, so it must re-invoke those augmenters on the newly added entries. The Resolver runs after assembly but before augmenters, so all schemas are present when augmenters start their single pass.
+Wiring resolvers into a build is covered in
+[Resolver configuration](/reference/builder#resolver); discovery and the convergence loop
+are in [Spec pipeline internals](/dev/pipeline).
 
-### Discovery
-
-Two sources are inspected to find unresolved FQCNs:
-
-- **Ref values** — walks all `$ref` attributes for raw FQCN strings (not yet rewritten to `#/components/...` paths). These are discoverable without `Names` or `Refs` having run.
-- **Reflector types** — walks schema class reflectors for non-builtin typed properties and constructor parameters. This reads `\ReflectionProperty::getType()` directly, no `Types` augmenter needed.
-
-A `ComponentIndex` is used to deduplicate against components already present in the specification.
-
-### Resolution loop
-
-The Resolver iterates in a convergence loop: discover unresolved FQCNs, pass each to the resolver chain (first resolver to claim success wins), then re-discover. This handles transitive references — resolving class A may add a schema referencing class B, which the next iteration discovers.
-
-### ResolverInterface
+### Writing a resolver
 
 ```php
 namespace OpenApi\Contracts;
@@ -71,53 +65,10 @@ interface ResolverInterface
 }
 ```
 
-Resolvers receive the `Assembler` that assembled the specification. Collecting a reflector with it adds the result straight into the specification being built; resolvers that assemble differently can use their own assembler and add to `$assembler->getSpecification()` directly. Returning `true` marks the FQCN as handled and stops the chain for it.
-
-### Resolver\Reflection
-
-The default resolver collects the referenced class with the assembler in use:
-
-```php
-class Reflection implements ResolverInterface
-{
-    public function resolve(string $fqcn, Assembler $assembler): bool
-    {
-        $assembler->collect(new \ReflectionClass($fqcn));
-
-        return $assembler->getSpecification()->buildComponentIndex()->find($fqcn) !== null;
-    }
-}
-```
-
-Because it is registered by default, **listing all related classes as builder sources is optional** — a single controller is enough as long as everything it references carries spec attributes:
-
-```php
-$result = (new Builder())
-    ->setMode(Mode::SPEC)
-    ->addSource(new \ReflectionClass(ProductController::class))
-    ->build();
-```
-
-Classes without spec attributes add nothing, so `resolve()` returns `false` and the next resolver in the chain gets a turn — that is where, for example, a resolver generating schemas for unannotated classes would slot in.
-
-### Configuring resolvers
-
-The default chain contains `Resolver\Reflection` only. Add to it, or place a resolver ahead of it, via `withResolvers()`:
-
-```php
-use OpenApi\Resolver;
-use OpenApi\Utils\TypedList;
-
-$builder->withResolver(function (Resolver $resolver) {
-    $resolver->withResolvers(fn (TypedList $resolvers) => $resolvers->add(new MyResolver()));
-});
-```
-
-To opt out of resolution altogether, replace the chain with an empty list — the step is skipped when no resolvers are registered:
-
-```php
-$builder->withResolver(fn (Resolver $resolver) => $resolver->setResolvers(new TypedList()));
-```
+Resolvers are handed the `Assembler` that built the specification, so collecting a reflector
+with it adds the result straight into the specification in progress. A resolver that
+assembles differently can add to `$assembler->getSpecification()` directly. Return `true` to
+mark the FQCN handled and stop the chain for it.
 
 ## Augmenters
 

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -154,18 +154,23 @@ The pipeline is grouped into three phases that run in order: **resolve** → **r
 
 ### Resolver configuration (spec/hybrid mode) {#resolver}
 
-Use `withResolver()` to register custom resolvers that handle unresolved FQCNs discovered in the specification. The resolver runs after assembly but before augmenters, so newly added schemas are processed by the full augmenter pipeline in a single pass.
+The resolver handles FQCNs that are referenced by the specification but have no matching component. It runs after assembly but before augmenters, so newly added schemas are processed by the full augmenter pipeline in a single pass.
+
+`Resolver\Reflection` is registered by default: it collects the referenced class with the assembler in use, so adding a single controller is enough to pick up everything it references — no need to list all related classes as sources.
+
+Use `withResolver()` to add your own:
 
 ```php
 use OpenApi\Resolver;
 use OpenApi\Utils\TypedList;
 
 $builder->withResolver(function (Resolver $resolver) {
-    $resolver->withResolvers(fn (TypedList $resolvers) => $resolvers->add(new MyResolver()));
+    $resolver->withResolvers(fn (TypedList $resolvers) => $resolvers
+        ->add(new MyResolver()));
 });
 ```
 
-Resolvers implement `OpenApi\Contracts\ResolverInterface`. See the [Resolver section](/reference/architecture#resolver) in the architecture docs for details.
+Resolvers implement `OpenApi\Contracts\ResolverInterface` and receive the FQCN and the `Assembler` in use. The first one to return `true` claims the FQCN. See the [Resolver section](/reference/architecture#resolver) in the architecture docs for details, including how to reorder or clear the chain.
 
 ### Attribute factory configuration (spec mode) {#attribute-factory}
 

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -32,7 +32,7 @@ $builder->setMode(Mode::CLASSIC);
 
 ### Spec (beta) {#mode-spec}
 
-Runs the spec attributes pipeline end-to-end: Assembler → Augmenters → Compiler. Uses attributes from the `OpenApi\Spec` namespace with typed DTOs and version-aware compilers.
+Runs the spec attributes pipeline end-to-end: Assembler → Resolver → Augmenters → Compiler. Uses attributes from the `OpenApi\Spec` namespace with typed DTOs and version-aware compilers.
 
 ```php
 $builder->setMode(Mode::SPEC);
@@ -150,7 +150,22 @@ $builder->withAugmenters(function (\OpenApi\Utils\Pipeline $pipeline) {
 });
 ```
 
-The pipeline is grouped into three phases that run in order: **resolve** → **reduce** → **augment**. See the [Augmenters reference](/reference/augmenters) for the full list and their configuration options.
+The pipeline is grouped into three phases that run in order: **resolve** → **reduce** → **augment**. See the [Augmenters reference](/reference/augmenters) for the full list and configuration options, and the [Augmenters section](/reference/architecture#augmenters) in the architecture docs for pipeline design and writing custom augmenters.
+
+### Resolver configuration (spec/hybrid mode) {#resolver}
+
+Use `withResolver()` to register custom resolvers that handle unresolved FQCNs discovered in the specification. The resolver runs after assembly but before augmenters, so newly added schemas are processed by the full augmenter pipeline in a single pass.
+
+```php
+use OpenApi\Resolver;
+use OpenApi\Utils\TypedList;
+
+$builder->withResolver(function (Resolver $resolver) {
+    $resolver->withResolvers(fn (TypedList $resolvers) => $resolvers->add(new MyResolver()));
+});
+```
+
+Resolvers implement `OpenApi\Contracts\ResolverInterface`. See the [Resolver section](/reference/architecture#resolver) in the architecture docs for details.
 
 ### Attribute factory configuration (spec mode) {#attribute-factory}
 
@@ -164,7 +179,7 @@ $builder->withAttributeFactory(function (AttributeFactory $factory): void {
 });
 ```
 
-Translators convert non-OA attributes (e.g. Symfony `#[Assert\*]`, framework route annotations) into spec DTOs during assembly.
+Translators convert non-OA attributes (e.g. Symfony `#[Assert\*]`, framework route annotations) into spec DTOs during assembly. See the [Assembler section](/reference/architecture#assembler) in the architecture docs for how assembly and slot-map nesting work.
 
 ## Result
 

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -50,6 +50,8 @@ class Builder
 
     protected ?CompilerInterface $compiler = null;
 
+    protected ?Resolver $resolver = null;
+
     /**
      * @var Utils\Pipeline<Specification>|null
      */
@@ -106,6 +108,25 @@ class Builder
     public function setCompiler(CompilerInterface $compiler): static
     {
         $this->compiler = $compiler;
+
+        return $this;
+    }
+
+    public function getResolver(): Resolver
+    {
+        $this->resolver ??= new Resolver();
+
+        return $this->resolver;
+    }
+
+    /**
+     * Configure the resolver via callable.
+     *
+     * @param callable(Resolver): (Resolver|void) $hook
+     */
+    public function withResolver(callable $hook): static
+    {
+        $hook($this->getResolver());
 
         return $this;
     }
@@ -230,6 +251,8 @@ class Builder
         }
 
         $specification = $assembler->getSpecification();
+
+        $this->getResolver()->resolve($specification);
 
         if ($hybrid) {
             $this->doHybridAssemble($specification);

--- a/src/Builder.php
+++ b/src/Builder.php
@@ -252,7 +252,7 @@ class Builder
 
         $specification = $assembler->getSpecification();
 
-        $this->getResolver()->resolve($specification);
+        $this->getResolver()->resolve($assembler);
 
         if ($hybrid) {
             $this->doHybridAssemble($specification);

--- a/src/Contracts/ResolverInterface.php
+++ b/src/Contracts/ResolverInterface.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Contracts;
+
+use OpenApi\Specification;
+
+interface ResolverInterface
+{
+    public function resolve(string $fqcn, Specification $specification): bool;
+}

--- a/src/Contracts/ResolverInterface.php
+++ b/src/Contracts/ResolverInterface.php
@@ -6,9 +6,18 @@
 
 namespace OpenApi\Contracts;
 
-use OpenApi\Specification;
+use OpenApi\Assembler;
 
 interface ResolverInterface
 {
-    public function resolve(string $fqcn, Specification $specification): bool;
+    /**
+     * Attempt to resolve a FQCN that is referenced by the specification but has no matching component.
+     *
+     * The assembler is the one used to assemble the specification being built; collecting a reflector
+     * with it adds the result straight into that specification. Resolvers that assemble differently
+     * may use their own assembler and add to `$assembler->getSpecification()` directly.
+     *
+     * @return bool <code>true</code> if the FQCN was handled; stops the resolver chain for this FQCN
+     */
+    public function resolve(string $fqcn, Assembler $assembler): bool;
 }

--- a/src/Resolver.php
+++ b/src/Resolver.php
@@ -8,6 +8,7 @@ namespace OpenApi;
 
 use OpenApi\Contracts\AttributeInterface;
 use OpenApi\Contracts\ResolverInterface;
+use OpenApi\Resolver\Reflection;
 use OpenApi\Spec as OA;
 use OpenApi\Specification\ComponentIndex;
 use OpenApi\Utils\TypedList;
@@ -24,10 +25,11 @@ class Resolver
     protected const MAX_ITERATIONS = 50;
 
     /**
-     * @param TypedList<ResolverInterface> $resolvers
+     * @param TypedList<ResolverInterface>|null $resolvers defaults to the built-in resolvers
      */
-    public function __construct(protected TypedList $resolvers = new TypedList())
+    public function __construct(protected TypedList|null $resolvers = null)
     {
+        $this->resolvers ??= new TypedList($this->getDefaultResolvers());
     }
 
     /**
@@ -53,15 +55,20 @@ class Resolver
     }
 
     /**
-     * Resolve all found unresolved FQCN in the given specification.
+     * Resolve all found unresolved FQCN in the specification assembled so far.
      *
      * The first resolver to claim success will resolve the FQCN.
      */
-    public function resolve(Specification $specification): void
+    public function resolve(Assembler $assembler): void
     {
         if ($this->resolvers->count() === 0) {
             return;
         }
+
+        $specification = $assembler->getSpecification();
+
+        // FQCN no resolver was able to handle; not worth another attempt in this run
+        $attempted = [];
 
         $iterations = 0;
         do {
@@ -72,14 +79,28 @@ class Resolver
             $unresolved = $this->findUnresolved($specification);
             $resolved = false;
             foreach ($unresolved as $fqcn) {
+                if (isset($attempted[$fqcn])) {
+                    continue;
+                }
+
                 foreach ($this->resolvers as $resolver) {
-                    if ($resolver->resolve($fqcn, $specification)) {
+                    if ($resolver->resolve($fqcn, $assembler)) {
                         $resolved = true;
-                        break;
+                        continue 2;
                     }
                 }
+
+                $attempted[$fqcn] = true;
             }
         } while ($resolved);
+    }
+
+    /**
+     * @return list<ResolverInterface>
+     */
+    protected function getDefaultResolvers(): array
+    {
+        return [new Reflection()];
     }
 
     /**

--- a/src/Resolver.php
+++ b/src/Resolver.php
@@ -1,0 +1,198 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi;
+
+use OpenApi\Contracts\AttributeInterface;
+use OpenApi\Contracts\ResolverInterface;
+use OpenApi\Spec as OA;
+use OpenApi\Specification\ComponentIndex;
+use OpenApi\Utils\TypedList;
+
+/**
+ * Finds and resolves FQCNs referenced by the specification that have no corresponding schema.
+ *
+ * Two sources are inspected:
+ * 1. Ref values that are raw FQCNs (not yet rewritten to `#/components/...` paths)
+ * 2. Property/parameter type hints on schema class reflectors
+ */
+class Resolver
+{
+    protected const MAX_ITERATIONS = 50;
+
+    /**
+     * @param TypedList<ResolverInterface> $resolvers
+     */
+    public function __construct(protected TypedList $resolvers = new TypedList())
+    {
+    }
+
+    /**
+     * @param TypedList<ResolverInterface> $resolvers
+     */
+    public function setResolvers(TypedList $resolvers): static
+    {
+        $this->resolvers = $resolvers;
+
+        return $this;
+    }
+
+    /**
+     * Configure the resolvers via callable.
+     *
+     * @param callable(TypedList<ResolverInterface>): (TypedList<ResolverInterface>|void) $hook
+     */
+    public function withResolvers(callable $hook): static
+    {
+        $hook($this->resolvers);
+
+        return $this;
+    }
+
+    /**
+     * Resolve all found unresolved FQCN in the given specification.
+     *
+     * The first resolver to claim success will resolve the FQCN.
+     */
+    public function resolve(Specification $specification): void
+    {
+        if ($this->resolvers->count() === 0) {
+            return;
+        }
+
+        $iterations = 0;
+        do {
+            if (++$iterations > static::MAX_ITERATIONS) {
+                throw new OpenApiException(sprintf('Resolver loop did not converge after %d iterations; check for resolvers that return true without resolving', static::MAX_ITERATIONS));
+            }
+
+            $unresolved = $this->findUnresolved($specification);
+            $resolved = false;
+            foreach ($unresolved as $fqcn) {
+                foreach ($this->resolvers as $resolver) {
+                    if ($resolver->resolve($fqcn, $specification)) {
+                        $resolved = true;
+                        break;
+                    }
+                }
+            }
+        } while ($resolved);
+    }
+
+    /**
+     * @return list<string> FQCNs that are referenced but have no schema in the specification
+     */
+    protected function findUnresolved(Specification $specification): array
+    {
+        $index = $specification->buildComponentIndex();
+        $unresolved = [];
+
+        $this->collectFromRefs($specification, $index, $unresolved);
+        $this->collectFromReflectors($specification, $index, $unresolved);
+
+        return array_values(array_unique($unresolved));
+    }
+
+    protected function collectFromRefs(Specification $specification, ComponentIndex $index, array &$unresolved): void
+    {
+        $specification->getWalker()->eachRef(function (AttributeInterface $attribute) use ($index, &$unresolved): void {
+            if (!property_exists($attribute, 'ref') || $attribute->ref === null) {
+                return;
+            }
+
+            $ref = $attribute->ref instanceof OA\Schema\Ref
+                ? $attribute->ref->ref
+                : $attribute->ref;
+
+            if (str_starts_with($ref, '#/')) {
+                return;
+            }
+
+            if (!class_exists($ref)) {
+                return;
+            }
+
+            if (!$index->find($ref) instanceof AttributeInterface) {
+                $unresolved[] = $ref;
+            }
+        });
+    }
+
+    protected function collectFromReflectors(Specification $specification, ComponentIndex $index, array &$unresolved): void
+    {
+        foreach ($specification->schemas as $schema) {
+            $reflector = $schema->getClassReflector();
+            if ($reflector === null) {
+                continue;
+            }
+
+            foreach ($this->getTypedReflectors($reflector) as $type) {
+                if ($type->isBuiltin()) {
+                    continue;
+                }
+
+                $fqcn = $type->getName();
+                if (!class_exists($fqcn) && !interface_exists($fqcn) && !enum_exists($fqcn)) {
+                    continue;
+                }
+
+                if (!$index->find($fqcn) instanceof AttributeInterface) {
+                    $unresolved[] = $fqcn;
+                }
+            }
+        }
+    }
+
+    /**
+     * @return list<\ReflectionNamedType>
+     */
+    protected function getTypedReflectors(\ReflectionClass $reflector): array
+    {
+        $types = [];
+
+        foreach ($reflector->getProperties(\ReflectionProperty::IS_PUBLIC) as $prop) {
+            if ($prop->getDeclaringClass()->getName() !== $reflector->getName()) {
+                continue;
+            }
+            foreach ($this->extractNamedTypes($prop->getType()) as $type) {
+                $types[] = $type;
+            }
+        }
+
+        if ($constructor = $reflector->getConstructor()) {
+            foreach ($constructor->getParameters() as $param) {
+                foreach ($this->extractNamedTypes($param->getType()) as $type) {
+                    $types[] = $type;
+                }
+            }
+        }
+
+        return $types;
+    }
+
+    /**
+     * @return list<\ReflectionNamedType>
+     */
+    protected function extractNamedTypes(?\ReflectionType $type): array
+    {
+        if ($type instanceof \ReflectionNamedType) {
+            return [$type];
+        }
+
+        if ($type instanceof \ReflectionUnionType || $type instanceof \ReflectionIntersectionType) {
+            $named = [];
+            foreach ($type->getTypes() as $inner) {
+                if ($inner instanceof \ReflectionNamedType) {
+                    $named[] = $inner;
+                }
+            }
+
+            return $named;
+        }
+
+        return [];
+    }
+}

--- a/src/Resolver/Reflection.php
+++ b/src/Resolver/Reflection.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Resolver;
+
+use OpenApi\Assembler;
+use OpenApi\Contracts\AttributeInterface;
+use OpenApi\Contracts\ResolverInterface;
+
+/**
+ * Resolves missing components by collecting the referenced class with the assembler in use.
+ *
+ * This makes listing all related classes as builder sources optional; adding a single controller
+ * is enough as long as everything it references (directly or transitively) carries spec attributes.
+ *
+ * A FQCN is considered resolved if the specification knows it once collected. Classes without any
+ * spec attributes are left to the next resolver in the chain.
+ */
+class Reflection implements ResolverInterface
+{
+    public function resolve(string $fqcn, Assembler $assembler): bool
+    {
+        if (!class_exists($fqcn) && !interface_exists($fqcn) && !enum_exists($fqcn)) {
+            return false;
+        }
+
+        $assembler->collect(new \ReflectionClass($fqcn));
+
+        return $assembler->getSpecification()->buildComponentIndex()->find($fqcn) instanceof AttributeInterface;
+    }
+}

--- a/tests/Fixtures/Resolver/CountingResolver.php
+++ b/tests/Fixtures/Resolver/CountingResolver.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Resolver;
+
+use OpenApi\Assembler;
+use OpenApi\Contracts\ResolverInterface;
+
+/**
+ * Never resolves anything, but records every FQCN it was offered.
+ */
+class CountingResolver implements ResolverInterface
+{
+    /**
+     * @var array<string, int>
+     */
+    public array $attempts = [];
+
+    public function resolve(string $fqcn, Assembler $assembler): bool
+    {
+        $this->attempts[$fqcn] = ($this->attempts[$fqcn] ?? 0) + 1;
+
+        return false;
+    }
+}

--- a/tests/Fixtures/Resolver/Manufacturer.php
+++ b/tests/Fixtures/Resolver/Manufacturer.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Resolver;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema(schema: 'Manufacturer')]
+class Manufacturer
+{
+    #[OA\Property(property: 'name')]
+    public string $name;
+}

--- a/tests/Fixtures/Resolver/Product.php
+++ b/tests/Fixtures/Resolver/Product.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Resolver;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema(schema: 'Product')]
+class Product
+{
+    #[OA\Property(property: 'name')]
+    public string $name;
+
+    // transitive; picked up via the property type
+    #[OA\Property(property: 'manufacturer')]
+    public Manufacturer $manufacturer;
+
+    // no spec attributes; not resolvable
+    public Weight $weight;
+}

--- a/tests/Fixtures/Resolver/ProductController.php
+++ b/tests/Fixtures/Resolver/ProductController.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Resolver;
+
+use OpenApi\Spec as OA;
+
+#[OA\Info(title: 'Resolver', version: '1.0.0')]
+class ProductController
+{
+    #[OA\Operation\Get(path: '/products')]
+    #[OA\Response(response: 200, description: 'OK', content: [
+        new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: Product::class)),
+    ])]
+    public function list()
+    {
+    }
+}

--- a/tests/Fixtures/Resolver/Weight.php
+++ b/tests/Fixtures/Resolver/Weight.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Resolver;
+
+class Weight
+{
+    public float $grams;
+}

--- a/tests/ResolverTest.php
+++ b/tests/ResolverTest.php
@@ -1,0 +1,129 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests;
+
+use OpenApi\Assembler;
+use OpenApi\Builder;
+use OpenApi\Builder\Mode;
+use OpenApi\Contracts\ResolverInterface;
+use OpenApi\Resolver;
+use OpenApi\Spec as OA;
+use OpenApi\Utils\TypedList;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class ResolverTest extends TestCase
+{
+    public function testResolvesRefAndTransitivePropertyTypeByDefault(): void
+    {
+        $assembler = $this->assembler(Fixtures\Resolver\ProductController::class);
+
+        // Resolver\Reflection is registered by default
+        (new Resolver())->resolve($assembler);
+
+        // Product comes from the ref, Manufacturer from Product's property type
+        $this->assertSame(['Product', 'Manufacturer'], $this->schemaNames($assembler));
+    }
+
+    public function testNoResolversIsNoop(): void
+    {
+        $assembler = $this->assembler(Fixtures\Resolver\ProductController::class);
+
+        $this->resolver()->resolve($assembler);
+
+        $this->assertSame([], $this->schemaNames($assembler));
+    }
+
+    public function testUnannotatedClassIsNotResolved(): void
+    {
+        $assembler = $this->assembler(Fixtures\Resolver\Product::class);
+
+        $this->resolver(new Resolver\Reflection())->resolve($assembler);
+
+        // Weight has no spec attributes and is left unresolved
+        $this->assertSame(['Product', 'Manufacturer'], $this->schemaNames($assembler));
+    }
+
+    public function testFailedFqcnIsAttemptedOnlyOncePerRun(): void
+    {
+        $assembler = $this->assembler(Fixtures\Resolver\ProductController::class);
+        $spy = new Fixtures\Resolver\CountingResolver();
+
+        // Reflection keeps the loop going for several iterations (Product, then Manufacturer)
+        $this->resolver(new Resolver\Reflection(), $spy)->resolve($assembler);
+
+        // ... while Weight, which nothing can resolve, is only offered once
+        $this->assertSame([Fixtures\Resolver\Weight::class => 1], $spy->attempts);
+    }
+
+    public static function fullBuildProvider(): iterable
+    {
+        yield 'single-controller' => [
+            (new Builder())
+                ->setMode(Mode::SPEC)
+                ->addSource(new \ReflectionClass(Fixtures\Resolver\ProductController::class)),
+        ];
+        yield 'no-resolver' => [
+            (new Builder())
+                ->setMode(Mode::SPEC)
+                ->withResolver(fn (Resolver $resolver): Resolver => $resolver->setResolvers(new TypedList()))
+                ->addSource([
+                    new \ReflectionClass(Fixtures\Resolver\Product::class),
+                    new \ReflectionClass(Fixtures\Resolver\Manufacturer::class),
+                    new \ReflectionClass(Fixtures\Resolver\ProductController::class),
+                    new \ReflectionClass(Fixtures\Resolver\Weight::class),
+                ]),
+        ];
+    }
+
+    #[DataProvider('fullBuildProvider')]
+    public function testFullBuild(Builder $builder): void
+    {
+        $result = $builder
+            ->build();
+
+        $spec = $result->toArray();
+
+        $this->assertSame(
+            ['Product', 'Manufacturer'],
+            array_keys($spec['components']['schemas'])
+        );
+        $this->assertSame(
+            '#/components/schemas/Product',
+            $spec['paths']['/products']['get']['responses'][200]['content']['application/json']['schema']['$ref']
+        );
+    }
+
+    protected function resolver(ResolverInterface ...$resolvers): Resolver
+    {
+        return new Resolver(new TypedList($resolvers));
+    }
+
+    /**
+     * @param class-string ...$classes
+     */
+    protected function assembler(string ...$classes): Assembler
+    {
+        $assembler = new Assembler();
+        foreach ($classes as $class) {
+            $assembler->collect(new \ReflectionClass($class));
+        }
+
+        return $assembler;
+    }
+
+    /**
+     * @return list<string>
+     */
+    protected function schemaNames(Assembler $assembler): array
+    {
+        return array_map(
+            static fn (OA\Schema $schema): ?string => $schema->schema,
+            $assembler->getSpecification()->schemas
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Add a new resolver step to the spec pipeline.
This gives users a chance to register one or more handlers to resolve classes/types that were not processes by the Assembler at all.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Enhancement (improvement to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactor (no functional changes)
- [ ] Chore (maintenance, dependencies, CI)

## Related Issues

<!-- Link related issues: Fixes #123, Closes #456 -->

## Test Plan

<!-- Describe the tests you ran or plan to run to verify the changes. -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass locally
- [ ] Any dependent changes have been merged and published
