### PR TITLE
fix(Spec): escape component names embedded in a $ref

### DIFF
--- a/src/Augmenter/Cleanup.php
+++ b/src/Augmenter/Cleanup.php
@@ -10,6 +10,7 @@ use OpenApi\Contracts\AttributeInterface;
 use OpenApi\Spec as OA;
 use OpenApi\Specification;
 use OpenApi\Utils\Config;
+use OpenApi\Utils\JsonPointer;
 use OpenApi\Utils\PipeInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
@@ -110,7 +111,7 @@ class Cleanup implements PipeInterface, LoggerAwareInterface
         $removed = false;
         foreach ($specification->{$field} as $index => $item) {
             $name = $nameExtractor($item);
-            if ($name !== null && !isset($usedRefs['#/components/' . $refPrefix . '/' . $name])) {
+            if ($name !== null && !isset($usedRefs[JsonPointer::ref('components', $refPrefix, $name)])) {
                 unset($specification->{$field}[$index]);
                 $removed = true;
             }

--- a/src/Augmenter/Inheritance/Schemas.php
+++ b/src/Augmenter/Inheritance/Schemas.php
@@ -10,6 +10,7 @@ use OpenApi\Spec as OA;
 use OpenApi\Specification;
 use OpenApi\Specification\ComponentIndex;
 use OpenApi\Utils\AttributeFactory;
+use OpenApi\Utils\JsonPointer;
 
 /**
  * Expands PHP class hierarchy into OpenAPI composition (allOf).
@@ -109,7 +110,7 @@ class Schemas
         $schema->allOf ??= [];
         $name = $referenced->schema ?? $referenced->getShortClassName();
         if ($name !== null) {
-            $schema->allOf[] = new OA\Schema(ref: '#/components/schemas/' . $name);
+            $schema->allOf[] = new OA\Schema(ref: JsonPointer::ref('components', 'schemas', $name));
         }
     }
 

--- a/src/Augmenter/Refs.php
+++ b/src/Augmenter/Refs.php
@@ -9,6 +9,7 @@ namespace OpenApi\Augmenter;
 use OpenApi\Contracts\AttributeInterface;
 use OpenApi\Spec as OA;
 use OpenApi\Specification;
+use OpenApi\Utils\JsonPointer;
 use OpenApi\Utils\PipeInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
@@ -137,11 +138,13 @@ class Refs implements PipeInterface, LoggerAwareInterface
                 return;
             }
 
-            $name = $matches[1];
+            // the captured name is escaped, `$candidates` is keyed by the raw one
+            $name = JsonPointer::decode($matches[1]);
             $path = $matches[2];
             if (array_key_exists($name, $candidates)) {
                 $index = $candidates[$name];
-                $attribute->ref = "#/components/schemas/{$name}/allOf/{$index}/{$path}";
+                // `$path` is copied through as captured — it is already-escaped tokens plus separators
+                $attribute->ref = JsonPointer::ref('components', 'schemas', $name, 'allOf', (string) $index) . '/' . $path;
             }
         });
     }

--- a/src/Specification/ComponentIndex.php
+++ b/src/Specification/ComponentIndex.php
@@ -9,6 +9,7 @@ namespace OpenApi\Specification;
 use OpenApi\Contracts\AttributeInterface;
 use OpenApi\Spec as OA;
 use OpenApi\Specification;
+use OpenApi\Utils\JsonPointer;
 
 /**
  * Resolves `$ref` values to their corresponding component objects.
@@ -50,7 +51,7 @@ class ComponentIndex
             }
 
             $bucket = substr($path, 0, $slash);
-            $name = substr($path, $slash + 1);
+            $name = JsonPointer::decode(substr($path, $slash + 1));
 
             return $this->getIndex($bucket)[$name] ?? null;
         }
@@ -124,7 +125,7 @@ class ComponentIndex
                 $name = $this->getComponentName($item, $bucket);
                 $fqcn = $item->getClassName();
                 if ($name !== null && $fqcn !== null) {
-                    $map[$fqcn] = self::COMPONENTS_PREFIX . $bucket . '/' . $name;
+                    $map[$fqcn] = JsonPointer::ref('components', $bucket, $name);
                 }
             }
         }

--- a/src/Utils/JsonPointer.php
+++ b/src/Utils/JsonPointer.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Utils;
+
+/**
+ * Escaping for a single JSON Pointer reference token.
+ *
+ * A component name is free-form, so it may contain the two characters that are structural in
+ * a pointer. They have to be escaped where the name is embedded in a `$ref`, and left alone
+ * where it is the key of a map — `components.schemas` holds the raw name.
+ *
+ * @see [RFC 6901](https://datatracker.ietf.org/doc/html/rfc6901#section-3)
+ */
+final class JsonPointer
+{
+    /**
+     * `~` is escaped before `/`, so that the `~1` produced by a slash is not itself escaped.
+     */
+    public static function encode(string $token): string
+    {
+        return str_replace('/', '~1', str_replace('~', '~0', $token));
+    }
+
+    /**
+     * `~1` is decoded before `~0`, so that a literal `~1` written as `~01` survives.
+     */
+    public static function decode(string $token): string
+    {
+        return str_replace('~0', '~', str_replace('~1', '/', $token));
+    }
+
+    /**
+     * Builds a local `$ref` from reference tokens, escaping each.
+     *
+     * Every argument is one token, so a name is passed whole and never pre-joined —
+     * `ref('components', 'schemas', 'Odd/Name')`, not `ref('components/schemas/Odd/Name')`.
+     * Structural segments cost nothing to pass through, since neither character is legal in
+     * a bucket name.
+     */
+    public static function ref(string ...$tokens): string
+    {
+        return '#/' . implode('/', array_map(self::encode(...), $tokens));
+    }
+}

--- a/src/Utils/SpecificationWalker.php
+++ b/src/Utils/SpecificationWalker.php
@@ -54,7 +54,7 @@ class SpecificationWalker
             // special case
             if ($attribute instanceof OA\Security\Requirement) {
                 foreach (array_keys($attribute->toArray()) as $schemeName) {
-                    $visitor(new OA\Security\Scheme(ref: '#/components/securitySchemes/' . $schemeName));
+                    $visitor(new OA\Security\Scheme(ref: JsonPointer::ref('components', 'securitySchemes', $schemeName)));
                 }
             }
         });

--- a/tests/Augmenter/RefsTest.php
+++ b/tests/Augmenter/RefsTest.php
@@ -30,6 +30,29 @@ final class RefsTest extends TestCase
         $this->assertSame('#/components/schemas/RefTarget', $schema->ref);
     }
 
+    /**
+     * The ref being rewritten carries the escaped name, while the lookup of schemas whose
+     * properties moved into `allOf` is keyed by the raw one — so the augmenter has to decode
+     * before matching and encode again when it rebuilds the pointer.
+     */
+    public function testRewritesAllOfPropertyRefForAnEscapedName(): void
+    {
+        $spec = new Specification();
+
+        $merged = new OA\Schema(schema: 'Odd/Name~With', allOf: [
+            new OA\Schema(properties: [new OA\Property(property: 'name', schema: new OA\Schema(type: 'string'))]),
+        ]);
+        $merged->setReflector(new \ReflectionClass(Fixtures\Augmenter\RefTarget::class));
+        $spec->schemas[] = $merged;
+
+        $pointing = new OA\Schema(schema: 'Pointer', ref: '#/components/schemas/Odd~1Name~0With/properties/name');
+        $spec->schemas[] = $pointing;
+
+        (new Augmenter\Refs())($spec);
+
+        $this->assertSame('#/components/schemas/Odd~1Name~0With/allOf/0/properties/name', $pointing->ref);
+    }
+
     public function testLeavesAlreadyResolvedUntouched(): void
     {
         $spec = new Specification();

--- a/tests/Fixtures/ComponentIndex/OddlyNamed.php
+++ b/tests/Fixtures/ComponentIndex/OddlyNamed.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\ComponentIndex;
+
+use OpenApi\Spec as OA;
+
+/**
+ * A component name is free-form, so both characters that are structural in a JSON Pointer
+ * are legal in one.
+ */
+#[OA\Schema(schema: 'Odd/Name~With')]
+class OddlyNamed
+{
+    #[OA\Property]
+    public string $name;
+}

--- a/tests/Specification/ComponentIndexTest.php
+++ b/tests/Specification/ComponentIndexTest.php
@@ -10,6 +10,7 @@ use OpenApi\Contracts\AttributeInterface;
 use OpenApi\Spec as OA;
 use OpenApi\Specification;
 use OpenApi\Tests\Concerns\AssemblesSpecification;
+use OpenApi\Tests\Fixtures\ComponentIndex\OddlyNamed;
 use OpenApi\Tests\Fixtures\ComponentIndex\Product;
 use OpenApi\Tests\Fixtures\ComponentIndex\UnnamedTag;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -89,6 +90,34 @@ final class ComponentIndexTest extends TestCase
             ->buildComponentIndex();
 
         $this->assertInstanceOf(OA\Parameter::class, $index->findParameter('#/components/parameters/page'));
+    }
+
+    /**
+     * `/` and `~` are structural in a JSON Pointer, so a component name containing either has
+     * to be escaped where it is embedded in a `$ref` — and left raw as the map key, which is
+     * what the compiler emits under `components.schemas`.
+     */
+    public function testRefMapEscapesTheComponentName(): void
+    {
+        $map = $this->assemble(OddlyNamed::class)->buildComponentIndex()->buildRefMap();
+
+        $this->assertSame('#/components/schemas/Odd~1Name~0With', $map[OddlyNamed::class]);
+    }
+
+    /**
+     * The escaped form is what `buildRefMap()` produces and so what the pipeline resolves. The
+     * raw form resolves as well, because everything after the bucket is taken as the name —
+     * lenient rather than designed, but worth pinning so a stricter parse is a deliberate
+     * change.
+     */
+    public function testFindResolvesAnEscapedComponentPath(): void
+    {
+        $index = $this->assemble(OddlyNamed::class)->buildComponentIndex();
+
+        $escaped = $index->find('#/components/schemas/Odd~1Name~0With');
+
+        $this->assertInstanceOf(OA\Schema::class, $escaped);
+        $this->assertSame($escaped, $index->find('#/components/schemas/Odd/Name~With'));
     }
 
     public function testBuildRefMapMapsFqcnToComponentPath(): void

--- a/tests/Utils/JsonPointerTest.php
+++ b/tests/Utils/JsonPointerTest.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Utils;
+
+use OpenApi\Utils\JsonPointer;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class JsonPointerTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function tokens(): iterable
+    {
+        yield 'nothing to escape' => ['plain', 'plain'];
+        yield 'slash' => ['a/b', 'a~1b'];
+        yield 'tilde' => ['a~b', 'a~0b'];
+        yield 'both' => ['Odd/Name~With', 'Odd~1Name~0With'];
+        yield 'empty' => ['', ''];
+
+        // a name that already looks like an escape has to survive the round trip
+        yield 'literal ~1' => ['~1', '~01'];
+        yield 'literal ~0' => ['~0', '~00'];
+        yield 'literal ~1 inside' => ['a~1b', 'a~01b'];
+    }
+
+    public function testRefEscapesEveryToken(): void
+    {
+        $this->assertSame(
+            '#/components/schemas/Odd~1Name~0With',
+            JsonPointer::ref('components', 'schemas', 'Odd/Name~With')
+        );
+    }
+
+    public function testRefTreatsEachArgumentAsOneToken(): void
+    {
+        $this->assertSame('#/a~1b/c', JsonPointer::ref('a/b', 'c'));
+        $this->assertSame('#/a/b/c', JsonPointer::ref('a', 'b', 'c'));
+    }
+
+    #[DataProvider('tokens')]
+    public function testEncode(string $raw, string $encoded): void
+    {
+        $this->assertSame($encoded, JsonPointer::encode($raw));
+    }
+
+    #[DataProvider('tokens')]
+    public function testDecodeReversesEncode(string $raw, string $encoded): void
+    {
+        $this->assertSame($raw, JsonPointer::decode($encoded));
+    }
+}


### PR DESCRIPTION
## Overview

A component name is free-form and may contain `/` or `~`, both structural in a JSON Pointer.
The pipeline built component refs by concatenation, so a schema named `Odd/Name~With` emitted
`$ref: '#/components/schemas/Odd/Name~With'` — a pointer a consumer resolves to nothing, with
no diagnostic.

`Augmenter\Cleanup` built the same unescaped string for its used-ref lookup, so the two agreed
with each other and nothing noticed.

## Changes

- `Utils\JsonPointer` provides RFC 6901 `encode()` / `decode()`, and a `ref()` builder taking
  one reference token per argument
- applied where a component ref is built — `ComponentIndex::buildRefMap()`,
  `Augmenter\Cleanup`, `Augmenter\Refs`, `Augmenter\Inheritance\Schemas`,
  `Utils\SpecificationWalker` — and reversed in `ComponentIndex::find()`
- `Augmenter\Refs` decodes the name it captures out of an existing ref before matching, since
  `resolveAllOfPropertyRefs()` keys its lookup by the raw name; the structural tail of the
  pointer is copied through as captured
- component names stay raw as map keys, which is what `components.schemas` emits — only the
  pointer is escaped
