### PR TITLE
chore(Deps): pin `phpstan/phpstan` to an exact version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,7 @@
     "require-dev": {
         "doctrine/annotations": "^2.0",
         "friendsofphp/php-cs-fixer": "3.95.23",
-        "phpstan/phpstan": "^2.2",
+        "phpstan/phpstan": "2.2.12",
         "phpunit/phpunit": "^11.5 || >=12.5.22",
         "rector/rector": "2.6.5"
     },


### PR DESCRIPTION
## Overview

`composer.lock` is not committed and every workflow installs with
`dependency-versions: highest`, so a new release of a static analysis or code style tool
adds checks to pull requests that did not change anything related. #2143 pinned
`rector/rector` and `friendsofphp/php-cs-fixer` for that reason and left
`phpstan/phpstan` on `^2.2`, which has the same exposure.

The loose constraint also understated the real floor. `rector/rector` 2.6.5 requires
`phpstan/phpstan` `^2.2.10`, so since #2143 the phpstan version in use has been dictated
transitively by a different package's pin — 2.2.9 cannot be installed at all. Pinning makes
the version that actually runs explicit rather than a side effect.

`phpunit/phpunit` deliberately stays wide: its `^11.5 || >=12.5.22` constraint spans the
PHP 8.2 to 8.6 build matrix.

## Changes

- pin `phpstan/phpstan` to `2.2.12`, the current release
