### PR TITLE
fix(Tests): tolerate the 3.0 mutualTLS warning in ScratchTest

### DIFF
--- a/tests/ScratchTest.php
+++ b/tests/ScratchTest.php
@@ -31,6 +31,7 @@ final class ScratchTest extends OpenApiTestCase
         // Compiler diagnostics raised in spec mode only. Tolerated rather than expected:
         // the key has no mode component, so demanding them would fail the classic case.
         $ignoredLogs = [
+            'Auth-3.0.0' => ['mutualTLS security schemes are not supported in OpenAPI 3.0'],
             'Docblocks-3.0.0' => ['const is not supported in OpenAPI 3.0'],
             'Tags-3.2.0' => ['references non-existent parent'],
         ];


### PR DESCRIPTION
`master` currently fails: `ScratchTest::testScratch@type-info-Auth-3.0.0-8.3-spec`

```
Unexpected log line: warning("mutualTLS security schemes are not supported in OpenAPI 3.0 and will be omitted")
```

Neither of the two PRs behind it fails on its own:

- #2137 added the mutualTLS warning to `OpenApi30Compiler`, but compiler diagnostics were not reaching the test's tracking logger at that point, so nothing had to declare the warning.
- #2138 routed compiler diagnostics to the configured logger, which made it visible.

#2138 introduced `$ignoredLogs` for exactly this case and seeded it with two entries. #2137 merged afterwards and added a third warning without one.

This adds the missing entry.

The warning is spec-only — classic `Auth` has no mutualTLS scheme, since `OAT\SecurityScheme` validates `type` against `http` / `apiKey` / `oauth2` / `openIdConnect`. Because the log key is `{fixture}-{version}` with no mode component, an *expectation* would fail the classic case, so it can only be tolerated. That silences the warning rather than asserting it, which is the same limitation the other two entries have.

Verified: `composer test` (1822 tests), `composer analyse` and `composer lint` all clean.