### PR TITLE
test(Spec): pin that an explicit null suppresses an inferred value

### DIFF
--- a/docs/dev/pipeline.md
+++ b/docs/dev/pipeline.md
@@ -10,8 +10,7 @@ Spec attributes are plain data containers, but they are **not** immutable, and n
 `Refs::mergeAllOf()` nulls `$schema->properties`, `Types` fills schema fields in place —
 and `Specification` exposes public arrays that `add()` appends to.
 
-What *is* true, and what distinguishes them from classic annotations, is that they carry no
-serialization logic. Serialization is the compiler's job.
+What *is* true is that they carry no serialization logic. Serialization is the compiler's job.
 
 ## Slot maps: the slot belongs to the parent
 
@@ -86,9 +85,8 @@ The user-facing version of this distinction is in
 
 `src/Spec/` nests directories for readability, not inheritance. Notably:
 
-- `Property extends AbstractAttribute` — **not** `Schema`. This is the deliberate change
-  from classic (where `Annotations\Property extends Schema`) and it is what makes stacking
-  `#[OA\Property]` and `#[OA\Schema]` on the same target work.
+- `Property extends AbstractAttribute` — **not** `Schema`. Being siblings is what lets
+  `#[OA\Property]` and `#[OA\Schema]` stack on the same target.
 - `Encoding extends AbstractAttribute` — **not** `MediaType`, despite `Property\Encoded`.
 - `Contact`, `License`, `ServerVariable` extend `AbstractAttribute`, not `Info`/`Server`.
 - `OA\Security` is a namespace, not a class. The classes are `Security\Requirement` and

--- a/docs/dev/pipeline.md
+++ b/docs/dev/pipeline.md
@@ -163,6 +163,33 @@ Classic uses the same sentinel — `Generator::UNDEFINED` is an alias of
 `Undefined::UNDEFINED` — so `HybridBridge` passes these values straight through rather than
 translating them.
 
+### An inferred field needs the sentinel too
+
+There is a second reason to reach for `Undefined::UNDEFINED`, and it decides which nullable
+properties get it. `Undefined::isDefault()` is true only for the sentinel, never for `null`,
+so an augmenter that fills a field in guards on it:
+
+```php
+// Augmenter\Docblocks
+if (!Undefined::isDefault($schema->description)) {
+    return;
+}
+```
+
+Writing `description: null` therefore means **no description**, and the docblock is left
+alone; leaving it out means "infer one". The attribute always wins, which is the rule
+inherited from classic. A field nothing infers keeps a plain `null` default — there is
+nothing to suppress.
+
+That is what separates the two sets. `summary` and `description` on the operations,
+parameters and schemas default to the sentinel because `Docblocks` and `EnumDescriptions`
+fill them; the rest of the nullable properties do not.
+
+**Adding inference for a field means changing its default.** Guarding a field that still
+defaults to `null` makes the guard true for every attribute, and the inference silently never
+runs. `DocblocksTest` pins both halves — that an absent value is inferred, and that
+an explicit `null` suppresses it.
+
 ## Why resolution is its own step
 
 Resolving unknown classes inside the augmenter pipeline would create an ordering problem: an

--- a/docs/dev/pipeline.md
+++ b/docs/dev/pipeline.md
@@ -177,9 +177,9 @@ if (!Undefined::isDefault($schema->description)) {
 ```
 
 Writing `description: null` therefore means **no description**, and the docblock is left
-alone; leaving it out means "infer one". The attribute always wins, which is the rule
-inherited from classic. A field nothing infers keeps a plain `null` default — there is
-nothing to suppress.
+alone; leaving it out means "infer one". The attribute always wins. Classic behaves
+identically, and uses the same sentinel to do it. A field nothing infers keeps a plain
+`null` default — there is nothing to suppress.
 
 That is what separates the two sets. `summary` and `description` on the operations,
 parameters and schemas default to the sentinel because `Docblocks` and `EnumDescriptions`

--- a/docs/dev/pipeline.md
+++ b/docs/dev/pipeline.md
@@ -177,9 +177,8 @@ if (!Undefined::isDefault($schema->description)) {
 ```
 
 Writing `description: null` therefore means **no description**, and the docblock is left
-alone; leaving it out means "infer one". The attribute always wins. Classic behaves
-identically, and uses the same sentinel to do it. A field nothing infers keeps a plain
-`null` default — there is nothing to suppress.
+alone; leaving it out means "infer one". The attribute always wins. Classic behaves the same
+way. A field nothing infers keeps a plain `null` default — there is nothing to suppress.
 
 That is what separates the two sets. `summary` and `description` on the operations,
 parameters and schemas default to the sentinel because `Docblocks` and `EnumDescriptions`

--- a/tests/Augmenter/DocblocksTest.php
+++ b/tests/Augmenter/DocblocksTest.php
@@ -52,4 +52,36 @@ final class DocblocksTest extends TestCase
 
         $this->assertSame('the thing identifier', $spec->operations[0]->parameters[0]->description);
     }
+
+    /**
+     * `null` is an explicit "no description", not an absent one — the attribute wins over
+     * the docblock. Only `Undefined::UNDEFINED` invites inference.
+     */
+    public function testExplicitNullSuppressesInferredSchemaDescription(): void
+    {
+        $spec = $this->assemble(Fixtures\Augmenter\SuppressedSchema::class);
+
+        (new Augmenter\Docblocks())($spec);
+
+        $this->assertNull($spec->schemas[0]->description);
+    }
+
+    public function testExplicitNullSuppressesInferredOperationSummaryAndDescription(): void
+    {
+        $spec = $this->assemble(Fixtures\Augmenter\SuppressedController::class);
+
+        (new Augmenter\Docblocks())($spec);
+
+        $this->assertNull($spec->operations[0]->summary);
+        $this->assertNull($spec->operations[0]->description);
+    }
+
+    public function testExplicitNullSuppressesInferredParameterDescription(): void
+    {
+        $spec = $this->assemble(Fixtures\Augmenter\SuppressedController::class);
+
+        (new Augmenter\Docblocks())($spec);
+
+        $this->assertNull($spec->operations[0]->parameters[0]->description);
+    }
 }

--- a/tests/Fixtures/Augmenter/SuppressedController.php
+++ b/tests/Fixtures/Augmenter/SuppressedController.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter;
+
+use OpenApi\Spec as OA;
+
+class SuppressedController
+{
+    /**
+     * Get a thing.
+     *
+     * Returns the thing by ID.
+     *
+     * @param int $id the thing identifier
+     */
+    #[OA\Operation\Get(path: '/things/{id}', summary: null, description: null)]
+    #[OA\Response(response: 200, description: 'OK')]
+    public function getThing(
+        #[OA\Parameter\Path(name: 'id', description: null)]
+        int $id,
+    ) {
+    }
+}

--- a/tests/Fixtures/Augmenter/SuppressedSchema.php
+++ b/tests/Fixtures/Augmenter/SuppressedSchema.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter;
+
+use OpenApi\Spec as OA;
+
+/**
+ * A documented schema whose description is suppressed.
+ */
+#[OA\Schema(schema: 'SuppressedSchema', description: null)]
+class SuppressedSchema
+{
+    #[OA\Property(property: 'name')]
+    public string $name;
+}


### PR DESCRIPTION
## Overview

Writing `description: null` on a spec attribute already means "no description" — the docblock
is left alone, and the attribute wins. Nothing documented or tested that, and the failure mode
is silent in both directions: guard a field that still defaults to `null` and the inference
never runs, widen `Undefined::isDefault()` to accept `null` and suppression quietly stops
working.

This also settles the last open item in the backlog's PR 8, which had been framed as whether
nullable properties should avoid a `null` default at all. They should not — the rule is
narrower.

Writing that up turned up two places in `dev/pipeline.md` explaining spec in terms of classic
internals, which will not survive classic being removed in v8.

## Changes

- `DocblocksTest` covers that an explicit `null` suppresses the inferred value for schema,
  operation and parameter descriptions, alongside the existing tests that an absent value is
  inferred.
- `dev/pipeline.md` states the rule the codebase already follows: a field an augmenter fills
  defaults to `Undefined::UNDEFINED` so an explicit `null` can suppress it; everything else
  keeps `null`.
- Two classic references in `dev/pipeline.md` reduced to what the reader can act on. The
  reason `#[OA\Property]` and `#[OA\Schema]` stack is that they are siblings, which holds
  without naming the classic class hierarchy.
