### PR TITLE
feat(Compiler): validate operationId uniqueness, response keys and schema types

### DIFF
--- a/src/Compiler/OpenApi30Compiler.php
+++ b/src/Compiler/OpenApi30Compiler.php
@@ -251,6 +251,8 @@ class OpenApi30Compiler extends OpenApi31Compiler
                 $this->logger->warning('Schema' . ($schema->schema ? " \"$schema->schema\"" : '') . ' has type "array" but no items');
             }
 
+            $this->validateSchemaType($schema);
+
             if ($schema->prefixItems !== null) {
                 $this->logger->warning('Schema' . ($schema->schema ? " \"$schema->schema\"" : '') . ': prefixItems is not supported in OpenAPI 3.0');
             }

--- a/src/Compiler/OpenApi31Compiler.php
+++ b/src/Compiler/OpenApi31Compiler.php
@@ -22,6 +22,14 @@ class OpenApi31Compiler implements CompilerInterface
 
     protected const OPERATION_REQUEST_BODY_METHODS = ['put', 'post', 'delete', 'patch'];
 
+    /**
+     * Every type the wire format accepts as input. `null` is included for 3.0 as well, where
+     * the compiler translates it to `nullable` rather than dropping it.
+     */
+    protected const SCHEMA_TYPES = ['string', 'number', 'integer', 'boolean', 'array', 'object', 'null'];
+
+    protected const RESPONSE_KEY = '/^(default|[1-5][0-9]{2}|[1-5]XX)$/';
+
     protected CollectingLogger $logger;
 
     public function __construct(?LoggerInterface $logger = null)
@@ -68,6 +76,10 @@ class OpenApi31Compiler implements CompilerInterface
         $this->validateSchemas($specification);
 
         $this->validateOperations($specification);
+
+        $this->validateOperationIds($specification);
+
+        $this->validateResponses($specification);
 
         return $this->logger->entries();
     }
@@ -678,6 +690,23 @@ class OpenApi31Compiler implements CompilerInterface
                     $this->logger->warning('Schema' . ($schema->schema ? " \"$schema->schema\"" : '') . ' has type "array" but no items in ' . $schema->getSourceLocation());
                 }
             }
+
+            $this->validateSchemaType($schema);
+        }
+    }
+
+    protected function validateSchemaType(OA\Schema $schema): void
+    {
+        if ($schema->type === null) {
+            return;
+        }
+
+        foreach (is_array($schema->type) ? $schema->type : [$schema->type] as $type) {
+            if (in_array($type, static::SCHEMA_TYPES, true)) {
+                continue;
+            }
+
+            $this->logger->warning('Schema' . ($schema->schema ? " \"$schema->schema\"" : '') . " has unknown type \"$type\", expecting one of " . implode(', ', static::SCHEMA_TYPES) . ' in ' . $schema->getSourceLocation());
         }
     }
 
@@ -686,6 +715,55 @@ class OpenApi31Compiler implements CompilerInterface
         $specification->getWalker()->visit(OA\Operation::class, function (OA\Operation $operation): void {
             if ($operation->requestBody instanceof OA\RequestBody && !in_array($operation->method, static::OPERATION_REQUEST_BODY_METHODS)) {
                 $this->logger->warning("Request body not supported for method {$operation->method} in " . $operation->getSourceLocation());
+            }
+        });
+    }
+
+    /**
+     * Generated ids cannot collide — `OperationIds` derives them from method, path and
+     * source — so this only ever fires for values set by hand.
+     *
+     * Uniqueness is a property of the document, so an operation carrying neither a path nor
+     * a webhook is skipped: it is emitted nowhere and its id is never written down.
+     */
+    protected function validateOperationIds(Specification $specification): void
+    {
+        $seen = [];
+        $specification->getWalker()->visit(OA\Operation::class, function (OA\Operation $operation) use (&$seen): void {
+            if ($operation->operationId === null || ($operation->path === null && $operation->webhook === null)) {
+                return;
+            }
+
+            if (isset($seen[$operation->operationId])) {
+                $this->logger->warning("operationId must be unique, found \"{$operation->operationId}\" again in " . $operation->getSourceLocation());
+
+                return;
+            }
+
+            $seen[$operation->operationId] = true;
+        });
+    }
+
+    /**
+     * Only responses nested in an operation are checked, because position is what gives
+     * `Response::$response` its meaning: a status code there, and a component key in the
+     * `responses` bucket, where `components.responses.product` is a name. `isRoot()` cannot
+     * tell them apart — it is true whenever the key is set.
+     *
+     * A nested response carries no reflector of its own, so the operation is reported
+     * instead, which is where the reader has to go to fix it anyway.
+     */
+    protected function validateResponses(Specification $specification): void
+    {
+        $specification->getWalker()->visit(OA\Operation::class, function (OA\Operation $operation): void {
+            foreach ($operation->responses ?? [] as $response) {
+                if ($response->response === null) {
+                    continue;
+                }
+
+                if (preg_match(static::RESPONSE_KEY, (string) $response->response) !== 1) {
+                    $this->logger->warning("Invalid response \"{$response->response}\", expecting \"default\", a HTTP status code or a range such as \"2XX\" in " . $operation->getSourceLocation());
+                }
             }
         });
     }

--- a/src/Utils/SpecificationWalker.php
+++ b/src/Utils/SpecificationWalker.php
@@ -68,8 +68,12 @@ class SpecificationWalker
      */
     public function visit(string $visitee, callable $visitor): void
     {
+        // one `$seen` for every bucket: an attribute reachable from two of them — an
+        // operation held both directly and inside a path item — is still one attribute
+        $seen = new \SplObjectStorage();
+
         foreach (get_object_vars($this->specification) as $buckets) {
-            $this->walk($visitee, $visitor, $buckets instanceof AttributeInterface ? [$buckets] : (array) $buckets);
+            $this->walk($visitee, $visitor, $buckets instanceof AttributeInterface ? [$buckets] : (array) $buckets, $seen);
         }
     }
 

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -482,6 +482,90 @@ final class CompilerTest extends TestCase
             $specArrayNoItems,
             'Schema "Bad" has type "array" but no items',
         ];
+
+        $specDuplicateOperationId = new Specification();
+        $specDuplicateOperationId->openapi = new OA\OpenApi(version: '3.1.0');
+        $specDuplicateOperationId->info = new OA\Info(title: 'T', version: '1.0');
+        $specDuplicateOperationId->operations[] = new OA\Operation(path: '/a', method: 'get', operationId: 'getItem');
+        $specDuplicateOperationId->operations[] = new OA\Operation(path: '/b', method: 'get', operationId: 'getItem');
+
+        yield 'duplicate operationId' => [
+            new OpenApi31Compiler(),
+            $specDuplicateOperationId,
+            'operationId must be unique, found "getItem" again in unknown',
+        ];
+
+        $specBadResponseKey = new Specification();
+        $specBadResponseKey->openapi = new OA\OpenApi(version: '3.1.0');
+        $specBadResponseKey->info = new OA\Info(title: 'T', version: '1.0');
+        $specBadResponseKey->operations[] = new OA\Operation(path: '/a', method: 'get', responses: [
+            new OA\Response(response: 'Default', description: 'misspelled'),
+        ]);
+
+        yield 'invalid response key' => [
+            new OpenApi31Compiler(),
+            $specBadResponseKey,
+            'Invalid response "Default", expecting "default", a HTTP status code or a range such as "2XX" in unknown',
+        ];
+
+        $specBadSchemaType = new Specification();
+        $specBadSchemaType->openapi = new OA\OpenApi(version: '3.1.0');
+        $specBadSchemaType->info = new OA\Info(title: 'T', version: '1.0');
+        $specBadSchemaType->schemas[] = new OA\Schema(schema: 'Typo', type: 'strig');
+
+        yield 'unknown schema type' => [
+            new OpenApi31Compiler(),
+            $specBadSchemaType,
+            'Schema "Typo" has unknown type "strig", expecting one of string, number, integer, boolean, array, object, null in unknown',
+        ];
+    }
+
+    // --- input validation ---
+
+    /**
+     * In the `responses` bucket `Response::$response` is the component key, so
+     * `components.responses.product` is a name rather than a malformed status code. Position
+     * is the only thing that distinguishes the two — `isRoot()` is true for both.
+     */
+    public function testComponentResponseKeyIsNotValidatedAsStatusCode(): void
+    {
+        $spec = new Specification();
+        $spec->openapi = new OA\OpenApi(version: '3.1.0');
+        $spec->info = new OA\Info(title: 'T', version: '1.0');
+        $spec->responses[] = new OA\Response(response: 'product', description: 'a reusable response');
+
+        $messages = array_column((new OpenApi31Compiler())->validate($spec), 'message');
+
+        $this->assertEmpty(array_filter($messages, fn (string $m): bool => str_contains($m, 'Invalid response')));
+    }
+
+    /**
+     * An operation with neither a path nor a webhook reaches no document, so its id takes no
+     * part in uniqueness. Hybrid mode produces exactly one of these per webhook.
+     */
+    public function testUnemittedOperationDoesNotCollide(): void
+    {
+        $spec = new Specification();
+        $spec->openapi = new OA\OpenApi(version: '3.1.0');
+        $spec->info = new OA\Info(title: 'T', version: '1.0');
+        $spec->operations[] = new OA\Operation(webhook: 'ev', method: 'post', operationId: 'new-pet');
+        $spec->operations[] = new OA\Operation(method: 'post', operationId: 'new-pet');
+
+        $messages = array_column((new OpenApi31Compiler())->validate($spec), 'message');
+
+        $this->assertEmpty(array_filter($messages, fn (string $m): bool => str_contains($m, 'operationId must be unique')));
+    }
+
+    public function testValidSchemaTypesAreAccepted(): void
+    {
+        $spec = new Specification();
+        $spec->openapi = new OA\OpenApi(version: '3.1.0');
+        $spec->info = new OA\Info(title: 'T', version: '1.0');
+        $spec->schemas[] = new OA\Schema(schema: 'Ok', type: ['string', 'null']);
+
+        $messages = array_column((new OpenApi31Compiler())->validate($spec), 'message');
+
+        $this->assertEmpty(array_filter($messages, fn (string $m): bool => str_contains($m, 'unknown type')));
     }
 
     #[DataProvider('validationProvider')]

--- a/tests/Utils/SpecificationWalkerTest.php
+++ b/tests/Utils/SpecificationWalkerTest.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Utils;
+
+use OpenApi\Spec as OA;
+use OpenApi\Specification;
+use PHPUnit\Framework\TestCase;
+
+final class SpecificationWalkerTest extends TestCase
+{
+    /**
+     * A reusable response sits in the `responses` bucket and in the operation that uses it.
+     * It is one attribute, and a visitor that counts occurrences has to see it once — a
+     * duplicate reads as two operations sharing an id, or two schemas sharing a name.
+     */
+    public function testAttributeReachableFromTwoBucketsIsVisitedOnce(): void
+    {
+        $shared = new OA\Response(response: 'product', description: 'a reusable response');
+
+        $specification = new Specification();
+        $specification->responses[] = $shared;
+        $specification->operations[] = new OA\Operation(path: '/products', method: 'get', responses: [$shared]);
+
+        $visited = [];
+        $specification->getWalker()->visit(OA\Response::class, function (OA\Response $response) use (&$visited): void {
+            $visited[] = $response;
+        });
+
+        $this->assertSame([$shared], $visited);
+    }
+
+    public function testNestedAttributesAreVisited(): void
+    {
+        $specification = new Specification();
+        $specification->schemas[] = new OA\Schema(schema: 'Product', properties: [
+            new OA\Property(property: 'name', schema: new OA\Schema(type: 'string')),
+        ]);
+
+        $properties = [];
+        $specification->getWalker()->visit(OA\Property::class, function (OA\Property $property) use (&$properties): void {
+            $properties[] = $property->property;
+        });
+
+        $this->assertSame(['name'], $properties);
+    }
+}


### PR DESCRIPTION
## Overview

The compilers validated what each OpenAPI version can carry, but not whether the input was
valid to begin with. Three kinds of invalid input reached the document with no diagnostic: a
duplicate explicit `operationId`, a response key that is neither `default` nor a status code
nor a range such as `2XX`, and a schema `type` outside the seven JSON Schema types. Each
produces a document that fails OpenAPI validation while the build reports success.

`composer redocly` rejects all three, but only inside a fixture, and no fixture contains a
typo — so nothing caught them.

## Changes

- `validate()` gains `validateOperationIds()` and `validateResponses()`; `validateSchemaType()`
  is called from both compilers' `validateSchemas()`
- uniqueness skips operations with neither a path nor a webhook, which reach no document —
  hybrid mode produces one of these per webhook
- response keys are checked only where they are status codes, inside an operation; in the
  `responses` bucket `Response::$response` is the component key, and `isRoot()` is true for
  both
- `SpecificationWalker::visit()` shares one `SplObjectStorage` across buckets, so an attribute
  reachable from two of them is visited once rather than twice

