### PR TITLE
chore(Spec): annotate array and generic types in the spec namespaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,8 @@ Read the relevant page before working in that part of the tree:
 - New pipeline work goes in `src/Spec/`, `src/Augmenter/`, `src/Compiler/`;
   `src/Annotations/` and `src/Attributes/` are classic and closed to new features —
   [ROADMAP.md](ROADMAP.md) has the v7/v8 plan
+- Repeated docblock unions get a `@phpstan-type` alias, imported with
+  `@phpstan-import-type` — see `BuilderSource` on `Builder`
 - Branches are `type/short-description`; commits are `type(Scope): subject`
   (`feat`, `fix`, `docs`, `chore`, `refactor`)
 

--- a/src/Assembler.php
+++ b/src/Assembler.php
@@ -40,6 +40,8 @@ class Assembler
 
     /**
      * Collect all OpenAPI attributes from the given reflectors into the specification.
+     *
+     * @param \ReflectionClass<object>|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant ...$reflectors
      */
     public function collect(\ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant ...$reflectors): static
     {
@@ -50,6 +52,9 @@ class Assembler
         return $this;
     }
 
+    /**
+     * @param \ReflectionClass<object>|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector
+     */
     protected function collectFromReflector(\ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector): void
     {
         $this->attributeFactory->resetTranslators();
@@ -61,6 +66,7 @@ class Assembler
 
     /**
      * @return list<AttributeInterface>
+     * @param  \ReflectionClass<object>|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector
      */
     protected function resolveReflector(\ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector): array
     {

--- a/src/Assembler.php
+++ b/src/Assembler.php
@@ -7,6 +7,7 @@
 namespace OpenApi;
 
 use OpenApi\Contracts\AttributeInterface;
+use OpenApi\Contracts\AttributeTranslatorInterface;
 use OpenApi\Utils\AttributeFactory;
 
 /**
@@ -19,6 +20,8 @@ use OpenApi\Utils\AttributeFactory;
  *
  * 2. Absorb (resolveHierarchy): resolved attributes flow upward level by level using
  *    contained() (first match wins). Roots that aren't absorbed pass through to the spec.
+ *
+ * @phpstan-import-type AttributeReflector from AttributeTranslatorInterface
  */
 class Assembler
 {
@@ -41,7 +44,7 @@ class Assembler
     /**
      * Collect all OpenAPI attributes from the given reflectors into the specification.
      *
-     * @param \ReflectionClass<object>|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant ...$reflectors
+     * @param AttributeReflector ...$reflectors
      */
     public function collect(\ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant ...$reflectors): static
     {
@@ -53,7 +56,7 @@ class Assembler
     }
 
     /**
-     * @param \ReflectionClass<object>|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector
+     * @param AttributeReflector $reflector
      */
     protected function collectFromReflector(\ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector): void
     {
@@ -66,7 +69,7 @@ class Assembler
 
     /**
      * @return list<AttributeInterface>
-     * @param  \ReflectionClass<object>|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector
+     * @param  AttributeReflector       $reflector
      */
     protected function resolveReflector(\ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector): array
     {

--- a/src/Assembler/AbstractAttributeTranslator.php
+++ b/src/Assembler/AbstractAttributeTranslator.php
@@ -6,6 +6,7 @@
 
 namespace OpenApi\Assembler;
 
+use OpenApi\Contracts\AttributeInterface;
 use OpenApi\Contracts\AttributeTranslatorInterface;
 
 /**
@@ -17,11 +18,21 @@ class AbstractAttributeTranslator implements AttributeTranslatorInterface
     {
     }
 
+    /**
+     * @param  \ReflectionClass<object>|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector
+     * @return array<\ReflectionAttribute<object>>
+     */
     public function getAttributes(\ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector): array
     {
         return [];
     }
 
+    /**
+     * @param  array<AttributeInterface>                                                                                    $attributes current attributes
+     * @param  array<object>                                                                                                $created    newly created attribute instances
+     * @param  \ReflectionClass<object>|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector
+     * @return array<AttributeInterface>
+     */
     public function translate(array $attributes, array $created, \ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector): array
     {
         return [...$attributes, ...$created];

--- a/src/Assembler/AbstractAttributeTranslator.php
+++ b/src/Assembler/AbstractAttributeTranslator.php
@@ -11,6 +11,8 @@ use OpenApi\Contracts\AttributeTranslatorInterface;
 
 /**
  * Convenience no-op base implementation of the `AttributeTranslatorInterface`.
+ *
+ * @phpstan-import-type AttributeReflector from AttributeTranslatorInterface
  */
 class AbstractAttributeTranslator implements AttributeTranslatorInterface
 {
@@ -19,7 +21,7 @@ class AbstractAttributeTranslator implements AttributeTranslatorInterface
     }
 
     /**
-     * @param  \ReflectionClass<object>|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector
+     * @param  AttributeReflector                  $reflector
      * @return array<\ReflectionAttribute<object>>
      */
     public function getAttributes(\ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector): array
@@ -28,9 +30,9 @@ class AbstractAttributeTranslator implements AttributeTranslatorInterface
     }
 
     /**
-     * @param  array<AttributeInterface>                                                                                    $attributes current attributes
-     * @param  array<object>                                                                                                $created    newly created attribute instances
-     * @param  \ReflectionClass<object>|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector
+     * @param  array<AttributeInterface> $attributes current attributes
+     * @param  array<object>             $created    newly created attribute instances
+     * @param  AttributeReflector        $reflector
      * @return array<AttributeInterface>
      */
     public function translate(array $attributes, array $created, \ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector): array

--- a/src/Assembler/DefaultAttributeTranslator.php
+++ b/src/Assembler/DefaultAttributeTranslator.php
@@ -13,6 +13,10 @@ use OpenApi\Contracts\AttributeInterface;
  */
 class DefaultAttributeTranslator extends AbstractAttributeTranslator
 {
+    /**
+     * @param  \ReflectionClass<object>|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector
+     * @return array<\ReflectionAttribute<object>>
+     */
     public function getAttributes(\ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector): array
     {
         return $reflector->getAttributes(

--- a/src/Assembler/DefaultAttributeTranslator.php
+++ b/src/Assembler/DefaultAttributeTranslator.php
@@ -7,14 +7,17 @@
 namespace OpenApi\Assembler;
 
 use OpenApi\Contracts\AttributeInterface;
+use OpenApi\Contracts\AttributeTranslatorInterface;
 
 /**
  * Default implementation handling native (OpenApi) attributes.
+ *
+ * @phpstan-import-type AttributeReflector from AttributeTranslatorInterface
  */
 class DefaultAttributeTranslator extends AbstractAttributeTranslator
 {
     /**
-     * @param  \ReflectionClass<object>|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector
+     * @param  AttributeReflector                  $reflector
      * @return array<\ReflectionAttribute<object>>
      */
     public function getAttributes(\ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector): array

--- a/src/Assembler/OptionalPropertyAttributeTranslator.php
+++ b/src/Assembler/OptionalPropertyAttributeTranslator.php
@@ -6,6 +6,7 @@
 
 namespace OpenApi\Assembler;
 
+use OpenApi\Contracts\AttributeInterface;
 use OpenApi\Spec as OA;
 
 /**
@@ -15,6 +16,12 @@ use OpenApi\Spec as OA;
  */
 class OptionalPropertyAttributeTranslator extends AbstractAttributeTranslator
 {
+    /**
+     * @param  array<AttributeInterface>                                                                                    $attributes current attributes
+     * @param  array<object>                                                                                                $created    newly created attribute instances
+     * @param  \ReflectionClass<object>|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector
+     * @return array<AttributeInterface>
+     */
     public function translate(array $attributes, array $created, \ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector): array
     {
         $hasInstance = fn (array $list, string $class): bool => array_reduce(

--- a/src/Assembler/OptionalPropertyAttributeTranslator.php
+++ b/src/Assembler/OptionalPropertyAttributeTranslator.php
@@ -7,19 +7,22 @@
 namespace OpenApi\Assembler;
 
 use OpenApi\Contracts\AttributeInterface;
+use OpenApi\Contracts\AttributeTranslatorInterface;
 use OpenApi\Spec as OA;
 
 /**
  * Add the required `OA\Property` on schema properties that only have:
  * - an `OA\Schema`
  * - an `OA\Encoding`
+ *
+ * @phpstan-import-type AttributeReflector from AttributeTranslatorInterface
  */
 class OptionalPropertyAttributeTranslator extends AbstractAttributeTranslator
 {
     /**
-     * @param  array<AttributeInterface>                                                                                    $attributes current attributes
-     * @param  array<object>                                                                                                $created    newly created attribute instances
-     * @param  \ReflectionClass<object>|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector
+     * @param  array<AttributeInterface> $attributes current attributes
+     * @param  array<object>             $created    newly created attribute instances
+     * @param  AttributeReflector        $reflector
      * @return array<AttributeInterface>
      */
     public function translate(array $attributes, array $created, \ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector): array

--- a/src/Augmenter/EnumDescriptions.php
+++ b/src/Augmenter/EnumDescriptions.php
@@ -76,6 +76,9 @@ class EnumDescriptions implements PipeInterface
         });
     }
 
+    /**
+     * @param \ReflectionEnum<\UnitEnum> $reflector
+     */
     protected function expandEnumDescriptionsForProperty(OA\Property $property, \ReflectionEnum $reflector): void
     {
         $values = [];

--- a/src/Augmenter/Enums.php
+++ b/src/Augmenter/Enums.php
@@ -91,6 +91,9 @@ class Enums implements PipeInterface
         }
     }
 
+    /**
+     * @param \ReflectionEnum<\UnitEnum> $reflector
+     */
     protected function shouldUseName(OA\Schema $schema, \ReflectionEnum $reflector): bool
     {
         if ($schema->type === null) {

--- a/src/Augmenter/Inheritance/Operations.php
+++ b/src/Augmenter/Inheritance/Operations.php
@@ -134,6 +134,8 @@ class Operations
      * Scan an ancestor class for operations and associate them with the child reflector.
      *
      * @return list<OA\Operation>
+     * @param  \ReflectionClass<object> $ancestor
+     * @param  \ReflectionClass<object> $childReflector
      */
     protected function discoverOperations(\ReflectionClass $ancestor, \ReflectionClass $childReflector): array
     {

--- a/src/Augmenter/Inheritance/Schemas.php
+++ b/src/Augmenter/Inheritance/Schemas.php
@@ -46,6 +46,10 @@ class Schemas
         return null;
     }
 
+    /**
+     * @param \ReflectionClass<object> $reflector
+     * @param list<string|null>        $existingProperties
+     */
     protected function expandParents(OA\Schema $schema, \ReflectionClass $reflector, ComponentIndex $index, array &$existingProperties): void
     {
         $parent = $reflector->getParentClass();
@@ -61,6 +65,10 @@ class Schemas
         }
     }
 
+    /**
+     * @param \ReflectionClass<object> $reflector
+     * @param list<string|null>        $existingProperties
+     */
     protected function expandTraits(OA\Schema $schema, \ReflectionClass $reflector, ComponentIndex $index, array &$existingProperties): void
     {
         foreach ($this->attributeFactory->getDirectTraits($reflector) as $trait) {
@@ -91,6 +99,10 @@ class Schemas
         }
     }
 
+    /**
+     * @param \ReflectionClass<object> $reflector
+     * @param list<string|null>        $existingProperties
+     */
     protected function expandInterfaces(OA\Schema $schema, \ReflectionClass $reflector, ComponentIndex $index, array &$existingProperties): void
     {
         $ownInterfaces = $this->attributeFactory->getDirectInterfaces($reflector);
@@ -114,6 +126,10 @@ class Schemas
         }
     }
 
+    /**
+     * @param \ReflectionClass<object> $class
+     * @param list<string|null>        $existingProperties
+     */
     protected function mergeMembers(OA\Schema $schema, \ReflectionClass $class, array &$existingProperties): void
     {
         $members = $this->attributeFactory->membersOf($class);

--- a/src/Augmenter/Refs.php
+++ b/src/Augmenter/Refs.php
@@ -66,6 +66,9 @@ class Refs implements PipeInterface, LoggerAwareInterface
         });
     }
 
+    /**
+     * @param array<string,string> $refMap
+     */
     protected function resolveFQCNRefs(Specification $specification, array $refMap): void
     {
         $unresolved = [];

--- a/src/Augmenter/Tags.php
+++ b/src/Augmenter/Tags.php
@@ -96,6 +96,10 @@ class Tags implements PipeInterface
         return array_values(array_unique($names));
     }
 
+    /**
+     * @param list<string>         $usedTagNames
+     * @param array<string,OA\Tag> $declaredTags
+     */
     protected function removeUnusedTags(array $usedTagNames, array $declaredTags, mixed $payload): void
     {
         if (in_array('*', $this->whitelist, true)) {

--- a/src/Compiler/OpenApi30Compiler.php
+++ b/src/Compiler/OpenApi30Compiler.php
@@ -88,6 +88,9 @@ class OpenApi30Compiler extends OpenApi31Compiler
         )));
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     #[\Override]
     protected function compileInfo(OA\Info $info): array
     {
@@ -101,6 +104,9 @@ class OpenApi30Compiler extends OpenApi31Compiler
         ], $info);
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     #[\Override]
     protected function compileLicense(OA\License $license): array
     {
@@ -112,6 +118,8 @@ class OpenApi30Compiler extends OpenApi31Compiler
 
     /**
      * Compile schema using OAS 3.0 / JSON Schema draft-04 semantics.
+     *
+     * @return array<string,mixed>|\stdClass
      */
     #[\Override]
     protected function compileSchema(OA\Schema|string $schema): array|\stdClass

--- a/src/Compiler/OpenApi31Compiler.php
+++ b/src/Compiler/OpenApi31Compiler.php
@@ -101,6 +101,9 @@ class OpenApi31Compiler implements CompilerInterface
         ], $specification->openapi);
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     protected function compileInfo(OA\Info $info): array
     {
         return $this->filter([
@@ -114,6 +117,9 @@ class OpenApi31Compiler implements CompilerInterface
         ], $info);
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     protected function compileContact(OA\Contact $contact): array
     {
         return $this->filter([
@@ -123,6 +129,9 @@ class OpenApi31Compiler implements CompilerInterface
         ], $contact);
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     protected function compileLicense(OA\License $license): array
     {
         return $this->filter([
@@ -132,6 +141,9 @@ class OpenApi31Compiler implements CompilerInterface
         ], $license);
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     protected function compileServer(OA\Server $server): array
     {
         $variables = null;
@@ -152,6 +164,9 @@ class OpenApi31Compiler implements CompilerInterface
         ], $server);
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     protected function compileServerVariable(OA\ServerVariable $variable): array
     {
         return $this->filter([
@@ -161,6 +176,9 @@ class OpenApi31Compiler implements CompilerInterface
         ], $variable);
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     protected function compileTag(OA\Tag $tag): array
     {
         return $this->filter([
@@ -170,6 +188,9 @@ class OpenApi31Compiler implements CompilerInterface
         ], $tag);
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     protected function compileExternalDocs(OA\ExternalDocumentation $docs): array
     {
         return $this->filter([
@@ -207,6 +228,9 @@ class OpenApi31Compiler implements CompilerInterface
         return $paths;
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     protected function compilePathItem(OA\PathItem $pathItem): array
     {
         return $this->filter([
@@ -237,6 +261,9 @@ class OpenApi31Compiler implements CompilerInterface
         return $webhooks;
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     protected function compileOperation(OA\Operation $operation): array
     {
         return $this->filter([
@@ -261,6 +288,9 @@ class OpenApi31Compiler implements CompilerInterface
 
     /**
      * Recursively compile callback structures, resolving any DTO objects found within.
+     *
+     * @param  array<string,mixed> $callbacks
+     * @return array<string,mixed>
      */
     protected function compileCallbacks(array $callbacks): array
     {
@@ -288,6 +318,9 @@ class OpenApi31Compiler implements CompilerInterface
         return $value;
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     protected function compileParameter(OA\Parameter $parameter): array
     {
         if ($parameter->ref !== null) {
@@ -311,6 +344,9 @@ class OpenApi31Compiler implements CompilerInterface
         ], $parameter);
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     protected function compileRequestBody(OA\RequestBody $body, ?string $method = null): array|\stdClass|null
     {
         if ($method && !in_array($method, static::OPERATION_REQUEST_BODY_METHODS)) {
@@ -339,6 +375,9 @@ class OpenApi31Compiler implements CompilerInterface
         return $this->compileNamedMap($responses, fn (OA\Response $response): string => (string) $response->response, $this->compileResponse(...));
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     protected function compileResponse(OA\Response $response): array
     {
         if ($response->ref !== null) {
@@ -353,6 +392,9 @@ class OpenApi31Compiler implements CompilerInterface
         ], $response);
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     protected function compileHeader(OA\Header $header): array
     {
         if ($header->ref !== null) {
@@ -381,6 +423,9 @@ class OpenApi31Compiler implements CompilerInterface
         return $this->compileNamedMap($mediaTypes, fn (OA\MediaType $mediaType): string => $mediaType->mediaType ?? 'application/json', $this->compileMediaType(...));
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     protected function compileMediaType(OA\MediaType $mediaType): array
     {
         return $this->filter([
@@ -391,6 +436,9 @@ class OpenApi31Compiler implements CompilerInterface
         ], $mediaType);
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     protected function compileEncoding(OA\Encoding $encoding): array
     {
         return $this->filter([
@@ -402,6 +450,9 @@ class OpenApi31Compiler implements CompilerInterface
         ], $encoding);
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     protected function compileLink(OA\Link $link): array
     {
         if ($link->ref !== null) {
@@ -423,6 +474,9 @@ class OpenApi31Compiler implements CompilerInterface
         return $result;
     }
 
+    /**
+     * @return array<string,mixed>|\stdClass
+     */
     protected function compileSchema(OA\Schema|string $schema): array|\stdClass
     {
         if (is_string($schema)) {
@@ -558,6 +612,9 @@ class OpenApi31Compiler implements CompilerInterface
         return $result;
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     protected function compileDiscriminator(OA\Discriminator $discriminator): array
     {
         return $this->filter([
@@ -566,6 +623,9 @@ class OpenApi31Compiler implements CompilerInterface
         ], $discriminator);
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     protected function compileXml(OA\Xml $xml): array
     {
         return $this->filter([
@@ -577,6 +637,9 @@ class OpenApi31Compiler implements CompilerInterface
         ], $xml);
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     protected function compileComponents(Specification $specification): array
     {
         return array_filter([
@@ -594,7 +657,8 @@ class OpenApi31Compiler implements CompilerInterface
     /**
      * Passing raw arrays is deprecated; use OA\Security\Requirement instances instead.
      *
-     * @param list<OA\Security\Requirement|array<string,list<string>>> $security
+     * @param  list<OA\Security\Requirement|array<string,list<string>>> $security
+     * @return list<array<string,mixed>>
      */
     protected function compileSecurity(array $security): array
     {
@@ -616,6 +680,9 @@ class OpenApi31Compiler implements CompilerInterface
         return $this->compileNamedMap($schemes, 'securityScheme', $this->compileSecurityScheme(...));
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     protected function compileSecurityScheme(OA\Security\Scheme $scheme): array
     {
         return $this->filter([
@@ -631,7 +698,8 @@ class OpenApi31Compiler implements CompilerInterface
     }
 
     /**
-     * @param list<OA\Flow> $flows
+     * @param  list<OA\Flow>       $flows
+     * @return array<string,mixed>
      */
     protected function compileFlows(array $flows): array
     {
@@ -646,6 +714,9 @@ class OpenApi31Compiler implements CompilerInterface
         return $result;
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     protected function compileFlow(OA\Flow $flow): array
     {
         return $this->filter([
@@ -656,6 +727,9 @@ class OpenApi31Compiler implements CompilerInterface
         ], $flow);
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     protected function compileExample(OA\Example $example): array
     {
         $result = $this->filter([
@@ -844,6 +918,9 @@ class OpenApi31Compiler implements CompilerInterface
 
     /**
      * Remove null entries and apply x- extensions.
+     *
+     * @param  array<string,mixed> $result
+     * @return array<string,mixed>
      */
     protected function filter(array $result, OA\AbstractAttribute|null $attribute = null): array
     {

--- a/src/Compiler/OpenApi32Compiler.php
+++ b/src/Compiler/OpenApi32Compiler.php
@@ -39,6 +39,9 @@ class OpenApi32Compiler extends OpenApi31Compiler
         return $this->logger->entries();
     }
 
+    /**
+     * @return array<string,mixed>
+     */
     #[\Override]
     protected function compileTag(OA\Tag $tag): array
     {

--- a/src/Contracts/AttributeInterface.php
+++ b/src/Contracts/AttributeInterface.php
@@ -70,6 +70,9 @@ interface AttributeInterface
 
     public function setReflector(?\Reflector $reflector): static;
 
+    /**
+     * @return \ReflectionClass<object>|null
+     */
     public function getClassReflector(): ?\ReflectionClass;
 
     public function getClassName(): ?string;

--- a/src/Contracts/AttributeTranslatorInterface.php
+++ b/src/Contracts/AttributeTranslatorInterface.php
@@ -16,6 +16,8 @@ namespace OpenApi\Contracts;
  *
  * Processing order within the Assembler is guaranteed structural:
  * class → method → parameters (outer before inner).
+ *
+ * @phpstan-type AttributeReflector \ReflectionClass<object>|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant
  */
 interface AttributeTranslatorInterface
 {
@@ -30,7 +32,7 @@ interface AttributeTranslatorInterface
     /**
      * Get attributes to load from the given reflector.
      *
-     * @param  \ReflectionClass<object>|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector
+     * @param  AttributeReflector                  $reflector
      * @return array<\ReflectionAttribute<object>>
      */
     public function getAttributes(\ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector): array;
@@ -43,9 +45,9 @@ interface AttributeTranslatorInterface
      * instances and newly instantiated objects from the current translator's
      * `getAttributes()` call.
      *
-     * @param  array<AttributeInterface>                                                                                    $attributes current attributes
-     * @param  array<object>                                                                                                $created    newly created attribute instances
-     * @param  \ReflectionClass<object>|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector
+     * @param  array<AttributeInterface> $attributes current attributes
+     * @param  array<object>             $created    newly created attribute instances
+     * @param  AttributeReflector        $reflector
      * @return array<AttributeInterface>
      */
     public function translate(array $attributes, array $created, \ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector): array;

--- a/src/Contracts/AttributeTranslatorInterface.php
+++ b/src/Contracts/AttributeTranslatorInterface.php
@@ -30,7 +30,8 @@ interface AttributeTranslatorInterface
     /**
      * Get attributes to load from the given reflector.
      *
-     * @return array<\ReflectionAttribute>
+     * @param  \ReflectionClass<object>|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector
+     * @return array<\ReflectionAttribute<object>>
      */
     public function getAttributes(\ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector): array;
 
@@ -42,8 +43,9 @@ interface AttributeTranslatorInterface
      * instances and newly instantiated objects from the current translator's
      * `getAttributes()` call.
      *
-     * @param  array<AttributeInterface> $attributes current attributes
-     * @param  array<object>             $created    newly created attribute instances
+     * @param  array<AttributeInterface>                                                                                    $attributes current attributes
+     * @param  array<object>                                                                                                $created    newly created attribute instances
+     * @param  \ReflectionClass<object>|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector
      * @return array<AttributeInterface>
      */
     public function translate(array $attributes, array $created, \ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector): array;

--- a/src/Spec/AbstractAttribute.php
+++ b/src/Spec/AbstractAttribute.php
@@ -45,6 +45,9 @@ abstract class AbstractAttribute implements AttributeInterface
         return $this->reflector;
     }
 
+    /**
+     * @return \ReflectionClass<object>|null
+     */
     public function getClassReflector(): ?\ReflectionClass
     {
         $reflector = $this->reflector;


### PR DESCRIPTION
## Overview

PHPStan runs at level 5. Level 6 adds missing-type reporting, which the codebase is a long
way from — 623 errors, most of them in classic and in the published examples.

The spec namespaces are much closer than that, and they are where new pipeline work goes.
This annotates the 58 gaps in them, so those namespaces are already clean when the level
does get raised — which becomes a far smaller job once classic is removed in v8.

The analysed level is unchanged. PHPStan has no per-path level setting, so nothing here is
enforced yet; this is the code side of a bump, not the bump.

## Changes

- Array value types on the compilers' `compileX()` methods and on the augmenters'
  array parameters.
- Type arguments on `\ReflectionClass`, `\ReflectionEnum` and `\ReflectionAttribute`
  across `OpenApi\Assembler` and `OpenApi\Contracts`.
- The reflector union that `Assembler` and the translators repeat is now an
  `AttributeReflector` alias on `AttributeTranslatorInterface`, imported where it is
  used — the same `@phpstan-type` pattern as `BuilderSource` on `Builder`. The native
  signatures still spell the union out; PHP has no type aliases.
- `OpenApi\Spec`, `Compiler`, `Augmenter`, `Assembler` and `Contracts` now report no
  errors at level 6.
- AGENTS.md records the alias convention, which had three instances and nothing
  pointing at it.
