### PR TITLE
docs(Spec): say what Server and ServerVariable are, not that they exist

### DIFF
--- a/docs/reference/spec-attributes.md
+++ b/docs/reference/spec-attributes.md
@@ -2006,7 +2006,7 @@ An OpenID Connect Discovery security scheme.
 
 ### [Server](https://github.com/zircote/swagger-php/tree/master/src/Spec/Server.php)
 
-Represents a Server.
+A host the API is available on, optionally templated with `ServerVariable` substitutions.
 
 #### Allowed in
 ---
@@ -2031,7 +2031,7 @@ Represents a Server.
 
 ### [ServerVariable](https://github.com/zircote/swagger-php/tree/master/src/Spec/ServerVariable.php)
 
-Represents a Server Variable for server URL template substitution.
+The allowed and default substitutions for one template variable in a `Server` URL.
 
 #### Allowed in
 ---

--- a/src/Spec/Server.php
+++ b/src/Spec/Server.php
@@ -7,7 +7,7 @@
 namespace OpenApi\Spec;
 
 /**
- * Represents a Server.
+ * A host the API is available on, optionally templated with `ServerVariable` substitutions.
  *
  * @see [Server Object](https://spec.openapis.org/oas/v3.1.1.html#server-object)
  */

--- a/src/Spec/ServerVariable.php
+++ b/src/Spec/ServerVariable.php
@@ -7,7 +7,7 @@
 namespace OpenApi\Spec;
 
 /**
- * Represents a Server Variable for server URL template substitution.
+ * The allowed and default substitutions for one template variable in a `Server` URL.
  *
  * @see [Server Variable Object](https://spec.openapis.org/oas/v3.1.1.html#server-variable-object)
  */


### PR DESCRIPTION
## Overview

`src/Spec/` docblocks are spliced into `reference/spec-attributes.md`, so an imprecise one
ships as published documentation. Two class summaries opened by restating the class name and
said nothing else: "Represents a Server." and "Represents a Server Variable for server URL
template substitution."

## Changes

- `Server` and `ServerVariable` summaries describe what the attribute is for
- `reference/spec-attributes.md` regenerated
