### PR TITLE
test(Scratch): make log expectations mode-aware

### DIFF
--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -60,15 +60,22 @@ Reach for a unit test when there is no document to validate — `ComponentIndexT
 | Trait | Use for |
 |---|---|
 | `AssemblesSpecification` | `assemble(...$classes)` — build a `Specification` from classes without touching the filesystem |
-| `AssertsBuilderResult` | asserting on a `Builder\Result`, including expected warnings and errors |
 | `AssertsSchemaStructure` | comparing compiled schema structure (`allOf` refs + property names) against a YAML fixture, independent of property order |
+| `AssertsSpecEquals` | deep-equality on a whole document — YAML, array or `stdClass` — order-independent for maps |
 | `CollectsSpecClasses` | enumerating every `OpenApi\Spec` attribute class, for suite-wide invariants |
+| `ExpectsLogEntries` | declaring which diagnostics a build is allowed to emit |
 | `GeneratesTestMatrix` | building version × mode combinations, with exclusions, and discovering fixtures by glob |
 | `UsesExamples` | registering a classloader for a `docs/examples` implementation |
+| `UsesFixtures` | resolving paths under `tests/Fixtures/` |
 
 `GeneratesTestMatrix` is the one to reach for when a test needs to run across versions and
 modes — it handles the cartesian product, the exclusions, and stable test-case naming, so
 providers stay short.
+
+`ExpectsLogEntries` is strict: an entry matching neither an expectation nor an allowance
+fails the test, so a new diagnostic cannot appear unnoticed. Prefer `expectLogEntry()` —
+`allowLogEntry()` asserts nothing, and is for diagnostics incidental to what the test is
+about.
 
 `SlotMapConsistencyTest` is a good example of the suite-wide-invariant style: rather than
 testing one attribute, it checks a property that must hold across all of them.
@@ -102,6 +109,11 @@ produces, and they are what the published docs display.
 - `tests/Fixtures/Scratch/` — spec-pipeline scratch fixtures with expected YAML, exercised
   by `ScratchTest`
 - `docs/examples/specs/` — full worked examples, doubling as published documentation
+
+A `Scratch` fixture that provokes a diagnostic declares it in `ScratchTest::scratchTestCases()`,
+keyed `{fixture}-{version}` when every mode raises it, or `{fixture}-{version}-{mode}` when
+only one does. Both keys apply when both are present, so a mode-specific entry adds to the
+shared one rather than replacing it.
 
 `composer redocly` validates the generated example specs against the OpenAPI schema. It
 passes, with warnings; known problems are suppressed via `.redocly.lint-ignore.yaml`, so a

--- a/src/Compiler/OpenApi30Compiler.php
+++ b/src/Compiler/OpenApi30Compiler.php
@@ -68,8 +68,6 @@ class OpenApi30Compiler extends OpenApi31Compiler
             }
         }
 
-        $this->validateSchemas($specification);
-
         return $this->logger->entries();
     }
 

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -568,6 +568,19 @@ final class CompilerTest extends TestCase
         $this->assertEmpty(array_filter($messages, fn (string $m): bool => str_contains($m, 'unknown type')));
     }
 
+    public function test30ReportsSchemaDiagnosticsOnce(): void
+    {
+        $spec = new Specification();
+        $spec->openapi = new OA\OpenApi(version: '3.0.0');
+        $spec->info = new OA\Info(title: 'T', version: '1.0');
+        $spec->operations[] = new OA\Operation(path: '/p', method: 'get');
+        $spec->schemas[] = new OA\Schema(schema: 'Bad', type: 'array');
+
+        $messages = array_column((new OpenApi30Compiler())->validate($spec), 'message');
+
+        $this->assertCount(1, array_filter($messages, fn (string $m): bool => str_contains($m, 'has type "array" but no items')));
+    }
+
     #[DataProvider('validationProvider')]
     public function testValidation(CompilerInterface $compiler, Specification $specification, string $expectedMessage): void
     {

--- a/tests/DocsAccuracyTest.php
+++ b/tests/DocsAccuracyTest.php
@@ -148,6 +148,27 @@ final class DocsAccuracyTest extends TestCase
         }
     }
 
+    public function testConcernsTableMatchesDocs(): void
+    {
+        $page = file_get_contents(self::DOCS . '/dev/testing.md');
+
+        preg_match('/^## Shared helpers$(.*?)^## /ms', $page, $section);
+        $this->assertNotEmpty($section, 'Could not find the "Shared helpers" section in docs/dev/testing.md');
+
+        preg_match_all('/^\| `(\w+)` \|/m', $section[1], $m);
+        $documented = $m[1];
+        sort($documented);
+
+        $traits = array_map(
+            static fn (string $file): string => basename($file, '.php'),
+            glob(__DIR__ . '/Concerns/*.php')
+        );
+        $traits = array_values(array_filter($traits, static fn (string $name): bool => !str_ends_with($name, 'Test')));
+        sort($traits);
+
+        $this->assertSame($traits, $documented, 'The tests/Concerns table in docs/dev/testing.md has drifted');
+    }
+
     public function testResultMethodListingMatchesDocs(): void
     {
         $page = file_get_contents(self::DOCS . '/reference/builder.md');

--- a/tests/ScratchTest.php
+++ b/tests/ScratchTest.php
@@ -24,16 +24,13 @@ final class ScratchTest extends OpenApiTestCase
         $basePath = self::fixture('Scratch');
         $phpVersion = self::phpVersion();
 
+        // Keyed `{fixture}-{version}`, applying to every mode, or `{fixture}-{version}-{mode}`
+        // for a diagnostic only one mode raises. Both keys contribute when both are present.
         $expectedLogs = [
             'Examples-3.0.0' => ['@OA\Schema() is only allowed as of 3.1.0'],
-        ];
-
-        // Compiler diagnostics raised in spec mode only. Tolerated rather than expected:
-        // the key has no mode component, so demanding them would fail the classic case.
-        $ignoredLogs = [
-            'Auth-3.0.0' => ['mutualTLS security schemes are not supported in OpenAPI 3.0'],
-            'Docblocks-3.0.0' => ['const is not supported in OpenAPI 3.0'],
-            'Tags-3.2.0' => ['references non-existent parent'],
+            'Auth-3.0.0-spec' => ['mutualTLS security schemes are not supported in OpenAPI 3.0'],
+            'Docblocks-3.0.0-spec' => ['const is not supported in OpenAPI 3.0'],
+            'Tags-3.2.0-spec' => ['references non-existent parent'],
         ];
 
         foreach (self::discoverFixtures("{$basePath}/*.php") as $scratchName => $scratch) {
@@ -58,7 +55,6 @@ final class ScratchTest extends OpenApiTestCase
                 if ($combo['mode'] === Builder\Mode::SPEC) {
                     $source = str_replace('.php', '-spec.php', $scratch);
                     if (!file_exists($source)) {
-                        echo $source . "\n";
                         continue;
                     }
                 }
@@ -84,20 +80,18 @@ final class ScratchTest extends OpenApiTestCase
                     $combo['mode'],
                     $spec,
                     $combo['version'],
-                    array_key_exists($logKey, $expectedLogs) ? $expectedLogs[$logKey] : [],
-                    array_key_exists($logKey, $ignoredLogs) ? $ignoredLogs[$logKey] : [],
+                    array_merge($expectedLogs[$logKey] ?? [], $expectedLogs["{$logKey}-{$combo['mode']->value}"] ?? []),
                 ];
             }
         }
     }
 
     #[DataProvider('scratchTestCases')]
-    public function testScratch(TypeResolverInterface $typeResolver, string $scratch, Builder\Mode $mode, string $spec, string $version, array $expectedLogs, array $ignoredLogs = []): void
+    public function testScratch(TypeResolverInterface $typeResolver, string $scratch, Builder\Mode $mode, string $spec, string $version, array $expectedLogs): void
     {
         foreach ($expectedLogs as $logLine) {
             $this->expectLogEntry($logLine);
         }
-        $this->allowLogEntry(...$ignoredLogs);
 
         require_once $scratch;
 


### PR DESCRIPTION
## Overview

`ScratchTest` keyed its log expectations by fixture and version only. A diagnostic that
just one mode raises could therefore never be *expected* — the key applies to both modes,
so demanding it fails the mode that does not raise it. Three such diagnostics were
tolerated instead, which asserts nothing.

Adding a mode component to the key turns all three into real assertions. Doing so
immediately caught a bug it had been hiding — every OpenAPI 3.0 schema diagnostic was being
reported twice.

## Changes

- `ScratchTest` log-expectation keys take an optional mode suffix, so a diagnostic only one
  mode raises can be expected rather than tolerated. `{fixture}-{version}` still applies to
  every mode, and both keys contribute when both are present.
- The three previously tolerated diagnostics — mutualTLS on 3.0, `const` on 3.0, and the
  orphaned tag parent — are now expectations, and `ScratchTest` no longer tolerates
  anything.
- `OpenApi30Compiler::validate()` reports schema diagnostics once instead of twice.
- Removed the debug `echo` naming fixtures that have no spec counterpart.
- Corrected the `tests/Concerns` table in `docs/dev/testing.md`, which listed a retired
  trait and omitted three others; it is now checked against the directory.
