### PR TITLE
  docs(Spec): add developer docs                                                                                                                                                                                                                                                                                                                                                                                         

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,4 +41,4 @@ jobs:
           composer-options: "${{ matrix.composer-options }}"
 
       - name: PHPUnit Tests
-        run: bin/phpunit --configuration phpunit.xml.dist --coverage-text
+        run: composer test -- --configuration phpunit.xml.dist --coverage-text

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# swagger-php
+
+Generates OpenAPI documents from PHP source. Two pipelines: `classic` (docblock annotations
+and `OpenApi\Attributes`) and `spec` (`OpenApi\Spec`), with a `hybrid` bridge between them.
+[ROADMAP.md](ROADMAP.md) covers where they are heading.
+
+Terminology is defined in [CONTEXT.md](CONTEXT.md). Classic and spec deliberately use
+different words for similar things — check there before naming anything.
+
+## Commands
+
+All tooling runs through composer:
+
+- `composer lint` — code style check (cs-fixer + rector, dry run)
+- `composer cs` / `composer rector` — apply style fixes
+- `composer analyse` — static analysis (phpstan)
+- `composer test` — unit tests (add `-- --filter ClassName` for a single class)
+- `composer docs:gen` — regenerate the reference docs
+- `composer redocly` — validate generated specs against the OpenAPI schema
+- `composer docs:dev` — local docs preview; **long-running, never returns**
+
+## Detail, by area
+
+Read the relevant page before working in that part of the tree:
+
+| Page | Covers |
+|---|---|
+| [docs/dev/pipeline.md](docs/dev/pipeline.md) | spec pipeline internals — slot maps, mutability, augmenter ordering, where new code goes |
+| [docs/dev/testing.md](docs/dev/testing.md) | data providers, the `tests/Concerns` helpers, how documentation is test-verified |
+| [docs/dev/docs-toolchain.md](docs/dev/docs-toolchain.md) | which documentation is generated, and the CLI's rough edges |
+| [docs/dev/writing-docs.md](docs/dev/writing-docs.md) | conventions for hand-written documentation |
+
+## Conventions
+
+- `protected` over `private` for methods and properties, so downstream can subclass
+- British spelling in `src/`, US in `docs/` — follow whichever is local to the file
+- New pipeline work goes in `src/Spec/`, `src/Augmenter/`, `src/Compiler/`;
+  `src/Annotations/` and `src/Attributes/` are classic and closed to new features
+- Branches are `type/short-description`; commits are `type(Scope): subject`
+  (`feat`, `fix`, `docs`, `chore`, `refactor`)
+
+## Before opening a pull request
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full checklist. The short version:
+`composer test`, `composer analyse`, and `composer docs:gen` leaving no diff.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,14 +28,15 @@ Read the relevant page before working in that part of the tree:
 | [docs/dev/pipeline.md](docs/dev/pipeline.md) | spec pipeline internals — slot maps, mutability, augmenter ordering, where new code goes |
 | [docs/dev/testing.md](docs/dev/testing.md) | data providers, the `tests/Concerns` helpers, how documentation is test-verified |
 | [docs/dev/docs-toolchain.md](docs/dev/docs-toolchain.md) | which documentation is generated, and the CLI's rough edges |
-| [docs/dev/writing-docs.md](docs/dev/writing-docs.md) | conventions for hand-written documentation |
+| [docs/dev/writing-docs.md](docs/dev/writing-docs.md) | conventions for hand-written documentation, and a checklist for reviewing doc changes |
 
 ## Conventions
 
 - `protected` over `private` for methods and properties, so downstream can subclass
 - British spelling in `src/`, US in `docs/` — follow whichever is local to the file
 - New pipeline work goes in `src/Spec/`, `src/Augmenter/`, `src/Compiler/`;
-  `src/Annotations/` and `src/Attributes/` are classic and closed to new features
+  `src/Annotations/` and `src/Attributes/` are classic and closed to new features —
+  [ROADMAP.md](ROADMAP.md) has the v7/v8 plan
 - Branches are `type/short-description`; commits are `type(Scope): subject`
   (`feat`, `fix`, `docs`, `chore`, `refactor`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,14 +1,5 @@
-# Tools
+# swagger-php
 
-All tools are run via composer:
+Project instructions live in [AGENTS.md](AGENTS.md), shared with other coding agents.
 
-- `composer lint` — check all code style issues (cs-fixer + rector)
-- `composer cs` / `composer rector` — fix code style issues
-- `composer analyse` — static analysis (phpstan)
-- `composer test` — lint + unit tests; use `./bin/phpunit` directly to run only tests (e.g. `./bin/phpunit --filter ClassName`)
-- `composer redocly` — validate spec fixtures (currently failing, fixtures not yet valid)
-
-# Tests
-
-- Prefer compact tests and data providers over repetition
-- Use shared traits from `tests/Concerns/` for common helpers (e.g. `AssemblesSpecification`)
+@AGENTS.md

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -21,8 +21,8 @@ Nested metadata describing where an annotation was found in the source hierarchy
 _Avoid_: Location, position
 
 **Generator**:
-The orchestrator that coordinates scanning, processing, and output — it generates an OpenAPI spec from annotations, not code from a spec.
-_Avoid_: Builder, compiler
+The **classic** orchestrator that coordinates scanning, processing, and output — it generates an OpenAPI spec from annotations, not code from a spec.
+_Avoid_: using "builder" or "compiler" as loose synonyms — both now name distinct classes in the spec pipeline (see below)
 
 **Processor**:
 A single transformation step in an ordered pipeline that converts raw Analysis into a valid, complete OpenAPI specification.
@@ -68,7 +68,44 @@ _Avoid_: Scanner (too narrow — TokenScanner is a sub-component), parser
 
 **AnnotationFactory**:
 Creates annotation objects from discovered PHP attributes or docblock comments during analysis.
-_Avoid_: Builder, constructor
+_Avoid_: constructor; and do not shorten it to "builder", which now names a class
+
+### Spec Pipeline
+
+The `spec` pipeline (`OpenApi\Spec`, `--mode spec`) has its own vocabulary. Terms here are
+deliberately distinct from the classic ones above; do not use them interchangeably.
+
+**Builder**:
+The unified entry point. Selects a processing mode and orchestrates the run, returning a `Result`.
+_Avoid_: Generator (that name is reserved for the classic orchestrator)
+
+**Assembler**:
+Collects spec attributes from PHP reflectors and resolves their nesting into a Specification.
+_Avoid_: Analyser (classic), parser, scanner
+
+**Specification**:
+A flat, typed container holding the collected spec attributes, one bucket per root attribute type.
+_Avoid_: Analysis (classic), tree, document
+
+**Augmenter**:
+A single pipe that enriches a Specification — the spec pipeline's counterpart to a classic Processor.
+_Avoid_: Processor (reserved for the classic pipeline), middleware, handler
+
+**Compiler**:
+Transforms a Specification into a versioned OpenAPI document array. One per supported OpenAPI version.
+_Avoid_: Serializer (classic output step), renderer
+
+**Slot map**:
+The `merge()` / `contained()` declarations by which an attribute names where it can nest. The slot names a property on the **target**, not on the declaring attribute.
+_Avoid_: nesting map (that is the classic `$_nested`)
+
+**Root attribute**:
+An attribute that can live in the Specification without a parent container, and therefore has its own bucket.
+_Avoid_: top-level (ambiguous with source-code position)
+
+**Mode**:
+Which pipeline a run uses: `classic`, `hybrid` or `spec`.
+_Avoid_: driver, backend
 
 ## Relationships
 
@@ -77,6 +114,13 @@ _Avoid_: Builder, constructor
 - **Processors** run sequentially on an **Analysis**, first **merging** unmerged annotations, then **expanding** inheritance, then **augmenting** missing fields
 - **Nesting** defines where an **Annotation** can be merged within the OpenAPI tree
 - A **Component** is an **Annotation** that has been merged into `#/components/` and is reachable by **Ref**
+
+In the spec pipeline:
+
+- A **Builder** runs an **Assembler** to produce a **Specification**
+- The **Assembler** resolves **slot maps** to decide what nests where; what survives are **root attributes**
+- **Augmenters** run over the **Specification** in phases (resolve → reduce → augment)
+- A **Compiler** turns the finished **Specification** into the output document
 
 ## Example dialogue
 
@@ -90,4 +134,5 @@ _Avoid_: Builder, constructor
 
 - "generate" — resolved: reserve for the full end-to-end pipeline (`Generator::generate()`). Use **analyse** for the discovery phase and **serialize** for producing JSON/YAML output.
 - "merge" — resolved: reserve for tree-placement (moving an annotation into its correct position in the OpenAPI object). Combining multiple annotations' fields into one (e.g. Properties into a Schema) is part of **augment**.
+- "augment" — **unresolved**. Classic uses it for filling in missing annotation fields (above). The spec pipeline also uses it as the name of the third augmenter phase (`Group::Augment`), which is narrower — `Types` and `Refs` do classic-style "augmenting" but run in the *resolve* phase. Say "the augment phase" when you mean the phase.
 - "nested" — resolved: use **nesting map** when referring to the `$_nested` declaration. Use **enclosing** when talking about the physical source code structure (file, class, method) that Context tracks.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,11 +32,9 @@ The documentation site has [some details](https://zircote.github.io/swagger-php/
 - [ ] Reference docs regenerated — `composer docs:gen` leaves **no** diff
 - [ ] Hand-written docs updated for any behaviour or API change
 
-That last one is easy to miss. `composer docs:gen` only rebuilds the six generated
-reference pages; everything else under `docs/` — the guides, `reference/architecture.md`,
-`reference/builder.md`, `reference/inheritance.md` — is hand-written and will not update
-itself. See [docs/dev/](docs/dev/) for which is which, and for the conventions those pages
-follow.
+`composer docs:gen` only rebuilds the generated pages; everything else under `docs/` is
+hand-written and will not update itself. See [docs/dev/](docs/dev/) for which is which, and
+for the conventions those pages follow.
 
 Pull request titles follow `type(Scope): subject`, e.g. `feat(Spec): add encoding shortcut`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,15 +16,29 @@ The documentation site has [some details](https://zircote.github.io/swagger-php/
 * [Checkout](https://git-scm.com/docs/git-checkout) the branch you want to make changes on.
     * Typically, this will be `master`. Note that most of the time, `master` represents the next release of swagger-php, so Pull Requests that break backwards compatibility might be postponed.
 * Install dependencies: `composer install`.
-* Create a new branch, e.g. `feature-foo` or `bugfix-bar`.
+* Create a new branch named `type/short-description`, e.g. `feat/encoding-shortcut` or
+  `fix/empty-schema-serialization`.
 * Make changes.
 * If you are adding functionality or fixing a bug - add a test!
 
   Prefer adding new test cases over modifying existing ones.
-* Update documentation: `composer docs:gen`.
-* Run static analysis using PHPStan/Psalm: `composer analyse`.
-* Check if tests pass: `composer test`.
-* Fix code style issues: `composer cs`.
+
+### Before opening a pull request
+
+- [ ] Tests pass — `composer test`
+- [ ] Static analysis is clean — `composer analyse`
+- [ ] Code style is clean — `composer lint` to check, `composer cs` and
+      `composer rector` to fix
+- [ ] Reference docs regenerated — `composer docs:gen` leaves **no** diff
+- [ ] Hand-written docs updated for any behaviour or API change
+
+That last one is easy to miss. `composer docs:gen` only rebuilds the six generated
+reference pages; everything else under `docs/` — the guides, `reference/architecture.md`,
+`reference/builder.md`, `reference/inheritance.md` — is hand-written and will not update
+itself. See [docs/dev/](docs/dev/) for which is which, and for the conventions those pages
+follow.
+
+Pull request titles follow `type(Scope): subject`, e.g. `feat(Spec): add encoding shortcut`.
 
 
 ## Documentation
@@ -39,9 +53,10 @@ The actual published content is managed in the [gh-pages](https://github.com/zir
 
 ## Useful commands
 
-### To run both unit tests and linting execute
+### Running the unit tests
 ```shell
 composer test
+composer test -- --filter CompilerTest   # a single test class
 ```
 
 ### To run static-analysis execute
@@ -49,24 +64,22 @@ composer test
 composer analyse
 ```
 
-### Running unit tests only
-```shell
-./bin/phpunit
-```
-
 ### Regenerate reference markup docs
 ```shell
 composer docs:gen
 ```
 
-### Running linting only
+### Checking code style
 ```shell
 composer lint
 ```
 
-### To make `php-cs-fixer` fix linting errors
+### Fixing code style issues
+`composer lint` runs both php-cs-fixer and rector in dry-run mode, so a failure can come
+from either. Apply the fixes with:
 ```shell
-composer cs
+composer cs       # php-cs-fixer
+composer rector   # rector
 ```
 
 ### Validate generated specs with Redocly

--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
         "cs": "Fix all codestyle issues",
         "rector": "Automatic refactoring",
         "lint": "Test codestyle",
-        "test": "Run all PHP, codestyle and rector tests",
+        "test": "Run the unit tests",
         "performance": "Run performance regression tests",
         "analyse": "Run static analysis (phpstan)",
         "redocly": "Validate generated specs with Redocly",
@@ -99,10 +99,7 @@
             "@cs --dry-run",
             "@rector --dry-run"
         ],
-        "test": [
-            "export XDEBUG_MODE=off && phpunit --display-all-issues @additional_args",
-            "@lint @no_additional_args"
-        ],
+        "test": "export XDEBUG_MODE=off && phpunit --display-all-issues @additional_args",
         "performance": "export XDEBUG_MODE=off && phpunit --group performance",
         "analyse": [
             "export XDEBUG_MODE=off && phpstan clear-result-cache -q && phpstan analyse --memory-limit=3G"

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -52,6 +52,15 @@ function getGuideSidebar() {
         { text: 'Related Projects', link: '/related-projects' },
       ]
     },
+    {
+      text: 'Contributing',
+      items: [
+        { text: 'Spec pipeline internals', link: '/dev/pipeline' },
+        { text: 'Testing', link: '/dev/testing' },
+        { text: 'Documentation toolchain', link: '/dev/docs-toolchain' },
+        { text: 'Writing documentation', link: '/dev/writing-docs' },
+      ]
+    },
   ]
 }
 

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -113,6 +113,7 @@ module.exports = {
 
     sidebar: {
       '/guide/': getGuideSidebar(),
+      '/dev/': getGuideSidebar(),
       '/reference/': getReferenceSidebar()
     },
 

--- a/docs/dev/docs-toolchain.md
+++ b/docs/dev/docs-toolchain.md
@@ -17,8 +17,8 @@ first.
 | `reference/annotations.md` | `src/Annotations/` docblocks + `snippets/preamble_annotations.md` |
 | `reference/attributes.md` | `src/Attributes/` docblocks + `snippets/preamble_attributes.md` |
 | `reference/spec-attributes.md` | `src/Spec/` docblocks + `snippets/preamble_spec-attributes.md` |
-| `reference/processors.md` | `src/Processors/` docblocks + prose in `ProcessorGenerator` |
-| `reference/augmenters.md` | `src/Augmenter/` docblocks + prose in `AugmenterGenerator` |
+| `reference/processors.md` | `src/Processors/` docblocks + `snippets/preamble_processors.md` + prose in `ProcessorGenerator` |
+| `reference/augmenters.md` | `src/Augmenter/` docblocks + `snippets/preamble_augmenters.md` + prose in `AugmenterGenerator` |
 | `guide/examples.md` | example sources + the per-example `docs/examples/specs/*/Readme.md` |
 
 To change one of these, change its source and re-run `composer docs:gen`.

--- a/docs/dev/docs-toolchain.md
+++ b/docs/dev/docs-toolchain.md
@@ -8,7 +8,7 @@ static analysis, tests, and what to run before a pull request — see
 
 ## Generated pages — do not edit
 
-Six pages are written by `composer docs:gen`. Editing them directly is wasted work: the next
+These pages are written by `composer docs:gen`. Editing them directly is wasted work: the next
 `docs:gen` overwrites your changes, and so does `composer docs:build`, which runs `docs:gen`
 first.
 
@@ -27,10 +27,8 @@ Note that some prose lives *inside* the generators rather than in any markdown f
 `-c` and `-D` explanations in the "Configuration" sections are string literals in
 `tools/src/Docs/Reference/{Augmenter,Processor}Generator.php`.
 
-Everything else under `docs/` is hand-written, including `reference/architecture.md`,
-`reference/builder.md`, `reference/inheritance.md` and all of `guide/` except
-`examples.md`. The **top-level** `docs/examples/Readme.md` is hand-written too; only the
-per-example Readmes are pulled into the generated page.
+Everything else under `docs/` is hand-written — including the top-level
+`docs/examples/Readme.md`, since only the per-example ones feed the generated page.
 
 ## `docs:gen` is a drift check
 
@@ -43,20 +41,17 @@ composer docs:gen && git status --porcelain docs/
 Any output means the committed pages have drifted, and the regenerated version is the
 correct one. Worth running before opening a pull request.
 
-Run it with an otherwise-clean tree, or scope the `git status` to the six files above —
-`docs/reference/` also holds hand-written pages (`architecture.md`, `builder.md`,
-`inheritance.md`, `index.md`), so a directory-wide check reports your own edits as drift.
+Run it with an otherwise-clean tree, or scope the `git status` to the generated pages —
+`docs/reference/` holds hand-written ones too, so a directory-wide check reports your own
+edits as drift.
 
 ## Commands
 
 | Command | Notes |
 |---|---|
-| `composer docs:gen` | regenerate the six pages above |
+| `composer docs:gen` | regenerate the pages listed above |
 | `composer docs:build` | runs `docs:gen`, then builds the static site |
 | `composer docs:dev` | local preview — **long-running**, prints its URL on startup and does not return |
-
-`composer docs:dev` starts a Vitepress dev server and blocks until interrupted. Do not run
-it as a build step or from an automated agent loop.
 
 ## What counts as a documented config setting
 
@@ -78,9 +73,7 @@ by construction; if you change one, check the other. The check is that
 - `-D` / `--defaults` prints the resolved default config, but still requires the `paths`
   argument: `./bin/openapi --mode spec -D src`, not `./bin/openapi --mode spec -D`.
 - `--version` sets the target **OpenAPI** version, not the tool version.
-- Help output is standard Symfony Console format. If you need it in a document, capture it
-  from `./bin/openapi -h` rather than writing it out — a hand-written approximation has
-  drifted from reality before.
+- Help output is standard Symfony Console format, from `./bin/openapi -h`.
 - Unknown `-c` keys are reported as warnings in **spec** mode, via
   `Pipeline::configure()`. In **classic** mode they are silently ignored, because
   configuration is routed through `Generator::setConfig()` instead. A typo in a classic

--- a/docs/dev/docs-toolchain.md
+++ b/docs/dev/docs-toolchain.md
@@ -53,7 +53,7 @@ Run it with an otherwise-clean tree, or scope the `git status` to the six files 
 |---|---|
 | `composer docs:gen` | regenerate the six pages above |
 | `composer docs:build` | runs `docs:gen`, then builds the static site |
-| `composer docs:dev` | local preview on `localhost:3000` — **long-running**, it does not return |
+| `composer docs:dev` | local preview — **long-running**, prints its URL on startup and does not return |
 
 `composer docs:dev` starts a Vitepress dev server and blocks until interrupted. Do not run
 it as a build step or from an automated agent loop.

--- a/docs/dev/docs-toolchain.md
+++ b/docs/dev/docs-toolchain.md
@@ -1,0 +1,92 @@
+# Documentation toolchain
+
+How the documentation under `docs/` is produced, and which parts of it you may edit by hand.
+
+This covers the *documentation* toolchain only. For the general development loop — lint,
+static analysis, tests, and what to run before a pull request — see
+[CONTRIBUTING.md](https://github.com/zircote/swagger-php/blob/master/CONTRIBUTING.md).
+
+## Generated pages — do not edit
+
+Six pages are written by `composer docs:gen`. Editing them directly is wasted work: the next
+`docs:gen` overwrites your changes, and so does `composer docs:build`, which runs `docs:gen`
+first.
+
+| Page | Built from |
+|---|---|
+| `reference/annotations.md` | `src/Annotations/` docblocks + `snippets/preamble_annotations.md` |
+| `reference/attributes.md` | `src/Attributes/` docblocks + `snippets/preamble_attributes.md` |
+| `reference/spec-attributes.md` | `src/Spec/` docblocks + `snippets/preamble_spec-attributes.md` |
+| `reference/processors.md` | `src/Processors/` docblocks + prose in `ProcessorGenerator` |
+| `reference/augmenters.md` | `src/Augmenter/` docblocks + prose in `AugmenterGenerator` |
+| `guide/examples.md` | example sources + the per-example `docs/examples/specs/*/Readme.md` |
+
+To change one of these, change its source and re-run `composer docs:gen`.
+
+Note that some prose lives *inside* the generators rather than in any markdown file — the
+`-c` and `-D` explanations in the "Configuration" sections are string literals in
+`tools/src/Docs/Reference/{Augmenter,Processor}Generator.php`.
+
+Everything else under `docs/` is hand-written, including `reference/architecture.md`,
+`reference/builder.md`, `reference/inheritance.md` and all of `guide/` except
+`examples.md`. The **top-level** `docs/examples/Readme.md` is hand-written too; only the
+per-example Readmes are pulled into the generated page.
+
+## `docs:gen` is a drift check
+
+The generators are deterministic, and committed output is expected to match its source. So:
+
+```shell
+composer docs:gen && git status --porcelain docs/
+```
+
+Any output means the committed pages have drifted, and the regenerated version is the
+correct one. Worth running before opening a pull request.
+
+## Commands
+
+| Command | Notes |
+|---|---|
+| `composer docs:gen` | regenerate the six pages above |
+| `composer docs:build` | runs `docs:gen`, then builds the static site |
+| `composer docs:dev` | local preview on `localhost:3000` — **long-running**, it does not return |
+
+`composer docs:dev` starts a Vitepress dev server and blocks until interrupted. Do not run
+it as a build step or from an automated agent loop.
+
+## What counts as a documented config setting
+
+`reference/augmenters.md` and `reference/processors.md` list the options accepted by
+`-c name.option=value`. A setting qualifies when it is **a constructor parameter that is
+not object typed**:
+
+- constructor parameters are the public configuration contract, by convention
+- object typed parameters — factories, resolvers, the generator — are collaborators, not
+  settings, and cannot be expressed as a CLI value
+
+This is implemented once, in `DocGenerator::configurableParameters()`, and mirrors what
+`Utils\Pipeline::getConfig()` reports at runtime. The two are aligned by hand rather than
+by construction; if you change one, check the other. The check is that
+`./bin/openapi --mode spec -D src` lists exactly the settings the reference page documents.
+
+## CLI behaviour worth knowing
+
+- `-D` / `--defaults` prints the resolved default config, but still requires the `paths`
+  argument: `./bin/openapi --mode spec -D src`, not `./bin/openapi --mode spec -D`.
+- `--version` sets the target **OpenAPI** version, not the tool version.
+- Help output is standard Symfony Console format. If you need it in a document, capture it
+  from `./bin/openapi -h` rather than writing it out — a hand-written approximation has
+  drifted from reality before.
+- Unknown `-c` keys are reported as warnings in **spec** mode, via
+  `Pipeline::configure()`. In **classic** mode they are silently ignored, because
+  configuration is routed through `Generator::setConfig()` instead. A typo in a classic
+  `-c` key fails invisibly.
+
+## Known rough edge
+
+`AugmenterGenerator` and `ProcessorGenerator` share a lot of near-identical code —
+`collectOptions()`, `resolveDefault()`, and their CLI prose blocks. A fix to one usually
+needs applying to the other. They have also diverged: `AugmenterGenerator` renders through
+the `tools/src/Docs/Sections/` abstraction and emits markdown lists, while
+`ProcessorGenerator` renders inline and emits HTML `<span>` markup, which is why the two
+reference pages look different.

--- a/docs/dev/docs-toolchain.md
+++ b/docs/dev/docs-toolchain.md
@@ -43,6 +43,10 @@ composer docs:gen && git status --porcelain docs/
 Any output means the committed pages have drifted, and the regenerated version is the
 correct one. Worth running before opening a pull request.
 
+Run it with an otherwise-clean tree, or scope the `git status` to the six files above —
+`docs/reference/` also holds hand-written pages (`architecture.md`, `builder.md`,
+`inheritance.md`, `index.md`), so a directory-wide check reports your own edits as drift.
+
 ## Commands
 
 | Command | Notes |
@@ -69,7 +73,7 @@ This is implemented once, in `DocGenerator::configurableParameters()`, and mirro
 by construction; if you change one, check the other. The check is that
 `./bin/openapi --mode spec -D src` lists exactly the settings the reference page documents.
 
-## CLI behaviour worth knowing
+## CLI behavior worth knowing
 
 - `-D` / `--defaults` prints the resolved default config, but still requires the `paths`
   argument: `./bin/openapi --mode spec -D src`, not `./bin/openapi --mode spec -D`.

--- a/docs/dev/pipeline.md
+++ b/docs/dev/pipeline.md
@@ -4,13 +4,6 @@ Things about the spec pipeline that are easy to get wrong from reading the sourc
 have caused incorrect documentation before. For the user-facing description see
 [Architecture](/reference/architecture); this page is for people changing the pipeline.
 
-## Where new code goes
-
-`src/Annotations/` and `src/Attributes/` are the classic pipeline. They are maintained but
-effectively closed to new features — see [ROADMAP](https://github.com/zircote/swagger-php/blob/master/ROADMAP.md)
-for the v7/v8 plan. New spec work belongs in `src/Spec/`, `src/Augmenter/` and
-`src/Compiler/`.
-
 ## The DTOs are mutable
 
 Spec attributes are plain data containers, but they are **not** immutable, and neither is
@@ -48,6 +41,32 @@ backwards — the interface's own docblock had it inverted for a while.
 Because the child declares the relationship, downstream code can extend the system: a
 custom attachable names its own nesting targets without touching any native attribute.
 
+### How resolution runs
+
+Resolution is driven purely by these declarations — it reads nothing from PHP's own
+structural semantics:
+
+1. **Sibling merge** — attributes on the same reflector compose via `merge()`
+2. **Hierarchical absorb** — what remains flows upward a level at a time via `contained()`,
+   first match wins
+
+If a level has containers, an unmatched non-root attribute is an error. If a level has no
+containers at all, unmatched attributes pass through to the level above.
+
+### What survives resolution
+
+Only *root* attributes should remain, and those are what enters the Specification. A root
+attribute is one that can stand alone — it owns a bucket and needs no parent.
+
+- **Always root**: `Schema`, `Operation`, `PathItem`, `OpenApi`, `Info`, `Tag`, `Server`,
+  `ExternalDocumentation`, `Security\Scheme`, `Components`, `Attachable`
+- **Conditionally root**: `Response` (with `response` set), `RequestBody` (with `request` set)
+- **Never root**: `Parameter`, `Header`, `Link`, `Example`, `MediaType`, `Property` — these
+  must nest inside a parent or sit in a `Components` container
+
+The user-facing version of this distinction is in
+[Using Spec Attributes](/guide/spec-attributes#components); this list is the full one.
+
 ## Directory layout is not the class hierarchy
 
 `src/Spec/` nests directories for readability, not inheritance. Notably:
@@ -63,9 +82,45 @@ custom attachable names its own nesting targets without touching any native attr
 Genuinely nested: `Schema\{AdditionalProperties,Items,Ref}`, `Property\Encoded`,
 `Operation\*`, `Parameter\*`, `MediaType\{Json,Xml}`, `Flow\*`, `Security\Scheme\*`.
 
+All spec attributes extend `AbstractAttribute`. Typed subclasses such as `Operation\Get`
+and `Parameter\Path` pre-fill fields the base class requires explicitly; the base class is
+always usable directly for full control.
+
 Do not hand-maintain a class tree in documentation. The generated
 [Spec Attributes reference](/reference/spec-attributes) lists every attribute with its
 parameters and what it can nest into, and cannot go stale.
+
+## Reflectors are the glue
+
+Every root DTO keeps the reflector it came from. This is how relationships that span
+buckets get resolved after assembly, without the DTOs having to reference each other:
+
+- **PathItem to Operation** — a PathItem sits on a class, operations on its methods; the
+  `PathItems` augmenter uses `ReflectionMethod::getDeclaringClass()` to pair them
+- **Prefix composition** — `ReflectionClass::getParentClass()` walks ancestors so parent
+  PathItems can contribute path prefixes
+- **OperationId generation** — class and method names come from the reflector
+- **Type inference** — `Types` reads PHP type declarations off property and parameter
+  reflectors
+
+This is what keeps the Assembler concerned only with nesting.
+
+## Normalise on input, store the simple form
+
+Where a property accepts both a rich input type and a plain serialized one, take both but
+convert immediately in the constructor. Properties always hold the simple form; enums,
+objects and convenience types are input sugar only.
+
+```php
+// FlowType enum accepted on input, stored as string
+public function __construct(string|FlowType|null $flow = null) {
+    parent::__construct([
+        'flow' => $flow instanceof \BackedEnum ? $flow->value : $flow,
+    ]);
+}
+```
+
+Augmenters, compilers and serialization then never need to branch on type.
 
 ## Augmenter ordering lives in one place
 

--- a/docs/dev/pipeline.md
+++ b/docs/dev/pipeline.md
@@ -59,9 +59,13 @@ attribute is one that can stand alone — it owns a bucket and needs no parent.
 
 - **Always root**: `Schema`, `Operation`, `PathItem`, `OpenApi`, `Info`, `Tag`, `Server`,
   `ExternalDocumentation`, `Security\Scheme`, `Components`, `Attachable`
-- **Conditionally root**: `Response` (with `response` set), `RequestBody` (with `request` set)
-- **Never root**: `Parameter`, `Header`, `Link`, `Example`, `MediaType`, `Property` — these
-  must nest inside a parent or sit in a `Components` container
+- **Conditionally root**, when their own key is set and `ref` is not: `Response`
+  (`response`), `Parameter` (`parameter`), `Link` (`link`); `RequestBody` needs `request`
+  set but has no `ref` check
+- **Never root**: `Header`, `Example`, `MediaType`, `Property` — these must nest inside a
+  parent or sit in a `Components` container
+
+Each attribute decides for itself, in `isRoot()`.
 
 The user-facing version of this distinction is in
 [Using Spec Attributes](/guide/spec-attributes#components); this list is the full one.
@@ -111,11 +115,13 @@ convert immediately in the constructor. Properties always hold the simple form; 
 objects and convenience types are input sugar only.
 
 ```php
-// FlowType enum accepted on input, stored as string
-public function __construct(string|FlowType|null $flow = null) {
-    parent::__construct([
-        'flow' => $flow instanceof \BackedEnum ? $flow->value : $flow,
-    ]);
+// OA\Flow — FlowType accepted on input, stored as string
+public function __construct(
+    string|FlowType|null $flow = null,
+    // ...
+) {
+    parent::__construct(x: $x, attachables: $attachables);
+    $this->flow = $flow instanceof \BackedEnum ? $flow->value : $flow;
 }
 ```
 

--- a/docs/dev/pipeline.md
+++ b/docs/dev/pipeline.md
@@ -13,9 +13,6 @@ and `Specification` exposes public arrays that `add()` appends to.
 What *is* true, and what distinguishes them from classic annotations, is that they carry no
 serialization logic. Serialization is the compiler's job.
 
-Documentation has repeatedly claimed these objects are immutable. They are not; do not
-reason about the pipeline as if nothing is being mutated.
-
 ## Slot maps: the slot belongs to the parent
 
 Nesting is declared by the child, via two methods on `AttributeInterface`:
@@ -34,8 +31,8 @@ public function contained(): array
 }
 ```
 
-A `[]` suffix appends to a collection; a bare name assigns a scalar. This is easy to read
-backwards — the interface's own docblock had it inverted for a while.
+A `[]` suffix appends to a collection; a bare name assigns a scalar. It is easy to read
+backwards.
 
 Because the child declares the relationship, downstream code can extend the system: a
 custom attachable names its own nesting targets without touching any native attribute.
@@ -85,13 +82,8 @@ The user-facing version of this distinction is in
 Genuinely nested: `Schema\{AdditionalProperties,Items,Ref}`, `Property\Encoded`,
 `Operation\*`, `Parameter\*`, `MediaType\{Json,Xml}`, `Flow\*`, `Security\Scheme\*`.
 
-All spec attributes extend `AbstractAttribute`. Typed subclasses such as `Operation\Get`
-and `Parameter\Path` pre-fill fields the base class requires explicitly; the base class is
-always usable directly for full control.
-
-Do not hand-maintain a class tree in documentation. The generated
-[Spec Attributes reference](/reference/spec-attributes) lists every attribute with its
-parameters and what it can nest into, and cannot go stale.
+The [Spec Attributes reference](/reference/spec-attributes) lists every attribute with its
+parameters and what it can nest into.
 
 ## Reflectors are the glue
 
@@ -135,12 +127,3 @@ follows registration order.
 
 Ordering that matters: `Inheritance` must run before `PathItems`, because inherited
 operations have to exist before path prefixes are resolved.
-
-Prose that re-lists the order drifts. Point at the method instead.
-
-## Typed operation subclasses drop `requestBody`
-
-`Operation\Get`, `Operation\Head`, `Operation\Options` and `Operation\Trace` have no
-`requestBody` constructor parameter. Passing one is a PHP
-`Error: Unknown named parameter $requestBody`, raised when the attribute is instantiated —
-not a validation warning. `Post`, `Put`, `Patch` and `Delete` accept it.

--- a/docs/dev/pipeline.md
+++ b/docs/dev/pipeline.md
@@ -1,0 +1,86 @@
+# Spec pipeline internals
+
+Things about the spec pipeline that are easy to get wrong from reading the source, and that
+have caused incorrect documentation before. For the user-facing description see
+[Architecture](/reference/architecture); this page is for people changing the pipeline.
+
+## Where new code goes
+
+`src/Annotations/` and `src/Attributes/` are the classic pipeline. They are maintained but
+effectively closed to new features — see [ROADMAP](https://github.com/zircote/swagger-php/blob/master/ROADMAP.md)
+for the v7/v8 plan. New spec work belongs in `src/Spec/`, `src/Augmenter/` and
+`src/Compiler/`.
+
+## The DTOs are mutable
+
+Spec attributes are plain data containers, but they are **not** immutable, and neither is
+`Specification`. Augmenters assign to attribute properties throughout —
+`Refs::mergeAllOf()` nulls `$schema->properties`, `Types` fills schema fields in place —
+and `Specification` exposes public arrays that `add()` appends to.
+
+What *is* true, and what distinguishes them from classic annotations, is that they carry no
+serialization logic. Serialization is the compiler's job.
+
+Documentation has repeatedly claimed these objects are immutable. They are not; do not
+reason about the pipeline as if nothing is being mutated.
+
+## Slot maps: the slot belongs to the parent
+
+Nesting is declared by the child, via two methods on `AttributeInterface`:
+
+- `merge()` — how this attribute composes into a **sibling** on the same reflector
+- `contained()` — which **outer-level** attribute types can absorb it from an inner level
+
+Both return `[TargetClass => 'slot']`, and in both cases the slot names a property on the
+**target**, not on the attribute declaring it:
+
+```php
+// OA\Property
+public function contained(): array
+{
+    return [Schema::class => 'properties[]'];   // `properties` lives on Schema
+}
+```
+
+A `[]` suffix appends to a collection; a bare name assigns a scalar. This is easy to read
+backwards — the interface's own docblock had it inverted for a while.
+
+Because the child declares the relationship, downstream code can extend the system: a
+custom attachable names its own nesting targets without touching any native attribute.
+
+## Directory layout is not the class hierarchy
+
+`src/Spec/` nests directories for readability, not inheritance. Notably:
+
+- `Property extends AbstractAttribute` — **not** `Schema`. This is the deliberate change
+  from classic (where `Annotations\Property extends Schema`) and it is what makes stacking
+  `#[OA\Property]` and `#[OA\Schema]` on the same target work.
+- `Encoding extends AbstractAttribute` — **not** `MediaType`, despite `Property\Encoded`.
+- `Contact`, `License`, `ServerVariable` extend `AbstractAttribute`, not `Info`/`Server`.
+- `OA\Security` is a namespace, not a class. The classes are `Security\Requirement` and
+  `Security\Scheme`.
+
+Genuinely nested: `Schema\{AdditionalProperties,Items,Ref}`, `Property\Encoded`,
+`Operation\*`, `Parameter\*`, `MediaType\{Json,Xml}`, `Flow\*`, `Security\Scheme\*`.
+
+Do not hand-maintain a class tree in documentation. The generated
+[Spec Attributes reference](/reference/spec-attributes) lists every attribute with its
+parameters and what it can nest into, and cannot go stale.
+
+## Augmenter ordering lives in one place
+
+Registration order is `Builder::getDefaultAugmenters()`. The phase each augmenter runs in
+comes from its own `group()` — `Resolve` → `Reduce` → `Augment`. Within a phase, execution
+follows registration order.
+
+Ordering that matters: `Inheritance` must run before `PathItems`, because inherited
+operations have to exist before path prefixes are resolved.
+
+Prose that re-lists the order drifts. Point at the method instead.
+
+## Typed operation subclasses drop `requestBody`
+
+`Operation\Get`, `Operation\Head`, `Operation\Options` and `Operation\Trace` have no
+`requestBody` constructor parameter. Passing one is a PHP
+`Error: Unknown named parameter $requestBody`, raised when the attribute is instantiated —
+not a validation warning. `Post`, `Put`, `Patch` and `Delete` accept it.

--- a/docs/dev/pipeline.md
+++ b/docs/dev/pipeline.md
@@ -1,8 +1,7 @@
 # Spec pipeline internals
 
-Things about the spec pipeline that are easy to get wrong from reading the source, and that
-have caused incorrect documentation before. For the user-facing description see
-[Architecture](/reference/architecture); this page is for people changing the pipeline.
+The parts of the spec pipeline that are easiest to get wrong when reading the source. For
+how the pipeline fits together, see [Architecture](/reference/architecture).
 
 ## The DTOs are mutable
 

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -1,0 +1,80 @@
+# Testing
+
+Conventions and helpers for the test suite.
+
+```shell
+composer test                            # the whole suite
+composer test -- --filter CompilerTest   # a single class
+composer performance                     # perf tests, excluded from the default run
+```
+
+`composer test` runs tests only. Code style is `composer lint` and static analysis is
+`composer analyse` — each command does one thing, matching how CI runs them.
+
+## Prefer data providers
+
+Most behaviour in this library varies along a few axes — OpenAPI version, processing mode,
+annotation vs attribute vs spec input. Repeating a test body per combination gets long and
+hides which case actually failed.
+
+Use `#[DataProvider]` and let the provider name the case, so a failure reports *which*
+combination broke rather than just the assertion. Most of the suite already works this
+way; follow the closest existing example rather than inventing a new shape.
+
+Prefer adding a case to an existing provider over copying a whole test method. Prefer
+adding new test cases over modifying existing ones — an existing case usually encodes a
+regression somebody cared about.
+
+## Shared helpers
+
+`tests/Concerns/` holds the reusable pieces. Look here before writing setup code:
+
+| Trait | Use for |
+|---|---|
+| `AssemblesSpecification` | `assemble(...$classes)` — build a `Specification` from classes without touching the filesystem |
+| `AssertsBuilderResult` | asserting on a `Builder\Result`, including expected warnings and errors |
+| `AssertsSchemaStructure` | comparing compiled schema structure (`allOf` refs + property names) against a YAML fixture, independent of property order |
+| `CollectsSpecClasses` | enumerating every `OpenApi\Spec` attribute class, for suite-wide invariants |
+| `GeneratesTestMatrix` | building version × mode combinations, with exclusions, and discovering fixtures by glob |
+| `UsesExamples` | registering a classloader for a `docs/examples` implementation |
+
+`GeneratesTestMatrix` is the one to reach for when a test needs to run across versions and
+modes — it handles the cartesian product, the exclusions, and stable test-case naming, so
+providers stay short.
+
+`SlotMapConsistencyTest` is a good example of the suite-wide-invariant style: rather than
+testing one attribute, it checks a property that must hold across all of them.
+
+## The docs are part of the test suite
+
+Two tests verify documentation against real output. Both will fail if you add documentation
+without its counterpart:
+
+**`DocSnippetsTest`** runs every `docs/snippets/*_an.php` and compares against the matching
+`-3.1.0.yaml`, across the applicable modes and implementations. Adding a snippet means
+adding *all* of:
+
+- `foo_an.php` (annotations), `foo_at.php` (attributes), `foo_spec.php` (spec attributes)
+- `foo-3.1.0.yaml` — the expected output
+
+Missing implementations are skipped rather than failing, but a missing or stale
+`-3.1.0.yaml` is a failure. The mode/implementation pairing is deliberate: spec snippets run
+only in spec mode, and classic mode never runs spec snippets.
+
+**`ExamplesTest`** does the same for `docs/examples/specs/*`, against the per-version
+`*-3.0.0.yaml` / `*-3.1.0.yaml` / `*-3.2.0.yaml` fixtures.
+
+This is why changing pipeline output shows up as a wall of documentation failures. That is
+the suite working: the expected YAML files are the specification of what the pipeline
+produces, and they are what the published docs display.
+
+## Fixtures
+
+- `tests/Fixtures/` — general test fixtures
+- `tests/Fixtures/Scratch/` — spec-pipeline scratch fixtures with expected YAML, exercised
+  by `ScratchTest`
+- `docs/examples/specs/` — full worked examples, doubling as published documentation
+
+`composer redocly` validates the generated example specs against the OpenAPI schema. It
+passes, with warnings; known problems are suppressed via `.redocly.lint-ignore.yaml`, so a
+*new* failure means something genuinely regressed.

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -58,8 +58,8 @@ adding *all* of:
 - `foo-3.1.0.yaml` — the expected output
 
 Missing implementations are skipped rather than failing, but a missing or stale
-`-3.1.0.yaml` is a failure. The mode/implementation pairing is deliberate: spec snippets run
-only in spec mode, and classic mode never runs spec snippets.
+`-3.1.0.yaml` is a failure. The mode/implementation pairing is deliberate: spec mode runs
+only spec snippets and classic mode never runs them, but hybrid runs all three.
 
 **`ExamplesTest`** does the same for `docs/examples/specs/*`, against the per-version
 `*-3.0.0.yaml` / `*-3.1.0.yaml` / `*-3.2.0.yaml` fixtures.

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -13,7 +13,7 @@ composer performance                     # perf tests, excluded from the default
 
 ## Prefer data providers
 
-Most behaviour in this library varies along a few axes — OpenAPI version, processing mode,
+Most behavior in this library varies along a few axes — OpenAPI version, processing mode,
 annotation vs attribute vs spec input. Repeating a test body per combination gets long and
 hides which case actually failed.
 

--- a/docs/dev/writing-docs.md
+++ b/docs/dev/writing-docs.md
@@ -45,15 +45,16 @@ When you find yourself writing something a second time, that is the signal to li
 When the same text genuinely has to appear in more than one output, extract it and pull it
 in. Copying is what rots.
 
-The mechanisms already in use:
+Two mechanisms are already in use here:
 
 - `docs/snippets/preamble_*.md` — markdown fragments the reference generators splice into
   their pages, via `DocGenerator::snippetContent()`. Editing the fragment updates the
   generated page.
 - `<<< @/snippets/path.php` — transcludes a real, test-executed source file into a page, so
   a documented example cannot drift from code that runs.
-- `<!--@include: ./path.md-->` — Vitepress markdown include, for prose shared between
-  hand-written pages.
+
+A third, `<!--@include: ./path.md-->`, is supported by Vitepress but not yet used here. It
+suits prose shared between hand-written pages.
 
 Prefer extracting a fragment over pasting, and prefer generating over both where the
 content is derivable at all — see [the toolchain notes](./docs-toolchain.md) for what is
@@ -166,8 +167,10 @@ a wrong docblock or generator, not a page to hand-edit.
 - [ ] **Section anchors verified, or dropped.** A `#heading-slug` link is only safe when
       the heading is plain words — punctuation and dashes make the generated slug
       ambiguous. If you have not confirmed it, link to the page.
-- [ ] **No volatile counts.** "six pages", "around 27 test files" — derive it, or drop the
-      number and describe it qualitatively.
+- [ ] **No volatile values.** Counts ("six pages", "around 27 test files"), ports,
+      versions, anything that shifts without anyone editing the doc. Derive it, describe it
+      qualitatively, or — where the tool announces it — say that instead. A dev server that
+      prints its own URL should be documented as printing its URL, not as a port number.
 - [ ] **Version and requirement claims match** `composer.json`.
 - [ ] **No marketing filler** — "production-ready", "seamless", "powerful", "clean",
       "simply", "robust", "comprehensive".

--- a/docs/dev/writing-docs.md
+++ b/docs/dev/writing-docs.md
@@ -3,9 +3,6 @@
 Conventions for the hand-written pages under `docs/`. For which pages are generated and
 must not be edited, see [Documentation toolchain](./docs-toolchain.md).
 
-These rules exist because each was broken at some point, and the result read plausibly
-enough that nobody noticed.
-
 ## State a fact once
 
 Do not restate something the page's own structure already establishes.
@@ -64,9 +61,12 @@ already generated.
 
 ## Write about the subject, not about the documentation
 
-A reader-facing page describes the software. It does not explain how the documentation is
-produced, who each page is written for, or why a cross-reference can be trusted. That is
-maintenance commentary, and it belongs in the contributor pages.
+A page describes its subject. Unless the documentation *is* the subject — as on this page,
+or the toolchain notes — it does not explain how the docs are produced or why a
+cross-reference can be trusted.
+
+No page, of either kind, needs to announce its own audience or justify its existence. The
+title and the link that brought the reader here have already done that.
 
 Three real examples, all from one page:
 
@@ -185,9 +185,11 @@ a wrong docblock or generator, not a page to hand-edit.
 - [ ] **The level matches the audience.** User-facing pages say what something does and
       link onward; contributor pages carry the mechanism. Neither should hold the other's
       half.
-- [ ] **No commentary about the documentation itself** on reader-facing pages — how a
-      page is generated, who it is for, why a link is trustworthy. Watch for a clause
+- [ ] **No commentary about the documentation itself**, unless the docs are the page's
+      subject — how a page is generated, why a link is trustworthy. Watch for a clause
       hanging off a link that explains the link.
+- [ ] **No page announcing its own audience or purpose.** "This page is for…", "these
+      notes exist because…". Applies to contributor pages too, not just user-facing ones.
 - [ ] **Nothing restates what the page's own structure already shows.** A status table, a
       heading, or a callout already told the reader; a sentence repeating it only rots.
 - [ ] **Spelling follows the file it is in** — `docs/` is US, `src/` is British. Neither is

--- a/docs/dev/writing-docs.md
+++ b/docs/dev/writing-docs.md
@@ -87,6 +87,18 @@ The usual tell is a clause attached to a link, explaining the link. Let the link
 that work: "see [Spec pipeline internals]" is complete. Anything after the comma is the
 page talking about itself.
 
+## Enumerate closed sets only
+
+A list someone has to remember to update is a list that will be wrong.
+
+Enumerate a set only when it is **closed** — defined somewhere in code, changing only when
+that code changes. The generated pages are closed: `tools/docgen.php` names them, so a table
+listing them holds until someone edits the generator. "Everything else under `docs/`" is
+open-ended; it grows whenever anyone adds a page, so it gets described rather than listed.
+
+The same test applies to a count attached to a list. If the set can change, so can the
+number — which is why "six pages" goes along with the enumeration it summarised.
+
 ## Do not hand-write what can be captured
 
 Command output, default configuration, and API listings should be copied from the real
@@ -150,10 +162,8 @@ a wrong docblock or generator, not a page to hand-edit.
 
 ### Checks you can run
 
-- [ ] **Generated pages untouched.** Run `composer docs:gen` and confirm the pages listed
-      in [the toolchain notes](./docs-toolchain.md) are
-      unchanged. Scope the check to those files — `docs/reference/` also holds
-      hand-written pages, so a directory-wide check reports your own edits.
+- [ ] **Generated pages untouched.** `composer docs:gen` leaves no diff on the pages listed
+      in [the toolchain notes](./docs-toolchain.md).
 - [ ] **Every `composer <script>` mentioned exists** in `composer.json`.
 - [ ] **Every code reference resolves.** Class names, `Class::method()`, file paths, CLI
       flags, config keys — check each against the source. This catches the most damaging
@@ -179,6 +189,9 @@ a wrong docblock or generator, not a page to hand-edit.
 
 ### Checks that need reading
 
+- [ ] **No open-ended set enumerated.** A list is for a set defined in code, which changes
+      only when that code changes. Anything that grows when someone adds a file gets
+      described instead.
 - [ ] **Detail appears exactly once.** Two pages may introduce the same subject; only one
       may carry the specifics. If you are writing something a second time, link instead.
 - [ ] **Claims are verified, not reasoned.** Hedges — "may", "should", "is expected to" —

--- a/docs/dev/writing-docs.md
+++ b/docs/dev/writing-docs.md
@@ -23,6 +23,45 @@ Marketing filler and restatement filler are the same defect wearing different cl
 Replacing "the stable, production-ready mode" with "the only mode not marked beta" is not
 an improvement.
 
+## Detail belongs in exactly one place
+
+Orientation may appear in several places; detail may not.
+
+It is fine — often necessary — for two pages to *introduce* the same subject, because they
+are read by different people arriving from different directions. What must not happen is
+the same specifics being spelled out twice, because the two copies drift and nothing
+reveals which one is stale.
+
+The split that works is by depth, not by topic. A page aimed at users says what a thing
+does and why it matters, then links onward. The page aimed at contributors carries the
+mechanism, the rules, the exact lists. Neither repeats the other's half.
+
+`reference/architecture.md` and `dev/pipeline.md` are the worked example: the reference
+page describes the Assembler in a paragraph and links onward, while the internals page owns
+slot maps, the resolution algorithm and the root-attribute list. Before this split both
+described slot maps, augmenter ordering and the class hierarchy, in different words.
+
+When you find yourself writing something a second time, that is the signal to link instead.
+
+## Reuse the content, do not copy it
+
+When the same text genuinely has to appear in more than one output, extract it and pull it
+in. Copying is what rots.
+
+The mechanisms already in use:
+
+- `docs/snippets/preamble_*.md` — markdown fragments the reference generators splice into
+  their pages, via `DocGenerator::snippetContent()`. Editing the fragment updates the
+  generated page.
+- `<<< @/snippets/path.php` — transcludes a real, test-executed source file into a page, so
+  a documented example cannot drift from code that runs.
+- `<!--@include: ./path.md-->` — Vitepress markdown include, for prose shared between
+  hand-written pages.
+
+Prefer extracting a fragment over pasting, and prefer generating over both where the
+content is derivable at all — see [the toolchain notes](./docs-toolchain.md) for what is
+already generated.
+
 ## Do not hand-write what can be captured
 
 Command output, default configuration, and API listings should be copied from the real
@@ -38,7 +77,7 @@ options — for as long as nobody ran it.
 ## Do not cite line numbers
 
 `Class::method()` survives refactoring; `Foo.php:110` does not. Of three line references in
-`docs/adr/001`, two had already rotted.
+ADR-001, two had already rotted.
 
 ## Do not claim what you have not verified
 
@@ -46,7 +85,7 @@ If a page compares spec mode to classic mode, run both. Hedged comparisons — "
 *may* emit the array form" — are a sign the comparison was reasoned about rather than
 tested, and they are impossible for a reader to act on.
 
-Either verify and state it plainly, or document only the behaviour you know.
+Either verify and state it plainly, or document only the behavior you know.
 
 ## Do not contradict the page you are on
 
@@ -75,3 +114,53 @@ Follow whichever convention is local to the file. Neither is worth "correcting" 
   the three implementations in sync.
 - Internal links use site-absolute paths (`/reference/architecture`), not relative file
   paths, so they survive being rendered at a different depth.
+
+## Reviewing documentation changes
+
+A pass to run over a documentation diff — your own or someone else's. Every item below
+caught a real defect in this codebase at least once.
+
+Where a check fails, fix the source rather than the symptom: a wrong generated page means
+a wrong docblock or generator, not a page to hand-edit.
+
+### Checks you can run
+
+- [ ] **Generated pages untouched.** Run `composer docs:gen` and confirm the pages listed
+      in [the toolchain notes](./docs-toolchain.md) are
+      unchanged. Scope the check to those files — `docs/reference/` also holds
+      hand-written pages, so a directory-wide check reports your own edits.
+- [ ] **Every `composer <script>` mentioned exists** in `composer.json`.
+- [ ] **Every code reference resolves.** Class names, `Class::method()`, file paths, CLI
+      flags, config keys — check each against the source. This catches the most damaging
+      class of error, where confident prose describes an API that was renamed or never
+      existed.
+- [ ] **Command output was captured, not composed.** Any `--help` text, default config
+      dump or API listing should come from a real run.
+- [ ] **No line-number citations.** `Foo.php:123` rots silently; cite `Class::method()`.
+- [ ] **Links resolve.** Relative links point at files that exist; the site build fails on
+      dead internal links, so `composer docs:build` covers the rest.
+- [ ] **No volatile counts.** "six pages", "around 27 test files" — derive it, or drop the
+      number and describe it qualitatively.
+- [ ] **Version and requirement claims match** `composer.json`.
+- [ ] **No marketing filler** — "production-ready", "seamless", "powerful", "clean",
+      "simply", "robust", "comprehensive".
+- [ ] **No stock phrase repeated** across the diff. If the same formulation appears twice,
+      one of them is padding.
+
+### Checks that need reading
+
+- [ ] **Detail appears exactly once.** Two pages may introduce the same subject; only one
+      may carry the specifics. If you are writing something a second time, link instead.
+- [ ] **Claims are verified, not reasoned.** Hedges — "may", "should", "is expected to" —
+      usually mark a claim nobody tested. Run it, then state it plainly, or cut it.
+- [ ] **The page does not contradict itself.** A claim the reader must ignore two
+      paragraphs later is worse than no claim.
+- [ ] **The level matches the audience.** User-facing pages say what something does and
+      link onward; contributor pages carry the mechanism. Neither should hold the other's
+      half.
+- [ ] **Nothing restates what the page's own structure already shows.** A status table, a
+      heading, or a callout already told the reader; a sentence repeating it only rots.
+- [ ] **Spelling follows the file it is in** — `docs/` is US, `src/` is British. Neither is
+      worth correcting in bulk.
+- [ ] **Shared content is reused, not copied** — see [above](#reuse-the-content-do-not-copy-it).
+

--- a/docs/dev/writing-docs.md
+++ b/docs/dev/writing-docs.md
@@ -62,6 +62,30 @@ Prefer extracting a fragment over pasting, and prefer generating over both where
 content is derivable at all — see [the toolchain notes](./docs-toolchain.md) for what is
 already generated.
 
+## Write about the subject, not about the documentation
+
+A reader-facing page describes the software. It does not explain how the documentation is
+produced, who each page is written for, or why a cross-reference can be trusted. That is
+maintenance commentary, and it belongs in the contributor pages.
+
+Three real examples, all from one page:
+
+> The Augmenters reference — **generated from the pipeline itself, so it cannot fall out of
+> step with the code**
+
+> see Spec pipeline internals, **which is written for people changing the pipeline rather
+> than using it**
+
+> **This page stays at the level of "what happens and in what order"**
+
+Each is true, and each is invisible to the only question the reader has, which is how the
+thing works. Whether a reference is generated matters to whoever maintains it; the reader
+just follows the link.
+
+The usual tell is a clause attached to a link, explaining the link. Let the link text do
+that work: "see [Spec pipeline internals]" is complete. Anything after the comma is the
+page talking about itself.
+
 ## Do not hand-write what can be captured
 
 Command output, default configuration, and API listings should be copied from the real
@@ -139,6 +163,9 @@ a wrong docblock or generator, not a page to hand-edit.
 - [ ] **No line-number citations.** `Foo.php:123` rots silently; cite `Class::method()`.
 - [ ] **Links resolve.** Relative links point at files that exist; the site build fails on
       dead internal links, so `composer docs:build` covers the rest.
+- [ ] **Section anchors verified, or dropped.** A `#heading-slug` link is only safe when
+      the heading is plain words — punctuation and dashes make the generated slug
+      ambiguous. If you have not confirmed it, link to the page.
 - [ ] **No volatile counts.** "six pages", "around 27 test files" — derive it, or drop the
       number and describe it qualitatively.
 - [ ] **Version and requirement claims match** `composer.json`.
@@ -158,6 +185,9 @@ a wrong docblock or generator, not a page to hand-edit.
 - [ ] **The level matches the audience.** User-facing pages say what something does and
       link onward; contributor pages carry the mechanism. Neither should hold the other's
       half.
+- [ ] **No commentary about the documentation itself** on reader-facing pages — how a
+      page is generated, who it is for, why a link is trustworthy. Watch for a clause
+      hanging off a link that explains the link.
 - [ ] **Nothing restates what the page's own structure already shows.** A status table, a
       heading, or a callout already told the reader; a sentence repeating it only rots.
 - [ ] **Spelling follows the file it is in** — `docs/` is US, `src/` is British. Neither is

--- a/docs/dev/writing-docs.md
+++ b/docs/dev/writing-docs.md
@@ -1,0 +1,77 @@
+# Writing documentation
+
+Conventions for the hand-written pages under `docs/`. For which pages are generated and
+must not be edited, see [Documentation toolchain](./docs-toolchain.md).
+
+These rules exist because each was broken at some point, and the result read plausibly
+enough that nobody noticed.
+
+## State a fact once
+
+Do not restate something the page's own structure already establishes.
+
+The beta status of the spec pipeline, for example, is carried by the **Status** row in
+`guide/modes.md`, by `(beta)` in the section headings, by the `::: warning Beta` callouts,
+by the version timeline, and by the 🧪 in the page titles. A sentence saying "this is the
+only mode not marked beta" adds nothing and rots independently of the places that do.
+
+The test is not "does this sentence read well" but "does the reader learn anything here
+they could not already see". This applies to maturity, version requirements, which
+namespace to use, and what a mode does.
+
+Marketing filler and restatement filler are the same defect wearing different clothes.
+Replacing "the stable, production-ready mode" with "the only mode not marked beta" is not
+an improvement.
+
+## Do not hand-write what can be captured
+
+Command output, default configuration, and API listings should be copied from the real
+thing, not composed. A hand-written `openapi -h` block once carried the wrong format, a
+wrong `--mode` description, a `--version` default that did not exist, and four missing
+options — for as long as nobody ran it.
+
+```shell
+./bin/openapi -h            # capture this
+./bin/openapi --mode spec -D src
+```
+
+## Do not cite line numbers
+
+`Class::method()` survives refactoring; `Foo.php:110` does not. Of three line references in
+`docs/adr/001`, two had already rotted.
+
+## Do not claim what you have not verified
+
+If a page compares spec mode to classic mode, run both. Hedged comparisons — "classic mode
+*may* emit the array form" — are a sign the comparison was reasoned about rather than
+tested, and they are impossible for a reader to act on.
+
+Either verify and state it plainly, or document only the behaviour you know.
+
+## Do not contradict the page you are on
+
+Two examples from the same page:
+
+- attributes described as "immutable" while the augmenter section describes writing to them
+- "all modes produce the same output", immediately above a table of differences between
+  modes
+
+If a claim needs the reader to ignore the next paragraph, cut the claim.
+
+## Spelling
+
+`docs/` is US-spelled throughout (`behavior`, `serialization`, `organized`) — the OpenAPI
+specification text it quotes is US-spelled, and the docs follow. `src/` uses British
+spelling for identifiers and prose (`normalise`), except `serializ*`, which is US
+everywhere.
+
+Follow whichever convention is local to the file. Neither is worth "correcting" in bulk.
+
+## Structure
+
+- Code snippets under `docs/snippets/` are executed by the test suite — see
+  [Testing](./testing.md) for what a new snippet requires.
+- The `<codeblock>` component renders annotation / attribute / spec variants as tabs; keep
+  the three implementations in sync.
+- Internal links use site-absolute paths (`/reference/architecture`), not relative file
+  paths, so they survive being rendered at a different depth.

--- a/docs/dev/writing-docs.md
+++ b/docs/dev/writing-docs.md
@@ -1,7 +1,7 @@
 # Writing documentation
 
 Conventions for the hand-written pages under `docs/`. For which pages are generated and
-must not be edited, see [Documentation toolchain](./docs-toolchain.md).
+must not be edited, see [Documentation toolchain](/dev/docs-toolchain).
 
 ## State a fact once
 
@@ -57,7 +57,7 @@ A third, `<!--@include: ./path.md-->`, is supported by Vitepress but not yet use
 suits prose shared between hand-written pages.
 
 Prefer extracting a fragment over pasting, and prefer generating over both where the
-content is derivable at all — see [the toolchain notes](./docs-toolchain.md) for what is
+content is derivable at all — see [the toolchain notes](/dev/docs-toolchain) for what is
 already generated.
 
 ## Write about the subject, not about the documentation
@@ -136,17 +136,16 @@ If a claim needs the reader to ignore the next paragraph, cut the claim.
 
 ## Spelling
 
-`docs/` is US-spelled throughout (`behavior`, `serialization`, `organized`) — the OpenAPI
-specification text it quotes is US-spelled, and the docs follow. `src/` uses British
-spelling for identifiers and prose (`normalise`), except `serializ*`, which is US
-everywhere.
+The codebase is mixed. `normalise` sits alongside `serialization`; both spellings of
+`behavio(u)r` appear in `src/` and in `docs/`. There is no single convention to appeal to.
 
-Follow whichever convention is local to the file. Neither is worth "correcting" in bulk.
+Match whatever the file you are editing already uses, and leave the rest alone. A bulk
+correction would churn far more than it fixes.
 
 ## Structure
 
 - Code snippets under `docs/snippets/` are executed by the test suite — see
-  [Testing](./testing.md) for what a new snippet requires.
+  [Testing](/dev/testing) for what a new snippet requires.
 - The `<codeblock>` component renders annotation / attribute / spec variants as tabs; keep
   the three implementations in sync.
 - Internal links use site-absolute paths (`/reference/architecture`), not relative file
@@ -163,7 +162,7 @@ a wrong docblock or generator, not a page to hand-edit.
 ### Checks you can run
 
 - [ ] **Generated pages untouched.** `composer docs:gen` leaves no diff on the pages listed
-      in [the toolchain notes](./docs-toolchain.md).
+      in [the toolchain notes](/dev/docs-toolchain).
 - [ ] **Every `composer <script>` mentioned exists** in `composer.json`.
 - [ ] **Every code reference resolves.** Class names, `Class::method()`, file paths, CLI
       flags, config keys — check each against the source. This catches the most damaging

--- a/docs/guide/under-the-hood.md
+++ b/docs/guide/under-the-hood.md
@@ -40,10 +40,8 @@ npm install
 
 ### Workflow
 
-* Edit `.md` files in the `docs` folder
-* Update annotation / attribute PHP docblocks.<br>These will be extracted during publishing into the [reference](../reference/) section.
-* Run 'composer docs:build' to check for any errors
-* Run 'composer docs:dev' to test the generated documentation locally; it prints the URL on startup
+* Edit `.md` files in the `docs` folder — see [the toolchain notes](/dev/docs-toolchain) for
+  which pages are generated from source and must not be edited by hand, and for the commands
 * Create PR and update `master`
 * Manually trigger the `gh-pages` workflow to update the online docs.
 

--- a/docs/guide/under-the-hood.md
+++ b/docs/guide/under-the-hood.md
@@ -43,7 +43,7 @@ npm install
 * Edit `.md` files in the `docs` folder
 * Update annotation / attribute PHP docblocks.<br>These will be extracted during publishing into the [reference](../reference/) section.
 * Run 'composer docs:build' to check for any errors
-* Run 'composer docs:dev' to test the generated documentation locally (`localhost:3000`)
+* Run 'composer docs:dev' to test the generated documentation locally; it prints the URL on startup
 * Create PR and update `master`
 * Manually trigger the `gh-pages` workflow to update the online docs.
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -1,7 +1,7 @@
 # 🧪 Spec Pipeline Architecture
 
 An overview of how the spec attributes pipeline turns your source code into an OpenAPI
-document — enough context to configure it, extend it, or reason about its output.
+document.
 
 For the internals — how nesting is resolved, why the DTOs are shaped the way they are —
 see [Spec pipeline internals](/dev/pipeline).

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -4,8 +4,7 @@ An overview of how the spec attributes pipeline turns your source code into an O
 document — enough context to configure it, extend it, or reason about its output.
 
 For the internals — how nesting is resolved, why the DTOs are shaped the way they are —
-see [Spec pipeline internals](/dev/pipeline), which is written for people changing the
-pipeline rather than using it.
+see [Spec pipeline internals](/dev/pipeline).
 
 ## Pipeline overview
 
@@ -29,7 +28,7 @@ class's schema.
 Each attribute declares where it can go, rather than the Assembler hard-coding the rules.
 That is what lets you introduce your own attributes and have them nest correctly. The
 declaration mechanism is described in
-[Spec pipeline internals](/dev/pipeline#slot-maps-the-slot-belongs-to-the-parent).
+[Spec pipeline internals](/dev/pipeline).
 
 Whatever is left once nesting is resolved is added to the Specification.
 
@@ -52,9 +51,8 @@ Augmenters form a grouped pipeline that enriches the Specification in three orde
 | **Augment** | Add derived metadata                                          |
 
 Each augmenter implements `PipeInterface` and receives the full Specification, and those
-within a phase run in registration order. Which augmenters belong to each phase, in the
-order they run, is listed in the [Augmenters reference](/reference/augmenters) — generated
-from the pipeline itself, so it cannot fall out of step with the code.
+within a phase run in registration order. The [Augmenters reference](/reference/augmenters)
+lists which augmenters belong to each phase, in the order they run.
 
 ### Configuring augmenters
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -1,6 +1,11 @@
 # 🧪 Spec Pipeline Architecture
 
-This page documents the internals of the spec attributes pipeline — for users who want to understand how it works, write custom augmenters, or debug pipeline behavior.
+An overview of how the spec attributes pipeline turns your source code into an OpenAPI
+document — enough context to configure it, extend it, or reason about its output.
+
+For the internals — how nesting is resolved, why the DTOs are shaped the way they are —
+see [Spec pipeline internals](/dev/pipeline), which is written for people changing the
+pipeline rather than using it.
 
 ## Pipeline overview
 
@@ -16,37 +21,17 @@ Source files → Assembler → Specification → Augmenters → Compiler → Ope
 
 ## Assembler
 
-The Assembler collects spec attributes from source files and resolves their nesting relationships.
+The Assembler reads spec attributes off your classes, methods, properties and parameters,
+and works out which ones belong inside which. An `#[OA\Response]` on a method ends up
+inside that method's operation; an `#[OA\Property]` on a class property ends up inside the
+class's schema.
 
-### Slot-map driven nesting
+Each attribute declares where it can go, rather than the Assembler hard-coding the rules.
+That is what lets you introduce your own attributes and have them nest correctly. The
+declaration mechanism is described in
+[Spec pipeline internals](/dev/pipeline#slot-maps-the-slot-belongs-to-the-parent).
 
-Each attribute declares its relationships via two methods:
-
-- `merge()` returns `[TargetClass => 'slot']` — how this attribute composes into siblings on the same reflector
-- `contained()` returns `[ParentClass => 'slot']` — which outer-level attribute types can absorb this attribute from inner reflector levels
-
-Slots use `[]` suffix for collection append (`'parameters[]'`), bare name for scalar assignment (`'requestBody'`).
-
-Both methods are child-driven: the attribute itself declares where it can go, whether same-level (merge) or cross-level (contained). This is what lets downstream code extend the system: custom attachables declare their own nesting targets without modifying native attributes.
-
-### Level-by-level resolution
-
-Assembler resolution itself is purely attribute-relationship driven — no PHP structural semantics:
-
-1. **Sibling merge** — attributes on the same reflector compose via `merge()` maps
-2. **Hierarchical absorb** — resolved attributes flow upward level by level via `contained()` maps (first match wins). If a level has containers, unmatched non-roots are errors. If a level has no containers, unmatched attributes pass through to the next level up.
-
-After resolution, only root attributes (should) remain and are added to the Specification.
-
-### Root attributes
-
-A "root" attribute is one that can exist independently in the Specification — it has its own bucket and doesn't require a parent container.
-
-Always root: `Schema`, `Operation`, `PathItem`, `OpenApi`, `Info`, `Tag`, `Server`, `ExternalDocumentation`, `Security\Scheme`, `Components`, `Attachable`
-
-Conditionally root: `Response` (when `response` key is set), `RequestBody` (when `request` key is set)
-
-Never root: `Parameter`, `Header`, `Link`, `Example`, `MediaType`, `Property`, etc. — these must be nested inside a parent or wrapped in a `Components` container.
+Whatever is left once nesting is resolved is added to the Specification.
 
 ## Specification
 
@@ -60,13 +45,16 @@ Augmenters form a grouped pipeline that enriches the Specification in three orde
 
 ### Pipeline phases
 
-| Phase       | Purpose                                                       | Examples                                                                   |
-| ----------- | ------------------------------------------------------------- | -------------------------------------------------------------------------- |
-| **Resolve** | Infer data from PHP reflection and cross-bucket relationships | `Inheritance`, `Names`, `Enums`, `Shortcuts`, `PathItems`, `Types`, `Refs` |
-| **Reduce**  | Filter or remove entries                                      | `PathFilter`, `Cleanup`                                                    |
-| **Augment** | Add derived metadata                                          | `MediaTypes`, `Docblocks`, `OperationIds`, `Tags`, `EnumDescriptions`      |
+| Phase       | Purpose                                                       |
+| ----------- | ------------------------------------------------------------- |
+| **Resolve** | Infer data from PHP reflection and cross-bucket relationships |
+| **Reduce**  | Filter or remove entries                                      |
+| **Augment** | Add derived metadata                                          |
 
-Each augmenter implements `PipeInterface` and receives the full Specification. Augmenters within a phase run in registration order, which is defined in `Builder::getDefaultAugmenters()`.
+Each augmenter implements `PipeInterface` and receives the full Specification, and those
+within a phase run in registration order. Which augmenters belong to each phase, in the
+order they run, is listed in the [Augmenters reference](/reference/augmenters) — generated
+from the pipeline itself, so it cannot fall out of step with the code.
 
 ### Configuring augmenters
 
@@ -136,45 +124,6 @@ Each OpenAPI version has its own compiler that handles version-specific output d
 | `OpenApi32Compiler` | 3.2.x   | Extends 3.1 (currently without additional features)               |
 
 The compiler transforms a Specification into a plain PHP array representing the OpenAPI document. Version selection is automatic based on `Builder::setVersion()` or the `#[OA\OpenApi(version: '...')]` attribute.
-
-## Design principles
-
-### Normalise early, store simple
-
-When a property has both a rich input type (e.g. a PHP enum) and a plain serialization type (e.g. string), accept both on input but normalise to the plain type immediately in the constructor. Properties always store the simple form — enums, objects, and convenience types are input sugar only. This keeps downstream code (augmenters, compilers, serialization) free of type-checking branches.
-
-```php
-// Example: FlowType enum accepted on input, stored as string
-public function __construct(string|FlowType|null $flow = null) {
-    parent::__construct([
-        'flow' => $flow instanceof \BackedEnum ? $flow->value : $flow,
-    ]);
-}
-```
-
-### Reflectors as glue
-
-Every root DTO carries its originating reflector (`ReflectionClass`, `ReflectionMethod`, etc.). This is the fundamental mechanism for resolving cross-bucket relationships at augmentation time.
-
-Key applications:
-
-- **PathItem ↔ Operation binding** — PathItem is placed on a class; operations on methods of that class. The `PathItems` augmenter walks `ReflectionMethod::getDeclaringClass()` to find which PathItem governs an operation.
-- **Prefix composition via inheritance** — PathItems on parent classes contribute prefixes. The augmenter walks `ReflectionClass::getParentClass()` to compose the full path prefix chain.
-- **OperationId generation** — the reflector provides class/method name context for auto-generated identifiers.
-- **Type inference** — the `Types` augmenter reads PHP type declarations from property/parameter reflectors.
-
-This design keeps the Assembler focused on nesting resolution and makes cross-cutting relationships resolvable without coupling DTOs to each other.
-
-### DTO class tree
-
-All spec attributes extend `AbstractAttribute` and live in the `OpenApi\Spec` namespace.
-Typed subclasses (e.g. `Operation\Get`, `Parameter\Path`) pre-fill fields that the base class
-requires explicitly; the base class can always be used directly for full control.
-
-Note that the directory layout does not mirror the class hierarchy: `Property` extends
-`AbstractAttribute` rather than `Schema`, `Encoding` is not a `MediaType`, and `Security` is a
-namespace rather than a class. For the current attributes, what each one accepts and where it
-can be nested, see the generated [Spec Attributes reference](/reference/spec-attributes).
 
 ## Classic processor mapping
 


### PR DESCRIPTION
## Summary

Adds contributor-facing documentation for the spec pipeline, written for humans and coding
agents alike.

- **`docs/dev/`** — four pages: spec pipeline internals, testing conventions, the
  documentation toolchain, and conventions for writing documentation
- **`AGENTS.md`** — project instructions moved to a vendor-neutral file that `CLAUDE.md`
  imports, so other tools read the same source rather than a copy
- **`CONTEXT.md`** — the `Generator` entry advised avoiding "builder" and "compiler"; both
  now name real classes. Adds the spec-pipeline vocabulary, and flags *augment* as
  overloaded between the two pipelines
- **`CONTRIBUTING.md`** — a pre-PR checklist, and branch naming corrected to the
  `type/short-description` form actually in use
- **`composer test` no longer runs lint**, so each script does one thing and `build.yml` can
  call `composer test` like the other workflows already do. No coverage gap —
  `code-style.yml` runs `composer lint` independently

The later commits are review findings against the rules this PR introduces: a wrong
root-attribute list, a code example that did not match its source, `/dev/` pages rendering
with no sidebar, and content duplicated across pages. Four rules were added or widened as a
result, each derived from a defect that survived several read-throughs.

Also corrects a stale claim predating this branch: `composer redocly` passes.

Verified: `composer lint`, `composer analyse`, 1797 tests, `composer docs:gen` leaving no
diff, and a clean site build.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Enhancement (improvement to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactor (no functional changes)
- [ ] Chore (maintenance, dependencies, CI)

## Related Issues

<!-- Link related issues: Fixes #123, Closes #456 -->

## Test Plan

<!-- Describe the tests you ran or plan to run to verify the changes. -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation accordingly
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass locally
- [ ] Any dependent changes have been merged and published

