### PR TITLE
docs(Guide): add an extension points page

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -105,7 +105,7 @@
         "analyse": [
             "export XDEBUG_MODE=off && phpstan clear-result-cache -q && phpstan analyse --memory-limit=3G"
         ],
-        "redocly": "npm run redocly -- lint 'docs/examples/specs/**/*.yaml' 'tests/Fixtures/Scratch/*.yaml'",
+        "redocly": "npm run redocly -- lint 'docs/examples/specs/**/*.yaml' 'docs/snippets/guide/extension-points/*.yaml' 'tests/Fixtures/Scratch/*.yaml'",
         "docs:check": "export XDEBUG_MODE=off && phpunit --filter DocsAccuracyTest",
         "docs:gen": "@php tools/docgen.php",
         "docs:dev": "cd docs && npm run dev",

--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -27,6 +27,7 @@ function getGuideSidebar() {
       items: [
         { text: 'Processing Modes', link: '/guide/modes' },
         { text: 'Using Spec Attributes', link: '/guide/spec-attributes' },
+        { text: 'Extension points', link: '/guide/extension-points' },
         { text: 'Spec Attributes Reference', link: '/reference/spec-attributes' },
         { text: 'Augmenters Reference', link: '/reference/augmenters' },
         { text: 'Inheritance', link: '/reference/inheritance' },

--- a/docs/guide/extension-points.md
+++ b/docs/guide/extension-points.md
@@ -1,0 +1,142 @@
+# Extension points 🧪
+
+The spec pipeline is assembled from parts that can be replaced or added to. Between them
+they cover feeding it from somewhere other than a directory scan, accepting attributes it
+does not know, and deriving fields nobody wrote by hand.
+
+They are described here roughly in the order the pipeline reaches them.
+
+## Translators
+
+A translator runs during assembly, once per reflector. `getAttributes()` says which raw
+attributes to read off it; `translate()` returns what the assembler should treat as declared.
+
+Given a framework attribute that knows nothing about swagger-php:
+
+<<< @/snippets/guide/extension-points/route_attribute.php
+
+a translator turns it into a spec attribute:
+
+<<< @/snippets/guide/extension-points/route_translator.php
+
+Turning a foreign attribute into a spec one is a use, not the use. The other is adding a
+native attribute nobody wrote, which is how swagger-php uses the mechanism itself:
+`DefaultAttributeTranslator` reads the `OpenApi\Spec` attributes, and
+`OptionalPropertyAttributeTranslator` implements the [implicit
+`OA\Property`](/guide/shortcuts#oa-property-spec-only) shortcut.
+
+`translate()` sees `$created`, what this translator read on this pass, and `$attributes`,
+what earlier translators already resolved. It can add to either, replace them, or leave them
+alone. Ordering follows registration.
+
+Translators are registered on the attribute factory, so `withTranslators()` nests inside
+`withAttributeFactory()`:
+
+```php
+$builder->withAttributeFactory(fn (AttributeFactory $factory) => $factory->withTranslators(
+    fn (TypedList $translators) => $translators->add(new RouteTranslator())
+));
+```
+
+## Subclassing a spec attribute
+
+Spec attributes are not `final`. A subclass can derive its own constructor arguments, usually
+by reflecting over the class it is given, which keeps the repetition out of the annotated
+code:
+
+<<< @/snippets/guide/extension-points/dto_attribute.php
+
+`#[Dto(of: Pet::class)]` then names the schema and marks every public property required,
+without either being written out. The subclass is an `OA\Schema` as far as the rest of the
+pipeline is concerned, so merging, containment and compilation treat it the same.
+
+## Resolvers
+
+Seeding from reflectors means the specification can name a class that was never a source: a
+controller is added, one of its `$ref`s points at a DTO, and nothing ever collected the DTO.
+Each such name goes to the resolver step.
+
+`Resolver\Reflection` is registered by default and covers the ordinary case — the class
+exists and carries spec attributes, so it is collected by reflection and the reference
+resolves. It returns `false` when the class yielded no component, and an unresolved reference
+is reported rather than silently dropped.
+
+`Builder::withResolver()` hands the resolver list to a callable. Resolvers are tried in
+order and the first success wins, so one added after the default is
+handed the classes the default could not resolve. What it makes of them is up to whoever
+writes it — deriving a schema from a class's public properties and PHP types is one option,
+and would let a DTO carrying no spec attributes appear in the document. `insert()` places a
+resolver ahead of the default rather than after it.
+
+## Augmenters
+
+An augmenter runs after assembly, over the whole `Specification`, and fills in what the
+attributes left out:
+
+<<< @/snippets/guide/extension-points/tag_augmenter.php
+
+It does not have to implement anything. Any callable taking the `Specification` and returning
+it will do; `PipeInterface` exists to declare a phase, and a pipe without it lands in the
+pipeline's default group:
+
+```php
+$pipeline->add(fn (Specification $spec) => $spec);
+```
+
+`Builder::withAugmenters()` hands the pipeline to a callable, which adds, replaces or
+removes. Phases run **resolve** → **reduce** → **augment**, and within a phase in
+registration order.
+The enum is `OpenApi\Augmenter\Group`. The [Augmenters
+reference](/reference/augmenters) lists the built-in pipeline and what each phase is for.
+
+## Compilers
+
+`Builder::setCompiler()` replaces the compiler that turns the `Specification` into a
+document. One is resolved from the target version otherwise, so this is for output a shipped
+compiler does not produce.
+
+## The classic escape hatch
+
+`Builder::withGenerator()` configures the classic `Generator` — the whole pipeline in
+classic mode, and the scanning pass in hybrid. The callable receives a default `Generator`
+and may configure it in place or return another. Spec mode has no `Generator`, so the hook
+is never called there.
+
+## Putting it together
+
+`RouteTranslator` and `TagFromController` from above, wired onto a builder seeded from a
+reflector rather than a directory:
+
+<<< @/snippets/guide/extension-points/wiring.php
+
+Given a controller carrying `#[Route(path: '/pets')]` and an `#[OA\Response]`, that produces:
+
+<<< @/snippets/guide/extension-points/wiring-3.1.0.yaml
+
+## Where the boundaries are
+
+Some things are deliberately not extension points. Each has a reason, and each has an
+alternative.
+
+**Property types are not widened for downstream convenience.** The strong typing is what
+makes the DTOs worth having. Metadata that only means something to one integration belongs
+in an `Attachable`, not in a widened `$ref: string|object`.
+
+**There is no framework-specific code, and no plans for any.** Translators, augmenters and
+attachables are the contract; anything a framework needs can be built from them, outside
+this repository.
+
+**There are no events or listeners.** The pipeline is deterministic and reads top to bottom,
+which is what makes a wrong document traceable to the step that produced it. Event ordering
+is not obvious from reading, and it is harder to test.
+
+**Assembler internals stay internal.** `collect()` is the contract. How it resolves nesting
+is free to change, and has.
+
+## Going further
+
+- [Builder reference](/reference/builder) — every hook on its own, with signatures
+- [Augmenters reference](/reference/augmenters) — the built-in pipeline and its phases
+- [Architecture](/reference/architecture) — how the stages fit together
+- [Spec pipeline internals](/dev/pipeline) — slot maps, resolution, and the rules a new
+  attribute has to follow

--- a/docs/guide/spec-attributes.md
+++ b/docs/guide/spec-attributes.md
@@ -261,7 +261,7 @@ Still useful even when nesting `OA\Schema` as the media type is prefilled either
 ### Items
 `#[OA\Schema\Items]` is the equivalent to the classic `OA\Items` attribute. Similar to `OA\MediaType\Json` and `Xml` it is a shortcut that allows to skip the outer `OA\Schema(type: 'array')`. The `Shortcuts` augmenter wraps it into `OA\Schema(type: 'array', items: ...)` automatically.
 
-Since `OA\Schema\Items` extends `OA\Schema`, the [implicit `OA\Property`](/guide/shortcuts#property-spec-only) shortcut applies — you can omit the explicit `#[OA\Property]` attribute:
+Since `OA\Schema\Items` extends `OA\Schema`, the [implicit `OA\Property`](/guide/shortcuts#oa-property-spec-only) shortcut applies — you can omit the explicit `#[OA\Property]` attribute:
 
 ```php
 // Verbose

--- a/docs/snippets/guide/extension-points/dto_attribute.php
+++ b/docs/snippets/guide/extension-points/dto_attribute.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace OpenApi\Snippets\Guide\ExtensionPoints;
+
+use OpenApi\Spec as OA;
+
+#[\Attribute(\Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
+final class Dto extends OA\Schema
+{
+    /**
+     * @param class-string $of
+     */
+    public function __construct(string $of)
+    {
+        $class = new \ReflectionClass($of);
+
+        parent::__construct(
+            schema: $class->getShortName(),
+            required: array_map(
+                static fn (\ReflectionProperty $property): string => $property->getName(),
+                $class->getProperties(\ReflectionProperty::IS_PUBLIC),
+            ),
+        );
+    }
+}

--- a/docs/snippets/guide/extension-points/pet.php
+++ b/docs/snippets/guide/extension-points/pet.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace OpenApi\Snippets\Guide\ExtensionPoints;
+
+use OpenApi\Spec as OA;
+
+#[Dto(of: Pet::class)]
+final class Pet
+{
+    #[OA\Property]
+    public string $name = '';
+
+    #[OA\Property]
+    public int $age = 0;
+}

--- a/docs/snippets/guide/extension-points/pet_controller.php
+++ b/docs/snippets/guide/extension-points/pet_controller.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace OpenApi\Snippets\Guide\ExtensionPoints;
+
+use OpenApi\Spec as OA;
+
+#[OA\Info(title: 'Pets', version: '1.0')]
+final class PetController
+{
+    #[Route(path: '/pets')]
+    #[OA\Response(response: 200, description: 'OK')]
+    public function list(): void
+    {
+    }
+}

--- a/docs/snippets/guide/extension-points/route_attribute.php
+++ b/docs/snippets/guide/extension-points/route_attribute.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace OpenApi\Snippets\Guide\ExtensionPoints;
+
+#[\Attribute(\Attribute::TARGET_METHOD)]
+final class Route
+{
+    public function __construct(public string $path, public string $method = 'get')
+    {
+    }
+}

--- a/docs/snippets/guide/extension-points/route_translator.php
+++ b/docs/snippets/guide/extension-points/route_translator.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace OpenApi\Snippets\Guide\ExtensionPoints;
+
+use OpenApi\Contracts\AttributeTranslatorInterface;
+use OpenApi\Spec as OA;
+
+final class RouteTranslator implements AttributeTranslatorInterface
+{
+    public function reset(): void
+    {
+    }
+
+    public function getAttributes(
+        \ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector,
+    ): array {
+        return $reflector->getAttributes(Route::class);
+    }
+
+    public function translate(
+        array $attributes,
+        array $created,
+        \ReflectionClass|\ReflectionMethod|\ReflectionProperty|\ReflectionParameter|\ReflectionClassConstant $reflector,
+    ): array {
+        foreach ($created as $route) {
+            if ($route instanceof Route) {
+                $attributes[] = new OA\Operation(
+                    path: $route->path,
+                    method: $route->method,
+                    operationId: $reflector->getName(),
+                );
+            }
+        }
+
+        return $attributes;
+    }
+}

--- a/docs/snippets/guide/extension-points/tag_augmenter.php
+++ b/docs/snippets/guide/extension-points/tag_augmenter.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace OpenApi\Snippets\Guide\ExtensionPoints;
+
+use OpenApi\Augmenter\Group;
+use OpenApi\Utils\PipeInterface;
+
+final class TagFromController implements PipeInterface
+{
+    public function __invoke(mixed $specification): mixed
+    {
+        foreach ($specification->operations as $operation) {
+            $reflector = $operation->getReflector();
+            if ($reflector instanceof \ReflectionMethod) {
+                $controller = $reflector->getDeclaringClass()->getShortName();
+                $operation->tags ??= [preg_replace('/Controller$/', '', $controller) . 's'];
+            }
+        }
+
+        return $specification;
+    }
+
+    public function group(): string|\BackedEnum
+    {
+        return Group::Augment;
+    }
+}

--- a/docs/snippets/guide/extension-points/wiring-3.1.0.yaml
+++ b/docs/snippets/guide/extension-points/wiring-3.1.0.yaml
@@ -1,0 +1,13 @@
+openapi: 3.1.0
+info:
+  title: Pets
+  version: '1.0'
+paths:
+  /pets:
+    get:
+      tags:
+        - Pets
+      operationId: list
+      responses:
+        200:
+          description: OK

--- a/docs/snippets/guide/extension-points/wiring.php
+++ b/docs/snippets/guide/extension-points/wiring.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace OpenApi\Snippets\Guide\ExtensionPoints;
+
+use OpenApi\Builder;
+use OpenApi\Builder\Mode;
+use OpenApi\Builder\Result;
+use OpenApi\Utils\AttributeFactory;
+use OpenApi\Utils\Pipeline;
+use OpenApi\Utils\TypedList;
+
+function buildSpec(): Result
+{
+    return (new Builder())
+        ->setMode(Mode::SPEC)
+        ->addSource(new \ReflectionClass(PetController::class))
+        ->withAttributeFactory(fn (AttributeFactory $factory) => $factory->withTranslators(
+            fn (TypedList $translators) => $translators->add(new RouteTranslator())
+        ))
+        ->withAugmenters(fn (Pipeline $augmenters) => $augmenters->add(new TagFromController()))
+        ->build();
+}

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,6 +9,9 @@ parameters:
         - tests
         - tools
         - docs/examples
+    scanDirectories:
+        # snippets are transcluded into the docs and exercised by tests; known, not analysed
+        - docs/snippets
     parallel:
         processTimeout: 300.0
     excludePaths:

--- a/tests/ExtensionPointsSnippetTest.php
+++ b/tests/ExtensionPointsSnippetTest.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests;
+
+use OpenApi\Augmenter\Cleanup;
+use OpenApi\Builder;
+use OpenApi\Builder\Mode;
+use OpenApi\Snippets\Guide\ExtensionPoints as Snippet;
+use OpenApi\Tests\Concerns\AssertsSpecEquals;
+use OpenApi\Utils\Pipeline;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Runs the snippets `guide/extension-points.md` transcludes. `DocSnippetsTest` cannot: it
+ * builds every snippet with one fixed `Builder`, so it has nowhere to register a translator.
+ *
+ * The test calls `buildSpec()` from `wiring.php` — the composed example the page shows —
+ * rather than restating it, so the two cannot drift apart.
+ */
+final class ExtensionPointsSnippetTest extends TestCase
+{
+    use AssertsSpecEquals;
+
+    private const SNIPPETS = __DIR__ . '/../docs/snippets/guide/extension-points';
+
+    public static function setUpBeforeClass(): void
+    {
+        foreach (glob(self::SNIPPETS . '/*.php') as $snippet) {
+            require_once $snippet;
+        }
+    }
+
+    public function testWiringProducesTheDocumentedOutput(): void
+    {
+        $this->assertSpecEquals(
+            file_get_contents(self::SNIPPETS . '/wiring-3.1.0.yaml'),
+            Snippet\buildSpec()->toYaml()
+        );
+    }
+
+    public function testSubclassedAttributeDerivesSchemaAndRequired(): void
+    {
+        $result = (new Builder())
+            ->setMode(Mode::SPEC)
+            ->addSource(new \ReflectionClass(Snippet\Pet::class))
+            ->setVersion('3.1.0')
+            ->withAugmenters(fn (Pipeline $augmenters): Pipeline => $augmenters->remove(Cleanup::class))
+            ->build();
+
+        $schema = $result->specification()->schemas[0];
+
+        $this->assertSame('Pet', $schema->schema);
+        $this->assertSame(['name', 'age'], $schema->required);
+    }
+}


### PR DESCRIPTION
## Overview

Nothing under `docs/` addressed integrators. `reference/builder.md` documents the hooks one
at a time, which is not the same as showing how they compose, and the constraints on how the
pipeline should *not* be extended were written down nowhere.

## Changes

- A page covering the extension points in pipeline order, with a worked example combining a
  translator, an augmenter and a reflector source.
- Every sample is an executed snippet — `ExtensionPointsSnippetTest` runs them against the
  document the page shows, and Redocly lints that document.
- Corrects the `OA\Property` shortcut anchor in `spec-attributes.md`, which pointed at a slug
  that does not exist.
