### PR TITLE
test(Spec): add scratch fixtures for Head/Options/Trace and Link roots

### DIFF
--- a/tests/Fixtures/Scratch/HttpMethods-spec.php
+++ b/tests/Fixtures/Scratch/HttpMethods-spec.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace Fixtures\Scratch;
+
+use OpenApi\Spec as OA;
+
+#[OA\Info(title: 'Http Methods', version: '1.0')]
+class HttpMethodsControllerSpec
+{
+    #[OA\Operation\Head(
+        path: '/things',
+        operationId: 'headThings',
+        responses: [
+            new OA\Response(response: 200, description: 'Headers only, no body'),
+        ],
+    )]
+    public function headThings()
+    {
+    }
+
+    #[OA\Operation\Options(
+        path: '/things',
+        operationId: 'optionsThings',
+        responses: [
+            new OA\Response(response: 200, description: 'Allowed methods'),
+        ],
+    )]
+    public function optionsThings()
+    {
+    }
+
+    #[OA\Operation\Trace(
+        path: '/things',
+        operationId: 'traceThings',
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Echo of the request',
+                content: new OA\MediaType(mediaType: 'message/http', schema: new OA\Schema(type: 'string')),
+            ),
+        ],
+    )]
+    public function traceThings()
+    {
+    }
+}

--- a/tests/Fixtures/Scratch/HttpMethods.php
+++ b/tests/Fixtures/Scratch/HttpMethods.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Scratch;
+
+use OpenApi\Attributes as OAT;
+
+#[OAT\Info(title: 'Http Methods', version: '1.0')]
+class HttpMethodsController
+{
+    #[OAT\Head(
+        path: '/things',
+        operationId: 'headThings',
+        responses: [
+            new OAT\Response(response: 200, description: 'Headers only, no body'),
+        ],
+    )]
+    public function headThings()
+    {
+    }
+
+    #[OAT\Options(
+        path: '/things',
+        operationId: 'optionsThings',
+        responses: [
+            new OAT\Response(response: 200, description: 'Allowed methods'),
+        ],
+    )]
+    public function optionsThings()
+    {
+    }
+
+    #[OAT\Trace(
+        path: '/things',
+        operationId: 'traceThings',
+        responses: [
+            new OAT\Response(
+                response: 200,
+                description: 'Echo of the request',
+                content: new OAT\MediaType(mediaType: 'message/http', schema: new OAT\Schema(type: 'string')),
+            ),
+        ],
+    )]
+    public function traceThings()
+    {
+    }
+}

--- a/tests/Fixtures/Scratch/HttpMethods3.0.0.yaml
+++ b/tests/Fixtures/Scratch/HttpMethods3.0.0.yaml
@@ -1,0 +1,25 @@
+openapi: 3.0.0
+info:
+  title: 'Http Methods'
+  version: '1.0'
+paths:
+  /things:
+    head:
+      operationId: headThings
+      responses:
+        200:
+          description: 'Headers only, no body'
+    options:
+      operationId: optionsThings
+      responses:
+        200:
+          description: 'Allowed methods'
+    trace:
+      operationId: traceThings
+      responses:
+        200:
+          description: 'Echo of the request'
+          content:
+            message/http:
+              schema:
+                type: string

--- a/tests/Fixtures/Scratch/HttpMethods3.1.0.yaml
+++ b/tests/Fixtures/Scratch/HttpMethods3.1.0.yaml
@@ -1,0 +1,25 @@
+openapi: 3.1.0
+info:
+  title: 'Http Methods'
+  version: '1.0'
+paths:
+  /things:
+    head:
+      operationId: headThings
+      responses:
+        200:
+          description: 'Headers only, no body'
+    options:
+      operationId: optionsThings
+      responses:
+        200:
+          description: 'Allowed methods'
+    trace:
+      operationId: traceThings
+      responses:
+        200:
+          description: 'Echo of the request'
+          content:
+            message/http:
+              schema:
+                type: string

--- a/tests/Fixtures/Scratch/HttpMethods3.2.0.yaml
+++ b/tests/Fixtures/Scratch/HttpMethods3.2.0.yaml
@@ -1,0 +1,25 @@
+openapi: 3.2.0
+info:
+  title: 'Http Methods'
+  version: '1.0'
+paths:
+  /things:
+    head:
+      operationId: headThings
+      responses:
+        200:
+          description: 'Headers only, no body'
+    options:
+      operationId: optionsThings
+      responses:
+        200:
+          description: 'Allowed methods'
+    trace:
+      operationId: traceThings
+      responses:
+        200:
+          description: 'Echo of the request'
+          content:
+            message/http:
+              schema:
+                type: string

--- a/tests/Fixtures/Scratch/Link-spec.php
+++ b/tests/Fixtures/Scratch/Link-spec.php
@@ -24,9 +24,10 @@ class LinkControllerSpec
             ),
         ],
     )]
-    #[OA\Parameter\Path(name: 'id', schema: new OA\Schema(type: 'string'))]
-    public function getWidget()
-    {
+    public function getWidget(
+        #[OA\Parameter\Path(name: 'id', schema: new OA\Schema(type: 'string'))]
+        string $id
+    ) {
     }
 
     #[OA\Operation\Get(

--- a/tests/Fixtures/Scratch/Link-spec.php
+++ b/tests/Fixtures/Scratch/Link-spec.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace Fixtures\Scratch;
+
+use OpenApi\Spec as OA;
+
+#[OA\Info(title: 'Link', version: '1.0')]
+class LinkControllerSpec
+{
+    #[OA\Operation\Get(
+        path: '/widgets/{id}',
+        operationId: 'getWidget',
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'The widget',
+                links: [
+                    new OA\Link(link: 'widgetOwner', ref: '#/components/links/WidgetOwner'),
+                ],
+            ),
+        ],
+    )]
+    #[OA\Parameter\Path(name: 'id', schema: new OA\Schema(type: 'string'))]
+    public function getWidget()
+    {
+    }
+
+    #[OA\Operation\Get(
+        path: '/owners/{id}',
+        operationId: 'getOwner',
+        responses: [
+            new OA\Response(response: 200, description: 'The owner'),
+        ],
+    )]
+    #[OA\Parameter\Path(name: 'id', schema: new OA\Schema(type: 'string'))]
+    #[OA\Link(link: 'WidgetOwner', operationId: 'getOwner', parameters: ['id' => '$response.body#/ownerId'])]
+    public function getOwner()
+    {
+    }
+}

--- a/tests/Fixtures/Scratch/Link.php
+++ b/tests/Fixtures/Scratch/Link.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Scratch;
+
+use OpenApi\Attributes as OAT;
+
+#[OAT\Info(title: 'Link', version: '1.0')]
+class LinkController
+{
+    #[OAT\Get(
+        path: '/widgets/{id}',
+        operationId: 'getWidget',
+        responses: [
+            new OAT\Response(
+                response: 200,
+                description: 'The widget',
+                links: [
+                    new OAT\Link(link: 'widgetOwner', ref: '#/components/links/WidgetOwner'),
+                ],
+            ),
+        ],
+    )]
+    #[OAT\PathParameter(name: 'id', schema: new OAT\Schema(type: 'string'))]
+    public function getWidget()
+    {
+    }
+
+    #[OAT\Get(
+        path: '/owners/{id}',
+        operationId: 'getOwner',
+        responses: [
+            new OAT\Response(response: 200, description: 'The owner'),
+        ],
+    )]
+    #[OAT\PathParameter(name: 'id', schema: new OAT\Schema(type: 'string'))]
+    #[OAT\Link(link: 'WidgetOwner', operationId: 'getOwner', parameters: ['id' => '$response.body#/ownerId'])]
+    public function getOwner()
+    {
+    }
+}

--- a/tests/Fixtures/Scratch/Link3.0.0.yaml
+++ b/tests/Fixtures/Scratch/Link3.0.0.yaml
@@ -1,0 +1,40 @@
+openapi: 3.0.0
+info:
+  title: Link
+  version: '1.0'
+paths:
+  '/widgets/{id}':
+    get:
+      operationId: getWidget
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: 'The widget'
+          links:
+            widgetOwner:
+              $ref: '#/components/links/WidgetOwner'
+  '/owners/{id}':
+    get:
+      operationId: getOwner
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: 'The owner'
+components:
+  links:
+    WidgetOwner:
+      operationId: getOwner
+      parameters:
+        id: '$response.body#/ownerId'

--- a/tests/Fixtures/Scratch/Link3.1.0.yaml
+++ b/tests/Fixtures/Scratch/Link3.1.0.yaml
@@ -1,0 +1,40 @@
+openapi: 3.1.0
+info:
+  title: Link
+  version: '1.0'
+paths:
+  '/widgets/{id}':
+    get:
+      operationId: getWidget
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: 'The widget'
+          links:
+            widgetOwner:
+              $ref: '#/components/links/WidgetOwner'
+  '/owners/{id}':
+    get:
+      operationId: getOwner
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: 'The owner'
+components:
+  links:
+    WidgetOwner:
+      operationId: getOwner
+      parameters:
+        id: '$response.body#/ownerId'

--- a/tests/Fixtures/Scratch/Link3.2.0.yaml
+++ b/tests/Fixtures/Scratch/Link3.2.0.yaml
@@ -1,0 +1,40 @@
+openapi: 3.2.0
+info:
+  title: Link
+  version: '1.0'
+paths:
+  '/widgets/{id}':
+    get:
+      operationId: getWidget
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: 'The widget'
+          links:
+            widgetOwner:
+              $ref: '#/components/links/WidgetOwner'
+  '/owners/{id}':
+    get:
+      operationId: getOwner
+      parameters:
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: 'The owner'
+components:
+  links:
+    WidgetOwner:
+      operationId: getOwner
+      parameters:
+        id: '$response.body#/ownerId'


### PR DESCRIPTION
## Summary
- Add `HttpMethods`/`HttpMethods-spec` scratch fixtures exercising the `Head`/`Options`/`Trace` shorthand operations end-to-end, classic and spec.
- Add `Link`/`Link-spec` scratch fixtures exercising `Link::isRoot()` both ways: a root link (no `ref`) that lands in `components.links`, and a non-root link (`ref` set) referenced from a response.