### PR TITLE
test(Tests): add ExpectsLogEntries trait for build diagnostics

### DIFF
--- a/tests/Concerns/ExpectsLogEntries.php
+++ b/tests/Concerns/ExpectsLogEntries.php
@@ -1,0 +1,206 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Concerns;
+
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\Attributes\Before;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Assertions about the diagnostics a build emits.
+ *
+ * Hand {@see self::trackingLogger()} to `Builder::setLogger()`, then declare what the
+ * build is allowed to say:
+ *
+ *   $this->expectLogEntry('info is required');            // must be logged
+ *   $this->allowLogEntry('const is not supported');       // may be logged
+ *
+ * Strict by default: any entry matching neither is a failure, which is what stops a
+ * diagnostic from appearing unnoticed. Use `allowLogEntry()` for diagnostics that are
+ * incidental to what the test is about — a fixture that deliberately omits `info` need
+ * not pretend to care about the resulting warning.
+ *
+ * Matching is by substring, and order-independent: expectations are not required to be
+ * logged in the order they were declared.
+ *
+ * The `#[Before]`/`#[After]` hooks run independently of `setUp()`/`tearDown()`, so a test
+ * needs nothing beyond `use ExpectsLogEntries;` — no hook methods, and no `parent::` call
+ * to forget.
+ */
+trait ExpectsLogEntries
+{
+    /** @var list<array{needle: string, level: string|null}> */
+    protected array $expectedLogEntries = [];
+
+    /** @var list<string> */
+    protected array $allowedLogEntries = [];
+
+    /** @var list<array{level: string, message: string}> */
+    protected array $recordedLogEntries = [];
+
+    /**
+     * Require an entry containing `$needle` to be logged, optionally at `$level`.
+     */
+    public function expectLogEntry(string $needle, ?string $level = null): void
+    {
+        $this->expectedLogEntries[] = ['needle' => $needle, 'level' => $level];
+    }
+
+    /**
+     * Permit entries containing any of `$needles` without requiring them.
+     */
+    public function allowLogEntry(string ...$needles): void
+    {
+        array_push($this->allowedLogEntries, ...$needles);
+    }
+
+    /**
+     * The logger to hand to `Builder::setLogger()`; forwards to `$delegate` if given.
+     */
+    public function trackingLogger(?LoggerInterface $delegate = null): LoggerInterface
+    {
+        $recorder = function (string $level, string $message): void {
+            $this->recordedLogEntries[] = ['level' => $level, 'message' => $message];
+        };
+
+        return new class ($recorder, $delegate) extends AbstractLogger {
+            public function __construct(protected \Closure $recorder, protected ?LoggerInterface $delegate)
+            {
+            }
+
+            public function log($level, $message, array $context = []): void
+            {
+                ($this->recorder)((string) $level, (string) $message);
+
+                $this->delegate?->log($level, $message, $context);
+            }
+        };
+    }
+
+    /**
+     * @return list<array{level: string, message: string}>
+     */
+    public function recordedLogEntries(): array
+    {
+        return $this->recordedLogEntries;
+    }
+
+    #[Before]
+    protected function resetLogEntryExpectations(): void
+    {
+        $this->expectedLogEntries = [];
+        $this->allowedLogEntries = [];
+        $this->recordedLogEntries = [];
+    }
+
+    #[After]
+    protected function assertLogEntryExpectations(): void
+    {
+        $unmatched = $this->recordedLogEntries;
+        $missing = [];
+
+        foreach ($this->expectedLogEntries as $expected) {
+            $index = $this->findLogEntry($unmatched, $expected['needle'], $expected['level']);
+
+            if ($index === null) {
+                $missing[] = $expected['level'] === null
+                    ? $expected['needle']
+                    : "[{$expected['level']}] {$expected['needle']}";
+                continue;
+            }
+
+            unset($unmatched[$index]);
+        }
+
+        $unexpected = [];
+        foreach ($unmatched as $entry) {
+            if (!$this->isAllowedLogEntry($entry['message'])) {
+                $unexpected[] = "[{$entry['level']}] {$entry['message']}";
+            }
+        }
+
+        // one assertion covering both, so a run reports every problem at once — and so a
+        // test whose only assertions are its log expectations is not flagged risky
+        $this->assertSame(
+            [],
+            array_merge($missing, $unexpected),
+            $this->describeProblems($missing, $unexpected),
+        );
+    }
+
+    /**
+     * @param array<int,array{level: string, message: string}> $entries
+     */
+    protected function findLogEntry(array $entries, string $needle, ?string $level): ?int
+    {
+        foreach ($entries as $index => $entry) {
+            if ($level !== null && $entry['level'] !== $level) {
+                continue;
+            }
+
+            if (str_contains($entry['message'], $needle)) {
+                return $index;
+            }
+        }
+
+        return null;
+    }
+
+    protected function isAllowedLogEntry(string $message): bool
+    {
+        foreach ($this->allowedLogEntries as $needle) {
+            if (str_contains($message, $needle)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param list<string> $missing
+     * @param list<string> $unexpected
+     */
+    protected function describeProblems(array $missing, array $unexpected): string
+    {
+        $problems = [];
+
+        if ($missing !== []) {
+            // what did arrive is the useful context for an expectation that did not match
+            $problems[] = 'Expected log entries were not logged:' . $this->describeList($missing)
+                . "\n" . $this->describeRecordedLogEntries();
+        }
+
+        if ($unexpected !== []) {
+            $problems[] = 'Unexpected log entries:' . $this->describeList($unexpected)
+                . "\nDeclare them with expectLogEntry() or allowLogEntry().";
+        }
+
+        return implode("\n\n", $problems);
+    }
+
+    protected function describeRecordedLogEntries(): string
+    {
+        if ($this->recordedLogEntries === []) {
+            return "\nNothing was logged.";
+        }
+
+        return "\nLogged:" . $this->describeList(array_map(
+            static fn (array $entry): string => "[{$entry['level']}] {$entry['message']}",
+            $this->recordedLogEntries,
+        ));
+    }
+
+    /**
+     * @param list<string> $items
+     */
+    protected function describeList(array $items): string
+    {
+        return $items === [] ? ' (none)' : "\n  " . implode("\n  ", $items);
+    }
+}

--- a/tests/Concerns/ExpectsLogEntriesTest.php
+++ b/tests/Concerns/ExpectsLogEntriesTest.php
@@ -1,0 +1,151 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Concerns;
+
+use OpenApi\Builder;
+use OpenApi\Builder\Mode;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+
+final class ExpectsLogEntriesTest extends TestCase
+{
+    use ExpectsLogEntries;
+
+    public function testExpectedEntryIsSatisfied(): void
+    {
+        $this->expectLogEntry('hello');
+
+        $this->trackingLogger()->warning('well, hello there');
+
+        // the #[After] hook asserts this; reaching it without failure is the assertion
+        $this->assertCount(1, $this->recordedLogEntries());
+    }
+
+    public function testExpectationsAreOrderIndependent(): void
+    {
+        $this->expectLogEntry('second');
+        $this->expectLogEntry('first');
+
+        $logger = $this->trackingLogger();
+        $logger->warning('the first one');
+        $logger->warning('the second one');
+
+        $this->assertCount(2, $this->recordedLogEntries());
+    }
+
+    public function testAllowedEntryIsToleratedButNotRequired(): void
+    {
+        $this->allowLogEntry('tolerated', 'also tolerated');
+
+        $this->trackingLogger()->warning('a tolerated diagnostic');
+
+        // 'also tolerated' was never logged, and that is not a failure
+        $this->assertCount(1, $this->recordedLogEntries());
+    }
+
+    public function testLevelIsMatchedWhenGiven(): void
+    {
+        $this->expectLogEntry('pinned', 'error');
+
+        $this->trackingLogger()->error('a pinned diagnostic');
+
+        $this->assertCount(1, $this->recordedLogEntries());
+    }
+
+    public function testDelegateReceivesEntries(): void
+    {
+        $received = [];
+        $delegate = new class ($received) extends AbstractLogger {
+            /**
+             * @param list<string> $received
+             */
+            public function __construct(public array &$received)
+            {
+            }
+
+            public function log($level, $message, array $context = []): void
+            {
+                $this->received[] = (string) $message;
+            }
+        };
+
+        $this->allowLogEntry('forwarded');
+        $this->trackingLogger($delegate)->warning('forwarded message');
+
+        $this->assertSame(['forwarded message'], $received);
+    }
+
+    public function testUnmetExpectationFails(): void
+    {
+        $this->expectLogEntry('never logged');
+
+        $this->assertHookFailsWith('never logged');
+    }
+
+    public function testWrongLevelFailsTheExpectation(): void
+    {
+        $this->expectLogEntry('pinned', 'error');
+        $this->trackingLogger()->warning('a pinned diagnostic');
+
+        $this->assertHookFailsWith('[error] pinned');
+    }
+
+    public function testUnexpectedEntryFails(): void
+    {
+        $this->trackingLogger()->warning('nobody asked for this');
+
+        $this->assertHookFailsWith('nobody asked for this');
+    }
+
+    public function testAnExpectationIsConsumedOnlyOnce(): void
+    {
+        $this->expectLogEntry('repeated');
+
+        $logger = $this->trackingLogger();
+        $logger->warning('repeated once');
+        $logger->warning('repeated twice');
+
+        // the second entry matches no remaining expectation, so it is unexpected
+        $this->assertHookFailsWith('repeated twice');
+    }
+
+    public function testAgainstARealBuild(): void
+    {
+        // the diagnostic this test is about ...
+        $this->expectLogEntry('info is required', 'error');
+        // ... and one that merely comes with an empty source set
+        $this->allowLogEntry('At least one of paths, webhooks, or components is required');
+
+        (new Builder())
+            ->setMode(Mode::SPEC)
+            ->setSources([])
+            ->setLogger($this->trackingLogger())
+            ->build();
+
+        $this->assertNotEmpty($this->recordedLogEntries());
+    }
+
+    /**
+     * Run the `#[After]` hook now, assert it failed, then clear state so the automatic
+     * invocation does not fail the test for the same reason.
+     */
+    protected function assertHookFailsWith(string $expectedMessage): void
+    {
+        try {
+            $this->assertLogEntryExpectations();
+            $failure = null;
+        } catch (ExpectationFailedException $expectationFailedException) {
+            $failure = $expectationFailedException;
+        } finally {
+            $this->resetLogEntryExpectations();
+        }
+
+        $this->assertInstanceOf(ExpectationFailedException::class, $failure, 'the hook should have failed');
+        $this->assertStringContainsString($expectedMessage, $failure->getMessage());
+    }
+}


### PR DESCRIPTION
## Overview
Tests that assert on what a build logs currently have to extend the classic-flavored
`OpenApiTestCase`, and the mechanism there is strict about ordering: expectations must
arrive in the order they were declared. That makes it awkward for a test to say the one
thing it usually wants to say — "this fixture deliberately omits `info`, so ignore the
warning about it, but do check the diagnostic I actually care about". This adds a
standalone trait for that, so new spec tests can express it without inheriting the
classic base class.

## Changes
- New `ExpectsLogEntries` trait: `expectLogEntry()` requires a diagnostic,
  `allowLogEntry()` permits one without requiring it, and anything else logged fails
  the test
- Matching is by substring and order-independent, with an optional log level
- Failures report missing and unexpected entries together, with the full log as context
- Uses `#[Before]`/`#[After]` hook methods, so a test needs only the `use` statement —
  they run independently of `setUp()`/`tearDown()`, including when a subclass overrides
  those without calling `parent::`