### PR TITLE
fix(Spec): give every spec attribute a usable target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,10 @@ Keep the description to the changes at hand. History that lives elsewhere — ea
 attempts, abandoned branches, related work in other pull requests — belongs in the issue
 or commit trail, not here, unless it has a direct bearing on the change being reviewed.
 
+The prose rules in [Writing documentation](docs/dev/writing-docs.md) apply to descriptions
+as well as to pages: state a fact once, do not claim what you have not verified, no
+marketing filler, no volatile values, no line-number citations.
+
 ## Documentation
 
 The documentation website is build from the [docs](docs/) folder with [vitepress](https://vitepress.vuejs.org).

--- a/docs/dev/writing-docs.md
+++ b/docs/dev/writing-docs.md
@@ -1,7 +1,23 @@
 # Writing documentation
 
-Conventions for the hand-written pages under `docs/`. For which pages are generated and
+Conventions for hand-written prose about this project. For which pages are generated and
 must not be edited, see [Documentation toolchain](/dev/docs-toolchain).
+
+## Where these rules apply
+
+Most of what follows is about precision and economy, which do not change with the surface.
+They apply to the pages under `docs/`, to docblocks in `src/` — which are spliced into the
+generated reference pages, so an imprecise one ships as published documentation — and to
+pull request descriptions and commit messages.
+
+Three sections are about pages only, and do not transfer: **Structure**, **Spelling**, and
+the generated-page items in the review checklist.
+
+Pull request descriptions carry one extra constraint of their own: they describe **the
+change**, and include context only where the change cannot be understood without it. How
+the work was found, what else was investigated, and what it might lead to are not part of
+the diff. [CONTRIBUTING](https://github.com/zircote/swagger-php/blob/master/CONTRIBUTING.md)
+has the template and the title format.
 
 ## State a fact once
 

--- a/src/Spec/Example.php
+++ b/src/Spec/Example.php
@@ -13,7 +13,7 @@ use OpenApi\Undefined;
  *
  * @see [Example Object](https://spec.openapis.org/oas/v3.1.1.html#example-object)
  */
-#[\Attribute(\Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_PROPERTY | \Attribute::TARGET_PARAMETER | \Attribute::IS_REPEATABLE)]
 class Example extends AbstractAttribute
 {
     /**

--- a/src/Spec/Flow.php
+++ b/src/Spec/Flow.php
@@ -39,7 +39,7 @@ namespace OpenApi\Spec;
  * @see [OAuth Flow Object](https://spec.openapis.org/oas/v3.1.1.html#oauth-flow-object)
  * @see [OAuth Flows Object](https://spec.openapis.org/oas/v3.1.1.html#oauth-flows-object)
  */
-#[\Attribute(\Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 class Flow extends AbstractAttribute
 {
     public ?string $flow = null;

--- a/src/Spec/Flow/AuthorizationCode.php
+++ b/src/Spec/Flow/AuthorizationCode.php
@@ -13,7 +13,7 @@ use OpenApi\Spec as OA;
  *
  * @see [OAuth Flow Object](https://spec.openapis.org/oas/v3.1.1.html#oauth-flow-object)
  */
-#[\Attribute(\Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 class AuthorizationCode extends OA\Flow
 {
     /**

--- a/src/Spec/Flow/ClientCredentials.php
+++ b/src/Spec/Flow/ClientCredentials.php
@@ -13,7 +13,7 @@ use OpenApi\Spec as OA;
  *
  * @see [OAuth Flow Object](https://spec.openapis.org/oas/v3.1.1.html#oauth-flow-object)
  */
-#[\Attribute(\Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 class ClientCredentials extends OA\Flow
 {
     /**

--- a/src/Spec/Flow/Implicit.php
+++ b/src/Spec/Flow/Implicit.php
@@ -13,7 +13,7 @@ use OpenApi\Spec as OA;
  *
  * @see [OAuth Flow Object](https://spec.openapis.org/oas/v3.1.1.html#oauth-flow-object)
  */
-#[\Attribute(\Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 class Implicit extends OA\Flow
 {
     /**

--- a/src/Spec/Flow/Password.php
+++ b/src/Spec/Flow/Password.php
@@ -13,7 +13,7 @@ use OpenApi\Spec as OA;
  *
  * @see [OAuth Flow Object](https://spec.openapis.org/oas/v3.1.1.html#oauth-flow-object)
  */
-#[\Attribute(\Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 class Password extends OA\Flow
 {
     /**

--- a/src/Spec/Header.php
+++ b/src/Spec/Header.php
@@ -13,7 +13,7 @@ use OpenApi\Undefined;
  *
  * @see [Header Object](https://spec.openapis.org/oas/v3.1.1.html#header-object)
  */
-#[\Attribute(\Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class Header extends AbstractAttribute
 {
     public ?string $style = null;

--- a/src/Spec/MediaType/Json.php
+++ b/src/Spec/MediaType/Json.php
@@ -33,7 +33,7 @@ use OpenApi\Undefined;
  *
  * @see [Media Type Object](https://spec.openapis.org/oas/v3.1.1.html#media-type-object)
  */
-#[\Attribute(\Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class Json extends OA\MediaType
 {
     /**

--- a/src/Spec/MediaType/Xml.php
+++ b/src/Spec/MediaType/Xml.php
@@ -33,7 +33,7 @@ use OpenApi\Undefined;
  *
  * @see [Media Type Object](https://spec.openapis.org/oas/v3.1.1.html#media-type-object)
  */
-#[\Attribute(\Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class Xml extends OA\MediaType
 {
     /**

--- a/src/Spec/ServerVariable.php
+++ b/src/Spec/ServerVariable.php
@@ -11,7 +11,7 @@ namespace OpenApi\Spec;
  *
  * @see [Server Variable Object](https://spec.openapis.org/oas/v3.1.1.html#server-variable-object)
  */
-#[\Attribute(\Attribute::IS_REPEATABLE)]
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class ServerVariable extends AbstractAttribute
 {
     /**

--- a/tests/Spec/AttributeTargetsTest.php
+++ b/tests/Spec/AttributeTargetsTest.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Spec;
+
+use OpenApi\Tests\Concerns\CollectsSpecClasses;
+use PHPUnit\Framework\TestCase;
+
+final class AttributeTargetsTest extends TestCase
+{
+    use CollectsSpecClasses;
+
+    /**
+     * `\Attribute::IS_REPEATABLE` is not a target, so declaring it alone leaves an attribute
+     * that PHP refuses in every position: "cannot target class (allowed targets: )".
+     *
+     * Such a class still works as a constructor argument, which is how fixtures tend to use
+     * the nested ones, so nothing fails until somebody writes it as an attribute.
+     */
+    public function testEveryAttributeDeclaresAtLeastOneTarget(): void
+    {
+        $failures = [];
+
+        foreach (self::allSpecClasses() as $class) {
+            $declared = (new \ReflectionClass($class))->getAttributes(\Attribute::class);
+            if ($declared === []) {
+                continue;
+            }
+
+            $flags = $declared[0]->newInstance()->flags;
+            if (($flags & \Attribute::TARGET_ALL) === 0) {
+                $failures[] = sprintf('%s declares #[\Attribute] with no TARGET_* flag, so it cannot be used as an attribute anywhere', $class);
+            }
+        }
+
+        $this->assertEmpty($failures, implode("\n", $failures));
+    }
+
+    /**
+     * A subclass narrowing targets is fine — `Parameter\Path` drops `TARGET_PROPERTY` that
+     * `Parameter` allows. Narrowing to nothing is what this catches, and it is how
+     * `MediaType\Json` and `MediaType\Xml` ended up unusable while `MediaType` was correct.
+     */
+    public function testAttributeSubclassesKeepAtLeastOneParentTarget(): void
+    {
+        $failures = [];
+
+        foreach (self::allSpecClasses() as $class) {
+            $reflection = new \ReflectionClass($class);
+            $parent = $reflection->getParentClass();
+            if ($parent === false) {
+                continue;
+            }
+
+            $own = $reflection->getAttributes(\Attribute::class);
+            $inherited = $parent->getAttributes(\Attribute::class);
+            if ($own === [] || $inherited === []) {
+                continue;
+            }
+
+            $ownTargets = $own[0]->newInstance()->flags & \Attribute::TARGET_ALL;
+            $parentTargets = $inherited[0]->newInstance()->flags & \Attribute::TARGET_ALL;
+            if ($parentTargets !== 0 && ($ownTargets & $parentTargets) === 0) {
+                $failures[] = sprintf('%s shares no target with %s, so it cannot be used where its parent can', $class, $parent->getName());
+            }
+        }
+
+        $this->assertEmpty($failures, implode("\n", $failures));
+    }
+}


### PR DESCRIPTION
## Overview

Ten spec attribute classes declared `#[\Attribute(\Attribute::IS_REPEATABLE)]` with no
`TARGET_*` flag. `IS_REPEATABLE` is not a target, so those classes could not be used as
attributes anywhere — PHP itself rejects them:

```
#[OA\Header(header: 'X-Rate')] class H {}
→ Attribute "OpenApi\Spec\Header" cannot target class (allowed targets: )
```

Nothing failed in the test suite because all of them are nested types that fixtures build as
constructor arguments (`content: new OA\MediaType\Json(...)`), which never consults attribute
targets. What was impossible is attribute position — the way users are told to write spec
attributes.

## Changes

- `Header`, `ServerVariable` and `MediaType\{Json,Xml}` take
  `TARGET_CLASS | TARGET_METHOD`, matching `Response`, `Server` and `MediaType`, the
  containers they nest into
- `Example` additionally takes `TARGET_PROPERTY | TARGET_PARAMETER`, the union of its three
  containers' targets, since `Parameter` allows both
- `Flow` and `Flow\{Implicit,AuthorizationCode,Password,ClientCredentials}` take
  `TARGET_CLASS`, matching `Security\Scheme` and its subclasses
- `AttributeTargetsTest` asserts every spec attribute declares at least one target, and that
  a subclass shares at least one target with its parent — a subclass narrowing is fine
  (`Parameter\Path` drops `TARGET_PROPERTY`), narrowing to nothing is not

- `writing-docs.md` states which surfaces its rules cover — pages, docblocks, pull request
  descriptions and commit messages — and which sections are page-only; `CONTRIBUTING.md`
  points descriptions at them rather than restating them
