### PR TITLE
fix(Spec): resolve sibling merge chains inner-to-outer

### DIFF
--- a/docs/dev/pipeline.md
+++ b/docs/dev/pipeline.md
@@ -46,6 +46,12 @@ structural semantics:
 2. **Hierarchical absorb** — what remains flows upward a level at a time via `contained()`,
    first match wins
 
+Sibling merge chains resolve inner-to-outer, not in declaration order: a `MediaType`
+stacked with a `Response` and an `Operation` finds its `Response` before the `Response` is
+folded into the `Operation`, whichever way the three are declared. Only attributes whose
+types name each other as merge targets — possible with custom attachables, not among the
+native attributes — cannot be ordered that way and resolve in declaration order instead.
+
 If a level has containers, an unmatched non-root attribute is an error. If a level has no
 containers at all, unmatched attributes pass through to the level above.
 

--- a/docs/guide/spec-attributes.md
+++ b/docs/guide/spec-attributes.md
@@ -167,6 +167,18 @@ public function show(int $id) {}
 public function show(int $id) {}
 ```
 
+The flat form extends to deeper nesting: a `MediaType` and `Schema` stacked alongside a `Response` merge into it, in any declaration order.
+
+```php
+#[OA\Operation\Get(path: '/pets/{id}')]
+#[OA\Response(response: 200, description: 'OK')]
+#[OA\MediaType(mediaType: 'application/json')]
+#[OA\Schema(type: 'string')]
+public function show(int $id) {}
+```
+
+The merge is by attribute type, so the flat form only works while it is unambiguous. Two `Response` siblings each expecting their own `MediaType`, or a `MediaType` next to both a `Response` and a `RequestBody`, fail with an `Ambiguous merge` error — nest those inline instead.
+
 ### Parameters on method arguments
 
 Parameters can be placed directly on method arguments:

--- a/src/Utils/AttributeFactory.php
+++ b/src/Utils/AttributeFactory.php
@@ -285,6 +285,12 @@ class AttributeFactory
     /**
      * Stack-resolve: merge sibling attributes on the same reflector using merge().
      *
+     * Chains resolve inner-to-outer regardless of declaration order: an attribute is
+     * held back while another sibling still wants to merge into it, so a MediaType
+     * finds its Response before the Response is folded into the Operation. Mutual
+     * targets — possible with custom attachables, not among the native attributes —
+     * cannot be ordered that way and resolve in declaration order instead.
+     *
      * @param  list<AttributeInterface> $attributes
      * @return list<AttributeInterface>
      */
@@ -296,37 +302,30 @@ class AttributeFactory
 
         $merged = [];
 
+        $pending = [];
         foreach ($attributes as $index => $attribute) {
-            $mergeTargets = $attribute->merge();
-
-            if ($mergeTargets === []) {
-                continue;
+            if ($attribute->merge() !== []) {
+                $pending[$index] = true;
             }
+        }
 
-            $matchingTarget = null;
-            $matchingSlot = null;
-            foreach ($attributes as $candidateIndex => $candidate) {
-                if ($candidateIndex === $index || isset($merged[$candidateIndex])) {
+        while ($pending !== []) {
+            $progress = false;
+
+            foreach (array_keys($pending) as $index) {
+                if ($this->isMergeTarget($attributes, $pending, $index)) {
                     continue;
                 }
 
-                foreach ($mergeTargets as $targetClass => $slot) {
-                    if ($candidate instanceof $targetClass) {
-                        if ($matchingTarget instanceof AttributeInterface) {
-                            throw OpenApiException::fromSource(
-                                sprintf('Ambiguous merge: %s matches multiple siblings on the same target', $attribute::class),
-                                $attribute->getSourceLocation(),
-                            );
-                        }
-                        $matchingTarget = $candidate;
-                        $matchingSlot = $slot;
-                    }
-                }
+                $this->mergeIntoSibling($attributes, $index, $merged);
+                unset($pending[$index]);
+                $progress = true;
             }
 
-            if ($matchingTarget instanceof AttributeInterface) {
-                $this->nestChild($matchingTarget, $attribute, $matchingSlot);
-                $merged[$index] = true;
+            if (!$progress) {
+                $index = array_key_first($pending);
+                $this->mergeIntoSibling($attributes, $index, $merged);
+                unset($pending[$index]);
             }
         }
 
@@ -338,6 +337,67 @@ class AttributeFactory
         }
 
         return $roots;
+    }
+
+    /**
+     * Whether another pending sibling names this attribute's type as a merge target.
+     *
+     * @param list<AttributeInterface> $attributes
+     * @param array<int,true>          $pending
+     */
+    protected function isMergeTarget(array $attributes, array $pending, int $index): bool
+    {
+        foreach (array_keys($pending) as $otherIndex) {
+            if ($otherIndex === $index) {
+                continue;
+            }
+
+            foreach (array_keys($attributes[$otherIndex]->merge()) as $targetClass) {
+                if ($attributes[$index] instanceof $targetClass) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Merge one attribute into a matching unmerged sibling, if there is exactly one.
+     *
+     * @param list<AttributeInterface> $attributes
+     * @param array<int,true>          $merged
+     */
+    protected function mergeIntoSibling(array $attributes, int $index, array &$merged): void
+    {
+        $attribute = $attributes[$index];
+        $mergeTargets = $attribute->merge();
+
+        $matchingTarget = null;
+        $matchingSlot = null;
+        foreach ($attributes as $candidateIndex => $candidate) {
+            if ($candidateIndex === $index || isset($merged[$candidateIndex])) {
+                continue;
+            }
+
+            foreach ($mergeTargets as $targetClass => $slot) {
+                if ($candidate instanceof $targetClass) {
+                    if ($matchingTarget instanceof AttributeInterface) {
+                        throw OpenApiException::fromSource(
+                            sprintf('Ambiguous merge: %s matches multiple siblings on the same target', $attribute::class),
+                            $attribute->getSourceLocation(),
+                        );
+                    }
+                    $matchingTarget = $candidate;
+                    $matchingSlot = $slot;
+                }
+            }
+        }
+
+        if ($matchingTarget instanceof AttributeInterface) {
+            $this->nestChild($matchingTarget, $attribute, $matchingSlot);
+            $merged[$index] = true;
+        }
     }
 
     protected function nestChild(AttributeInterface $parent, AttributeInterface $child, string $slot): void

--- a/tests/Fixtures/Assembler/Attachable/MutualFirstAttachable.php
+++ b/tests/Fixtures/Assembler/Attachable/MutualFirstAttachable.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Assembler\Attachable;
+
+use OpenApi\Spec as OA;
+
+/**
+ * Names {@see MutualSecondAttachable} as a merge target, which names this class back.
+ */
+#[\Attribute(\Attribute::TARGET_ALL | \Attribute::IS_REPEATABLE)]
+class MutualFirstAttachable extends OA\Attachable
+{
+    public function merge(): array
+    {
+        return [
+            MutualSecondAttachable::class => 'attachables[]',
+        ];
+    }
+}

--- a/tests/Fixtures/Assembler/Attachable/MutualSecondAttachable.php
+++ b/tests/Fixtures/Assembler/Attachable/MutualSecondAttachable.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Assembler\Attachable;
+
+use OpenApi\Spec as OA;
+
+/**
+ * Names {@see MutualFirstAttachable} as a merge target, which names this class back.
+ */
+#[\Attribute(\Attribute::TARGET_ALL | \Attribute::IS_REPEATABLE)]
+class MutualSecondAttachable extends OA\Attachable
+{
+    public function merge(): array
+    {
+        return [
+            MutualFirstAttachable::class => 'attachables[]',
+        ];
+    }
+}

--- a/tests/Fixtures/Assembler/MutualMergeAttachables.php
+++ b/tests/Fixtures/Assembler/MutualMergeAttachables.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Assembler;
+
+use OpenApi\Tests\Fixtures\Assembler\Attachable\MutualFirstAttachable;
+use OpenApi\Tests\Fixtures\Assembler\Attachable\MutualSecondAttachable;
+
+class MutualMergeAttachables
+{
+    #[MutualFirstAttachable]
+    #[MutualSecondAttachable]
+    public function firstDeclaredFirst()
+    {
+    }
+
+    #[MutualSecondAttachable]
+    #[MutualFirstAttachable]
+    public function secondDeclaredFirst()
+    {
+    }
+}

--- a/tests/Fixtures/Assembler/StackedMergeChain.php
+++ b/tests/Fixtures/Assembler/StackedMergeChain.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Assembler;
+
+use OpenApi\Spec as OA;
+
+class StackedMergeChain
+{
+    #[OA\Operation\Get(path: '/outer-first')]
+    #[OA\Response(response: 200, description: 'OK')]
+    #[OA\MediaType(mediaType: 'application/json')]
+    #[OA\Schema(type: 'string')]
+    public function outerFirst()
+    {
+    }
+
+    #[OA\Schema(type: 'string')]
+    #[OA\MediaType(mediaType: 'application/json')]
+    #[OA\Response(response: 200, description: 'OK')]
+    #[OA\Operation\Get(path: '/inner-first')]
+    public function innerFirst()
+    {
+    }
+
+    #[OA\Response(response: 200, description: 'OK')]
+    #[OA\Operation\Get(path: '/mixed')]
+    #[OA\Schema(type: 'string')]
+    #[OA\MediaType(mediaType: 'application/json')]
+    public function mixed()
+    {
+    }
+}

--- a/tests/Fixtures/Scratch/Encoding-spec.php
+++ b/tests/Fixtures/Scratch/Encoding-spec.php
@@ -39,23 +39,22 @@ class MultipartFormDataSpec
 #[OA\Info(title: 'Encoding', version: '1.0')]
 class EncodingControllerSpec
 {
+    // Stacked siblings: Schema -> MediaType -> RequestBody -> Post. Encoding
+    // only targets properties, so it stays inline on the MediaType.
+    #[OA\Schema(ref: MultipartFormDataSpec::class)]
+    #[OA\MediaType(
+        mediaType: 'multipart/form-data',
+        encoding: [
+            new OA\Encoding(
+                encoding: 'metadata',
+                contentType: 'application/xml; charset=utf-8',
+            ),
+        ]
+    )]
+    #[OA\RequestBody]
     #[OA\Operation\Post(
         path: '/endpoint/multipart-form-data-ref',
         operationId: 'multipartFormDataRef',
-        requestBody: new OA\RequestBody(
-            content: new OA\MediaType(
-                mediaType: 'multipart/form-data',
-                schema: new OA\Schema(
-                    ref: MultipartFormDataSpec::class,
-                ),
-                encoding: [
-                    new OA\Encoding(
-                        encoding: 'metadata',
-                        contentType: 'application/xml; charset=utf-8',
-                    ),
-                ]
-            ),
-        ),
         responses: [
             new OA\Response(
                 response: 200,

--- a/tests/Fixtures/Scratch/RequestBody-spec.php
+++ b/tests/Fixtures/Scratch/RequestBody-spec.php
@@ -28,13 +28,14 @@ class RequestBodyRefFooSpec
 #[OA\Info(title: 'RequestBody', version: '1.0')]
 class RequestBodyControllerSpec
 {
+    // Stacked siblings: Json -> RequestBody -> Post. The responses stay inline
+    // because MediaType merges into Response and RequestBody alike — with both
+    // as siblings the merge would be ambiguous.
+    #[OA\MediaType\Json(ref: RequestBodySchemaSpec::class)]
+    #[OA\RequestBody(description: 'Information about a new pet in the system')]
     #[OA\Operation\Post(
         path: '/endpoint/schema-ref-json',
         operationId: 'postSchemaRefJson',
-        requestBody: new OA\RequestBody(
-            description: 'Information about a new pet in the system',
-            content: new OA\MediaType\Json(ref: RequestBodySchemaSpec::class),
-        ),
         responses: [
             new OA\Response(
                 response: 200,
@@ -46,16 +47,13 @@ class RequestBodyControllerSpec
     {
     }
 
+    // As above, one level deeper: Schema -> MediaType -> RequestBody -> Post.
+    #[OA\Schema(ref: RequestBodySchemaSpec::class)]
+    #[OA\MediaType(mediaType: 'application/json')]
+    #[OA\RequestBody(description: 'Information about a new pet in the system')]
     #[OA\Operation\Post(
         path: '/endpoint/schema-ref',
         operationId: 'postSchemaRef',
-        requestBody: new OA\RequestBody(
-            description: 'Information about a new pet in the system',
-            content: new OA\MediaType(
-                mediaType: 'application/json',
-                schema: new OA\Schema(ref: RequestBodySchemaSpec::class)
-            ),
-        ),
         responses: [
             new OA\Response(
                 response: 200,

--- a/tests/Fixtures/Scratch/Response-spec.php
+++ b/tests/Fixtures/Scratch/Response-spec.php
@@ -11,23 +11,16 @@ use OpenApi\Spec as OA;
 #[OA\Info(title: 'Response', version: '1.0')]
 class ResponseControllerSpec
 {
+    // Stacked siblings instead of constructor nesting, declared container-first:
+    // the merge chain (Schema -> MediaType -> Response -> Post) resolves
+    // inner-to-outer, so declaration order does not matter.
     #[OA\Operation\Post(
         path: '/endpoint/response-schema',
         operationId: 'responseSchema',
-        responses: [
-            new OA\Response(
-                response: 200,
-                description: 'All good',
-                content: new OA\MediaType(
-                    mediaType: 'application/octet-stream',
-                    schema: new OA\Schema(
-                        type: 'string',
-                        format: 'byte',
-                    ),
-                ),
-            ),
-        ]
     )]
+    #[OA\Response(response: 200, description: 'All good')]
+    #[OA\MediaType(mediaType: 'application/octet-stream')]
+    #[OA\Schema(type: 'string', format: 'byte')]
     public function responseSchema()
     {
     }

--- a/tests/Utils/AttributeFactoryTest.php
+++ b/tests/Utils/AttributeFactoryTest.php
@@ -12,12 +12,17 @@ use OpenApi\Contracts\AttributeInterface;
 use OpenApi\OpenApiException;
 use OpenApi\Spec as OA;
 use OpenApi\Tests\Fixtures\Assembler\AmbiguousMerge;
+use OpenApi\Tests\Fixtures\Assembler\Attachable\MutualFirstAttachable;
+use OpenApi\Tests\Fixtures\Assembler\Attachable\MutualSecondAttachable;
 use OpenApi\Tests\Fixtures\Assembler\Attachable\RequestPayload;
 use OpenApi\Tests\Fixtures\Assembler\ImplicitPropertyProduct;
+use OpenApi\Tests\Fixtures\Assembler\MutualMergeAttachables;
 use OpenApi\Tests\Fixtures\Assembler\SimpleController;
 use OpenApi\Tests\Fixtures\Assembler\SimpleProduct;
+use OpenApi\Tests\Fixtures\Assembler\StackedMergeChain;
 use OpenApi\Utils\AttributeFactory;
 use OpenApi\Utils\TypedList;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class AttributeFactoryTest extends TestCase
@@ -81,6 +86,61 @@ final class AttributeFactoryTest extends TestCase
 
         $factory = new AttributeFactory();
         $factory->fromReflector(new \ReflectionProperty(AmbiguousMerge::class, 'value'));
+    }
+
+    /**
+     * Mutual merge targets cannot resolve inner-to-outer; the first-declared
+     * attribute merges into the later one.
+     */
+    public static function mutualMergeCases(): iterable
+    {
+        yield 'first declared first' => ['firstDeclaredFirst', MutualSecondAttachable::class, MutualFirstAttachable::class];
+        yield 'second declared first' => ['secondDeclaredFirst', MutualFirstAttachable::class, MutualSecondAttachable::class];
+    }
+
+    #[DataProvider('mutualMergeCases')]
+    public function testMutualMergeTargetsResolveInDeclarationOrder(string $method, string $expectedRoot, string $expectedNested): void
+    {
+        $factory = new AttributeFactory();
+        $result = $factory->fromReflector(new \ReflectionMethod(MutualMergeAttachables::class, $method));
+
+        $this->assertCount(1, $result);
+        $root = $result[0];
+        $this->assertInstanceOf(OA\Attachable::class, $root);
+        $this->assertInstanceOf($expectedRoot, $root);
+        $this->assertNotNull($root->attachables);
+        $this->assertCount(1, $root->attachables);
+        $this->assertInstanceOf($expectedNested, $root->attachables[0]);
+    }
+
+    public static function mergeChainOrderCases(): iterable
+    {
+        yield 'outer first' => ['outerFirst', '/outer-first'];
+        yield 'inner first' => ['innerFirst', '/inner-first'];
+        yield 'mixed' => ['mixed', '/mixed'];
+    }
+
+    #[DataProvider('mergeChainOrderCases')]
+    public function testSiblingMergeChainIsOrderIndependent(string $method, string $path): void
+    {
+        $factory = new AttributeFactory();
+        $result = $factory->fromReflector(new \ReflectionMethod(StackedMergeChain::class, $method));
+
+        $this->assertCount(1, $result);
+        $operation = $result[0];
+        $this->assertInstanceOf(OA\Operation::class, $operation);
+        $this->assertSame($path, $operation->path);
+
+        $this->assertCount(1, $operation->responses);
+        $response = $operation->responses[0];
+        $this->assertInstanceOf(OA\Response::class, $response);
+
+        $this->assertCount(1, $response->content);
+        $mediaType = $response->content[0];
+        $this->assertInstanceOf(OA\MediaType::class, $mediaType);
+
+        $this->assertInstanceOf(OA\Schema::class, $mediaType->schema);
+        $this->assertSame('string', $mediaType->schema->type);
     }
 
     public function testMembersOfCollectsOwnProperties(): void


### PR DESCRIPTION
## Summary

Sibling merge consumed attributes in declaration order, so whether a stacked attribute
merged depended on where it sat. In a container-first stack the `Response` was folded into
the `Operation` before the `MediaType` had its turn, leaving it to bubble away silently or
fail as a leftover non-root attribute — same three attributes, different outcome per order.

`AttributeFactory::resolveNesting()` now defers an attribute while another pending sibling
names its type as a merge target, so chains resolve inner-to-outer whichever way they are
declared. Mutual merge targets — possible with custom attachables, not among the native
attributes — cannot be ordered that way and fall back to declaration order rather than
deadlocking; the fallback is pinned by a fixture with two mutually-targeting attachables.

The flat form stays limited to unambiguous stacks: a `MediaType` next to both a `Response`
and a `RequestBody` fails with a deterministic `Ambiguous merge` error (previously the
outcome depended on declaration order and could be silent).

## Fixtures

Scratch fixtures for `Response`, `RequestBody` and `Encoding` now declare part of their
trees as stacked siblings instead of constructor arguments — one of them container-first —
so the merge path is covered by the byte-identical fixture comparison across all versions
and modes.

## Docs

- `dev/pipeline.md`: sibling merge resolution order documented
- `guide/spec-attributes.md`: the flat form now shows a deeper chain and states the
  ambiguity limits (both failure claims verified by running them)