### PR TITLE
fix(Spec): stop a method-level Schema crashing the build

### DIFF
--- a/docs/dev/pipeline.md
+++ b/docs/dev/pipeline.md
@@ -34,6 +34,10 @@ public function contained(): array
 A `[]` suffix appends to a collection; a bare name assigns a scalar. It is easy to read
 backwards.
 
+The target's own type has to admit the class declaring the slot — `Schema` once named
+`Schema::$properties`, a `list<Property>`, which crashed the inheritance augmenter as soon
+as anything reached it. `SlotMapConsistencyTest` checks every slot against its target.
+
 Because the child declares the relationship, downstream code can extend the system: a
 custom attachable names its own nesting targets without touching any native attribute.
 
@@ -70,6 +74,11 @@ attribute is one that can stand alone — it owns a bucket and needs no parent.
 
 Each attribute decides for itself, in `isRoot()`.
 
+Root does not mean un-nested. `isRoot()` says what an attribute may be when nothing consumes
+it; `merge()` and `contained()` run first, and often do. `Schema` is always root, and is
+routinely merged into a sibling — a `Property` or a `MediaType`, say — instead of reaching
+the Specification at all.
+
 The user-facing version of this distinction is in
 [Using Spec Attributes](/guide/spec-attributes#components); this list is the full one.
 
@@ -103,8 +112,16 @@ buckets get resolved after assembly, without the DTOs having to reference each o
 - **OperationId generation** — class and method names come from the reflector
 - **Type inference** — `Types` reads PHP type declarations off property and parameter
   reflectors
+- **Naming** — a component schema takes its name from the class it sits on; a property
+  takes its name from the property, parameter or constant it sits on
 
 This is what keeps the Assembler concerned only with nesting.
+
+A method reflector supplies no name — `getUnnamed()` is not the property `unnamed`, and the
+pipeline does not guess at accessor prefixes. So a bare `Schema` becomes a `Property` only
+where the reflector declares a value the schema owns: a property, or a constructor
+parameter. On a method, or on a parameter of anything else, the attribute carries its own
+`schema` or `property` or the compiler reports it missing.
 
 ## Normalise on input, store the simple form
 

--- a/docs/guide/shortcuts.md
+++ b/docs/guide/shortcuts.md
@@ -77,6 +77,17 @@ This also applies to `OA\Schema` subclasses like `OA\Schema\Items`:
 public array $tags;
 ```
 
+The shortcut stops at methods, which supply no property name — `getTags()` is not `tags`, and the pipeline does not guess at
+accessor prefixes. A getter needs the explicit `OA\Property`, carrying the name:
+
+```php
+#[OA\Property(property: 'tags')]
+#[OA\Schema\Items(ref: Tag::class)]
+public function getTags(): array
+```
+
+Without it the property is reported as missing its name and left out of the schema.
+
 ## `OA\Parameter`
 
 The `OA\Parameter` annotation requires specifying the `in` property to indicate where in the request the parameter is located.

--- a/docs/guide/spec-attributes.md
+++ b/docs/guide/spec-attributes.md
@@ -261,7 +261,7 @@ Still useful even when nesting `OA\Schema` as the media type is prefilled either
 ### Items
 `#[OA\Schema\Items]` is the equivalent to the classic `OA\Items` attribute. Similar to `OA\MediaType\Json` and `Xml` it is a shortcut that allows to skip the outer `OA\Schema(type: 'array')`. The `Shortcuts` augmenter wraps it into `OA\Schema(type: 'array', items: ...)` automatically.
 
-Since `OA\Schema\Items` extends `OA\Schema`, the [implicit `OA\Property`](#property-spec-only) shortcut applies — you can omit the explicit `#[OA\Property]` attribute:
+Since `OA\Schema\Items` extends `OA\Schema`, the [implicit `OA\Property`](/guide/shortcuts#property-spec-only) shortcut applies — you can omit the explicit `#[OA\Property]` attribute:
 
 ```php
 // Verbose

--- a/docs/reference/spec-attributes.md
+++ b/docs/reference/spec-attributes.md
@@ -1278,6 +1278,10 @@ name+in (parameters).
 
 Defines a single property within a Schema object.
 
+The name comes from the property, parameter or constant the attribute sits on. A method
+supplies none, so a getter needs `property:` explicitly; without it the property is
+reported as missing one and omitted.
+
 #### Allowed in
 ---
 <a href="#schema">Schema</a>
@@ -1405,13 +1409,16 @@ Inline — used within parameters, responses, or other schemas:
 
   new OA\Schema(type: 'array', items: new OA\Schema(ref: Pet::class))
 
+Only a class supplies a name. On a method or a parameter, pass `schema:` explicitly;
+without it the schema has no component key and is reported as missing one.
+
 #### Allowed in
 ---
-<a href="#schema">Schema</a>
+<a href="#components">Components</a>, <a href="#property">Property</a>, <a href="#parameter">Parameter</a>, <a href="#header">Header</a>, <a href="#mediatype">MediaType</a>
 
 #### Nested elements
 ---
-<a href="#property">Property</a>, <a href="#property-encoded">Property\Encoded</a>, <a href="#schema">Schema</a>, <a href="#schema-additionalproperties">Schema\AdditionalProperties</a>, <a href="#schema-items">Schema\Items</a>, <a href="#schema-ref">Schema\Ref</a>
+<a href="#property">Property</a>, <a href="#property-encoded">Property\Encoded</a>
 
 #### Parameters
 ---
@@ -1543,7 +1550,7 @@ schemas with constrained additional properties:
 
 #### Allowed in
 ---
-<a href="#schema">Schema</a>
+<a href="#components">Components</a>, <a href="#property">Property</a>, <a href="#parameter">Parameter</a>, <a href="#header">Header</a>, <a href="#mediatype">MediaType</a>
 
 #### Parameters
 ---
@@ -1683,7 +1690,7 @@ Since Items extends Schema, the implicit `OA\Property` shortcut applies — no e
 
 #### Allowed in
 ---
-<a href="#schema">Schema</a>
+<a href="#components">Components</a>, <a href="#property">Property</a>, <a href="#parameter">Parameter</a>, <a href="#header">Header</a>, <a href="#mediatype">MediaType</a>
 
 #### Parameters
 ---
@@ -1816,7 +1823,7 @@ If used on a `$ref` directly, only the ref value is used.
 
 #### Allowed in
 ---
-<a href="#schema">Schema</a>
+<a href="#components">Components</a>, <a href="#property">Property</a>, <a href="#parameter">Parameter</a>, <a href="#header">Header</a>, <a href="#mediatype">MediaType</a>
 
 #### Parameters
 ---

--- a/src/Augmenter/Names.php
+++ b/src/Augmenter/Names.php
@@ -32,10 +32,17 @@ class Names implements PipeInterface
         return Group::Resolve;
     }
 
+    /**
+     * A schema takes its name from the class it is declared on. Declared anywhere else —
+     * a method, a parameter — the class reflector belongs to the *declaring* class, whose
+     * name is already taken by that class's own schema, so nothing is inferred.
+     */
     protected function inferSchemaNames(Specification $specification): void
     {
         foreach ($specification->schemas as $schema) {
-            $schema->schema ??= $schema->getShortClassName();
+            if ($schema->getReflector() instanceof \ReflectionClass) {
+                $schema->schema ??= $schema->getShortClassName();
+            }
         }
     }
 

--- a/src/Compiler/OpenApi31Compiler.php
+++ b/src/Compiler/OpenApi31Compiler.php
@@ -81,6 +81,8 @@ class OpenApi31Compiler implements CompilerInterface
 
         $this->validateResponses($specification);
 
+        $this->validateNames($specification);
+
         return $this->logger->entries();
     }
 
@@ -604,6 +606,10 @@ class OpenApi31Compiler implements CompilerInterface
         $result = [];
 
         foreach ($properties as $property) {
+            if ($property->property === null) {
+                continue;
+            }
+
             $result[$property->property] = $property->schema instanceof OA\Schema
                 ? $this->compileSchema($property->schema)
                 : new \stdClass();
@@ -642,8 +648,11 @@ class OpenApi31Compiler implements CompilerInterface
      */
     protected function compileComponents(Specification $specification): array
     {
+        $schemaName = fn (OA\Schema $schema): ?string => $schema->schema ?? $schema->title;
+        $namedSchemas = array_values(array_filter($specification->schemas, fn (OA\Schema $schema): bool => $schemaName($schema) !== null));
+
         return array_filter([
-            'schemas' => $this->compileNamedMap($specification->schemas, fn (OA\Schema $schema): string => $schema->schema ?? $schema->title ?? 'Schema', $this->compileSchema(...)),
+            'schemas' => $this->compileNamedMap($namedSchemas, $schemaName, $this->compileSchema(...)),
             'responses' => $this->compileNamedMap($specification->responses, fn (OA\Response $response): string => (string) $response->response, $this->compileResponse(...)),
             'parameters' => $this->compileNamedMap($specification->parameters, fn (OA\Parameter $parameter): string => $parameter->parameter ?? $parameter->name ?? 'param', $this->compileParameter(...)),
             'requestBodies' => $this->compileNamedMap($specification->requestBodies, fn (OA\RequestBody $body, int $index): string => $body->request ?? 'body' . $index, $this->compileRequestBody(...)),
@@ -752,6 +761,28 @@ class OpenApi31Compiler implements CompilerInterface
     protected function compileExamples(array $examples): array
     {
         return $this->compileNamedMap($examples, 'example', $this->compileExample(...));
+    }
+
+    /**
+     * A component schema takes its key from `schema`, and a property from `property`.
+     * Neither can be derived from a method or a non-constructor parameter, so an attribute
+     * declared there has to carry its own name — the same requirement classic enforces.
+     */
+    protected function validateNames(Specification $specification): void
+    {
+        foreach ($specification->schemas as $schema) {
+            if ($schema->schema === null && $schema->title === null) {
+                $this->logger->warning('Schema is missing key-field: "schema" in ' . $schema->getSourceLocation());
+            }
+        }
+
+        foreach ($this->collectSchemas($specification) as $schema) {
+            foreach ($schema->properties ?? [] as $property) {
+                if ($property->property === null) {
+                    $this->logger->warning('Property is missing key-field: "property" in ' . $property->getSourceLocation());
+                }
+            }
+        }
     }
 
     protected function validateSchemas(Specification $specification): void

--- a/src/Spec/Property.php
+++ b/src/Spec/Property.php
@@ -9,6 +9,10 @@ namespace OpenApi\Spec;
 /**
  * Defines a single property within a Schema object.
  *
+ * The name comes from the property, parameter or constant the attribute sits on. A method
+ * supplies none, so a getter needs `property:` explicitly; without it the property is
+ * reported as missing one and omitted.
+ *
  * @see [Schema Object](https://spec.openapis.org/oas/v3.1.1.html#schema-object)
  */
 #[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_METHOD | \Attribute::TARGET_PARAMETER | \Attribute::TARGET_CLASS_CONSTANT | \Attribute::IS_REPEATABLE)]

--- a/src/Spec/Schema.php
+++ b/src/Spec/Schema.php
@@ -34,6 +34,9 @@ use OpenApi\Undefined;
  *
  *   new OA\Schema(type: 'array', items: new OA\Schema(ref: Pet::class))
  *
+ * Only a class supplies a name. On a method or a parameter, pass `schema:` explicitly;
+ * without it the schema has no component key and is reported as missing one.
+ *
  * @see [Schema Object](https://spec.openapis.org/oas/v3.1.1.html#schema-object)
  * @see [JSON Schema](https://json-schema.org/draft/2020-12/json-schema-validation)
  */
@@ -209,13 +212,6 @@ class Schema extends AbstractAttribute
             Parameter::class => 'schema',
             Header::class => 'schema',
             MediaType::class => 'schema',
-        ];
-    }
-
-    public function contained(): array
-    {
-        return [
-            Schema::class => 'properties[]',
         ];
     }
 }

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -483,6 +483,28 @@ final class CompilerTest extends TestCase
             'Schema "Bad" has type "array" but no items',
         ];
 
+        $specUnnamedSchema = new Specification();
+        $specUnnamedSchema->openapi = new OA\OpenApi(version: '3.1.0');
+        $specUnnamedSchema->info = new OA\Info(title: 'T', version: '1.0');
+        $specUnnamedSchema->schemas[] = new OA\Schema(type: 'string');
+
+        yield 'component schema without a name' => [
+            new OpenApi31Compiler(),
+            $specUnnamedSchema,
+            'Schema is missing key-field: "schema" in unknown',
+        ];
+
+        $specUnnamedProperty = new Specification();
+        $specUnnamedProperty->openapi = new OA\OpenApi(version: '3.1.0');
+        $specUnnamedProperty->info = new OA\Info(title: 'T', version: '1.0');
+        $specUnnamedProperty->schemas[] = new OA\Schema(schema: 'Thing', properties: [new OA\Property()]);
+
+        yield 'schema property without a name' => [
+            new OpenApi31Compiler(),
+            $specUnnamedProperty,
+            'Property is missing key-field: "property" in unknown',
+        ];
+
         $specDuplicateOperationId = new Specification();
         $specDuplicateOperationId->openapi = new OA\OpenApi(version: '3.1.0');
         $specDuplicateOperationId->info = new OA\Info(title: 'T', version: '1.0');
@@ -677,6 +699,30 @@ final class CompilerTest extends TestCase
     }
 
     // --- Undefined vs null on mixed properties ---
+
+    public function testUnnamedSchemaIsOmittedFromComponents(): void
+    {
+        $spec = $this->createSpecification('3.1.0');
+        $spec->schemas[] = new OA\Schema(schema: 'Thing');
+        $spec->schemas[] = new OA\Schema(type: 'string');
+
+        $output = (new OpenApi31Compiler())->compile($spec);
+
+        $this->assertSame(['Thing'], array_keys($output['components']['schemas']));
+    }
+
+    public function testUnnamedPropertyIsOmittedFromSchema(): void
+    {
+        $spec = $this->createSpecification('3.1.0');
+        $spec->schemas[] = new OA\Schema(schema: 'Thing', properties: [
+            new OA\Property(property: 'ok', schema: new OA\Schema(type: 'string')),
+            new OA\Property(schema: new OA\Schema(type: 'integer')),
+        ]);
+
+        $output = (new OpenApi31Compiler())->compile($spec);
+
+        $this->assertSame(['ok'], array_keys($output['components']['schemas']['Thing']['properties']));
+    }
 
     public function testExampleValueNullIsEmitted(): void
     {

--- a/tests/Fixtures/Scratch/MethodProperty-spec.php
+++ b/tests/Fixtures/Scratch/MethodProperty-spec.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Scratch;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema(schema: 'MethodProperty')]
+class MethodPropertySpec
+{
+    /**
+     * The identifier.
+     */
+    #[OA\Property(property: 'id')]
+    public function getId(): int
+    {
+        return 0;
+    }
+
+    // a method supplies no name, so `property` is required here
+    #[OA\Property(property: 'name')]
+    public function getName(): ?string
+    {
+        return null;
+    }
+}
+
+#[OA\Info(
+    title: 'Method Property Scratch',
+    version: '1.0'
+)]
+#[OA\Operation\Get(
+    path: '/api/endpoint',
+    description: 'An endpoint',
+    operationId: 'getMethodProperty',
+    responses: [new OA\Response(response: 200, description: 'OK')]
+)]
+class MethodPropertyEndpointSpec
+{
+}

--- a/tests/Fixtures/Scratch/MethodProperty.php
+++ b/tests/Fixtures/Scratch/MethodProperty.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Scratch;
+
+use OpenApi\Attributes as OAT;
+
+#[OAT\Schema]
+class MethodProperty
+{
+    /**
+     * The identifier.
+     */
+    #[OAT\Property(property: 'id')]
+    public function getId(): int
+    {
+        return 0;
+    }
+
+    // a method supplies no name, so `property` is required here
+    #[OAT\Property(property: 'name')]
+    public function getName(): ?string
+    {
+        return null;
+    }
+}
+
+#[OAT\Info(
+    title: 'Method Property Scratch',
+    version: '1.0'
+)]
+#[OAT\Get(
+    path: '/api/endpoint',
+    description: 'An endpoint',
+    operationId: 'getMethodProperty',
+    responses: [new OAT\Response(response: 200, description: 'OK')]
+)]
+class MethodPropertyEndpoint
+{
+}

--- a/tests/Fixtures/Scratch/MethodProperty3.0.0.yaml
+++ b/tests/Fixtures/Scratch/MethodProperty3.0.0.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.0
+info:
+  title: 'Method Property Scratch'
+  version: '1.0'
+paths:
+  /api/endpoint:
+    get:
+      description: 'An endpoint'
+      operationId: getMethodProperty
+      responses:
+        200:
+          description: OK
+components:
+  schemas:
+    MethodProperty:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: 'The identifier.'
+        name:
+          type: string
+          nullable: true

--- a/tests/Fixtures/Scratch/MethodProperty3.1.0.yaml
+++ b/tests/Fixtures/Scratch/MethodProperty3.1.0.yaml
@@ -1,0 +1,24 @@
+openapi: 3.1.0
+info:
+  title: 'Method Property Scratch'
+  version: '1.0'
+paths:
+  /api/endpoint:
+    get:
+      description: 'An endpoint'
+      operationId: getMethodProperty
+      responses:
+        200:
+          description: OK
+components:
+  schemas:
+    MethodProperty:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: 'The identifier.'
+        name:
+          type:
+            - string
+            - 'null'

--- a/tests/Fixtures/Scratch/MethodProperty3.2.0.yaml
+++ b/tests/Fixtures/Scratch/MethodProperty3.2.0.yaml
@@ -1,0 +1,24 @@
+openapi: 3.2.0
+info:
+  title: 'Method Property Scratch'
+  version: '1.0'
+paths:
+  /api/endpoint:
+    get:
+      description: 'An endpoint'
+      operationId: getMethodProperty
+      responses:
+        200:
+          description: OK
+components:
+  schemas:
+    MethodProperty:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: 'The identifier.'
+        name:
+          type:
+            - string
+            - 'null'

--- a/tests/Fixtures/Scratch/XmlContentEquiv-spec.php
+++ b/tests/Fixtures/Scratch/XmlContentEquiv-spec.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Scratch;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema(schema: 'XmlContentEquiv')]
+class XmlContentEquivSpec
+{
+    #[OA\Property]
+    public string $name = '';
+}
+
+#[OA\Info(title: 'XmlContentEquiv', version: '1.0')]
+#[OA\Operation\Get(
+    path: '/endpoint/xml-content',
+    operationId: 'xmlContentEquiv1',
+    responses: [
+        new OA\Response(
+            response: 200,
+            description: 'All good',
+            content: [
+                new OA\MediaType\Xml(ref: XmlContentEquivSpec::class),
+            ]
+        ),
+    ]
+)]
+class XmlContentEquivEndpoint1Spec
+{
+}
+
+#[OA\Operation\Get(
+    path: '/endpoint/media-type',
+    operationId: 'xmlContentEquiv2',
+    responses: [
+        new OA\Response(
+            response: 200,
+            description: 'All good',
+            content: [
+                new OA\MediaType(
+                    mediaType: 'application/xml',
+                    schema: new OA\Schema(ref: XmlContentEquivSpec::class)
+                ),
+            ]
+        ),
+    ]
+)]
+class XmlContentEquivEndpoint2Spec
+{
+}
+
+#[OA\Operation\Get(
+    path: '/endpoint/xml-array',
+    operationId: 'xmlContentEquiv3',
+    responses: [
+        new OA\Response(
+            response: 200,
+            description: 'All good',
+            content: [
+                new OA\MediaType\Xml(type: 'array', items: new OA\Schema\Items(ref: XmlContentEquivSpec::class)),
+            ]
+        ),
+    ]
+)]
+class XmlContentEquivEndpoint3Spec
+{
+}

--- a/tests/Fixtures/Scratch/XmlContentEquiv.php
+++ b/tests/Fixtures/Scratch/XmlContentEquiv.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Scratch;
+
+use OpenApi\Attributes as OAT;
+
+#[OAT\Schema]
+class XmlContentEquiv
+{
+    #[OAT\Property]
+    public string $name = '';
+}
+
+#[OAT\Info(title: 'XmlContentEquiv', version: '1.0')]
+#[OAT\Get(
+    path: '/endpoint/xml-content',
+    operationId: 'xmlContentEquiv1',
+    responses: [
+        new OAT\Response(
+            response: 200,
+            description: 'All good',
+            content: [
+                new OAT\XmlContent(ref: XmlContentEquiv::class),
+            ]
+        ),
+    ]
+)]
+class XmlContentEquivEndpoint1
+{
+}
+
+#[OAT\Get(
+    path: '/endpoint/media-type',
+    operationId: 'xmlContentEquiv2',
+    responses: [
+        new OAT\Response(
+            response: 200,
+            description: 'All good',
+            content: [
+                new OAT\MediaType(
+                    mediaType: 'application/xml',
+                    schema: new OAT\Schema(ref: XmlContentEquiv::class)
+                ),
+            ]
+        ),
+    ]
+)]
+class XmlContentEquivEndpoint2
+{
+}
+
+#[OAT\Get(
+    path: '/endpoint/xml-array',
+    operationId: 'xmlContentEquiv3',
+    responses: [
+        new OAT\Response(
+            response: 200,
+            description: 'All good',
+            content: [
+                new OAT\XmlContent(type: 'array', items: new OAT\Items(ref: XmlContentEquiv::class)),
+            ]
+        ),
+    ]
+)]
+class XmlContentEquivEndpoint3
+{
+}

--- a/tests/Fixtures/Scratch/XmlContentEquiv3.0.0.yaml
+++ b/tests/Fixtures/Scratch/XmlContentEquiv3.0.0.yaml
@@ -1,0 +1,44 @@
+openapi: 3.0.0
+info:
+  title: XmlContentEquiv
+  version: '1.0'
+paths:
+  /endpoint/xml-content:
+    get:
+      operationId: xmlContentEquiv1
+      responses:
+        200:
+          description: 'All good'
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/XmlContentEquiv'
+  /endpoint/media-type:
+    get:
+      operationId: xmlContentEquiv2
+      responses:
+        200:
+          description: 'All good'
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/XmlContentEquiv'
+  /endpoint/xml-array:
+    get:
+      operationId: xmlContentEquiv3
+      responses:
+        200:
+          description: 'All good'
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/XmlContentEquiv'
+components:
+  schemas:
+    XmlContentEquiv:
+      type: object
+      properties:
+        name:
+          type: string

--- a/tests/Fixtures/Scratch/XmlContentEquiv3.1.0.yaml
+++ b/tests/Fixtures/Scratch/XmlContentEquiv3.1.0.yaml
@@ -1,0 +1,44 @@
+openapi: 3.1.0
+info:
+  title: XmlContentEquiv
+  version: '1.0'
+paths:
+  /endpoint/xml-content:
+    get:
+      operationId: xmlContentEquiv1
+      responses:
+        200:
+          description: 'All good'
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/XmlContentEquiv'
+  /endpoint/media-type:
+    get:
+      operationId: xmlContentEquiv2
+      responses:
+        200:
+          description: 'All good'
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/XmlContentEquiv'
+  /endpoint/xml-array:
+    get:
+      operationId: xmlContentEquiv3
+      responses:
+        200:
+          description: 'All good'
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/XmlContentEquiv'
+components:
+  schemas:
+    XmlContentEquiv:
+      type: object
+      properties:
+        name:
+          type: string

--- a/tests/Fixtures/Scratch/XmlContentEquiv3.2.0.yaml
+++ b/tests/Fixtures/Scratch/XmlContentEquiv3.2.0.yaml
@@ -1,0 +1,44 @@
+openapi: 3.2.0
+info:
+  title: XmlContentEquiv
+  version: '1.0'
+paths:
+  /endpoint/xml-content:
+    get:
+      operationId: xmlContentEquiv1
+      responses:
+        200:
+          description: 'All good'
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/XmlContentEquiv'
+  /endpoint/media-type:
+    get:
+      operationId: xmlContentEquiv2
+      responses:
+        200:
+          description: 'All good'
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/XmlContentEquiv'
+  /endpoint/xml-array:
+    get:
+      operationId: xmlContentEquiv3
+      responses:
+        200:
+          description: 'All good'
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/XmlContentEquiv'
+components:
+  schemas:
+    XmlContentEquiv:
+      type: object
+      properties:
+        name:
+          type: string

--- a/tests/Spec/SlotMapConsistencyTest.php
+++ b/tests/Spec/SlotMapConsistencyTest.php
@@ -8,6 +8,11 @@ namespace OpenApi\Tests\Spec;
 
 use OpenApi\Tests\Concerns\CollectsSpecClasses;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\Type\CollectionType;
+use Symfony\Component\TypeInfo\Type\ObjectType;
+use Symfony\Component\TypeInfo\Type\UnionType;
+use Symfony\Component\TypeInfo\TypeResolver\TypeResolver;
 
 final class SlotMapConsistencyTest extends TestCase
 {
@@ -66,5 +71,72 @@ final class SlotMapConsistencyTest extends TestCase
         }
 
         $this->assertEmpty($failures, implode("\n", $failures));
+    }
+
+    /**
+     * A slot names a property on the target, so the target's own type has to admit the
+     * class declaring the slot. `Schema` once named `Schema::$properties`, a `list<Property>`,
+     * which crashed the inheritance augmenter as soon as anything reached it.
+     */
+    public function testSlotsAcceptTheDeclaringClass(): void
+    {
+        $typeResolver = TypeResolver::create();
+        $failures = [];
+
+        foreach (self::allSpecClasses() as $class) {
+            $instance = (new \ReflectionClass($class))->newInstanceWithoutConstructor();
+
+            foreach (['merge' => $instance->merge(), 'contained' => $instance->contained()] as $kind => $map) {
+                foreach ($map as $target => $slot) {
+                    $property = rtrim($slot, '[]');
+                    if (!class_exists($target) || !property_exists($target, $property)) {
+                        continue; // reported by testSlotsNameRealPropertiesOnTheirTarget
+                    }
+
+                    $accepted = self::objectTypesIn($typeResolver->resolve(new \ReflectionProperty($target, $property)));
+                    if ($accepted === []) {
+                        continue; // untyped or scalar slot: nothing to check against
+                    }
+
+                    foreach ($accepted as $candidate) {
+                        if ($class === $candidate || is_subclass_of($class, $candidate)) {
+                            continue 2;
+                        }
+                    }
+
+                    $failures[] = sprintf(
+                        '%s::%s() declares slot "%s" on %s, which accepts only %s',
+                        $class,
+                        $kind,
+                        $slot,
+                        $target,
+                        implode(', ', $accepted)
+                    );
+                }
+            }
+        }
+
+        $this->assertSame([], $failures, implode("\n", $failures));
+    }
+
+    /**
+     * @return list<class-string>
+     */
+    protected static function objectTypesIn(Type $type): array
+    {
+        if ($type instanceof UnionType) {
+            $types = [];
+            foreach ($type->getTypes() as $member) {
+                $types = [...$types, ...self::objectTypesIn($member)];
+            }
+
+            return $types;
+        }
+
+        if ($type instanceof CollectionType) {
+            return self::objectTypesIn($type->getCollectionValueType());
+        }
+
+        return $type instanceof ObjectType ? [$type->getClassName()] : [];
     }
 }


### PR DESCRIPTION
## Overview

A bare `#[OA\Schema]` on a method crashed the build with a `TypeError`. `Schema` declared
that it could be absorbed into a parent schema's `properties` — a list that only ever holds
`Property` objects — so the inheritance augmenter received the wrong type the moment
anything reached that path.

Classic already handles this code by reporting a missing key-field and carrying on. Spec now
does the same, rather than crashing or, once the bad slot was gone, silently overwriting the
schema it collided with.

## Changes

- `Schema` no longer declares that it nests into another schema's `properties`.
- A schema takes its name only from the class it is declared on. On a method it used to
  inherit the declaring class's name and silently replace that class's real schema.
- An unnamed component schema, and an unnamed property, are now reported as missing their
  key-field and left out of the document, instead of being emitted under a placeholder name
  or an empty key.
- `SlotMapConsistencyTest` checks that every slot's target can hold the class declaring it,
  which is what makes this class of defect visible.
- Where attribute names come from — and where they cannot be derived — is documented in the
  pipeline notes, the shortcut guide, and the `Schema` and `Property` docblocks.
