### PR TITLE
docs(Reference): keep augmenter configuration in one place

### DIFF
--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -86,24 +86,6 @@ Each augmenter implements `PipeInterface` and receives the full Specification, a
 within a phase run in registration order. The [Augmenters reference](/reference/augmenters)
 lists which augmenters belong to each phase, in the order they run.
 
-### Configuring augmenters
-
-```php
-$builder->withAugmenters(function (\OpenApi\Utils\Pipeline $pipeline) {
-    // Get a typed reference to configure
-    $pipeline->get(Augmenter\OperationIds::class)?->setHash(true);
-
-    // Enable/disable
-    $pipeline->get(Augmenter\Cleanup::class)?->setEnabled(false);
-
-    // Insert before another
-    $pipeline->insert(new CustomAugmenter(), Augmenter\Inheritance::class);
-
-    // Remove entirely
-    $pipeline->remove(Augmenter\EnumDescriptions::class);
-});
-```
-
 ### Writing a custom augmenter
 
 A custom augmenter implements `PipeInterface`:
@@ -145,8 +127,8 @@ class CustomAugmenter implements PipeInterface
 
 ### Declaring configuration
 
-Mark a constructor parameter with `#[Config]` to make it settable via `-D`/`-c` (see
-[Configuring augmenters](#configuring-augmenters) above) and to have it appear in the
+Mark a constructor parameter with `#[Config]` to make it settable via `-D`/`-c` and via
+[`withAugmenters()`](/reference/builder#augmenters), and to have it appear in the
 [generated reference docs](/reference/augmenters). It needs a matching `set*()` method —
 that's what `-c` and `Pipeline::configure()` call.
 


### PR DESCRIPTION
## Overview

`reference/architecture.md` and `reference/builder.md` both showed a `withAugmenters()` block
doing the same four things. `builder.md`'s version is a superset and already links back for
pipeline design, so the architecture page keeps what the phases are and how to write an
augmenter, and the builder page keeps the wiring — the same split #2130 applied to the
resolver.

## Changes

- "Configuring augmenters" removed from `reference/architecture.md`.
- "Declaring configuration" repointed at `reference/builder.md`, which is where the
  `withAugmenters()` form now lives.
