### PR TITLE
chore(Deps): follow rector 2.6.5 rule changes and pin tooling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,10 +72,10 @@
     },
     "require-dev": {
         "doctrine/annotations": "^2.0",
-        "friendsofphp/php-cs-fixer": "^3.62",
+        "friendsofphp/php-cs-fixer": "3.95.23",
         "phpstan/phpstan": "^2.2",
         "phpunit/phpunit": "^11.5 || >=12.5.22",
-        "rector/rector": "^2.3"
+        "rector/rector": "2.6.5"
     },
     "conflict": {
         "symfony/process": ">=6, <6.4.14"

--- a/src/Annotations/AbstractAnnotation.php
+++ b/src/Annotations/AbstractAnnotation.php
@@ -469,7 +469,7 @@ abstract class AbstractAnnotation implements \JsonSerializable
         }
 
         // validate refs
-        if ($analysis?->openapi && property_exists($this, 'ref') && !Undefined::isDefault($this->ref) && is_string($this->ref)) {
+        if ($analysis?->openapi instanceof OpenApi && property_exists($this, 'ref') && !Undefined::isDefault($this->ref) && is_string($this->ref)) {
             if (str_starts_with($this->ref, '#/')) {
                 try {
                     $analysis->openapi->ref($this->ref);

--- a/src/Context.php
+++ b/src/Context.php
@@ -64,7 +64,7 @@ class Context implements \Stringable
         return array_filter(get_object_vars($this), static function ($value): bool {
             $rc = is_object($value) ? new \ReflectionClass($value) : null;
 
-            return (!$rc || !$rc->isAnonymous())
+            return (!$rc instanceof \ReflectionClass || !$rc->isAnonymous())
                 && !$value instanceof \Reflector
                 && !$value instanceof \Closure;
         });

--- a/src/Type/LegacyTypeResolver.php
+++ b/src/Type/LegacyTypeResolver.php
@@ -186,7 +186,7 @@ class LegacyTypeResolver extends AbstractTypeResolver
     {
         $docComment = match (true) {
             $reflector instanceof \ReflectionProperty => $reflector->isPromoted()
-            && $reflector->getDeclaringClass() && $reflector->getDeclaringClass()->getConstructor()
+            && $reflector->getDeclaringClass() instanceof \ReflectionClass && $reflector->getDeclaringClass()->getConstructor() instanceof \ReflectionMethod
                 ? $reflector->getDeclaringClass()->getConstructor()->getDocComment()
                 : $reflector->getDocComment(),
             $reflector instanceof \ReflectionParameter => $reflector->getDeclaringFunction()->getDocComment(),

--- a/src/Type/TypeResolver.php
+++ b/src/Type/TypeResolver.php
@@ -62,7 +62,7 @@ class TypeResolver
         }
 
         $nullable = null;
-        if (($docblockType && $docblockType->isNullable()) || ($reflectionType && $reflectionType->isNullable())) {
+        if (($docblockType instanceof Type && $docblockType->isNullable()) || ($reflectionType instanceof Type && $reflectionType->isNullable())) {
             $nullable = true;
         }
 
@@ -86,7 +86,7 @@ class TypeResolver
     {
         $docComment = match (true) {
             $reflector instanceof \ReflectionProperty => $reflector->isPromoted()
-                && $reflector->getDeclaringClass() && $reflector->getDeclaringClass()->getConstructor()
+                && $reflector->getDeclaringClass() instanceof \ReflectionClass && $reflector->getDeclaringClass()->getConstructor() instanceof \ReflectionMethod
                     ? $reflector->getDeclaringClass()->getConstructor()->getDocComment()
                     : $reflector->getDocComment(),
             $reflector instanceof \ReflectionParameter => $reflector->getDeclaringFunction()->getDocComment(),


### PR DESCRIPTION
`composer.lock` is not committed and CI installs `dependency-versions: highest`, so a new rector or php-cs-fixer release turns unrelated PRs red.

Rector 2.6.5 added `BinaryOpNullableToInstanceofRector`, applied to `AbstractAnnotation`, `Context`, `LegacyTypeResolver` and `TypeResolver`.

Pinned `rector/rector` to 2.6.5 and `friendsofphp/php-cs-fixer` to 3.95.23. Both are `require-dev`, so consumers are unaffected.