### PR TITLE
docs(Reference): generate a page for the default extension points

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -30,6 +30,7 @@ function getGuideSidebar() {
         { text: 'Extension points', link: '/guide/extension-points' },
         { text: 'Spec Attributes Reference', link: '/reference/spec-attributes' },
         { text: 'Augmenters Reference', link: '/reference/augmenters' },
+        { text: 'Extension Points Reference', link: '/reference/extension-points' },
         { text: 'Inheritance', link: '/reference/inheritance' },
         { text: 'Architecture', link: '/reference/architecture' },
       ]
@@ -82,6 +83,7 @@ function getReferenceSidebar() {
         { text: 'Generator', link: '/reference/generator' },
         { text: 'Processors', link: '/reference/processors' },
         { text: '🧪 Augmenters', link: '/reference/augmenters' },
+        { text: '🧪 Extension Points', link: '/reference/extension-points' },
         { text: '🧪 Inheritance', link: '/reference/inheritance' },
         { text: '🧪 Architecture', link: '/reference/architecture' },
       ]

--- a/docs/guide/extension-points.md
+++ b/docs/guide/extension-points.md
@@ -20,10 +20,9 @@ a translator turns it into a spec attribute:
 <<< @/snippets/guide/extension-points/route_translator.php
 
 Turning a foreign attribute into a spec one is a use, not the use. The other is adding a
-native attribute nobody wrote, which is how swagger-php uses the mechanism itself:
-`DefaultAttributeTranslator` reads the `OpenApi\Spec` attributes, and
-`OptionalPropertyAttributeTranslator` implements the [implicit
-`OA\Property`](/guide/shortcuts#oa-property-spec-only) shortcut.
+native attribute nobody wrote, which is how swagger-php uses the mechanism itself — both
+`DefaultAttributeTranslator` and `OptionalPropertyAttributeTranslator` ship by default. The
+[extension points reference](/reference/extension-points) says what each does.
 
 `translate()` sees `$created`, what this translator read on this pass, and `$attributes`,
 what earlier translators already resolved. It can add to either, replace them, or leave them

--- a/docs/reference/extension-points.md
+++ b/docs/reference/extension-points.md
@@ -1,0 +1,39 @@
+# Extension Point Reference
+
+This page is generated automatically from the `swagger-php` sources.
+
+For improvements head over to [GitHub](https://github.com/zircote/swagger-php) and create a PR ;)
+
+What the assembler, the attribute factory and the resolver run by default at each extension
+point, in the order they run. For adding your own, see
+[Extension points](/guide/extension-points).
+
+[Augmenters](/reference/augmenters) and [compilers](/reference/architecture#compilers) have
+their own listings.
+
+## Default Translators
+
+### [DefaultAttributeTranslator](https://github.com/zircote/swagger-php/tree/master/src/Assembler/DefaultAttributeTranslator.php)
+
+Default implementation handling native (OpenApi) attributes.
+
+### [OptionalPropertyAttributeTranslator](https://github.com/zircote/swagger-php/tree/master/src/Assembler/OptionalPropertyAttributeTranslator.php)
+
+Add the required `OA\Property` on schema properties that only have:
+- an `OA\Schema`
+- an `OA\Encoding`
+
+This is what implements the implicit `OA\Property` shortcut. The `OA\MediaType` shortcuts
+are the `Augmenter\Shortcuts` augmenter; the `OA\Parameter` ones are plain subclasses.
+
+## Default Resolvers
+
+### [Reflection](https://github.com/zircote/swagger-php/tree/master/src/Resolver/Reflection.php)
+
+Resolves missing components by collecting the referenced class with the assembler in use.
+
+This makes listing all related classes as builder sources optional; adding a single controller
+is enough as long as everything it references (directly or transitively) carries spec attributes.
+
+A FQCN is considered resolved if the specification knows it once collected. Classes without any
+spec attributes are left to the next resolver in the chain.

--- a/docs/snippets/preamble_extension-points.md
+++ b/docs/snippets/preamble_extension-points.md
@@ -1,0 +1,6 @@
+What the assembler, the attribute factory and the resolver run by default at each extension
+point, in the order they run. For adding your own, see
+[Extension points](/guide/extension-points).
+
+[Augmenters](/reference/augmenters) and [compilers](/reference/architecture#compilers) have
+their own listings.

--- a/src/Assembler/OptionalPropertyAttributeTranslator.php
+++ b/src/Assembler/OptionalPropertyAttributeTranslator.php
@@ -15,6 +15,9 @@ use OpenApi\Spec as OA;
  * - an `OA\Schema`
  * - an `OA\Encoding`
  *
+ * This is what implements the implicit `OA\Property` shortcut. The `OA\MediaType` shortcuts
+ * are the `Augmenter\Shortcuts` augmenter; the `OA\Parameter` ones are plain subclasses.
+ *
  * @phpstan-import-type AttributeReflector from AttributeTranslatorInterface
  */
 class OptionalPropertyAttributeTranslator extends AbstractAttributeTranslator

--- a/tools/docgen.php
+++ b/tools/docgen.php
@@ -5,6 +5,7 @@ require_once __DIR__ . '/../vendor/autoload.php';
 use OpenApi\Tools\Docs\Reference\AttributeGenerator;
 use OpenApi\Tools\Docs\Reference\AugmenterGenerator;
 use OpenApi\Tools\Docs\Reference\ExampleGenerator;
+use OpenApi\Tools\Docs\Reference\ExtensionPointGenerator;
 use OpenApi\Tools\Docs\Reference\ProcessorGenerator;
 use OpenApi\Tools\Docs\Reference\SpecAttributeGenerator;
 
@@ -16,6 +17,7 @@ $generators = [
     'proc' => new ProcessorGenerator($projectRoot),
     'aug' => new AugmenterGenerator($projectRoot),
     'example' => new ExampleGenerator($projectRoot),
+    'ext' => new ExtensionPointGenerator($projectRoot),
 ];
 
 $requested = array_slice($argv ?? [], 1);
@@ -29,6 +31,7 @@ $outputMap = [
     'spec-attributes' => 'reference/spec-attributes.md',
     'processors' => 'reference/processors.md',
     'augmenters' => 'reference/augmenters.md',
+    'extension-points' => 'reference/extension-points.md',
     'examples' => 'guide/examples.md',
 ];
 

--- a/tools/src/Docs/Reference/ExtensionPointGenerator.php
+++ b/tools/src/Docs/Reference/ExtensionPointGenerator.php
@@ -1,0 +1,90 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tools\Docs\Reference;
+
+use OpenApi\Resolver;
+use OpenApi\Tools\Docs\DocGenerator;
+use OpenApi\Utils\AttributeFactory;
+use OpenApi\Utils\TypedList;
+
+/**
+ * What runs by default at each extension point.
+ *
+ * Discovery walks the live defaults rather than a directory, so the page lists what actually
+ * ships and in the order it runs. Augmenters and compilers are documented elsewhere and are
+ * linked rather than repeated.
+ */
+class ExtensionPointGenerator extends DocGenerator
+{
+    public function generate(): array
+    {
+        $content = $this->renderer->preamble(
+            'Extension Point',
+            $this->snippetContent('extension-points'),
+        );
+
+        $content .= "\n" . $this->renderer->sectionHeader('Default Translators');
+        foreach ($this->collect($this->translators()) as $data) {
+            $content .= "\n" . $this->renderer->classHeader($data['name'], 'Assembler');
+            $content .= $this->renderSections($data);
+        }
+
+        $content .= "\n" . $this->renderer->sectionHeader('Default Resolvers');
+        foreach ($this->collect($this->resolvers()) as $data) {
+            $content .= "\n" . $this->renderer->classHeader($data['name'], 'Resolver');
+            $content .= $this->renderSections($data);
+        }
+
+        return ['extension-points' => $content];
+    }
+
+    /**
+     * @return list<object>
+     */
+    protected function translators(): array
+    {
+        return iterator_to_array((new AttributeFactory())->getTranslators());
+    }
+
+    /**
+     * @return list<object>
+     */
+    protected function resolvers(): array
+    {
+        $resolvers = [];
+        (new Resolver())->withResolvers(function (TypedList $list) use (&$resolvers): void {
+            $resolvers = iterator_to_array($list);
+        });
+
+        return $resolvers;
+    }
+
+    /**
+     * @param  list<object>                                                                                                                                                                    $instances
+     * @return list<array{name: string, description: string, configPrefix: string, options: list<array{name: string, type: string, default: string, description: string}>, see: list<string>}>
+     */
+    protected function collect(array $instances): array
+    {
+        $collected = [];
+
+        foreach ($instances as $instance) {
+            $rc = new \ReflectionClass($instance);
+            $classDoc = $this->parseDocblock($rc->getDocComment());
+            $description = preg_replace('/\n?@phpstan-\w+[^\n]+/', '', $classDoc['content']);
+
+            $collected[] = [
+                'name' => $rc->getShortName(),
+                'description' => trim((string) $description),
+                'configPrefix' => lcfirst($rc->getShortName()) . '.',
+                'options' => $this->collectOptions($rc),
+                'see' => $classDoc['see'],
+            ];
+        }
+
+        return $collected;
+    }
+}


### PR DESCRIPTION
## Overview

`guide/extension-points.md` explains how to add a translator, a resolver or an augmenter, but
nothing says what already runs. Finding out means reading `src/`.

Augmenters have had a generated reference for a while. This gives translators and resolvers
the same, so a reader can see what they are plugging in alongside.

Stacked on #2168 and includes its commits; merge that one first.

## Changes

- `reference/extension-points.md`, generated from the live defaults rather than a directory
  listing, so it stays in step with what a build actually runs.
- `OptionalPropertyAttributeTranslator`'s docblock names the shortcut it implements and
  points at where the `OA\MediaType` and `OA\Parameter` ones live.
- `guide/extension-points.md` links to the new reference instead of describing the default
  translators itself.
