### PR TITLE
feat(Augmenter): add #[Config] attribute for declaring settings

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,7 @@ technical detail unless it's fundamental to understanding the change. -->
 
 ## Changes
 
-<!-- Key changes, high level. No code snippets unless genuinely unavoidable. -->
+<!-- Key changes, high level. No code snippets unless genuinely unavoidable. Wrap class
+names, method calls, file paths and other identifiers in backticks. -->
 
 -

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,9 @@
 ## Overview
 
 <!-- Why this change exists — the problem or situation, not the implementation. Skip
-technical detail unless it's fundamental to understanding the change. -->
+technical detail unless it's fundamental to understanding the change. Keep to the changes
+at hand: no history of earlier attempts, abandoned branches or related work elsewhere,
+unless it has a direct bearing on this diff. -->
 
 ## Changes
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+## Overview
+
+<!-- Why this change exists — the problem or situation, not the implementation. Skip
+technical detail unless it's fundamental to understanding the change. -->
+
+## Changes
+
+<!-- Key changes, high level. No code snippets unless genuinely unavoidable. -->
+
+-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,10 @@ for the conventions those pages follow.
 
 Pull request titles follow `type(Scope): subject`, e.g. `feat(Spec): add encoding shortcut`.
 
+Pull request descriptions follow the [template](.github/PULL_REQUEST_TEMPLATE.md): a short
+**Overview** explaining why the change exists, in plain language — the problem, not the
+implementation — followed by a **Changes** list of the key changes, kept high level and
+free of code snippets unless one is genuinely unavoidable.
 
 ## Documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,8 @@ Pull request titles follow `type(Scope): subject`, e.g. `feat(Spec): add encodin
 Pull request descriptions follow the [template](.github/PULL_REQUEST_TEMPLATE.md): a short
 **Overview** explaining why the change exists, in plain language — the problem, not the
 implementation — followed by a **Changes** list of the key changes, kept high level and
-free of code snippets unless one is genuinely unavoidable.
+free of code snippets unless one is genuinely unavoidable. Wrap class names, method calls,
+file paths and other identifiers in backticks.
 
 ## Documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,10 @@ implementation — followed by a **Changes** list of the key changes, kept high 
 free of code snippets unless one is genuinely unavoidable. Wrap class names, method calls,
 file paths and other identifiers in backticks.
 
+Keep the description to the changes at hand. History that lives elsewhere — earlier
+attempts, abandoned branches, related work in other pull requests — belongs in the issue
+or commit trail, not here, unless it has a direct bearing on the change being reviewed.
+
 ## Documentation
 
 The documentation website is build from the [docs](docs/) folder with [vitepress](https://vitepress.vuejs.org).

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -143,6 +143,39 @@ class CustomAugmenter implements PipeInterface
 }
 ```
 
+### Declaring configuration
+
+Mark a constructor parameter with `#[Config]` to make it settable via `-D`/`-c` (see
+[Configuring augmenters](#configuring-augmenters) above) and to have it appear in the
+[generated reference docs](/reference/augmenters). It needs a matching `set*()` method —
+that's what `-c` and `Pipeline::configure()` call.
+
+```php
+use OpenApi\Utils\Config;
+use OpenApi\Utils\PipeInterface;
+
+class CustomAugmenter implements PipeInterface
+{
+    public function __construct(
+        #[Config('Whether the custom rule is applied.')]
+        protected bool $enabled = true,
+    ) {
+    }
+
+    public function setEnabled(bool $enabled): static
+    {
+        $this->enabled = $enabled;
+
+        return $this;
+    }
+
+    // ...
+}
+```
+
+Parameters without `#[Config]` are collaborators, not settings — `Pipeline::getConfig()`
+(what `-D` prints) won't report them.
+
 ## Compilers
 
 Each OpenAPI version has its own compiler that handles version-specific output differences:

--- a/src/Augmenter/Cleanup.php
+++ b/src/Augmenter/Cleanup.php
@@ -9,6 +9,7 @@ namespace OpenApi\Augmenter;
 use OpenApi\Contracts\AttributeInterface;
 use OpenApi\Spec as OA;
 use OpenApi\Specification;
+use OpenApi\Utils\Config;
 use OpenApi\Utils\PipeInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
@@ -28,6 +29,7 @@ class Cleanup implements PipeInterface, LoggerAwareInterface
     protected const MAX_ITERATIONS = 10;
 
     public function __construct(
+        #[Config('Enables/disables removal of unreferenced components.')]
         protected bool $enabled = true,
     ) {
     }
@@ -51,9 +53,6 @@ class Cleanup implements PipeInterface, LoggerAwareInterface
         return null;
     }
 
-    /**
-     * Enables/disables removal of unreferenced components.
-     */
     public function setEnabled(bool $enabled): static
     {
         $this->enabled = $enabled;

--- a/src/Augmenter/EnumDescriptions.php
+++ b/src/Augmenter/EnumDescriptions.php
@@ -9,6 +9,7 @@ namespace OpenApi\Augmenter;
 use OpenApi\Spec as OA;
 use OpenApi\Specification;
 use OpenApi\Undefined;
+use OpenApi\Utils\Config;
 use OpenApi\Utils\PipeInterface;
 
 /**
@@ -18,8 +19,10 @@ use OpenApi\Utils\PipeInterface;
  */
 class EnumDescriptions implements PipeInterface
 {
-    public function __construct(protected bool $enabled = false)
-    {
+    public function __construct(
+        #[Config('Enables/disables generation of descriptions for enum based properties.')]
+        protected bool $enabled = false,
+    ) {
     }
 
     public function __invoke(mixed $payload): mixed
@@ -33,9 +36,6 @@ class EnumDescriptions implements PipeInterface
         return null;
     }
 
-    /**
-     * Enables/disables generation of descriptions for enum based properties.
-     */
     public function setEnabled(bool $enabled): static
     {
         $this->enabled = $enabled;

--- a/src/Augmenter/Enums.php
+++ b/src/Augmenter/Enums.php
@@ -8,6 +8,7 @@ namespace OpenApi\Augmenter;
 
 use OpenApi\Spec as OA;
 use OpenApi\Specification;
+use OpenApi\Utils\Config;
 use OpenApi\Utils\PipeInterface;
 
 /**
@@ -28,6 +29,7 @@ use OpenApi\Utils\PipeInterface;
 class Enums implements PipeInterface
 {
     public function __construct(
+        #[Config('If set, stores enum case names in a vendor extension with this key (e.g. <code>x-enum-varnames</code>).')]
         protected ?string $enumNames = null,
     ) {
     }
@@ -40,9 +42,6 @@ class Enums implements PipeInterface
         return null;
     }
 
-    /**
-     * If set, stores enum case names in a vendor extension with this key (e.g. <code>x-enum-varnames</code>).
-     */
     public function setEnumNames(?string $enumNames): static
     {
         $this->enumNames = $enumNames;

--- a/src/Augmenter/OperationIds.php
+++ b/src/Augmenter/OperationIds.php
@@ -8,6 +8,7 @@ namespace OpenApi\Augmenter;
 
 use OpenApi\Spec as OA;
 use OpenApi\Specification;
+use OpenApi\Utils\Config;
 use OpenApi\Utils\PipeInterface;
 
 /**
@@ -17,10 +18,8 @@ use OpenApi\Utils\PipeInterface;
  */
 class OperationIds implements PipeInterface
 {
-    /**
-     * @param bool $hash If set to true, generate ids (md5) instead of clear text operation ids
-     */
     public function __construct(
+        #[Config('If set to <code>true</code> generate ids (md5) instead of clear text operation ids.')]
         protected bool $hash = true,
     ) {
     }
@@ -41,9 +40,6 @@ class OperationIds implements PipeInterface
         return null;
     }
 
-    /**
-     * If set to <code>true</code> generate ids (md5) instead of clear text operation ids.
-     */
     public function setHash(bool $hash): static
     {
         $this->hash = $hash;

--- a/src/Augmenter/PathFilter.php
+++ b/src/Augmenter/PathFilter.php
@@ -8,6 +8,7 @@ namespace OpenApi\Augmenter;
 
 use OpenApi\Spec as OA;
 use OpenApi\Specification;
+use OpenApi\Utils\Config;
 use OpenApi\Utils\PipeInterface;
 
 /**
@@ -25,7 +26,9 @@ class PathFilter implements PipeInterface
      * @param list<string> $paths Regular expressions to match operation paths
      */
     public function __construct(
+        #[Config('A list of regular expressions to match <code>tags</code> to include.')]
         protected array $tags = [],
+        #[Config('A list of regular expressions to match <code>paths</code> to include.')]
         protected array $paths = [],
     ) {
     }
@@ -45,8 +48,6 @@ class PathFilter implements PipeInterface
     }
 
     /**
-     * A list of regular expressions to match <code>tags</code> to include.
-     *
      * @param list<string> $tags
      */
     public function setTags(array $tags): static
@@ -57,8 +58,6 @@ class PathFilter implements PipeInterface
     }
 
     /**
-     * A list of regular expressions to match <code>paths</code> to include.
-     *
      * @param list<string> $paths
      */
     public function setPaths(array $paths): static

--- a/src/Augmenter/Tags.php
+++ b/src/Augmenter/Tags.php
@@ -8,6 +8,7 @@ namespace OpenApi\Augmenter;
 
 use OpenApi\Spec as OA;
 use OpenApi\Specification;
+use OpenApi\Utils\Config;
 use OpenApi\Utils\PipeInterface;
 
 /**
@@ -24,7 +25,9 @@ class Tags implements PipeInterface
      * @param list<string> $whitelist
      */
     public function __construct(
+        #[Config("Whitelist tags to keep even if not used. Use '*' to keep all.")]
         protected array $whitelist = [],
+        #[Config('Enables/disables generation of default tag descriptions.')]
         protected bool $withDescription = true,
     ) {
     }
@@ -57,8 +60,6 @@ class Tags implements PipeInterface
     }
 
     /**
-     * Whitelist tags to keep even if not used. Use '*' to keep all.
-     *
      * @param list<string> $whitelist
      */
     public function setWhitelist(array $whitelist): static
@@ -68,9 +69,6 @@ class Tags implements PipeInterface
         return $this;
     }
 
-    /**
-     * Enables/disables generation of default tag descriptions.
-     */
     public function setWithDescription(bool $withDescription): static
     {
         $this->withDescription = $withDescription;

--- a/src/Utils/Config.php
+++ b/src/Utils/Config.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Utils;
+
+/**
+ * Declares a pipe constructor parameter as a configurable setting.
+ *
+ * `Pipeline::getConfig()` reports the current value of any parameter carrying this
+ * attribute (via its matching `set*()` method) under `-D`/`-c` and the CLI config file;
+ * the description is what the generated reference docs show for it.
+ */
+#[\Attribute(\Attribute::TARGET_PARAMETER)]
+class Config
+{
+    public function __construct(
+        public string $description,
+    ) {
+    }
+
+    /**
+     * This attribute's instances on $rc's constructor parameters, keyed by parameter name.
+     *
+     * @return array<string,self>
+     */
+    public static function forConstructor(\ReflectionClass $rc): array
+    {
+        if (!$rc->hasMethod('__construct')) {
+            return [];
+        }
+
+        $found = [];
+        foreach ($rc->getMethod('__construct')->getParameters() as $parameter) {
+            $attributes = $parameter->getAttributes(self::class);
+            if ($attributes !== []) {
+                $found[$parameter->getName()] = $attributes[0]->newInstance();
+            }
+        }
+
+        return $found;
+    }
+}

--- a/src/Utils/Pipeline.php
+++ b/src/Utils/Pipeline.php
@@ -83,10 +83,9 @@ class Pipeline extends TypedList
     /**
      * Collect the configurable settings of all pipes, keyed by pipe name.
      *
-     * A setting is considered configurable when a pipe exposes a `setX()` method
-     * for a property `x`; the reported value is that property's current value.
-     * Object valued properties (factories, resolvers) are treated as collaborators
-     * rather than config and are omitted.
+     * A setting is a constructor parameter carrying a {@see Config} attribute, with a
+     * matching `setX()` method for a property `x`; the reported value is that property's
+     * current value.
      *
      * The result uses the same keys accepted by {@see self::configure()}.
      *
@@ -100,29 +99,14 @@ class Pipeline extends TypedList
             $rc = new \ReflectionClass($pipe);
             $settings = [];
 
-            foreach ($rc->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
-                if (!str_starts_with($method->getName(), 'set') || $method->getNumberOfParameters() !== 1) {
-                    continue;
-                }
-
-                // LoggerAwareInterface is plumbing, not config
-                if ($method->getName() === 'setLogger') {
-                    continue;
-                }
-
-                $name = lcfirst(substr($method->getName(), 3));
-                if (!$rc->hasProperty($name)) {
+            foreach (self::configurableParameters($rc) as $name) {
+                $setter = 'set' . ucfirst($name);
+                if (!$rc->hasMethod($setter) || !$rc->hasProperty($name)) {
                     continue;
                 }
 
                 $property = $rc->getProperty($name);
-                $value = $property->isInitialized($pipe) ? $property->getValue($pipe) : null;
-
-                if (is_object($value)) {
-                    continue;
-                }
-
-                $settings[$name] = $value;
+                $settings[$name] = $property->isInitialized($pipe) ? $property->getValue($pipe) : null;
             }
 
             if ($settings !== []) {
@@ -175,6 +159,14 @@ class Pipeline extends TypedList
                 $this->logger->warning("Unknown config key '{$pipeKey}'; no matching pipe in this pipeline");
             }
         }
+    }
+
+    /**
+     * @return list<string> constructor parameter names carrying a {@see Config} attribute
+     */
+    protected static function configurableParameters(\ReflectionClass $rc): array
+    {
+        return array_keys(Config::forConstructor($rc));
     }
 
     /**

--- a/tests/Utils/ConfigTest.php
+++ b/tests/Utils/ConfigTest.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Utils;
+
+use OpenApi\Utils\Config;
+use PHPUnit\Framework\TestCase;
+
+final class ConfigTest extends TestCase
+{
+    /**
+     * A #[Config] parameter with no matching setter is silently invisible to
+     * Pipeline::getConfig() — this guards against that going unnoticed.
+     */
+    public function testEveryAnnotatedAugmenterParameterHasAMatchingSetter(): void
+    {
+        $failures = [];
+
+        foreach ($this->allAugmenterClasses() as $class) {
+            $rc = new \ReflectionClass($class);
+
+            foreach (array_keys(Config::forConstructor($rc)) as $name) {
+                $setter = 'set' . ucfirst($name);
+                if (!$rc->hasMethod($setter)) {
+                    $failures[] = "{$class}::\${$name} carries #[Config] but has no {$setter}()";
+                }
+            }
+        }
+
+        $this->assertEmpty($failures, implode("\n", $failures));
+    }
+
+    /**
+     * @return list<class-string>
+     */
+    private function allAugmenterClasses(): array
+    {
+        $dir = dirname(__DIR__, 2) . '/src/Augmenter';
+        $classes = [];
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $file) {
+            if ($file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $class = 'OpenApi\\Augmenter\\' . str_replace(
+                ['/', '.php'],
+                ['\\', ''],
+                substr($file->getPathname(), strlen($dir) + 1)
+            );
+
+            if (!class_exists($class) || !(new \ReflectionClass($class))->isInstantiable()) {
+                continue;
+            }
+
+            $classes[] = $class;
+        }
+
+        sort($classes);
+
+        return $classes;
+    }
+}

--- a/tools/src/Docs/DocGenerator.php
+++ b/tools/src/Docs/DocGenerator.php
@@ -10,6 +10,7 @@ use OpenApi\Tools\Docs\Sections\ConfigSettingsSection;
 use OpenApi\Tools\Docs\Sections\DescriptionSection;
 use OpenApi\Tools\Docs\Sections\ReferencesSection;
 use OpenApi\Tools\Docs\Sections\SectionInterface;
+use OpenApi\Utils\Config;
 use OpenApi\Utils\Pipeline;
 
 abstract class DocGenerator
@@ -57,15 +58,22 @@ abstract class DocGenerator
     /**
      * Names of the constructor parameters that count as public configuration.
      *
-     * Constructor parameters are the configuration contract by convention. Object typed
-     * ones (factories, resolvers, the generator) are collaborators rather than settings
-     * and are excluded, matching {@see Pipeline::getConfig()} and therefore the `-D`
-     * output.
+     * If any parameter carries a {@see Config} attribute, those are the configurable ones
+     * — explicit opt-in, matching {@see Pipeline::getConfig()} exactly. Otherwise falls
+     * back to the ctor-param heuristic: object typed parameters (factories, resolvers, the
+     * generator) are collaborators rather than settings and are excluded. Classes not yet
+     * converted to `#[Config]` (currently everything under `src/Processors/`) go through
+     * this fallback.
      *
      * @return list<string>
      */
     public function configurableParameters(\ReflectionClass $rc): array
     {
+        $attributed = array_keys(Config::forConstructor($rc));
+        if ($attributed !== []) {
+            return $attributed;
+        }
+
         if (!$rc->hasMethod('__construct')) {
             return [];
         }
@@ -241,6 +249,7 @@ abstract class DocGenerator
     {
         $options = [];
         $configurable = $this->configurableParameters($rc);
+        $configAttributes = Config::forConstructor($rc);
 
         foreach ($rc->getMethods() as $method) {
             if (!str_starts_with($method->getName(), 'set')) {
@@ -259,12 +268,18 @@ abstract class DocGenerator
                 }
             }
 
-            $phpdoc = $this->parseDocblock($method->getDocComment());
-            $description = '';
-            if ($phpdoc['content']) {
-                $description = $phpdoc['content'];
-            } elseif (array_key_exists($pname, $phpdoc['params']) && $phpdoc['params'][$pname]['content']) {
-                $description = $phpdoc['params'][$pname]['content'];
+            if (array_key_exists($pname, $configAttributes)) {
+                // #[Config] is the source of truth once a class uses it; the setter's
+                // docblock, if any, would only duplicate it.
+                $description = $configAttributes[$pname]->description;
+            } else {
+                $phpdoc = $this->parseDocblock($method->getDocComment());
+                $description = '';
+                if ($phpdoc['content']) {
+                    $description = $phpdoc['content'];
+                } elseif (array_key_exists($pname, $phpdoc['params']) && $phpdoc['params'][$pname]['content']) {
+                    $description = $phpdoc['params'][$pname]['content'];
+                }
             }
 
             $options[] = [


### PR DESCRIPTION
## Overview
Augmenter settings — whether to hash operation IDs, which tags to keep, and so on — have
had two hand-maintained lists deciding what counts as a public setting: one driving the
`-D`/`-c` command-line flags, one driving the generated reference docs. They only agreed
with each other because someone kept them in sync by hand. This lets a setting be declared
once, on the augmenter itself, so both places read from the same source and can't drift.

## Changes
- New `#[Config]` attribute marks a constructor parameter as a public setting, with its
  description
- The augmenters that expose settings today are annotated; everything else (factories,
  resolvers passed as collaborators) stays excluded, now explicitly rather than by
  guessing from the parameter's type
- The generated reference docs read the same attribute, falling back to their previous
  behaviour for the classic pipeline, which hasn't adopted this yet
- Documented for anyone writing a custom augmenter
- Added a PR description template (Overview + Changes) to `.github/` and documented it
  in `CONTRIBUTING.md`