### PR TITLE
fix(Spec): collect nested operations from the parent that owns them

### DIFF
--- a/src/HybridBridge.php
+++ b/src/HybridBridge.php
@@ -30,9 +30,9 @@ class HybridBridge
                 $annotation instanceof Annotations\Server => $specification->servers[] = $this->convertServer($annotation),
                 $annotation instanceof Annotations\Tag => $specification->tags[] = $this->convertTag($annotation),
                 $annotation instanceof Annotations\SecurityScheme => $specification->securitySchemes[] = $this->convertSecurityScheme($annotation),
-                $annotation instanceof Annotations\PathItem && !$annotation->_context->is('nested') && !Undefined::isDefault($annotation->path) && !($annotation instanceof Annotations\Webhook) => $specification->pathItems[] = $this->convertPathItem($annotation),
+                $annotation instanceof Annotations\PathItem && !$annotation->_context->is('nested') && !Undefined::isDefault($annotation->path) && !($annotation instanceof Annotations\Webhook) => $this->collectPathItem($annotation, $specification),
                 $annotation instanceof Annotations\Components && !$annotation->_context->is('nested') => $this->convertComponents($annotation, $specification),
-                $annotation instanceof Annotations\Operation => $specification->operations[] = $this->convertOperation($annotation, $this->val($annotation->path), $this->methodFromAnnotation($annotation)),
+                $annotation instanceof Annotations\Operation && !$annotation->_context->is('nested') => $specification->operations[] = $this->convertOperation($annotation, $this->val($annotation->path), $this->methodFromAnnotation($annotation)),
                 $annotation instanceof Annotations\Schema && $annotation->_context->reflector instanceof \ReflectionClass && !$annotation->_context->is('nested') => $classSchemas[$annotation->_context->reflector->getName()][] = $annotation,
                 $annotation instanceof Annotations\Property && $this->isClassMember($annotation) => $memberProperties[] = $annotation,
                 $annotation instanceof Annotations\Response && !$annotation->_context->is('nested') && !Undefined::isDefault($annotation->response) => $specification->responses[] = $this->convertResponse($annotation),
@@ -273,16 +273,40 @@ class HybridBridge
 
     protected function convertWebhook(Annotations\PathItem $webhook, Specification $spec): void
     {
-        $methods = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'];
         $name = $webhook instanceof Annotations\Webhook
             ? $this->val($webhook->webhook)
             : $this->val($webhook->path);
 
-        foreach ($methods as $method) {
-            if (!Undefined::isDefault($webhook->{$method})) {
-                $operation = $this->convertOperation($webhook->{$method}, null, $method);
-                $operation->webhook = $name;
-                $spec->operations[] = $operation;
+        foreach ($this->nestedOperations($webhook) as $method => $operation) {
+            $converted = $this->convertOperation($operation, null, $method);
+            $converted->webhook = $name;
+            $spec->operations[] = $converted;
+        }
+    }
+
+    /**
+     * A `PathItem` and the operations nested in it. The operations carry no path of their
+     * own — it belongs to the `PathItem` — so they are collected here rather than by the
+     * flat `Operation` branch, which would leave them pathless and unemitted.
+     */
+    protected function collectPathItem(Annotations\PathItem $pathItem, Specification $spec): void
+    {
+        $spec->pathItems[] = $this->convertPathItem($pathItem);
+
+        $path = $this->val($pathItem->path);
+        foreach ($this->nestedOperations($pathItem) as $method => $operation) {
+            $spec->operations[] = $this->convertOperation($operation, $path, $method);
+        }
+    }
+
+    /**
+     * @return iterable<string, Annotations\Operation>
+     */
+    protected function nestedOperations(Annotations\PathItem $pathItem): iterable
+    {
+        foreach (['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'] as $method) {
+            if (!Undefined::isDefault($pathItem->{$method})) {
+                yield $method => $pathItem->{$method};
             }
         }
     }

--- a/tests/Fixtures/HybridBridge/NestedPathItem.php
+++ b/tests/Fixtures/HybridBridge/NestedPathItem.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\HybridBridge;
+
+use OpenApi\Attributes as OAT;
+
+/**
+ * An operation nested in a `PathItem` carries no path of its own — it belongs to the
+ * `PathItem` — so the bridge has to take it from the parent.
+ */
+#[OAT\Info(version: '1.0.0', title: 'Nested PathItem')]
+#[OAT\PathItem(
+    path: '/nested',
+    get: new OAT\Get(
+        operationId: 'nestedGet',
+        responses: [new OAT\Response(response: 200, description: 'ok')],
+    ),
+)]
+class NestedPathItem
+{
+}

--- a/tests/Fixtures/HybridBridge/NestedWebhook.php
+++ b/tests/Fixtures/HybridBridge/NestedWebhook.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+/*
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\HybridBridge;
+
+use OpenApi\Attributes as OAT;
+
+/**
+ * A webhook's operation is collected by the webhook that owns it. Collecting it a second
+ * time as a flat operation yields a copy with neither path nor webhook.
+ */
+#[OAT\OpenApi(
+    info: new OAT\Info(version: '1.0.0', title: 'Nested Webhook'),
+    webhooks: [
+        new OAT\Webhook(
+            webhook: 'newPet',
+            post: new OAT\Post(
+                operationId: 'newPet',
+                responses: [new OAT\Response(response: 200, description: 'ok')],
+            ),
+        ),
+    ],
+)]
+class NestedWebhook
+{
+}

--- a/tests/HybridBridgeTest.php
+++ b/tests/HybridBridgeTest.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests;
+
+use OpenApi\Augmenter\Cleanup;
+use OpenApi\Builder;
+use OpenApi\Builder\Mode;
+use OpenApi\Tests\Concerns\AssertsSpecEquals;
+use OpenApi\Utils\Pipeline;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Hybrid bridges classic annotations into the spec pipeline, so its document should be the
+ * one classic produces. `ScratchTest` compares classic against spec and never runs hybrid,
+ * which is why nested operations could go missing unnoticed.
+ */
+final class HybridBridgeTest extends TestCase
+{
+    use AssertsSpecEquals;
+
+    public static function fixtures(): iterable
+    {
+        yield 'operation nested in a PathItem' => ['NestedPathItem'];
+        yield 'operation nested in a Webhook' => ['NestedWebhook'];
+    }
+
+    #[DataProvider('fixtures')]
+    public function testHybridMatchesClassic(string $fixture): void
+    {
+        $this->assertSpecEquals(
+            $this->build($fixture, Mode::CLASSIC)->toYaml(),
+            $this->build($fixture, Mode::HYBRID)->toYaml(),
+        );
+    }
+
+    public function testWebhookOperationIsCollectedOnce(): void
+    {
+        $specification = $this->build('NestedWebhook', Mode::HYBRID)->specification();
+
+        $this->assertCount(1, $specification->operations);
+        $this->assertSame('newPet', $specification->operations[0]->webhook);
+    }
+
+    protected function build(string $fixture, Mode $mode): Builder\Result
+    {
+        // classic scans files, so hybrid does too — a reflector source yields nothing here
+        return (new Builder())
+            ->setMode($mode)
+            ->addSource(__DIR__ . "/Fixtures/HybridBridge/{$fixture}.php")
+            ->setVersion('3.1.0')
+            // an unreferenced component would be dropped before the comparison
+            ->withAugmenters(fn (Pipeline $augmenters): Pipeline => $augmenters->remove(Cleanup::class))
+            ->build();
+    }
+}


### PR DESCRIPTION
## Overview

An operation nested in a `PathItem` was emitted by classic and silently lost by hybrid:

```yaml
classic:  /nested: {get: {operationId: nestedGet, …}}
hybrid:   /nested: []
```

`HybridBridge` collected every operation through one flat branch, nested or not. A nested
operation carries no path of its own — the path belongs to the `PathItem` — so the copy it
produced had `path` unset and the compiler dropped it. The same branch also picked up a
webhook's operation a second time, after `convertWebhook()` had already collected it.

Nothing compared hybrid against the classic document it exists to reproduce, which is why
neither showed. `ScratchTest` runs classic and spec only.

## Changes

- A `PathItem`'s nested operations are collected with its path, as `convertWebhook()` already
  did for webhooks, and the flat branch takes the `is('nested')` guard its neighbours carry.
- `HybridBridgeTest` compares hybrid against classic for both shapes, and pins that a
  webhook's operation is collected once.
