### PR TITLE
fix(Tools): guard `$argv` in the doc generator entry point

### DIFF
--- a/tools/docgen.php
+++ b/tools/docgen.php
@@ -18,7 +18,7 @@ $generators = [
     'example' => new ExampleGenerator($projectRoot),
 ];
 
-$requested = array_slice($argv, 1);
+$requested = array_slice($argv ?? [], 1);
 if ($requested) {
     $generators = array_intersect_key($generators, array_flip($requested));
 }


### PR DESCRIPTION
## Overview

`composer analyse` fails with `Variable $argv might not be defined` in `tools/docgen.php`
on some machines and not others. phpstan decides whether `$argv` is defined by reading the
**running** PHP's `register_argc_argv` ini setting, so the result depends on the local PHP
build rather than on anything in the repository. CI runs PHP 8.3 with the setting on, which
is why this has never shown up there.

The CLI SAPI populates `$argv` whatever the setting says, so guarding it changes no
behaviour — it just stops the analysis result depending on the machine it runs on.

Noticed while pinning `phpstan/phpstan` in #2151; unrelated to that change, and present
since `tools/` came under analysis in #2141.

## Changes

- coalesce `$argv` to an empty array in `tools/docgen.php` before slicing it
