### PR TITLE
Fix/strict config keys and isvalid

### DIFF
--- a/bin/openapi
+++ b/bin/openapi
@@ -2,13 +2,13 @@
 <?php
 
 use OpenApi\Console\GenerateCommand;
-use OpenApi\Generator;
+use OpenApi\Undefined;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\ConsoleOutput;
 
-if (class_exists(Generator::class) === false) {
+if (class_exists(Undefined::class) === false) {
     if (file_exists(__DIR__.'/../vendor/autoload.php')) {  // cloned / dev environment?
         require_once(__DIR__.'/../vendor/autoload.php');
     } else {

--- a/docs/guide/generating-openapi-documents.md
+++ b/docs/guide/generating-openapi-documents.md
@@ -92,7 +92,7 @@ $result->toArray();       // PHP array
 $result->files();         // list of scanned files
 $result->warnings();      // validation warnings
 $result->errors();        // validation errors
-$result->isValid();       // true if spec was generated
+$result->isValid();       // true if spec was generated and no errors were reported
 $result->specification(); // the final `Specification` instance
 ```
 

--- a/docs/guide/generating-openapi-documents.md
+++ b/docs/guide/generating-openapi-documents.md
@@ -42,9 +42,9 @@ For a list of all available options use the `-h` option
 Usage: openapi [--option value] [/path/to/project ...]
 
 Options:
-  --config (-c)               Generator config.
+  --config (-c)               Generator (classic, hybrid) or augmenter (spec) config.
                               ex: -c operationId.hash=false
-  --defaults (-D)             Show default config.
+  --defaults (-D)             Show default config for the selected --mode.
   --output (-o)               Path to store the generated documentation.
                               ex: --output openapi.yaml
   --exclude (-e)              Exclude path(s).

--- a/docs/reference/augmenters.md
+++ b/docs/reference/augmenters.md
@@ -17,8 +17,10 @@ Augmenters are part of the spec-attributes pipeline (`--mode spec` or `--mode hy
 The `-c` option allows to specify a name/value pair with the name consisting
 of the augmenter name (starting lowercase) and option name separated by a dot (`.`).
 
+Use `-D` (with `--mode spec`) to list the available augmenter names and options.
+
 ```shell
-> ./vendor/bin/openapi --mode spec -c operationId.hash=true // ...
+> ./vendor/bin/openapi --mode spec -c operationIds.hash=true // ...
 > ./vendor/bin/openapi --mode spec -c pathFilter.tags[]=/pets/ -c pathFilter.tags[]=/store/ // ...
 ```
 
@@ -29,7 +31,7 @@ and configure individual augmenters via `Pipeline::get()`.
 ```php
 (new Builder())
     ->withAugmenters(function ($pipeline) {
-        $pipeline->get(Augmenter\OperationId::class)->setHash(true);
+        $pipeline->get(Augmenter\OperationIds::class)->setHash(true);
         $pipeline->get(Augmenter\PathFilter::class)->setTags(['/pets/', '/store/']);
     });
 ```

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -173,7 +173,7 @@ The `build()` method returns a `\OpenApi\Builder\Result` instance:
 ```php
 $result = $builder->build();
 
-$result->isValid();      // bool — true if a spec was generated
+$result->isValid();      // bool — true if a spec was generated and no errors were reported
 $result->toArray();       // array — the spec as a PHP array
 $result->toJson();        // string — JSON output
 $result->toYaml();        // string — YAML output

--- a/src/Builder/Result.php
+++ b/src/Builder/Result.php
@@ -71,9 +71,17 @@ class Result
         return $this->specification;
     }
 
+    /**
+     * Whether a document was produced and no errors were reported.
+     *
+     * Mirrors the exit code of the console command: warnings do not make a
+     * result invalid, errors do.
+     */
     public function isValid(): bool
     {
-        return $this->openApi instanceof OpenApi || $this->specOutput !== null;
+        $generated = $this->openApi instanceof OpenApi || $this->specOutput !== null;
+
+        return $generated && $this->errors() === [];
     }
 
     /**

--- a/src/Console/GenerateCommand.php
+++ b/src/Console/GenerateCommand.php
@@ -42,7 +42,7 @@ class GenerateCommand
 
         if ($input->defaults) {
             $io->title('Default config');
-            $io->writeln(json_encode((new Generator())->getDefaultConfig(), JSON_PRETTY_PRINT));
+            $io->writeln(json_encode($this->getDefaultConfig($input), JSON_PRETTY_PRINT));
 
             return 0;
         }
@@ -65,6 +65,21 @@ class GenerateCommand
         }
 
         return $this->logger->hasErrored() ? 1 : 0;
+    }
+
+    /**
+     * The config keys `--config` accepts; these differ per mode.
+     *
+     * Mirrors the routing in {@see self::generate()}: spec mode configures the
+     * augmenter pipeline, classic and hybrid configure the Generator.
+     *
+     * @return array<string,mixed>
+     */
+    protected function getDefaultConfig(GenerateInput $input): array
+    {
+        return $input->mode->isSpec()
+            ? (new Builder())->getAugmenters()->getConfig()
+            : (new Generator())->getDefaultConfig();
     }
 
     protected function generate(GenerateInput $input): Result

--- a/src/Console/GenerateInput.php
+++ b/src/Console/GenerateInput.php
@@ -16,7 +16,7 @@ class GenerateInput
     #[Argument('Source path(s) to scan')]
     public array $paths;
 
-    #[Option('Generator/Augmenter config (e.g. -c operationId.hash=false)', shortcut: 'c')]
+    #[Option('Generator/Augmenter config; keys differ per mode, see -D (e.g. -c operationId.hash=false)', shortcut: 'c')]
     public array $config = [];
 
     #[Option('Show default config', shortcut: 'D')]

--- a/src/Utils/Pipeline.php
+++ b/src/Utils/Pipeline.php
@@ -80,6 +80,61 @@ class Pipeline extends TypedList
         return $payload;
     }
 
+    /**
+     * Collect the configurable settings of all pipes, keyed by pipe name.
+     *
+     * A setting is considered configurable when a pipe exposes a `setX()` method
+     * for a property `x`; the reported value is that property's current value.
+     * Object valued properties (factories, resolvers) are treated as collaborators
+     * rather than config and are omitted.
+     *
+     * The result uses the same keys accepted by {@see self::configure()}.
+     *
+     * @return array<string,array<string,mixed>>
+     */
+    public function getConfig(): array
+    {
+        $config = [];
+
+        $walker = function (callable $pipe) use (&$config): void {
+            $rc = new \ReflectionClass($pipe);
+            $settings = [];
+
+            foreach ($rc->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
+                if (!str_starts_with($method->getName(), 'set') || $method->getNumberOfParameters() !== 1) {
+                    continue;
+                }
+
+                // LoggerAwareInterface is plumbing, not config
+                if ($method->getName() === 'setLogger') {
+                    continue;
+                }
+
+                $name = lcfirst(substr($method->getName(), 3));
+                if (!$rc->hasProperty($name)) {
+                    continue;
+                }
+
+                $property = $rc->getProperty($name);
+                $value = $property->isInitialized($pipe) ? $property->getValue($pipe) : null;
+
+                if (is_object($value)) {
+                    continue;
+                }
+
+                $settings[$name] = $value;
+            }
+
+            if ($settings !== []) {
+                $config[lcfirst($rc->getShortName())] = $settings;
+            }
+        };
+
+        $this->walk($walker);
+
+        return $config;
+    }
+
     public function configure(array $config): void
     {
         $config = $this->normaliseConfig($config);

--- a/src/Utils/Pipeline.php
+++ b/src/Utils/Pipeline.php
@@ -135,26 +135,46 @@ class Pipeline extends TypedList
         return $config;
     }
 
+    /**
+     * Apply config to the pipes in this pipeline.
+     *
+     * Keys that match no pipe, and options with no matching setter, are reported
+     * as warnings; they would otherwise be silently ignored. See {@see self::getConfig()}
+     * for the keys a pipeline accepts.
+     */
     public function configure(array $config): void
     {
         $config = $this->normaliseConfig($config);
+        $applied = [];
 
-        $walker = function (callable $pipe) use ($config): void {
+        $walker = function (callable $pipe) use ($config, &$applied): void {
             $rc = new \ReflectionClass($pipe);
 
             // apply config
             $pipeKey = lcfirst($rc->getShortName());
-            if (array_key_exists($pipeKey, $config)) {
-                foreach ($config[$pipeKey] as $name => $value) {
-                    $setter = 'set' . ucfirst($name);
-                    if (method_exists($pipe, $setter)) {
-                        $pipe->{$setter}($value);
-                    }
+            if (!array_key_exists($pipeKey, $config) || !is_array($config[$pipeKey])) {
+                return;
+            }
+
+            $applied[$pipeKey] = true;
+
+            foreach ($config[$pipeKey] as $name => $value) {
+                $setter = 'set' . ucfirst($name);
+                if (method_exists($pipe, $setter)) {
+                    $pipe->{$setter}($value);
+                } else {
+                    $this->logger->warning("Unknown config option '{$pipeKey}.{$name}'");
                 }
             }
         };
 
         $this->walk($walker);
+
+        foreach (array_keys($config) as $pipeKey) {
+            if (!isset($applied[$pipeKey])) {
+                $this->logger->warning("Unknown config key '{$pipeKey}'; no matching pipe in this pipeline");
+            }
+        }
     }
 
     /**

--- a/tests/Builder/ResultTest.php
+++ b/tests/Builder/ResultTest.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Builder;
+
+use OpenApi\Annotations as OA;
+use OpenApi\Builder\Result;
+use OpenApi\Specification;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class ResultTest extends TestCase
+{
+    public static function validityCases(): iterable
+    {
+        yield 'no log' => [[], true];
+        yield 'warning only' => [[['level' => 'warning', 'message' => 'meh']], true];
+        yield 'notice only' => [[['level' => 'notice', 'message' => 'fyi']], true];
+        yield 'error' => [[['level' => 'error', 'message' => 'boom']], false];
+        yield 'error and warning' => [
+            [['level' => 'warning', 'message' => 'meh'], ['level' => 'error', 'message' => 'boom']],
+            false,
+        ];
+    }
+
+    #[DataProvider('validityCases')]
+    public function testIsValidOnlyErrorsCount(array $log, bool $expected): void
+    {
+        $result = Result::fromSpec(['a.php'], new Specification(), ['openapi' => '3.1.0'], $log);
+
+        $this->assertSame($expected, $result->isValid());
+    }
+
+    #[DataProvider('validityCases')]
+    public function testIsValidOnlyErrorsCountForClassic(array $log, bool $expected): void
+    {
+        $result = Result::fromClassic(['a.php'], new OA\OpenApi([]), $log);
+
+        $this->assertSame($expected, $result->isValid());
+    }
+
+    public function testIsInvalidWhenNothingWasGenerated(): void
+    {
+        $this->assertFalse(Result::fromClassic(['a.php'], null)->isValid());
+    }
+}

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -38,6 +38,20 @@ final class BuilderTest extends OpenApiTestCase
         $this->assertNotEmpty($result->toYaml());
     }
 
+    public function testIsValidReportsCompilerErrors(): void
+    {
+        // no OA\Info anywhere -> the compiler reports "info is required"
+        $result = (new Builder())
+            ->setMode(Mode::SPEC)
+            ->addSource((string) self::fixture('Assembler/SimpleController.php'))
+            ->setLogger(new NullLogger())
+            ->build();
+
+        $this->assertNotEmpty($result->toArray(), 'a document is still produced');
+        $this->assertContains('info is required', $result->errors());
+        $this->assertFalse($result->isValid(), 'errors must make the result invalid');
+    }
+
     public function testBuildMatchesGenerator(): void
     {
         $this->registerExampleClassloader('petstore');

--- a/tests/CommandlineTest.php
+++ b/tests/CommandlineTest.php
@@ -80,6 +80,31 @@ final class CommandlineTest extends OpenApiTestCase
         $this->assertStringContainsString("openapi: {$expectedVersion}", implode(PHP_EOL, $output));
     }
 
+    /**
+     * `--defaults` must report the config keys `--config` actually accepts,
+     * which differ per mode: spec configures augmenters, classic/hybrid the Generator.
+     */
+    public static function defaultsCases(): iterable
+    {
+        yield 'classic (implicit)' => ['', 'generator', 'operationIds'];
+        yield 'classic' => ['-m classic', 'generator', 'operationIds'];
+        yield 'hybrid' => ['-m hybrid', 'generator', 'operationIds'];
+        yield 'spec' => ['-m spec', 'operationIds', 'generator'];
+    }
+
+    #[DataProvider('defaultsCases')]
+    public function testDefaultsAreModeAware(string $args, string $expected, string $unexpected): void
+    {
+        $basePath = self::examplePath('petstore');
+        $cmd = __DIR__ . '/../bin/openapi -D ' . $args . ' ' . escapeshellarg("{$basePath}/annotations");
+        exec($this->getCommandToExecute($cmd, '2>'), $output, $retval);
+
+        $this->assertSame(0, $retval, $cmd . PHP_EOL . implode(PHP_EOL, $output));
+        $output = implode(PHP_EOL, $output);
+        $this->assertStringContainsString($expected, $output);
+        $this->assertStringNotContainsString($unexpected, $output);
+    }
+
     private function getCommandToExecute(string $cmd, ?string $devNullRedir = null): string
     {
         if (PHP_OS_FAMILY === 'Windows') {

--- a/tests/Concerns/AssertsBuilderResult.php
+++ b/tests/Concerns/AssertsBuilderResult.php
@@ -26,8 +26,6 @@ trait AssertsBuilderResult
 
     public function assertBuilderResult(Result $result): void
     {
-        $this->assertTrue($result->isValid());
-
         $filterByContains = (fn (array $list, array $patterns): array => array_filter($list, function (string $item) use ($patterns): bool {
             foreach ($patterns as $pattern) {
                 if (str_contains($item, $pattern)) {
@@ -43,5 +41,11 @@ trait AssertsBuilderResult
 
         $this->assertCount(0, $warnings, '[Warning] ' . implode("\n[Warning] ", $result->warnings()));
         $this->assertCount(0, $errors, '[Error] ' . implode("\n[Error] ", $result->errors()));
+
+        // isValid() does not know about $errorExcludes, so only assert it when
+        // no errors are expected
+        if ($this->errorExcludes === []) {
+            $this->assertTrue($result->isValid());
+        }
     }
 }

--- a/tests/Utils/PipelineTest.php
+++ b/tests/Utils/PipelineTest.php
@@ -9,6 +9,7 @@ namespace OpenApi\Tests\Utils;
 use OpenApi\Augmenter\OperationIds;
 use OpenApi\Augmenter\Tags;
 use OpenApi\Augmenter\Types;
+use OpenApi\Utils\CollectingLogger;
 use OpenApi\Utils\PipeInterface;
 use OpenApi\Utils\Pipeline;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -159,6 +160,44 @@ final class PipelineTest extends TestCase
         $this->assertSame(['operationIds' => ['hash' => true]], $pipeline->getConfig());
 
         $pipeline->configure(['operationIds.hash=false']);
+        $this->assertSame(['operationIds' => ['hash' => false]], $pipeline->getConfig());
+    }
+
+    public static function unknownConfigCases(): iterable
+    {
+        yield 'unknown pipe' => [
+            ['noSuchPipe.hash' => false],
+            "Unknown config key 'noSuchPipe'; no matching pipe in this pipeline",
+        ];
+        yield 'unknown option' => [
+            ['operationIds.noSuchOption' => false],
+            "Unknown config option 'operationIds.noSuchOption'",
+        ];
+        yield 'stale classic key' => [
+            ['operationId.hash' => false],
+            "Unknown config key 'operationId'; no matching pipe in this pipeline",
+        ];
+    }
+
+    #[DataProvider('unknownConfigCases')]
+    public function testConfigureWarnsAboutUnknownConfig(array $config, string $expected): void
+    {
+        $logger = new CollectingLogger();
+        $pipeline = new Pipeline([new OperationIds(hash: true)], logger: $logger);
+
+        $pipeline->configure($config);
+
+        $this->assertSame([['level' => 'warning', 'message' => $expected]], $logger->entries());
+    }
+
+    public function testConfigureIsQuietForKnownConfig(): void
+    {
+        $logger = new CollectingLogger();
+        $pipeline = new Pipeline([new OperationIds(hash: true)], logger: $logger);
+
+        $pipeline->configure(['operationIds.hash=false']);
+
+        $this->assertSame([], $logger->entries());
         $this->assertSame(['operationIds' => ['hash' => false]], $pipeline->getConfig());
     }
 

--- a/tests/Utils/PipelineTest.php
+++ b/tests/Utils/PipelineTest.php
@@ -7,6 +7,8 @@
 namespace OpenApi\Tests\Utils;
 
 use OpenApi\Augmenter\OperationIds;
+use OpenApi\Augmenter\Tags;
+use OpenApi\Augmenter\Types;
 use OpenApi\Utils\PipeInterface;
 use OpenApi\Utils\Pipeline;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -123,6 +125,41 @@ final class PipelineTest extends TestCase
         $rp = new \ReflectionProperty(OperationIds::class, 'hash');
         $this->assertInstanceOf(OperationIds::class, $operationIds);
         $this->assertEquals($expected, $rp->getValue($operationIds));
+    }
+
+    public function testGetConfigReportsPipeSettings(): void
+    {
+        $pipeline = new Pipeline([
+            new OperationIds(hash: false),
+            new Tags(whitelist: ['pets'], withDescription: false),
+        ]);
+
+        $this->assertSame([
+            'operationIds' => ['hash' => false],
+            'tags' => ['whitelist' => ['pets'], 'withDescription' => false],
+        ], $pipeline->getConfig());
+    }
+
+    public function testGetConfigOmitsCollaborators(): void
+    {
+        // Types only exposes setTypeResolver() -- an object, so not config
+        $pipeline = new Pipeline([new Types()]);
+
+        $this->assertSame([], $pipeline->getConfig());
+    }
+
+    public function testGetConfigRoundTripsThroughConfigure(): void
+    {
+        $pipeline = new Pipeline([new OperationIds(hash: true)]);
+
+        $this->assertSame(['operationIds' => ['hash' => true]], $pipeline->getConfig());
+
+        // the keys getConfig() reports must be the keys configure() accepts
+        $pipeline->configure($pipeline->getConfig());
+        $this->assertSame(['operationIds' => ['hash' => true]], $pipeline->getConfig());
+
+        $pipeline->configure(['operationIds.hash=false']);
+        $this->assertSame(['operationIds' => ['hash' => false]], $pipeline->getConfig());
     }
 
     // --- Grouping ---

--- a/tools/src/Docs/Reference/AugmenterGenerator.php
+++ b/tools/src/Docs/Reference/AugmenterGenerator.php
@@ -81,8 +81,10 @@ class AugmenterGenerator extends DocGenerator
 The `-c` option allows to specify a name/value pair with the name consisting
 of the augmenter name (starting lowercase) and option name separated by a dot (`.`).
 
+Use `-D` (with `--mode spec`) to list the available augmenter names and options.
+
 ```shell
-> ./vendor/bin/openapi --mode spec -c operationId.hash=true // ...
+> ./vendor/bin/openapi --mode spec -c operationIds.hash=true // ...
 > ./vendor/bin/openapi --mode spec -c pathFilter.tags[]=/pets/ -c pathFilter.tags[]=/store/ // ...
 ```
 
@@ -97,7 +99,7 @@ and configure individual augmenters via `Pipeline::get()`.
 ```php
 (new Builder())
     ->withAugmenters(function ($pipeline) {
-        $pipeline->get(Augmenter\OperationId::class)->setHash(true);
+        $pipeline->get(Augmenter\OperationIds::class)->setHash(true);
         $pipeline->get(Augmenter\PathFilter::class)->setTags(['/pets/', '/store/']);
     });
 ```


### PR DESCRIPTION
## Summary

Emit warnings when using invalid / unknown confg keys. Also, improve `Result::isValid()`, aligning it more with how classic works.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Enhancement (improvement to existing functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional changes)
- [ ] Chore (maintenance, dependencies, CI)

## Related Issues

<!-- Link related issues: Fixes #123, Closes #456 -->

## Test Plan

<!-- Describe the tests you ran or plan to run to verify the changes. -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass locally
- [ ] Any dependent changes have been merged and published
