### PR TITLE
chore(CS): follow rector rule changes

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -11,6 +11,7 @@ use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\If_\RemoveAlwaysTrueIfConditionRector;
 use Rector\DeadCode\Rector\If_\RemoveDeadInstanceOfRector;
 use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
+use Rector\Php74\Rector\If_\IfToNullCoalescingAssignRector;
 use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
 use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
 use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
@@ -48,6 +49,11 @@ return RectorConfig::configure()
         ],
         ArrayToFirstClassCallableRector::class => [
             __DIR__ . '/tests/Analysers/ComposerAutoloaderScannerTest.php',
+        ],
+        // `Operation::$operationId` is documented `@var string`, so phpstan rejects `??=`
+        // on it; the null check here is deliberate defensive handling
+        IfToNullCoalescingAssignRector::class => [
+            __DIR__ . '/src/Processors/OperationId.php',
         ],
     ])
     ->withPreparedSets(

--- a/src/Annotations/AbstractAnnotation.php
+++ b/src/Annotations/AbstractAnnotation.php
@@ -243,9 +243,7 @@ abstract class AbstractAnnotation implements \JsonSerializable
      */
     public function toYaml(?int $flags = null): string
     {
-        if ($flags === null) {
-            $flags = Yaml::DUMP_OBJECT_AS_MAP ^ Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE;
-        }
+        $flags ??= Yaml::DUMP_OBJECT_AS_MAP ^ Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE;
 
         return Yaml::dump(json_decode($this->toJson(JSON_INVALID_UTF8_IGNORE)), 10, 2, $flags);
     }
@@ -255,9 +253,7 @@ abstract class AbstractAnnotation implements \JsonSerializable
      */
     public function toJson(?int $flags = null): string
     {
-        if ($flags === null) {
-            $flags = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_IGNORE;
-        }
+        $flags ??= JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_IGNORE;
 
         return json_encode($this, $flags);
     }

--- a/src/Augmenter/Types.php
+++ b/src/Augmenter/Types.php
@@ -306,9 +306,7 @@ class Types implements PipeInterface
             $this->applySchemaType($schema, $schemaType);
         }
 
-        if ($schema->nullable === null) {
-            $schema->nullable = $schemaType->nullable;
-        }
+        $schema->nullable ??= $schemaType->nullable;
     }
 
     protected function applySchemaType(OA\Schema $schema, SchemaType $schemaType): void
@@ -325,17 +323,11 @@ class Types implements PipeInterface
             }
         }
 
-        if ($schema->format === null) {
-            $schema->format = $schemaType->format;
-        }
+        $schema->format ??= $schemaType->format;
 
-        if ($schema->minimum === null) {
-            $schema->minimum = $schemaType->minimum;
-        }
+        $schema->minimum ??= $schemaType->minimum;
 
-        if ($schema->maximum === null) {
-            $schema->maximum = $schemaType->maximum;
-        }
+        $schema->maximum ??= $schemaType->maximum;
 
         if ($schemaType->not !== null && !$schema->not instanceof OA\Schema) {
             $schema->not = new OA\Schema(const: $schemaType->not['const']);

--- a/src/Processors/DocBlockDescriptions.php
+++ b/src/Processors/DocBlockDescriptions.php
@@ -60,9 +60,7 @@ class DocBlockDescriptions
     protected function description(OA\AbstractAnnotation $annotation): void
     {
         if (!Undefined::isDefault($annotation->description)) {
-            if ($annotation->description === null) {
-                $annotation->description = Undefined::UNDEFINED;
-            }
+            $annotation->description ??= Undefined::UNDEFINED;
 
             return;
         }


### PR DESCRIPTION
## Summary

Rector 2.6 adds IfToNullCoalescingAssignRector. Skipped for Processors/OperationId.php, where phpstan rejects `??=` because Operation::$operationId is documented `@var string`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Enhancement (improvement to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor (no functional changes)
- [ ] Chore (maintenance, dependencies, CI)

## Related Issues

<!-- Link related issues: Fixes #123, Closes #456 -->

## Test Plan

<!-- Describe the tests you ran or plan to run to verify the changes. -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass locally
- [ ] Any dependent changes have been merged and published
