### PR TITLE
refactor(Spec): prefer stacked attributes over inline nesting

### DIFF
--- a/docs/examples/specs/misc/spec/Endpoint.php
+++ b/docs/examples/specs/misc/spec/Endpoint.php
@@ -34,11 +34,9 @@ class Endpoint
                 )],
             ),
         ],
-        responses: [
-            new OA\Response(response: 200, ref: '#/components/responses/200'),
-        ],
         security: [new OA\Security\Requirement(scheme: 'bearerAuth', scopes: [])],
     )]
+    #[OA\Response(response: 200, ref: '#/components/responses/200')]
     public function endpoint()
     {
     }

--- a/docs/examples/specs/misc/spec/MultiValueQueryParamEndpoint.php
+++ b/docs/examples/specs/misc/spec/MultiValueQueryParamEndpoint.php
@@ -30,11 +30,9 @@ class MultiValueQueryParamEndpoint
                 schema: new OA\Schema(type: 'array', items: new OA\Schema(type: 'integer')),
             ),
         ],
-        responses: [
-            new OA\Response(response: 200, ref: '#/components/responses/200'),
-        ],
         security: [new OA\Security\Requirement(scheme: 'bearerAuth', scopes: [])],
     )]
+    #[OA\Response(response: 200, ref: '#/components/responses/200')]
     public function anotherEndpoint()
     {
     }

--- a/docs/examples/specs/misc/spec/UserAddEndpoint.php
+++ b/docs/examples/specs/misc/spec/UserAddEndpoint.php
@@ -32,23 +32,21 @@ class UserAddEndpoint
                 ),
             )],
         ),
-        responses: [
-            new OA\Response(
-                response: 200,
-                description: 'OK',
-                content: [new OA\MediaType(
-                    mediaType: 'application/json',
-                    schema: new OA\Schema(oneOf: [
-                        new OA\Schema(ref: '#/components/schemas/Result'),
-                        new OA\Schema(type: 'boolean'),
-                    ]),
-                    examples: [
-                        new OA\Example(example: 'result', summary: 'An result object.', value: ['success' => true]),
-                        new OA\Example(example: 'bool', summary: 'A boolean value.', value: false),
-                    ],
-                )],
-            ),
-        ],
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'OK',
+        content: [new OA\MediaType(
+            mediaType: 'application/json',
+            schema: new OA\Schema(oneOf: [
+                new OA\Schema(ref: '#/components/schemas/Result'),
+                new OA\Schema(type: 'boolean'),
+            ]),
+            examples: [
+                new OA\Example(example: 'result', summary: 'An result object.', value: ['success' => true]),
+                new OA\Example(example: 'bool', summary: 'A boolean value.', value: false),
+            ],
+        )],
     )]
     public function addUser()
     {

--- a/docs/examples/specs/misc/spec/UserUpdateEndpoint.php
+++ b/docs/examples/specs/misc/spec/UserUpdateEndpoint.php
@@ -29,10 +29,8 @@ class UserUpdateEndpoint
                 ],
             ),
         ],
-        responses: [
-            new OA\Response(response: 200, description: 'OK'),
-        ],
     )]
+    #[OA\Response(response: 200, description: 'OK')]
     public function updateUser()
     {
     }

--- a/docs/examples/specs/nesting/spec/ApiController.php
+++ b/docs/examples/specs/nesting/spec/ApiController.php
@@ -29,16 +29,14 @@ class ApiController
                 schema: new OA\Schema(type: 'integer', format: 'int64'),
             ),
         ],
-        responses: [
-            new OA\Response(
-                response: 200,
-                description: 'successful operation',
-                content: [new OA\MediaType(
-                    mediaType: 'application/json',
-                    schema: new OA\Schema(ref: '#/components/schemas/ActualModel'),
-                )],
-            ),
-        ],
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'successful operation',
+        content: [new OA\MediaType(
+            mediaType: 'application/json',
+            schema: new OA\Schema(ref: '#/components/schemas/ActualModel'),
+        )],
     )]
     public function get($id)
     {

--- a/docs/examples/specs/petstore/spec/Controllers/PetController.php
+++ b/docs/examples/specs/petstore/spec/Controllers/PetController.php
@@ -19,11 +19,10 @@ class PetController
     /**
      * Add a new pet to the store.
      */
-    #[OA\Operation\Post(path: '/pet', operationId: 'addPet', tags: ['pet'], requestBody: new OA\RequestBody(ref: PetRequestBody::class), responses: [
-        new OA\Response(response: 405, description: 'Invalid input'),
-    ], security: [
+    #[OA\Operation\Post(path: '/pet', operationId: 'addPet', tags: ['pet'], requestBody: new OA\RequestBody(ref: PetRequestBody::class), security: [
         new OA\Security\Requirement(scheme: 'petstore_auth', scopes: ['write:pets', 'read:pets']),
     ])]
+    #[OA\Response(response: 405, description: 'Invalid input')]
     public function addPet()
     {
     }
@@ -31,13 +30,12 @@ class PetController
     /**
      * Update an existing pet.
      */
-    #[OA\Operation\Put(path: '/pet', operationId: 'updatePet', tags: ['pet'], requestBody: new OA\RequestBody(ref: PetRequestBody::class), responses: [
-        new OA\Response(response: 400, description: 'Invalid ID supplied'),
-        new OA\Response(response: 404, description: 'Pet not found'),
-        new OA\Response(response: 405, description: 'Validation exception'),
-    ], security: [
+    #[OA\Operation\Put(path: '/pet', operationId: 'updatePet', tags: ['pet'], requestBody: new OA\RequestBody(ref: PetRequestBody::class), security: [
         new OA\Security\Requirement(scheme: 'petstore_auth', scopes: ['write:pets', 'read:pets']),
     ])]
+    #[OA\Response(response: 400, description: 'Invalid ID supplied')]
+    #[OA\Response(response: 404, description: 'Pet not found')]
+    #[OA\Response(response: 405, description: 'Validation exception')]
     public function updatePet()
     {
     }
@@ -51,19 +49,18 @@ class PetController
             explode: true,
             schema: new OA\Schema(type: 'string', enum: ['available', 'pending', 'sold'], default: 'available'),
         ),
-    ], responses: [
-        new OA\Response(
-            response: 200,
-            description: 'successful operation',
-            content: [
-                new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema\Items(ref: Pet::class)),
-                new OA\MediaType(mediaType: 'application/xml', schema: new OA\Schema(type: 'array', items: new OA\Schema(ref: Pet::class))),
-            ],
-        ),
-        new OA\Response(response: 400, description: 'Invalid status value'),
     ], deprecated: true, security: [
         new OA\Security\Requirement(scheme: 'petstore_auth', scopes: ['write:pets', 'read:pets']),
     ])]
+    #[OA\Response(
+        response: 200,
+        description: 'successful operation',
+        content: [
+            new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema\Items(ref: Pet::class)),
+            new OA\MediaType(mediaType: 'application/xml', schema: new OA\Schema(type: 'array', items: new OA\Schema(ref: Pet::class))),
+        ],
+    )]
+    #[OA\Response(response: 400, description: 'Invalid status value')]
     public function findPetsByStatus()
     {
     }
@@ -77,19 +74,18 @@ class PetController
             explode: true,
             schema: new OA\Schema(type: 'array', items: new OA\Schema(type: 'string')),
         ),
-    ], responses: [
-        new OA\Response(
-            response: 200,
-            description: 'successful operation',
-            content: [
-                new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(type: 'array', items: new OA\Schema(ref: Pet::class))),
-                new OA\MediaType(mediaType: 'application/xml', schema: new OA\Schema(type: 'array', items: new OA\Schema(ref: Pet::class))),
-            ],
-        ),
-        new OA\Response(response: 400, description: 'Invalid tag value'),
     ], security: [
         new OA\Security\Requirement(scheme: 'petstore_auth', scopes: ['write:pets', 'read:pets']),
     ])]
+    #[OA\Response(
+        response: 200,
+        description: 'successful operation',
+        content: [
+            new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(type: 'array', items: new OA\Schema(ref: Pet::class))),
+            new OA\MediaType(mediaType: 'application/xml', schema: new OA\Schema(type: 'array', items: new OA\Schema(ref: Pet::class))),
+        ],
+    )]
+    #[OA\Response(response: 400, description: 'Invalid tag value')]
     public function findByTags()
     {
     }
@@ -102,20 +98,19 @@ class PetController
             required: true,
             schema: new OA\Schema(type: 'integer', format: 'int64'),
         ),
-    ], responses: [
-        new OA\Response(
-            response: 200,
-            description: 'successful operation',
-            content: [
-                new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: Pet::class)),
-                new OA\MediaType(mediaType: 'application/xml', schema: new OA\Schema(ref: Pet::class)),
-            ],
-        ),
-        new OA\Response(response: 400, description: 'Invalid ID supplier'),
-        new OA\Response(response: 404, description: 'Pet not found'),
     ], security: [
         new OA\Security\Requirement(scheme: 'api_key', scopes: []),
     ])]
+    #[OA\Response(
+        response: 200,
+        description: 'successful operation',
+        content: [
+            new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: Pet::class)),
+            new OA\MediaType(mediaType: 'application/xml', schema: new OA\Schema(ref: Pet::class)),
+        ],
+    )]
+    #[OA\Response(response: 400, description: 'Invalid ID supplier')]
+    #[OA\Response(response: 404, description: 'Pet not found')]
     public function getPetById(int $id)
     {
     }
@@ -142,11 +137,10 @@ class PetController
                 ),
             ),
         ],
-    ), responses: [
-        new OA\Response(response: 405, description: 'Invalid input'),
-    ], security: [
+    ), security: [
         new OA\Security\Requirement(scheme: 'petstore_auth', scopes: ['write:pets', 'read:pets']),
     ])]
+    #[OA\Response(response: 405, description: 'Invalid input')]
     public function updatePetWithForm()
     {
     }
@@ -154,12 +148,11 @@ class PetController
     #[OA\Operation\Delete(path: '/pet/{petId}', operationId: 'deletePet', summary: 'Deletes a pet', tags: ['pet'], parameters: [
         new OA\Parameter(name: 'api_key', in: 'header', required: false, schema: new OA\Schema(type: 'string')),
         new OA\Parameter(name: 'petId', in: 'path', description: 'Pet id to delete', required: true, schema: new OA\Schema(type: 'integer', format: 'int64')),
-    ], responses: [
-        new OA\Response(response: 400, description: 'Invalid ID supplied'),
-        new OA\Response(response: 404, description: 'Pet not found'),
     ], security: [
         new OA\Security\Requirement(scheme: 'petstore_auth', scopes: ['write:pets', 'read:pets']),
     ])]
+    #[OA\Response(response: 400, description: 'Invalid ID supplied')]
+    #[OA\Response(response: 404, description: 'Pet not found')]
     public function deletePet()
     {
     }
@@ -180,15 +173,14 @@ class PetController
                 schema: new OA\Schema(type: 'string', format: 'binary'),
             ),
         ],
-    ), responses: [
-        new OA\Response(
-            response: 200,
-            description: 'successful operation',
-            content: [new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: ApiResponse::class))],
-        ),
-    ], security: [
+    ), security: [
         new OA\Security\Requirement(scheme: 'petstore_auth', scopes: ['write:pets', 'read:pets']),
     ])]
+    #[OA\Response(
+        response: 200,
+        description: 'successful operation',
+        content: [new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: ApiResponse::class))],
+    )]
     public function uploadFile()
     {
     }

--- a/docs/examples/specs/petstore/spec/Controllers/StoreController.php
+++ b/docs/examples/specs/petstore/spec/Controllers/StoreController.php
@@ -14,20 +14,19 @@ use OpenApi\Spec as OA;
  */
 class StoreController
 {
-    #[OA\Operation\Get(path: '/store', operationId: 'getInventory', summary: 'Returns pet inventories by status', description: 'Returns a map of status codes to quantities', tags: ['store'], responses: [
-        new OA\Response(
-            response: 200,
-            description: 'successful operation',
-            content: [
+    #[OA\Operation\Get(path: '/store', operationId: 'getInventory', summary: 'Returns pet inventories by status', description: 'Returns a map of status codes to quantities', tags: ['store'], security: [
+        new OA\Security\Requirement(scheme: 'api_key', scopes: []),
+    ])]
+    #[OA\Response(
+        response: 200,
+        description: 'successful operation',
+        content: [
                 new OA\MediaType(
                     mediaType: 'application/json',
                     schema: new OA\Schema(additionalProperties: new OA\Schema(type: 'integer', format: 'int32')),
                 ),
             ],
-        ),
-    ], security: [
-        new OA\Security\Requirement(scheme: 'api_key', scopes: []),
-    ])]
+    )]
     public function getInventory()
     {
     }
@@ -42,15 +41,13 @@ class StoreController
             required: true,
             content: [new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: Order::class))],
         ),
-        responses: [
-            new OA\Response(
-                response: 200,
-                description: 'successful operation',
-                content: [
-                    new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: Order::class)),
-                    new OA\MediaType(mediaType: 'application/xml', schema: new OA\Schema(ref: Order::class)),
-                ],
-            ),
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'successful operation',
+        content: [
+            new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: Order::class)),
+            new OA\MediaType(mediaType: 'application/xml', schema: new OA\Schema(ref: Order::class)),
         ],
     )]
     public function placeOrder()
@@ -71,19 +68,17 @@ class StoreController
                 schema: new OA\Schema(type: 'integer', format: 'int64', minimum: 1, maximum: 10),
             ),
         ],
-        responses: [
-            new OA\Response(
-                response: 200,
-                description: 'successful operation',
-                content: [
-                    new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: Order::class)),
-                    new OA\MediaType(mediaType: 'application/xml', schema: new OA\Schema(ref: Order::class)),
-                ],
-            ),
-            new OA\Response(response: 400, description: 'Invalid ID supplied'),
-            new OA\Response(response: 404, description: 'Order not found'),
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'successful operation',
+        content: [
+            new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: Order::class)),
+            new OA\MediaType(mediaType: 'application/xml', schema: new OA\Schema(ref: Order::class)),
         ],
     )]
+    #[OA\Response(response: 400, description: 'Invalid ID supplied')]
+    #[OA\Response(response: 404, description: 'Order not found')]
     public function getOrderById()
     {
     }
@@ -103,11 +98,9 @@ class StoreController
                 schema: new OA\Schema(type: 'integer', format: 'int64', minimum: 1),
             ),
         ],
-        responses: [
-            new OA\Response(response: 400, description: 'Invalid ID supplied'),
-            new OA\Response(response: 404, description: 'Order not found'),
-        ],
     )]
+    #[OA\Response(response: 400, description: 'Invalid ID supplied')]
+    #[OA\Response(response: 404, description: 'Order not found')]
     public function deleteOrder()
     {
     }

--- a/docs/examples/specs/petstore/spec/Controllers/UserController.php
+++ b/docs/examples/specs/petstore/spec/Controllers/UserController.php
@@ -26,10 +26,8 @@ class UserController
             required: true,
             content: [new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: User::class))],
         ),
-        responses: [
-            new OA\Response(response: 'default', description: 'successful operation'),
-        ],
     )]
+    #[OA\Response(response: 'default', description: 'successful operation')]
     public function createUser()
     {
     }
@@ -40,10 +38,8 @@ class UserController
         summary: 'Create list of users with given input array',
         tags: ['user'],
         requestBody: new OA\RequestBody(ref: UserArrayRequestBody::class),
-        responses: [
-            new OA\Response(response: 'default', description: 'successful operation'),
-        ],
     )]
+    #[OA\Response(response: 'default', description: 'successful operation')]
     public function createUsersWithListInput()
     {
     }
@@ -57,22 +53,20 @@ class UserController
             new OA\Parameter(name: 'username', in: 'query', description: 'The user name for login', required: true, schema: new OA\Schema(type: 'string')),
             new OA\Parameter(name: 'password', in: 'query', required: true, schema: new OA\Schema(type: 'string')),
         ],
-        responses: [
-            new OA\Response(
-                response: 200,
-                description: 'successful operation',
-                headers: [
-                    new OA\Header(header: 'X-Rate-Limit', description: 'calls per hour allowed by the user', schema: new OA\Schema(type: 'integer', format: 'int32')),
-                    new OA\Header(header: 'X-Expires-After', description: 'date in UTC when token expires', schema: new OA\Schema(type: 'string', format: 'datetime')),
-                ],
-                content: [
-                    new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(type: 'string')),
-                    new OA\MediaType(mediaType: 'application/xml', schema: new OA\Schema(type: 'string')),
-                ],
-            ),
-            new OA\Response(response: 400, description: 'Invalid username/password supplied'),
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'successful operation',
+        headers: [
+            new OA\Header(header: 'X-Rate-Limit', description: 'calls per hour allowed by the user', schema: new OA\Schema(type: 'integer', format: 'int32')),
+            new OA\Header(header: 'X-Expires-After', description: 'date in UTC when token expires', schema: new OA\Schema(type: 'string', format: 'datetime')),
+        ],
+        content: [
+            new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(type: 'string')),
+            new OA\MediaType(mediaType: 'application/xml', schema: new OA\Schema(type: 'string')),
         ],
     )]
+    #[OA\Response(response: 400, description: 'Invalid username/password supplied')]
     public function loginUser()
     {
     }
@@ -82,10 +76,8 @@ class UserController
         operationId: 'logoutUser',
         summary: 'Logs out current logged in user session',
         tags: ['user'],
-        responses: [
-            new OA\Response(response: 'default', description: 'successful operation'),
-        ],
     )]
+    #[OA\Response(response: 'default', description: 'successful operation')]
     public function logoutUser()
     {
     }
@@ -97,19 +89,17 @@ class UserController
         parameters: [
             new OA\Parameter(name: 'username', in: 'path', required: true, schema: new OA\Schema(type: 'string')),
         ],
-        responses: [
-            new OA\Response(
-                response: 200,
-                description: 'successful operation',
-                content: [
-                    new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: User::class)),
-                    new OA\MediaType(mediaType: 'application/xml', schema: new OA\Schema(ref: User::class)),
-                ],
-            ),
-            new OA\Response(response: 400, description: 'Invalid username supplied'),
-            new OA\Response(response: 404, description: 'User not found'),
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'successful operation',
+        content: [
+            new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: User::class)),
+            new OA\MediaType(mediaType: 'application/xml', schema: new OA\Schema(ref: User::class)),
         ],
     )]
+    #[OA\Response(response: 400, description: 'Invalid username supplied')]
+    #[OA\Response(response: 404, description: 'User not found')]
     public function getUserByName()
     {
     }
@@ -127,11 +117,9 @@ class UserController
             required: true,
             content: [new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: User::class))],
         ),
-        responses: [
-            new OA\Response(response: 400, description: 'Invalid user supplied'),
-            new OA\Response(response: 404, description: 'User not found'),
-        ],
     )]
+    #[OA\Response(response: 400, description: 'Invalid user supplied')]
+    #[OA\Response(response: 404, description: 'User not found')]
     public function updateUser()
     {
     }
@@ -144,11 +132,9 @@ class UserController
         parameters: [
             new OA\Parameter(name: 'username', in: 'path', description: 'The name that needs to be deleted', required: true, schema: new OA\Schema(type: 'string')),
         ],
-        responses: [
-            new OA\Response(response: 400, description: 'Invalid username supplied'),
-            new OA\Response(response: 404, description: 'User not found'),
-        ],
     )]
+    #[OA\Response(response: 400, description: 'Invalid username supplied')]
+    #[OA\Response(response: 404, description: 'User not found')]
     public function deleteUser()
     {
     }

--- a/docs/examples/specs/polymorphism/spec/Controller.php
+++ b/docs/examples/specs/polymorphism/spec/Controller.php
@@ -18,13 +18,11 @@ class Controller
         operationId: 'test',
         description: 'Get test',
         tags: ['api'],
-        responses: [
-            new OA\Response(
-                response: 200,
-                description: 'Polymorphism',
-                content: [new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: Request::class))],
-            ),
-        ],
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Polymorphism',
+        content: [new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: Request::class))],
     )]
     public function getProduct($id)
     {

--- a/docs/examples/specs/using-interfaces/spec/ProductController.php
+++ b/docs/examples/specs/using-interfaces/spec/ProductController.php
@@ -24,16 +24,14 @@ class ProductController
                 schema: new OA\Schema(type: 'string'),
             ),
         ],
-        responses: [
-            new OA\Response(
-                response: 200,
-                description: 'successful operation',
-                content: [new OA\MediaType(
-                    mediaType: 'application/json',
-                    schema: new OA\Schema(ref: '#/components/schemas/Product'),
-                )],
-            ),
-        ],
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'successful operation',
+        content: [new OA\MediaType(
+            mediaType: 'application/json',
+            schema: new OA\Schema(ref: '#/components/schemas/Product'),
+        )],
     )]
     public function getProduct($id)
     {
@@ -53,16 +51,14 @@ class ProductController
                 schema: new OA\Schema(type: 'string'),
             ),
         ],
-        responses: [
-            new OA\Response(
-                response: 200,
-                description: 'successful operation',
-                content: [new OA\MediaType(
-                    mediaType: 'application/json',
-                    schema: new OA\Schema(ref: '#/components/schemas/GreenProduct'),
-                )],
-            ),
-        ],
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'successful operation',
+        content: [new OA\MediaType(
+            mediaType: 'application/json',
+            schema: new OA\Schema(ref: '#/components/schemas/GreenProduct'),
+        )],
     )]
     public function getGreenProduct($id)
     {

--- a/docs/examples/specs/using-links/spec/RepositoriesController.php
+++ b/docs/examples/specs/using-links/spec/RepositoriesController.php
@@ -10,6 +10,9 @@ use OpenApi\Spec as OA;
 
 class RepositoriesController
 {
+    // Responses stay nested in these operations: the `OA\Link` attributes beside them
+    // are component links, and a sibling `OA\Response` would capture them into the
+    // response instead.
     #[OA\Operation\Get(
         path: '/2.0/repositories/{username}',
         operationId: 'getRepositoriesByOwner',

--- a/docs/examples/specs/using-links/spec/UsersController.php
+++ b/docs/examples/specs/using-links/spec/UsersController.php
@@ -19,14 +19,12 @@ class UsersController
         parameters: [
             new OA\Parameter(name: 'username', in: 'path', required: true, schema: new OA\Schema(type: 'string')),
         ],
-        responses: [
-            new OA\Response(
-                response: 200,
-                description: 'The User',
-                content: [new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: '#/components/schemas/user'))],
-                links: [new OA\Link(link: 'userRepositories', ref: '#/components/links/UserRepositories')],
-            ),
-        ],
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'The User',
+        content: [new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: '#/components/schemas/user'))],
+        links: [new OA\Link(link: 'userRepositories', ref: '#/components/links/UserRepositories')],
     )]
     public function getUserByName(string $username)
     {

--- a/docs/examples/specs/using-refs/spec/ProductController.php
+++ b/docs/examples/specs/using-refs/spec/ProductController.php
@@ -17,10 +17,8 @@ class ProductController
         path: '/products/{product_id}',
         operationId: 'getProduct',
         tags: ['Products'],
-        responses: [
-            new OA\Response(response: 'default', ref: new OA\Schema\Ref(ref: '#/components/responses/product')),
-        ],
     )]
+    #[OA\Response(response: 'default', ref: new OA\Schema\Ref(ref: '#/components/responses/product'))]
     public function getProduct($id)
     {
     }
@@ -30,10 +28,8 @@ class ProductController
         operationId: 'updateProduct',
         tags: ['Products'],
         requestBody: new OA\RequestBody(ref: '#/components/requestBodies/product_in_body'),
-        responses: [
-            new OA\Response(response: 'default', ref: '#/components/responses/product'),
-        ],
     )]
+    #[OA\Response(response: 'default', ref: '#/components/responses/product')]
     public function updateProduct($id)
     {
     }

--- a/docs/examples/specs/using-refs/spec/PropertyRefController.php
+++ b/docs/examples/specs/using-refs/spec/PropertyRefController.php
@@ -17,10 +17,8 @@ class PropertyRefController
         parameters: [
             new OA\Parameter(ref: '#/components/schemas/Product/properties/id'),
         ],
-        responses: [
-            new OA\Response(response: 'default', ref: '#/components/responses/todo'),
-        ],
     )]
+    #[OA\Response(response: 'default', ref: '#/components/responses/todo')]
     public function doStuff($id)
     {
     }

--- a/docs/examples/specs/using-traits/spec/DeleteEntity.php
+++ b/docs/examples/specs/using-traits/spec/DeleteEntity.php
@@ -23,10 +23,8 @@ trait DeleteEntity
                 schema: new OA\Schema(type: 'string'),
             ),
         ],
-        responses: [
-            new OA\Response(response: 'default', description: 'successful operation'),
-        ],
     )]
+    #[OA\Response(response: 'default', description: 'successful operation')]
     public function deleteEntity($id)
     {
     }

--- a/docs/examples/specs/using-traits/spec/ProductController.php
+++ b/docs/examples/specs/using-traits/spec/ProductController.php
@@ -25,20 +25,18 @@ class ProductController
                 schema: new OA\Schema(type: 'string'),
             ),
         ],
-        responses: [
-            new OA\Response(
-                response: 'default',
-                description: 'successful operation',
-                content: [new OA\MediaType(
-                    mediaType: 'application/json',
-                    schema: new OA\Schema(oneOf: [
-                        new OA\Schema(ref: '#/components/schemas/SimpleProduct'),
-                        new OA\Schema(ref: '#/components/schemas/Product'),
-                        new OA\Schema(ref: '#/components/schemas/TrickyProduct'),
-                    ]),
-                )],
-            ),
-        ],
+    )]
+    #[OA\Response(
+        response: 'default',
+        description: 'successful operation',
+        content: [new OA\MediaType(
+            mediaType: 'application/json',
+            schema: new OA\Schema(oneOf: [
+                new OA\Schema(ref: '#/components/schemas/SimpleProduct'),
+                new OA\Schema(ref: '#/components/schemas/Product'),
+                new OA\Schema(ref: '#/components/schemas/TrickyProduct'),
+            ]),
+        )],
     )]
     public function getProduct($id)
     {

--- a/docs/examples/specs/webhooks/spec/NewPetWebhook.php
+++ b/docs/examples/specs/webhooks/spec/NewPetWebhook.php
@@ -18,10 +18,8 @@ class NewPetWebhook
             description: 'Information about a new pet in the system',
             content: [new OA\MediaType(mediaType: 'application/json', schema: new OA\Schema(ref: Pet::class))],
         ),
-        responses: [
-            new OA\Response(response: 200, description: 'Return a 200 status to indicate that the data was received successfully'),
-        ],
     )]
+    #[OA\Response(response: 200, description: 'Return a 200 status to indicate that the data was received successfully')]
     public function newPet()
     {
     }

--- a/docs/snippets/guide/cookbook/multi_value_query_parameter_at.php
+++ b/docs/snippets/guide/cookbook/multi_value_query_parameter_at.php
@@ -23,10 +23,8 @@ class Controller
                 )
             ),
         ],
-        responses: [
-            new OA\Response(response: '200', description: 'All good'),
-        ]
     )]
+    #[OA\Response(response: '200', description: 'All good')]
     public function endpoint()
     {
         // ...

--- a/docs/snippets/guide/cookbook/multi_value_query_parameter_spec.php
+++ b/docs/snippets/guide/cookbook/multi_value_query_parameter_spec.php
@@ -23,10 +23,8 @@ class Controller
                 )
             ),
         ],
-        responses: [
-            new OA\Response(response: '200', description: 'All good'),
-        ]
     )]
+    #[OA\Response(response: '200', description: 'All good')]
     public function endpoint()
     {
         // ...

--- a/docs/snippets/guide/cookbook/reusing_response_at.php
+++ b/docs/snippets/guide/cookbook/reusing_response_at.php
@@ -20,12 +20,10 @@ class ProductController
     #[OA\Get(
         tags: ['Products'],
         path: '/products/{product_id}',
-        responses: [
-            new OA\Response(
-                response: 'default',
-                ref: '#/components/responses/product'
-            ),
-        ],
+    )]
+    #[OA\Response(
+        response: 'default',
+        ref: '#/components/responses/product'
     )]
     public function getProduct($id)
     {

--- a/docs/snippets/guide/cookbook/reusing_response_spec.php
+++ b/docs/snippets/guide/cookbook/reusing_response_spec.php
@@ -23,12 +23,10 @@ class ProductController
     #[OA\Operation\Get(
         tags: ['Products'],
         path: '/products/{product_id}',
-        responses: [
-            new OA\Response(
-                response: 'default',
-                ref: '#/components/responses/product'
-            ),
-        ],
+    )]
+    #[OA\Response(
+        response: 'default',
+        ref: '#/components/responses/product'
     )]
     public function getProduct($id)
     {

--- a/docs/snippets/guide/cookbook/set_xml_root_name_at.php
+++ b/docs/snippets/guide/cookbook/set_xml_root_name_at.php
@@ -11,16 +11,14 @@ use OpenApi\Attributes as OA;
 )]
 #[OA\Post(
     path: '/foobar',
-    responses: [
-        new OA\Response(
-            response: 400,
-            description: 'Request error',
-            content: new OA\XmlContent(
-                ref: '#/components/schemas/Error',
-                xml: new OA\Xml(name: 'error'),
-            ),
-        ),
-    ],
+)]
+#[OA\Response(
+    response: 400,
+    description: 'Request error',
+    content: new OA\XmlContent(
+        ref: '#/components/schemas/Error',
+        xml: new OA\Xml(name: 'error'),
+    ),
 )]
 class OpenApiSpec
 {

--- a/docs/snippets/guide/cookbook/set_xml_root_name_spec.php
+++ b/docs/snippets/guide/cookbook/set_xml_root_name_spec.php
@@ -11,19 +11,17 @@ use OpenApi\Spec as OA;
 )]
 #[OA\Operation\Post(
     path: '/foobar',
-    responses: [
-        new OA\Response(
-            response: 400,
-            description: 'Request error',
-            content: [new OA\MediaType(
-                mediaType: 'application/xml',
-                schema: new OA\Schema(
-                    ref: '#/components/schemas/Error',
-                    xml: new OA\Xml(name: 'error'),
-                ),
-            )],
+)]
+#[OA\Response(
+    response: 400,
+    description: 'Request error',
+    content: [new OA\MediaType(
+        mediaType: 'application/xml',
+        schema: new OA\Schema(
+            ref: '#/components/schemas/Error',
+            xml: new OA\Xml(name: 'error'),
         ),
-    ],
+    )],
 )]
 class OpenApiSpec
 {

--- a/tests/Fixtures/Scratch/AttributeInheritance-spec.php
+++ b/tests/Fixtures/Scratch/AttributeInheritance-spec.php
@@ -42,8 +42,8 @@ class Child2Spec extends BaseSpec
     path: '/api/endpoint',
     description: 'An endpoint',
     operationId: 'getEndpoint',
-    responses: [new OA\Response(response: 200, description: 'OK')]
 )]
+#[OA\Response(response: 200, description: 'OK')]
 class AttributeInheritanceEndpointSpec
 {
 }

--- a/tests/Fixtures/Scratch/Auth-spec.php
+++ b/tests/Fixtures/Scratch/Auth-spec.php
@@ -70,10 +70,8 @@ class AuthOtherSchemesSpec
         new OA\Security\Requirement(scheme: 'bearerAuth'),
         new OA\Security\Requirement(scheme: 'oauth2', scopes: ['read:pets']),
     ],
-    responses: [
-        new OA\Response(response: 200, description: 'All good'),
-    ],
 )]
+#[OA\Response(response: 200, description: 'All good')]
 class AuthEndpointSpec
 {
 }

--- a/tests/Fixtures/Scratch/ClassRef-spec.php
+++ b/tests/Fixtures/Scratch/ClassRef-spec.php
@@ -17,13 +17,11 @@ class ClassRefSpec
 #[OA\Operation\Get(
     path: '/endpoint',
     operationId: 'ClassRefEndpoint',
-    responses: [
-        new OA\Response(
-            response: 200,
-            description: 'All good',
-            content: new OA\MediaType\Json(ref: ClassRefSpec::class)
-        ),
-    ]
+)]
+#[OA\Response(
+    response: 200,
+    description: 'All good',
+    content: new OA\MediaType\Json(ref: ClassRefSpec::class)
 )]
 class ClassRefEndpointSpec
 {

--- a/tests/Fixtures/Scratch/Components-spec.php
+++ b/tests/Fixtures/Scratch/Components-spec.php
@@ -37,12 +37,10 @@ class ComponentsClass2Spec
 #[OA\Operation\Get(
     path: '/endpoint',
     operationId: 'getEndpoint',
-    responses: [
-        new OA\Response(
-            response: 200,
-            description: 'All good',
-        ),
-    ]
+)]
+#[OA\Response(
+    response: 200,
+    description: 'All good',
 )]
 class ComponentsEndpointSpec
 {

--- a/tests/Fixtures/Scratch/CustomAttributeSchema-spec.php
+++ b/tests/Fixtures/Scratch/CustomAttributeSchema-spec.php
@@ -26,8 +26,8 @@ class MyClassSpec
     path: '/api/endpoint',
     description: 'An endpoint',
     operationId: 'customAttributeSchemaEndpoint',
-    responses: [new OA\Response(response: 200, description: 'OK')]
 )]
+#[OA\Response(response: 200, description: 'OK')]
 class CustomAttributeSchemaEndpointSpec
 {
 }

--- a/tests/Fixtures/Scratch/CustomAttributes-spec.php
+++ b/tests/Fixtures/Scratch/CustomAttributes-spec.php
@@ -96,8 +96,8 @@ class CAModelSpec
     path: '/api/endpoint',
     description: 'An endpoint',
     operationId: 'CAEndpoint',
-    responses: [new OA\Response(response: 200, description: 'OK')]
 )]
+#[OA\Response(response: 200, description: 'OK')]
 class CAEndpointSpec
 {
 }

--- a/tests/Fixtures/Scratch/DuplicateRef-spec.php
+++ b/tests/Fixtures/Scratch/DuplicateRef-spec.php
@@ -13,8 +13,8 @@ use OpenApi\Spec as OA;
     path: '/api/endpoint',
     description: 'An endpoint',
     operationId: 'getEndpoint',
-    responses: [new OA\Response(response: 200, description: 'OK')]
 )]
+#[OA\Response(response: 200, description: 'OK')]
 class DuplicateRefEndpointSpec
 {
 }

--- a/tests/Fixtures/Scratch/DynamicEnumCase-spec.php
+++ b/tests/Fixtures/Scratch/DynamicEnumCase-spec.php
@@ -13,8 +13,8 @@ use OpenApi\Spec as OA;
     path: '/api/endpoint',
     description: 'An endpoint',
     operationId: 'dynamicEnumCase',
-    responses: [new OA\Response(response: 200, description: 'OK')]
 )]
+#[OA\Response(response: 200, description: 'OK')]
 class DynamicEnumCaseEndpointSpec
 {
 }

--- a/tests/Fixtures/Scratch/Encoding-spec.php
+++ b/tests/Fixtures/Scratch/Encoding-spec.php
@@ -40,7 +40,9 @@ class MultipartFormDataSpec
 class EncodingControllerSpec
 {
     // Stacked siblings: Schema -> MediaType -> RequestBody -> Post. Encoding
-    // only targets properties, so it stays inline on the MediaType.
+    // only targets properties, so it stays inline on the MediaType, and the
+    // responses stay inline too — MediaType merges into Response and RequestBody
+    // alike, so stacking both would be ambiguous.
     #[OA\Schema(ref: MultipartFormDataSpec::class)]
     #[OA\MediaType(
         mediaType: 'multipart/form-data',

--- a/tests/Fixtures/Scratch/Examples-spec.php
+++ b/tests/Fixtures/Scratch/Examples-spec.php
@@ -51,10 +51,8 @@ class ExampleSchemaSpec
             ]
         ),
     ],
-    responses: [
-        new OA\Response(response: 200, description: 'OK'),
-    ]
 )]
+#[OA\Response(response: 200, description: 'OK')]
 class ExamplesEndpointSpec
 {
 }

--- a/tests/Fixtures/Scratch/ExclusiveMinMax-spec.php
+++ b/tests/Fixtures/Scratch/ExclusiveMinMax-spec.php
@@ -43,8 +43,8 @@ class ExclusiveMinMaxSpec
         path: '/api/endpoint',
         description: 'An endpoint',
         operationId: 'exclusiveMinMax',
-        responses: [new OA\Response(response: 200, description: 'OK')]
     )]
+    #[OA\Response(response: 200, description: 'OK')]
     public function exclusiveMinMaxSpec()
     {
     }

--- a/tests/Fixtures/Scratch/HttpMethods-spec.php
+++ b/tests/Fixtures/Scratch/HttpMethods-spec.php
@@ -14,10 +14,8 @@ class HttpMethodsControllerSpec
     #[OA\Operation\Head(
         path: '/things',
         operationId: 'headThings',
-        responses: [
-            new OA\Response(response: 200, description: 'Headers only, no body'),
-        ],
     )]
+    #[OA\Response(response: 200, description: 'Headers only, no body')]
     public function headThings()
     {
     }
@@ -25,10 +23,8 @@ class HttpMethodsControllerSpec
     #[OA\Operation\Options(
         path: '/things',
         operationId: 'optionsThings',
-        responses: [
-            new OA\Response(response: 200, description: 'Allowed methods'),
-        ],
     )]
+    #[OA\Response(response: 200, description: 'Allowed methods')]
     public function optionsThings()
     {
     }
@@ -36,13 +32,11 @@ class HttpMethodsControllerSpec
     #[OA\Operation\Trace(
         path: '/things',
         operationId: 'traceThings',
-        responses: [
-            new OA\Response(
-                response: 200,
-                description: 'Echo of the request',
-                content: new OA\MediaType(mediaType: 'message/http', schema: new OA\Schema(type: 'string')),
-            ),
-        ],
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Echo of the request',
+        content: new OA\MediaType(mediaType: 'message/http', schema: new OA\Schema(type: 'string')),
     )]
     public function traceThings()
     {

--- a/tests/Fixtures/Scratch/JsonContentEquiv-spec.php
+++ b/tests/Fixtures/Scratch/JsonContentEquiv-spec.php
@@ -17,14 +17,12 @@ class JsonContentEquivSpec
 #[OA\Operation\Get(
     path: '/endpoint/json-content',
     operationId: 'jsonContentEquiv1',
-    responses: [
-        new OA\Response(
-            response: 200,
-            description: 'All good',
-            content: [
-                new OA\MediaType\Json(ref: JsonContentEquivSpec::class),
-            ]
-        ),
+)]
+#[OA\Response(
+    response: 200,
+    description: 'All good',
+    content: [
+        new OA\MediaType\Json(ref: JsonContentEquivSpec::class),
     ]
 )]
 class JsonContentEquivEndpoint1Spec
@@ -34,16 +32,14 @@ class JsonContentEquivEndpoint1Spec
 #[OA\Operation\Get(
     path: '/endpoint/media-type',
     operationId: 'jsonContentEquiv2',
-    responses: [
-        new OA\Response(
-            response: 200,
-            description: 'All good',
-            content: [
-                new OA\MediaType(
-                    mediaType: 'application/json',
-                    schema: new OA\Schema(ref: JsonContentEquivSpec::class)
-                ),
-            ]
+)]
+#[OA\Response(
+    response: 200,
+    description: 'All good',
+    content: [
+        new OA\MediaType(
+            mediaType: 'application/json',
+            schema: new OA\Schema(ref: JsonContentEquivSpec::class)
         ),
     ]
 )]

--- a/tests/Fixtures/Scratch/Link-spec.php
+++ b/tests/Fixtures/Scratch/Link-spec.php
@@ -11,6 +11,9 @@ use OpenApi\Spec as OA;
 #[OA\Info(title: 'Link', version: '1.0')]
 class LinkControllerSpec
 {
+    // Responses stay nested in these operations rather than stacked as siblings: the
+    // `OA\Link` attributes merge into the response beside them, which only holds while
+    // that response is part of the operation.
     #[OA\Operation\Get(
         path: '/widgets/{id}',
         operationId: 'getWidget',

--- a/tests/Fixtures/Scratch/MethodProperty-spec.php
+++ b/tests/Fixtures/Scratch/MethodProperty-spec.php
@@ -36,8 +36,8 @@ class MethodPropertySpec
     path: '/api/endpoint',
     description: 'An endpoint',
     operationId: 'getMethodProperty',
-    responses: [new OA\Response(response: 200, description: 'OK')]
 )]
+#[OA\Response(response: 200, description: 'OK')]
 class MethodPropertyEndpointSpec
 {
 }

--- a/tests/Fixtures/Scratch/MultiTypeProperty-spec.php
+++ b/tests/Fixtures/Scratch/MultiTypeProperty-spec.php
@@ -41,8 +41,8 @@ class MultiTypePropertySpec
     path: '/api/endpoint',
     description: 'An endpoint',
     operationId: 'multiTypePropertyEndpoint',
-    responses: [new OA\Response(response: 200, description: 'OK')]
 )]
+#[OA\Response(response: 200, description: 'OK')]
 class MultiTypePropertyEndpointSpec
 {
 }

--- a/tests/Fixtures/Scratch/MultiplePathsForEndpoint-spec.php
+++ b/tests/Fixtures/Scratch/MultiplePathsForEndpoint-spec.php
@@ -8,6 +8,9 @@ namespace OpenApi\Tests\Fixtures\Scratch;
 
 use OpenApi\Spec as OA;
 
+// Responses stay nested in the operation here rather than stacked as siblings: two
+// operations share one target, so a stacked `OA\Response` matches both and fails with
+// `Ambiguous merge`.
 #[OA\Info(
     title: 'Multiple Paths For Endpoint Scratch',
     version: '1.0'

--- a/tests/Fixtures/Scratch/NestedAdditionalProperties-spec.php
+++ b/tests/Fixtures/Scratch/NestedAdditionalProperties-spec.php
@@ -16,8 +16,8 @@ use OpenApi\Spec as OA;
     path: '/api/endpoint',
     description: 'An endpoint',
     operationId: 'nestedAdditionalProperties',
-    responses: [new OA\Response(response: 200, description: 'OK')]
 )]
+#[OA\Response(response: 200, description: 'OK')]
 #[OA\Schema(
     schema: 'NestedAdditionalProperties',
     additionalProperties: new OA\Schema\AdditionalProperties(

--- a/tests/Fixtures/Scratch/NestedSchema-spec.php
+++ b/tests/Fixtures/Scratch/NestedSchema-spec.php
@@ -92,8 +92,8 @@ class NestedSchemaControllerSpec
                 ]
             )
         )]),
-        responses: [new OA\Response(response: 200, description: 'OK')]
     )]
+    #[OA\Response(response: 200, description: 'OK')]
     public function post()
     {
 

--- a/tests/Fixtures/Scratch/NullRef-spec.php
+++ b/tests/Fixtures/Scratch/NullRef-spec.php
@@ -22,16 +22,14 @@ class NullRefSpec
     #[OA\Operation\Get(
         path: '/api/refonly',
         operationId: 'refonly',
-        responses: [
-            new OA\Response(
-                response: 200,
-                description: 'Ref response',
-                content: new OA\MediaType\Json(
-                    ref: '#/components/schemas/repository',
-                    schema: new OA\Schema(nullable: true),
-                )
-            ),
-        ]
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Ref response',
+        content: new OA\MediaType\Json(
+            ref: '#/components/schemas/repository',
+            schema: new OA\Schema(nullable: true),
+        )
     )]
     public function refonly()
     {
@@ -40,19 +38,17 @@ class NullRefSpec
     #[OA\Operation\Get(
         path: '/api/refplus',
         operationId: 'refplus',
-        responses: [
-            new OA\Response(
-                response: 200,
-                description: 'Ref plus response',
-                content: new OA\MediaType\Json(
-                    ref: '#/components/schemas/repository',
-                    schema: new OA\Schema(
-                        description: 'The repository',
-                        nullable: true,
-                    ),
-                )
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Ref plus response',
+        content: new OA\MediaType\Json(
+            ref: '#/components/schemas/repository',
+            schema: new OA\Schema(
+                description: 'The repository',
+                nullable: true,
             ),
-        ]
+        )
     )]
     public function refplusy()
     {

--- a/tests/Fixtures/Scratch/Nullable-spec.php
+++ b/tests/Fixtures/Scratch/Nullable-spec.php
@@ -71,8 +71,8 @@ class NullableSpec
     path: '/api/endpoint',
     description: 'An endpoint',
     operationId: 'nullableEndpoint',
-    responses: [new OA\Response(response: 200, description: 'OK')]
 )]
+#[OA\Response(response: 200, description: 'OK')]
 class NullableEndpointSpec
 {
 }

--- a/tests/Fixtures/Scratch/ParameterContent-spec.php
+++ b/tests/Fixtures/Scratch/ParameterContent-spec.php
@@ -31,8 +31,8 @@ use OpenApi\Spec as OA;
             )
         ),
     ],
-    responses: [new OA\Response(response: 200, description: 'OK')]
 )]
+#[OA\Response(response: 200, description: 'OK')]
 class ParameterContentEndpointSpec
 {
 }

--- a/tests/Fixtures/Scratch/PromotedProperty-spec.php
+++ b/tests/Fixtures/Scratch/PromotedProperty-spec.php
@@ -73,8 +73,8 @@ class PromotedPropertyDescriptionSpec
     path: '/api/endpoint',
     description: 'An endpoint',
     operationId: 'getPromotedPropertyDescription',
-    responses: [new OA\Response(response: 200, description: 'OK')]
 )]
+#[OA\Response(response: 200, description: 'OK')]
 class PromotedPropertyDescriptionEndpointSpec
 {
 }

--- a/tests/Fixtures/Scratch/PropertyItems-spec.php
+++ b/tests/Fixtures/Scratch/PropertyItems-spec.php
@@ -74,8 +74,8 @@ class PropertyItemsSpec
     path: '/api/endpoint',
     description: 'An endpoint',
     operationId: 'getInheritedFilters',
-    responses: [new OA\Response(response: 200, description: 'OK')]
 )]
+#[OA\Response(response: 200, description: 'OK')]
 class PropertyItemsEndpointSpec
 {
 }

--- a/tests/Fixtures/Scratch/Security-spec.php
+++ b/tests/Fixtures/Scratch/Security-spec.php
@@ -37,12 +37,10 @@ class SecuritySpec
 #[OA\Operation\Get(
     path: '/endpoint',
     operationId: 'getInheritedFilters',
-    responses: [
-        new OA\Response(
-            response: 200,
-            description: 'All good',
-        ),
-    ]
+)]
+#[OA\Response(
+    response: 200,
+    description: 'All good',
 )]
 class SecurityEndpointSpec
 {

--- a/tests/Fixtures/Scratch/Tags-spec.php
+++ b/tests/Fixtures/Scratch/Tags-spec.php
@@ -24,12 +24,10 @@ use OpenApi\Spec as OA;
     description: 'Sandbox endpoint',
     operationId: 'tagsEndpoint',
     tags: ['sandbox', 'other', 'nested', 'invalidparent'],
-    responses: [
-        new OA\Response(
-            response: 200,
-            description: 'All good'
-        ),
-    ]
+)]
+#[OA\Response(
+    response: 200,
+    description: 'All good'
 )]
 class TagsEndpointSpec
 {

--- a/tests/Fixtures/Scratch/Types-spec.php
+++ b/tests/Fixtures/Scratch/Types-spec.php
@@ -29,8 +29,8 @@ class TypesSpec
     path: '/api/endpoint',
     description: 'An endpoint',
     operationId: 'getTypes',
-    responses: [new OA\Response(response: 200, description: 'OK')]
 )]
+#[OA\Response(response: 200, description: 'OK')]
 class TypesEndpointSpec
 {
 }

--- a/tests/Fixtures/Scratch/UsingRefs-spec.php
+++ b/tests/Fixtures/Scratch/UsingRefs-spec.php
@@ -14,11 +14,9 @@ class UsingRefsParameterSpec
 {
 }
 
-#[OA\Components(
-    responses: [
-        new OA\Response(response: 'default', description: 'Item response'),
-    ]
-)]
+#[OA\Components
+]
+#[OA\Response(response: 'default', description: 'Item response')]
 class UsingRefsResponseSpec
 {
 }
@@ -30,10 +28,8 @@ class UsingRefsResponseSpec
     parameters: [
         new OA\Parameter(ref: '#/components/parameters/item_name'),
     ],
-    responses: [
-        new OA\Response(response: 200, ref: '#/components/responses/default'),
-    ]
 )]
+#[OA\Response(response: 200, ref: '#/components/responses/default')]
 class UsingRefsControllerSpec
 {
 }

--- a/tests/Fixtures/Scratch/VendorExtensions-spec.php
+++ b/tests/Fixtures/Scratch/VendorExtensions-spec.php
@@ -32,8 +32,8 @@ class VendorExtensionsSpec
     path: '/api/endpoint',
     description: 'An endpoint',
     operationId: 'get',
-    responses: [new OA\Response(response: 200, description: 'OK')]
 )]
+#[OA\Response(response: 200, description: 'OK')]
 class VendorExtensionsEndpointSpec
 {
 }

--- a/tests/Fixtures/Scratch/XmlContentEquiv-spec.php
+++ b/tests/Fixtures/Scratch/XmlContentEquiv-spec.php
@@ -19,14 +19,12 @@ class XmlContentEquivSpec
 #[OA\Operation\Get(
     path: '/endpoint/xml-content',
     operationId: 'xmlContentEquiv1',
-    responses: [
-        new OA\Response(
-            response: 200,
-            description: 'All good',
-            content: [
-                new OA\MediaType\Xml(ref: XmlContentEquivSpec::class),
-            ]
-        ),
+)]
+#[OA\Response(
+    response: 200,
+    description: 'All good',
+    content: [
+        new OA\MediaType\Xml(ref: XmlContentEquivSpec::class),
     ]
 )]
 class XmlContentEquivEndpoint1Spec
@@ -36,16 +34,14 @@ class XmlContentEquivEndpoint1Spec
 #[OA\Operation\Get(
     path: '/endpoint/media-type',
     operationId: 'xmlContentEquiv2',
-    responses: [
-        new OA\Response(
-            response: 200,
-            description: 'All good',
-            content: [
-                new OA\MediaType(
-                    mediaType: 'application/xml',
-                    schema: new OA\Schema(ref: XmlContentEquivSpec::class)
-                ),
-            ]
+)]
+#[OA\Response(
+    response: 200,
+    description: 'All good',
+    content: [
+        new OA\MediaType(
+            mediaType: 'application/xml',
+            schema: new OA\Schema(ref: XmlContentEquivSpec::class)
         ),
     ]
 )]
@@ -56,14 +52,12 @@ class XmlContentEquivEndpoint2Spec
 #[OA\Operation\Get(
     path: '/endpoint/xml-array',
     operationId: 'xmlContentEquiv3',
-    responses: [
-        new OA\Response(
-            response: 200,
-            description: 'All good',
-            content: [
-                new OA\MediaType\Xml(type: 'array', items: new OA\Schema\Items(ref: XmlContentEquivSpec::class)),
-            ]
-        ),
+)]
+#[OA\Response(
+    response: 200,
+    description: 'All good',
+    content: [
+        new OA\MediaType\Xml(items: new OA\Schema\Items(ref: XmlContentEquivSpec::class)),
     ]
 )]
 class XmlContentEquivEndpoint3Spec

--- a/tests/Fixtures/Scratch/XmlContentEquiv.php
+++ b/tests/Fixtures/Scratch/XmlContentEquiv.php
@@ -61,7 +61,7 @@ class XmlContentEquivEndpoint2
             response: 200,
             description: 'All good',
             content: [
-                new OAT\XmlContent(type: 'array', items: new OAT\Items(ref: XmlContentEquiv::class)),
+                new OAT\XmlContent(items: new OAT\Items(ref: XmlContentEquiv::class)),
             ]
         ),
     ]


### PR DESCRIPTION
## Overview

Fixtures, examples and snippets all declared responses inside the operation attribute, as
`responses: [new OA\Response(...)]`. That has two costs. It never exercises sibling merge,
so the resolution path reworked in #2159 was covered by only a handful of fixtures. And it
is the clunkier way to write attributes by hand — more nesting, and a `new` for every
element — in files that people copy.

Declaring the response as a sibling avoids both. No generated document changes: not one
fixture YAML, published example spec or snippet output differs.

Stacked on #2162 and includes its commits; merge that one first.

## Changes

- 27 scratch fixtures, 17 spec-mode examples and 6 cookbook snippets declare their responses
  as stacked siblings.
- `XmlContentEquiv` drops the `type: 'array'` that `items` already implies, so it pins the
  inference rather than the literal.
- Five files keep the nested form and carry a comment saying why — each has a second
  attribute on the same target that a sibling response would make ambiguous, or capture.
