### PR TITLE
Fix typo in documentation for spec attributes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ Add `swagger-php` attributes (or legacy annotations) to your source code.
 possible attributes should be used.
 
 ::: info `spec` [mode](guide/modes)
-As of version 6.5.0, a new, improved set of attributes has beend introduced - the `spec` attributes.
+As of version 6.5.0, a new, improved set of attributes has been introduced - the `spec` attributes.
 When using those, the mode needs to be set to `spec` in order to generate OpenAPI documents.
 ```shell
 > ./vendor/bin/openapi -m spec ...


### PR DESCRIPTION
## Summary

Typo change from 'beend' to 'been'

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Enhancement (improvement to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update
- [ ] Refactor (no functional changes)
- [ ] Chore (maintenance, dependencies, CI)

## Checklist

- [X] I have updated the documentation accordingly



