### PR TITLE
refactor(Tests): migrate OpenApiTestCase to extracted traits

### DIFF
--- a/tests/Annotations/AbstractAnnotationTest.php
+++ b/tests/Annotations/AbstractAnnotationTest.php
@@ -24,7 +24,7 @@ final class AbstractAnnotationTest extends OpenApiTestCase
     {
         $openapi = $this->createOpenApiWithInfo();
         $openapi->merge($this->annotationsFromDocBlockParser('@OA\Items()'));
-        $this->assertOpenApiLogEntryContains('Unexpected @OA\Items(), expected to be inside @OA\\');
+        $this->expectLogEntry('Unexpected @OA\Items(), expected to be inside @OA\\');
         $openapi->validate();
     }
 
@@ -39,7 +39,7 @@ final class AbstractAnnotationTest extends OpenApiTestCase
 )
 END;
         $annotations = $this->annotationsFromDocBlockParser($comment);
-        $this->assertOpenApiLogEntryContains('Only one @OA\Contact() allowed for @OA\Info() multiple found in:');
+        $this->expectLogEntry('Only one @OA\Contact() allowed for @OA\Info() multiple found in:');
         $annotations[0]->validate();
     }
 
@@ -64,7 +64,7 @@ END;
 )
 END;
         $annotations = $this->annotationsFromDocBlockParser($comment);
-        $this->assertOpenApiLogEntryContains('Multiple @OA\Header() with the same header="X-CSRF-Token":');
+        $this->expectLogEntry('Multiple @OA\Header() with the same header="X-CSRF-Token":');
         $annotations[0]->validate();
     }
 
@@ -72,8 +72,8 @@ END;
     {
         $annotations = $this->annotationsFromDocBlockParser('@OA\Info()');
         $info = $annotations[0];
-        $this->assertOpenApiLogEntryContains('Missing required field "title" for @OA\Info() in ');
-        $this->assertOpenApiLogEntryContains('Missing required field "version" for @OA\Info() in ');
+        $this->expectLogEntry('Missing required field "title" for @OA\Info() in ');
+        $this->expectLogEntry('Missing required field "version" for @OA\Info() in ');
         $info->validate();
     }
 
@@ -91,9 +91,9 @@ END;
 END;
         $annotations = $this->annotationsFromDocBlockParser($comment);
         $parameter = $annotations[0];
-        $this->assertOpenApiLogEntryContains('@OA\Parameter(name=123,in="dunno")->name is a "integer", expecting a "string" in ');
-        $this->assertOpenApiLogEntryContains('@OA\Parameter(name=123,in="dunno")->in "dunno" is invalid, expecting "query", "header", "path", "cookie" in ');
-        $this->assertOpenApiLogEntryContains('@OA\Parameter(name=123,in="dunno")->required is a "string", expecting a "boolean" in ');
+        $this->expectLogEntry('@OA\Parameter(name=123,in="dunno")->name is a "integer", expecting a "string" in ');
+        $this->expectLogEntry('@OA\Parameter(name=123,in="dunno")->in "dunno" is invalid, expecting "query", "header", "path", "cookie" in ');
+        $this->expectLogEntry('@OA\Parameter(name=123,in="dunno")->required is a "string", expecting a "boolean" in ');
         $parameter->validate();
     }
 
@@ -120,7 +120,7 @@ END;
                 'DuplicateOperationId.php',
             ], $this->processorPipeline());
 
-        $this->assertOpenApiLogEntryContains('operationId must be unique. Duplicate value found: "getItem"');
+        $this->expectLogEntry('operationId must be unique. Duplicate value found: "getItem"');
         $this->assertFalse($analysis->validate());
     }
 
@@ -137,9 +137,9 @@ END;
             'BadExampleParameter.php',
         ], $this->processorPipeline());
 
-        $this->assertOpenApiLogEntryContains('Required @OA\Info() not found');
-        $this->assertOpenApiLogEntryContains('Required @OA\PathItem() not found');
-        $this->assertOpenApiLogEntryContains('"example" and "examples" are mutually exclusive');
+        $this->expectLogEntry('Required @OA\Info() not found');
+        $this->expectLogEntry('Required @OA\PathItem() not found');
+        $this->expectLogEntry('"example" and "examples" are mutually exclusive');
 
         $analysis->validate();
     }
@@ -185,7 +185,7 @@ END;
             '_context' => $this->getContext(),
         ]);
 
-        $this->assertOpenApiLogEntryContains('is missing key-field: "header"');
+        $this->expectLogEntry('is missing key-field: "header"');
         $response->validate();
     }
 }

--- a/tests/Annotations/ItemsTest.php
+++ b/tests/Annotations/ItemsTest.php
@@ -14,14 +14,14 @@ final class ItemsTest extends OpenApiTestCase
     public function testItemTypeArray(): void
     {
         $annotations = $this->annotationsFromDocBlockParser('@OA\Items(type="array")');
-        $this->assertOpenApiLogEntryContains('@OA\Items() is required when @OA\Items() has type "array" in ');
+        $this->expectLogEntry('@OA\Items() is required when @OA\Items() has type "array" in ');
         $annotations[0]->validate();
     }
 
     public function testSchemaTypeArray(): void
     {
         $annotations = $this->annotationsFromDocBlockParser('@OA\Schema(type="array")');
-        $this->assertOpenApiLogEntryContains('@OA\Items() is required when @OA\Schema() has type "array" in ');
+        $this->expectLogEntry('@OA\Items() is required when @OA\Schema() has type "array" in ');
         $annotations[0]->validate();
     }
 

--- a/tests/Annotations/LicenseTest.php
+++ b/tests/Annotations/LicenseTest.php
@@ -18,7 +18,7 @@ final class LicenseTest extends OpenApiTestCase
 
     public function testValidation3_1_0(): void
     {
-        $this->assertOpenApiLogEntryContains('@OA\License() url and identifier are mutually exclusive');
+        $this->expectLogEntry('@OA\License() url and identifier are mutually exclusive');
 
         $annotations = $this->annotationsFromDocBlockParser('@OA\License(name="MIT", identifier="MIT", url="http://localhost")', [], '3.1.1');
         $annotations[0]->validate(version: '3.1.1');

--- a/tests/Annotations/OpenApiTest.php
+++ b/tests/Annotations/OpenApiTest.php
@@ -14,8 +14,8 @@ final class OpenApiTest extends OpenApiTestCase
 {
     public function testValidVersion(): void
     {
-        $this->assertOpenApiLogEntryContains('Required @OA\Info() not found');
-        $this->assertOpenApiLogEntryContains('Required @OA\PathItem() not found');
+        $this->expectLogEntry('Required @OA\Info() not found');
+        $this->expectLogEntry('Required @OA\PathItem() not found');
 
         $openapi = new OA\OpenApi(['_context' => $this->getContext()]);
         $openapi->openapi = '3.0.3';
@@ -24,8 +24,8 @@ final class OpenApiTest extends OpenApiTestCase
 
     public function testValidVersion3_1_0(): void
     {
-        $this->assertOpenApiLogEntryContains('Required @OA\Info() not found');
-        $this->assertOpenApiLogEntryContains('At least one of @OA\PathItem(), @OA\Components() or @OA\Webhook() required');
+        $this->expectLogEntry('Required @OA\Info() not found');
+        $this->expectLogEntry('At least one of @OA\PathItem(), @OA\Components() or @OA\Webhook() required');
 
         $openapi = new OA\OpenApi(['_context' => $this->getContext()]);
         $openapi->openapi = '3.1.1';
@@ -34,8 +34,8 @@ final class OpenApiTest extends OpenApiTestCase
 
     public function testInvalidVersion(): void
     {
-        $this->assertOpenApiLogEntryContains('Required @OA\Info() not found');
-        $this->assertOpenApiLogEntryContains('Unsupported OpenAPI version "2". Allowed versions are:');
+        $this->expectLogEntry('Required @OA\Info() not found');
+        $this->expectLogEntry('Unsupported OpenAPI version "2". Allowed versions are:');
 
         $openapi = new OA\OpenApi(['_context' => $this->getContext()]);
         $openapi->openapi = '2';

--- a/tests/Annotations/ResponseTest.php
+++ b/tests/Annotations/ResponseTest.php
@@ -33,7 +33,7 @@ final class ResponseTest extends OpenApiTestCase
         /*
          * @see Annotations/Operation.php:187
          */
-        $this->assertOpenApiLogEntryContains(
+        $this->expectLogEntry(
             'Invalid value "' . $response . '" for @OA\Response()->response, expecting "default"'
             . ', a HTTP Status Code or HTTP '
         );

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -26,7 +26,7 @@ final class BuilderTest extends OpenApiTestCase
 
         $result = (new Builder())
             ->addSource(self::examplePath('petstore/annotations'))
-            ->setLogger($this->getTrackingLogger())
+            ->setLogger($this->trackingLogger())
             ->withGenerator(function (Generator $generator): void {
                 $generator->setAnalyser($this->getAnalyzer());
                 $generator->setTypeResolver($this->getTypeResolver());
@@ -149,13 +149,13 @@ final class BuilderTest extends OpenApiTestCase
 
     public function testBuildEmptySources(): void
     {
-        $this->assertOpenApiLogEntryContains('Required @OA\Info() not found');
-        $this->assertOpenApiLogEntryContains('Required @OA\PathItem() not found');
+        $this->expectLogEntry('Required @OA\Info() not found');
+        $this->expectLogEntry('Required @OA\PathItem() not found');
 
         $result = (new Builder())
             ->setMode(Mode::CLASSIC)
             ->setSources([])
-            ->setLogger($this->getTrackingLogger())
+            ->setLogger($this->trackingLogger())
             ->build();
 
         $this->assertEmpty($result->files());

--- a/tests/Concerns/UsesFixtures.php
+++ b/tests/Concerns/UsesFixtures.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Concerns;
+
+trait UsesFixtures
+{
+    public static function fixture(string $file): ?string
+    {
+        $fixtures = static::fixtures([$file]);
+
+        return $fixtures !== [] ? $fixtures[0] : null;
+    }
+
+    /**
+     * Resolve fixture filenames.
+     *
+     * @return array resolved filenames for loading scanning etc
+     */
+    public static function fixtures(array $files): array
+    {
+        return array_map(fn (string $file): string => dirname(__DIR__) . '/Fixtures/' . $file, $files);
+    }
+}

--- a/tests/ConstantsTest.php
+++ b/tests/ConstantsTest.php
@@ -19,7 +19,7 @@ final class ConstantsTest extends OpenApiTestCase
         self::$counter++;
         $const = 'OPENAPI_TEST_' . self::$counter;
         $this->assertFalse(defined($const));
-        $this->assertOpenApiLogEntryContains("[Semantical Error] Couldn't find constant " . $const);
+        $this->expectLogEntry("[Semantical Error] Couldn't find constant " . $const);
         $this->annotationsFromDocBlockParser('@OA\Contact(email=' . $const . ')');
 
         define($const, 'me@domain.org');
@@ -38,7 +38,7 @@ final class ConstantsTest extends OpenApiTestCase
 
     public function testInvalidClass(): void
     {
-        $this->assertOpenApiLogEntryContains("[Semantical Error] Couldn't find constant ConstantsTest::URL");
+        $this->expectLogEntry("[Semantical Error] Couldn't find constant ConstantsTest::URL");
         $this->annotationsFromDocBlockParser('@OA\Contact(url=ConstantsTest::URL)');
     }
 

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -18,11 +18,11 @@ final class ContextTest extends OpenApiTestCase
 {
     public function testFullyQualifiedName(): void
     {
-        $this->assertOpenApiLogEntryContains('Required @OA\PathItem() not found');
+        $this->expectLogEntry('Required @OA\PathItem() not found');
         $result = (new Builder())
             ->setMode(Mode::CLASSIC)
             ->addSource($this->fixture('Customer.php'))
-            ->setLogger($this->getTrackingLogger())
+            ->setLogger($this->trackingLogger())
             ->withGenerator(fn (Generator $generator): Generator => $generator
                 ->setAnalyser($this->getAnalyzer())
                 ->setTypeResolver($this->getTypeResolver()))
@@ -44,7 +44,7 @@ final class ContextTest extends OpenApiTestCase
     public function testEnsureRoot(): void
     {
         $root = new Context(['logger' => new NullLogger(), 'version' => OA\OpenApi::VERSION_3_1_0]);
-        $context = new Context(['logger' => $this->getTrackingLogger()]);
+        $context = new Context(['logger' => $this->trackingLogger()]);
 
         // assert defaults set
         $this->assertNotInstanceOf(NullLogger::class, $context->logger);
@@ -59,11 +59,11 @@ final class ContextTest extends OpenApiTestCase
 
     public function testDebugLocation(): void
     {
-        $this->assertOpenApiLogEntryContains('Required @OA\PathItem() not found');
+        $this->expectLogEntry('Required @OA\PathItem() not found');
         $result = (new Builder())
             ->setMode(Mode::CLASSIC)
             ->addSource($this->fixture('Customer.php'))
-            ->setLogger($this->getTrackingLogger())
+            ->setLogger($this->trackingLogger())
             ->withGenerator(fn (Generator $generator): Generator => $generator->setTypeResolver($this->getTypeResolver()))
             ->build();
 

--- a/tests/ExamplesTest.php
+++ b/tests/ExamplesTest.php
@@ -90,7 +90,7 @@ final class ExamplesTest extends OpenApiTestCase
     {
         $this->registerExampleClassloader($name, $implementation);
 
-        $this->ignoreLogEntries(
+        $this->allowLogEntry(
             'Schema: const is not supported in OpenAPI 3.0, using enum fallback',
             'License identifier is not supported in OpenAPI 3.0, use url instead',
         );
@@ -102,7 +102,7 @@ final class ExamplesTest extends OpenApiTestCase
             ->setMode($mode)
             ->addSource($path)
             ->setVersion($version)
-            ->setLogger($this->getTrackingLogger())
+            ->setLogger($this->trackingLogger())
             ->withGenerator(fn (Generator $generator): Generator => $generator->setTypeResolver($typeResolver))
             ->build();
         // file_put_contents($specFilename, $result->toYaml());

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -41,11 +41,11 @@ final class GeneratorTest extends OpenApiTestCase
 
     public function testScanInvalidSource(): void
     {
-        $this->assertOpenApiLogEntryContains('Skipping invalid source: /tmp/__swagger_php_does_not_exist__');
-        $this->assertOpenApiLogEntryContains('Required @OA\Info() not found');
-        $this->assertOpenApiLogEntryContains('Required @OA\PathItem() not found');
+        $this->expectLogEntry('Skipping invalid source: /tmp/__swagger_php_does_not_exist__');
+        $this->expectLogEntry('Required @OA\Info() not found');
+        $this->expectLogEntry('Required @OA\PathItem() not found');
 
-        (new Generator($this->getTrackingLogger()))
+        (new Generator($this->trackingLogger()))
             ->setAnalyser($this->getAnalyzer())
             ->setTypeResolver($this->getTypeResolver())
             ->generate(['/tmp/__swagger_php_does_not_exist__']);

--- a/tests/OpenApiTestCase.php
+++ b/tests/OpenApiTestCase.php
@@ -31,12 +31,6 @@ class OpenApiTestCase extends TestCase
     use ExpectsLogEntries;
     use UsesFixtures;
 
-    #[Before]
-    protected function allowClassicDebugNoise(): void
-    {
-        $this->allowLogEntry('Analysing source:', 'JetBrains');
-    }
-
     public function getContext(array $properties = [], ?string $version = OA\OpenApi::DEFAULT_VERSION): Context
     {
         return new Context(
@@ -134,6 +128,12 @@ class OpenApiTestCase extends TestCase
         }
 
         return $classes;
+    }
+
+    #[Before]
+    protected function allowClassicDebugNoise(): void
+    {
+        $this->allowLogEntry('Analysing source:', 'JetBrains');
     }
 
     /**

--- a/tests/OpenApiTestCase.php
+++ b/tests/OpenApiTestCase.php
@@ -15,96 +15,26 @@ use OpenApi\Analysis;
 use OpenApi\Annotations as OA;
 use OpenApi\Context;
 use OpenApi\Generator;
-use OpenApi\GeneratorAwareInterface;
 use OpenApi\Tests\Concerns\AssertsSpecEquals;
+use OpenApi\Tests\Concerns\ExpectsLogEntries;
+use OpenApi\Tests\Concerns\UsesFixtures;
 use OpenApi\Type\LegacyTypeResolver;
 use OpenApi\Type\TypeInfoTypeResolver;
 use OpenApi\TypeResolverInterface;
 use OpenApi\Utils\Pipeline;
+use PHPUnit\Framework\Attributes\Before;
 use PHPUnit\Framework\TestCase;
-use Psr\Log\AbstractLogger;
-use Psr\Log\LoggerInterface;
-use Psr\Log\LogLevel;
 
 class OpenApiTestCase extends TestCase
 {
     use AssertsSpecEquals;
+    use ExpectsLogEntries;
+    use UsesFixtures;
 
-    /**
-     * @var array
-     */
-    public $expectedLogMessages = [];
-
-    /** @var list<string> */
-    public array $ignoredLogMessages = [];
-
-    protected function setUp(): void
+    #[Before]
+    protected function allowClassicDebugNoise(): void
     {
-        $this->expectedLogMessages = [];
-        $this->ignoredLogMessages = [];
-
-        parent::setUp();
-    }
-
-    protected function tearDown(): void
-    {
-        $this->assertEmpty(
-            $this->expectedLogMessages,
-            implode(PHP_EOL . '  => ', array_merge(
-                ['OpenApi\Logger messages were not triggered:'],
-                array_map(fn (array $value) => $value[1], $this->expectedLogMessages)
-            ))
-        );
-
-        parent::tearDown();
-    }
-
-    /**
-     * Log lines containing any of these are dropped rather than matched against
-     * expectations. For diagnostics that are incidental to what a test asserts — a
-     * compiler warning about the target version, say — where demanding they appear
-     * would couple the test to something it is not about.
-     */
-    public function ignoreLogEntries(string ...$needles): void
-    {
-        $this->ignoredLogMessages = array_merge($this->ignoredLogMessages, $needles);
-    }
-
-    public function getTrackingLogger(bool $debug = false): ?LoggerInterface
-    {
-        return new class ($this, $debug) extends AbstractLogger {
-            protected OpenApiTestCase $testCase;
-
-            protected bool $debug;
-
-            public function __construct(OpenApiTestCase $testCase, bool $debug = false)
-            {
-                $this->testCase = $testCase;
-                $this->debug = $debug;
-            }
-
-            public function log($level, $message, array $context = []): void
-            {
-                if (LogLevel::DEBUG == $level) {
-                    if (str_starts_with((string) $message, 'Analysing source:') || str_contains((string) $message, 'JetBrains')) {
-                        return;
-                    }
-                }
-
-                foreach ($this->testCase->ignoredLogMessages as $needle) {
-                    if (str_contains((string) $message, $needle)) {
-                        return;
-                    }
-                }
-
-                if (count($this->testCase->expectedLogMessages)) {
-                    [$assertion] = array_shift($this->testCase->expectedLogMessages);
-                    $assertion($message, $level);
-                } else {
-                    $this->testCase->fail('Unexpected log line: ' . $level . '("' . $message . '")');
-                }
-            }
-        };
+        $this->allowLogEntry('Analysing source:', 'JetBrains');
     }
 
     public function getContext(array $properties = [], ?string $version = OA\OpenApi::DEFAULT_VERSION): Context
@@ -112,7 +42,7 @@ class OpenApiTestCase extends TestCase
         return new Context(
             [
                 'version' => $version,
-                'logger' => $this->getTrackingLogger(),
+                'logger' => $this->trackingLogger(),
             ] + $properties
         );
     }
@@ -135,47 +65,6 @@ class OpenApiTestCase extends TestCase
         ];
     }
 
-    public function initializeProcessors(array $processors): array
-    {
-        $generator = (new Generator())
-            ->setTypeResolver($this->getTypeResolver());
-
-        array_walk($processors, function ($processor) use ($generator): void {
-            if (is_a($processor, GeneratorAwareInterface::class)) {
-                $processor->setGenerator($generator);
-            }
-        });
-
-        return $processors;
-    }
-
-    public function assertOpenApiLogEntryContains(string $needle, string $message = ''): void
-    {
-        $this->expectedLogMessages[] = [function ($entry, $type) use ($needle, $message): void {
-            if ($entry instanceof \Exception) {
-                $entry = $entry->getMessage();
-            }
-            $this->assertStringContainsString($needle, (string) $entry, $message);
-        }, $needle];
-    }
-
-    public static function fixture(string $file): ?string
-    {
-        $fixtures = static::fixtures([$file]);
-
-        return $fixtures !== [] ? $fixtures[0] : null;
-    }
-
-    /**
-     * Resolve fixture filenames.
-     *
-     * @return array resolved filenames for loading scanning etc
-     */
-    public static function fixtures(array $files): array
-    {
-        return array_map(fn (string $file): string => __DIR__ . '/Fixtures/' . $file, $files);
-    }
-
     public function processorPipeline(?array $processors = null, array $strip = []): Pipeline
     {
         $generator = (new Generator())
@@ -193,7 +82,7 @@ class OpenApiTestCase extends TestCase
     {
         $analysis = new Analysis([], $this->getContext());
 
-        (new Generator($this->getTrackingLogger()))
+        (new Generator($this->trackingLogger()))
             ->setConfig($config)
             ->setAnalyser($analyzer ?: $this->getAnalyzer())
             ->setTypeResolver($this->getTypeResolver())

--- a/tests/Processors/CleanUnmergedTest.php
+++ b/tests/Processors/CleanUnmergedTest.php
@@ -48,8 +48,8 @@ END;
         $this->assertCount(3, $between->merged->annotations, 'Generated @OA\OpenApi, @OA\PathItem and @OA\Info');
         $this->assertCount(2, $between->unmerged->annotations, '@OA\License + @OA\Contact');
         $this->assertCount(2, $analysis->openapi->_unmerged); // 1 would also be oke, Could a'Only the @OA\License'
-        $this->assertOpenApiLogEntryContains('Unexpected @OA\License(), expected to be inside @OA\Info in ');
-        $this->assertOpenApiLogEntryContains('Unexpected @OA\Contact(), expected to be inside @OA\Info in ');
+        $this->expectLogEntry('Unexpected @OA\License(), expected to be inside @OA\Info in ');
+        $this->expectLogEntry('Unexpected @OA\Contact(), expected to be inside @OA\Info in ');
         $analysis->validate();
 
         // When a processor places a previously unmerged annotation into the swagger obect.
@@ -65,7 +65,7 @@ END;
         $this->assertCount(4, $after->merged->annotations, 'Generated @OA\OpenApi, @OA\PathItem, @OA\Info and @OA\Contact');
         $this->assertCount(1, $after->unmerged->annotations, '@OA\License');
         $this->assertCount(1, $analysis->openapi->_unmerged);
-        $this->assertOpenApiLogEntryContains('Unexpected @OA\License(), expected to be inside @OA\Info in ');
+        $this->expectLogEntry('Unexpected @OA\License(), expected to be inside @OA\Info in ');
         $analysis->validate();
     }
 }

--- a/tests/Processors/MergeJsonContentTest.php
+++ b/tests/Processors/MergeJsonContentTest.php
@@ -87,7 +87,7 @@ END;
 
     public function testNoParent(): void
     {
-        $this->assertOpenApiLogEntryContains('Unexpected @OA\JsonContent() must be nested');
+        $this->expectLogEntry('Unexpected @OA\JsonContent() must be nested');
         $comment = <<<END
             @OA\JsonContent(type="array",
                 @OA\Items(ref="#/components/schemas/repository")
@@ -99,7 +99,7 @@ END;
 
     public function testInvalidParent(): void
     {
-        $this->assertOpenApiLogEntryContains('Unexpected @OA\JsonContent() in @OA\Property() in');
+        $this->expectLogEntry('Unexpected @OA\JsonContent() in @OA\Property() in');
         $comment = <<<END
             @OA\Property(
                 @OA\JsonContent(type="array",

--- a/tests/Processors/MergeXmlContentTest.php
+++ b/tests/Processors/MergeXmlContentTest.php
@@ -85,7 +85,7 @@ END;
 
     public function testNoParent(): void
     {
-        $this->assertOpenApiLogEntryContains('Unexpected @OA\XmlContent() must be nested');
+        $this->expectLogEntry('Unexpected @OA\XmlContent() must be nested');
         $comment = <<<END
             @OA\XmlContent(type="array",
                 @OA\Items(ref="#/components/schemas/repository")
@@ -97,7 +97,7 @@ END;
 
     public function testInvalidParent(): void
     {
-        $this->assertOpenApiLogEntryContains('Unexpected @OA\XmlContent() in @OA\Property() in');
+        $this->expectLogEntry('Unexpected @OA\XmlContent() in @OA\Property() in');
         $comment = <<<END
             @OA\Property(
                 @OA\XmlContent(type="array",

--- a/tests/ScratchTest.php
+++ b/tests/ScratchTest.php
@@ -95,9 +95,9 @@ final class ScratchTest extends OpenApiTestCase
     public function testScratch(TypeResolverInterface $typeResolver, string $scratch, Builder\Mode $mode, string $spec, string $version, array $expectedLogs, array $ignoredLogs = []): void
     {
         foreach ($expectedLogs as $logLine) {
-            $this->assertOpenApiLogEntryContains($logLine);
+            $this->expectLogEntry($logLine);
         }
-        $this->ignoreLogEntries(...$ignoredLogs);
+        $this->allowLogEntry(...$ignoredLogs);
 
         require_once $scratch;
 
@@ -105,7 +105,7 @@ final class ScratchTest extends OpenApiTestCase
             ->setMode($mode)
             ->addSource($scratch)
             ->setVersion($version)
-            ->setLogger($this->getTrackingLogger())
+            ->setLogger($this->trackingLogger())
             ->withAugmenters(function (Pipeline $pipeline): void {
                 $pipeline->get(Cleanup::class)->setEnabled(false);
             })

--- a/tests/Utils/SourceScannerTest.php
+++ b/tests/Utils/SourceScannerTest.php
@@ -6,14 +6,16 @@
 
 namespace OpenApi\Tests\Utils;
 
+use OpenApi\Tests\Concerns\ExpectsLogEntries;
 use OpenApi\Tests\Concerns\UsesExamples;
-use OpenApi\Tests\OpenApiTestCase;
 use OpenApi\Utils\SourceFinder;
 use OpenApi\Utils\SourceScanner;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
 
-final class SourceScannerTest extends OpenApiTestCase
+final class SourceScannerTest extends TestCase
 {
+    use ExpectsLogEntries;
     use UsesExamples;
 
     public static function sourcesProvider(): iterable
@@ -28,7 +30,7 @@ final class SourceScannerTest extends OpenApiTestCase
     #[DataProvider('sourcesProvider')]
     public function testScan(iterable $sources): void
     {
-        $scanner = new SourceScanner($this->getTrackingLogger());
+        $scanner = new SourceScanner($this->trackingLogger());
         $files = $scanner->scan($sources);
 
         $this->assertNotEmpty($files);
@@ -40,9 +42,9 @@ final class SourceScannerTest extends OpenApiTestCase
 
     public function testScanInvalidSource(): void
     {
-        $this->assertOpenApiLogEntryContains('Skipping invalid source: /tmp/__swagger_php_does_not_exist__');
+        $this->expectLogEntry('Skipping invalid source: /tmp/__swagger_php_does_not_exist__');
 
-        $scanner = new SourceScanner($this->getTrackingLogger());
+        $scanner = new SourceScanner($this->trackingLogger());
         $files = $scanner->scan(['/tmp/__swagger_php_does_not_exist__']);
 
         $this->assertEmpty($files);
@@ -53,7 +55,7 @@ final class SourceScannerTest extends OpenApiTestCase
         $sourceDir = self::examplePath('petstore/annotations');
         $nested = [new SourceFinder($sourceDir)];
 
-        $scanner = new SourceScanner($this->getTrackingLogger());
+        $scanner = new SourceScanner($this->trackingLogger());
         $files = $scanner->scan($nested);
 
         $this->assertNotEmpty($files);
@@ -66,7 +68,7 @@ final class SourceScannerTest extends OpenApiTestCase
         $splFiles = iterator_to_array($finder);
         $first = reset($splFiles);
 
-        $scanner = new SourceScanner($this->getTrackingLogger());
+        $scanner = new SourceScanner($this->trackingLogger());
         $files = $scanner->scan([$first]);
 
         $this->assertCount(1, $files);
@@ -77,7 +79,7 @@ final class SourceScannerTest extends OpenApiTestCase
     {
         $reflector = new \ReflectionClass(self::class);
 
-        $scanner = new SourceScanner($this->getTrackingLogger());
+        $scanner = new SourceScanner($this->trackingLogger());
         $files = $scanner->scan([$reflector]);
 
         $this->assertEmpty($files);
@@ -90,7 +92,7 @@ final class SourceScannerTest extends OpenApiTestCase
         $sourceDir = self::examplePath('petstore/annotations');
         $reflector = new \ReflectionClass(self::class);
 
-        $scanner = new SourceScanner($this->getTrackingLogger());
+        $scanner = new SourceScanner($this->trackingLogger());
         $files = $scanner->scan([$sourceDir, $reflector]);
 
         $this->assertNotEmpty($files);


### PR DESCRIPTION
## Summary

- Extract `UsesFixtures` trait (`fixture()`/`fixtures()` path helpers)
- Compose `ExpectsLogEntries`, `AssertsSpecEquals`, and `UsesFixtures` into `OpenApiTestCase`
- Migrate all 15 test files from old logger API (`assertOpenApiLogEntryContains`, `ignoreLogEntries`, `getTrackingLogger`) to the `ExpectsLogEntries` trait API (`expectLogEntry`, `allowLogEntry`, `trackingLogger`)
- Remove dead `initializeProcessors()` method (zero callers)
- Move `SourceScannerTest` off `OpenApiTestCase` to plain `TestCase` — it needed nothing classic
- Add `allowClassicDebugNoise()` hook to suppress the "Analysing source:" and "JetBrains" debug entries the old logger silently dropped

What remains on `OpenApiTestCase` is classic-only: `getContext`, `getAnalyzer`, `processorPipeline`, `analysisFromFixtures`, `annotationsFromDocBlockParser`, `createOpenApiWithInfo`, `allAnnotationClasses`, `allAttributeClasses`, `getTypeResolver`, `getTypeResolvers`. All deletable with classic in v8.

## Test plan

- [x] Full test suite passes (1877 tests, 16M assertions)
- [x] phpstan clean
- [ ] CI green