### PR TITLE
fix(Type): resolve a generic docblock to the type it parameterises

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -22,6 +22,11 @@ $finder = PhpCsFixer\Finder::create()
             // parameter docblock for PHP 8.6
             && !strpos($file->getPathname(), 'tests/Fixtures/Scratch/Docblocks.php')
             && !strpos($file->getPathname(), 'tests/Fixtures/Scratch/Docblocks-spec.php')
+            // the short-name docblocks are the subject of the test; no_superfluous_phpdoc_tags
+            // deletes them and fully_qualified_strict_types rewrites what is left
+            && !strpos($file->getPathname(), 'tests/Fixtures/PHP/GlobalNamespaceTypes.php')
+            && !strpos($file->getPathname(), 'tests/Fixtures/Scratch/DocblockGenerics.php')
+            && !strpos($file->getPathname(), 'tests/Fixtures/Scratch/DocblockGenerics-spec.php')
         ;
     })
     ->in(__DIR__);

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -12,6 +12,9 @@ parameters:
     scanDirectories:
         # snippets are transcluded into the docs and exercised by tests; known, not analysed
         - docs/snippets
+    scanFiles:
+        # global namespace on purpose, so not autoloadable and not discovered on its own
+        - tests/Fixtures/PHP/GlobalNamespaceTypes.php
     parallel:
         processTimeout: 300.0
     excludePaths:

--- a/src/Type/TypeResolver.php
+++ b/src/Type/TypeResolver.php
@@ -25,6 +25,7 @@ use Symfony\Component\TypeInfo\Type\ArrayShapeType;
 use Symfony\Component\TypeInfo\Type\BuiltinType;
 use Symfony\Component\TypeInfo\Type\CollectionType;
 use Symfony\Component\TypeInfo\Type\CompositeTypeInterface;
+use Symfony\Component\TypeInfo\Type\GenericType;
 use Symfony\Component\TypeInfo\Type\IntersectionType;
 use Symfony\Component\TypeInfo\Type\NullableType;
 use Symfony\Component\TypeInfo\Type\ObjectType;
@@ -155,11 +156,16 @@ class TypeResolver
         }
 
         if ($type instanceof ObjectType) {
-            if ($type->getClassName() === \stdClass::class) {
+            // In the global namespace a short-name docblock comes back as `\Foo`, while
+            // `\Foo` itself comes back as `Foo`. `ComponentIndex` keys on `getClassName()`,
+            // which carries no leading slash.
+            $className = ltrim($type->getClassName(), '\\');
+
+            if ($className === \stdClass::class) {
                 return new SchemaType(type: 'object');
             }
 
-            return new SchemaType(type: $type->getClassName());
+            return new SchemaType(type: $className);
         }
 
         if ($type instanceof IntRangeType) {
@@ -180,6 +186,13 @@ class TypeResolver
 
         if ($type instanceof CollectionType) {
             return $this->mapCollectionType($type);
+        }
+
+        // `Foo<T>` on a class. OpenAPI can express nothing about the parameters, so the
+        // type being parameterised is what is left. Last, so `array<...>` and `int<...>`
+        // reach the arms above.
+        if ($type instanceof GenericType) {
+            return $this->mapType($type->getWrappedType());
         }
 
         return new SchemaType();

--- a/tests/Fixtures/PHP/DocblockAndTypehintTypes.php
+++ b/tests/Fixtures/PHP/DocblockAndTypehintTypes.php
@@ -78,6 +78,12 @@ class DocblockAndTypehintTypes
     public DocblockAndTypehintTypes $class;
 
     /**
+     * @var DocblockAndTypehintTypes<string>
+     */
+    #[OAT\Property]
+    public DocblockAndTypehintTypes $genericClass;
+
+    /**
      * @var DocblockAndTypehintTypes|null
      */
     #[OAT\Property]

--- a/tests/Fixtures/PHP/GlobalNamespaceTypes.php
+++ b/tests/Fixtures/PHP/GlobalNamespaceTypes.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+use OpenApi\Attributes as OAT;
+
+// Global namespace on purpose: a short-name docblock resolves against the declaring class's
+// namespace, and only here can that produce a leading backslash.
+
+#[OAT\Schema(schema: 'GlobalNamespaceTarget')]
+class GlobalNamespaceTarget
+{
+    #[OAT\Property]
+    public string $name;
+}
+
+#[OAT\Schema(schema: 'GlobalNamespaceHolder')]
+class GlobalNamespaceHolder
+{
+    /** No docblock at all — the reflection type is what gets resolved. */
+    #[OAT\Property]
+    public GlobalNamespaceTarget $native;
+
+    /** @var GlobalNamespaceTarget */
+    #[OAT\Property]
+    public GlobalNamespaceTarget $shortName;
+
+    /** @var \GlobalNamespaceTarget */
+    #[OAT\Property]
+    public GlobalNamespaceTarget $fullyQualified;
+
+    /** @var GlobalNamespaceTarget<string> */
+    #[OAT\Property]
+    public GlobalNamespaceTarget $shortNameGeneric;
+}

--- a/tests/Fixtures/Scratch/DocblockGenerics-spec.php
+++ b/tests/Fixtures/Scratch/DocblockGenerics-spec.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Scratch;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema(schema: 'DocblockGenericsTarget')]
+class DocblockGenericsTargetSpec
+{
+    #[OA\Property]
+    public string $name;
+}
+
+// The same PHP type three ways. Only the docblock differs, so all three resolve to one `$ref`.
+#[OA\Schema(schema: 'DocblockGenericsHolder')]
+class DocblockGenericsHolderSpec
+{
+    #[OA\Property]
+    public DocblockGenericsTargetSpec $native;
+
+    /** @var DocblockGenericsTargetSpec */
+    #[OA\Property]
+    public DocblockGenericsTargetSpec $docblock;
+
+    /** @var DocblockGenericsTargetSpec<string> */
+    #[OA\Property]
+    public DocblockGenericsTargetSpec $generic;
+}
+
+#[OA\Info(title: 'DocblockGenerics', version: '1.0')]
+#[OA\Operation\Get(path: '/holder', operationId: 'getHolder')]
+#[OA\Response(response: 200, description: 'All good', content: [
+    new OA\MediaType\Json(ref: DocblockGenericsHolderSpec::class),
+])]
+class DocblockGenericsEndpointSpec
+{
+}

--- a/tests/Fixtures/Scratch/DocblockGenerics.php
+++ b/tests/Fixtures/Scratch/DocblockGenerics.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Scratch;
+
+use OpenApi\Attributes as OAT;
+
+#[OAT\Schema(schema: 'DocblockGenericsTarget')]
+class DocblockGenericsTarget
+{
+    #[OAT\Property]
+    public string $name;
+}
+
+// The same PHP type three ways. Only the docblock differs, so all three resolve to one `$ref`.
+#[OAT\Schema(schema: 'DocblockGenericsHolder')]
+class DocblockGenericsHolder
+{
+    #[OAT\Property]
+    public DocblockGenericsTarget $native;
+
+    /** @var DocblockGenericsTarget */
+    #[OAT\Property]
+    public DocblockGenericsTarget $docblock;
+
+    /** @var DocblockGenericsTarget<string> */
+    #[OAT\Property]
+    public DocblockGenericsTarget $generic;
+}
+
+#[OAT\Info(title: 'DocblockGenerics', version: '1.0')]
+#[OAT\Get(path: '/holder', operationId: 'getHolder', responses: [
+    new OAT\Response(response: 200, description: 'All good', content: new OAT\JsonContent(ref: DocblockGenericsHolder::class)),
+])]
+class DocblockGenericsEndpoint
+{
+}

--- a/tests/Fixtures/Scratch/DocblockGenerics3.0.0.yaml
+++ b/tests/Fixtures/Scratch/DocblockGenerics3.0.0.yaml
@@ -1,0 +1,31 @@
+openapi: 3.0.0
+info:
+  title: DocblockGenerics
+  version: '1.0'
+paths:
+  /holder:
+    get:
+      operationId: getHolder
+      responses:
+        '200':
+          description: 'All good'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DocblockGenericsHolder'
+components:
+  schemas:
+    DocblockGenericsTarget:
+      properties:
+        name:
+          type: string
+      type: object
+    DocblockGenericsHolder:
+      properties:
+        native:
+          $ref: '#/components/schemas/DocblockGenericsTarget'
+        docblock:
+          $ref: '#/components/schemas/DocblockGenericsTarget'
+        generic:
+          $ref: '#/components/schemas/DocblockGenericsTarget'
+      type: object

--- a/tests/Fixtures/Scratch/DocblockGenerics3.1.0.yaml
+++ b/tests/Fixtures/Scratch/DocblockGenerics3.1.0.yaml
@@ -1,0 +1,31 @@
+openapi: 3.1.0
+info:
+  title: DocblockGenerics
+  version: '1.0'
+paths:
+  /holder:
+    get:
+      operationId: getHolder
+      responses:
+        '200':
+          description: 'All good'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DocblockGenericsHolder'
+components:
+  schemas:
+    DocblockGenericsTarget:
+      properties:
+        name:
+          type: string
+      type: object
+    DocblockGenericsHolder:
+      properties:
+        native:
+          $ref: '#/components/schemas/DocblockGenericsTarget'
+        docblock:
+          $ref: '#/components/schemas/DocblockGenericsTarget'
+        generic:
+          $ref: '#/components/schemas/DocblockGenericsTarget'
+      type: object

--- a/tests/Fixtures/Scratch/DocblockGenerics3.2.0.yaml
+++ b/tests/Fixtures/Scratch/DocblockGenerics3.2.0.yaml
@@ -1,0 +1,31 @@
+openapi: 3.2.0
+info:
+  title: DocblockGenerics
+  version: '1.0'
+paths:
+  /holder:
+    get:
+      operationId: getHolder
+      responses:
+        '200':
+          description: 'All good'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DocblockGenericsHolder'
+components:
+  schemas:
+    DocblockGenericsTarget:
+      properties:
+        name:
+          type: string
+      type: object
+    DocblockGenericsHolder:
+      properties:
+        native:
+          $ref: '#/components/schemas/DocblockGenericsTarget'
+        docblock:
+          $ref: '#/components/schemas/DocblockGenericsTarget'
+        generic:
+          $ref: '#/components/schemas/DocblockGenericsTarget'
+      type: object

--- a/tests/Type/TypeResolverTest.php
+++ b/tests/Type/TypeResolverTest.php
@@ -8,6 +8,7 @@ namespace OpenApi\Tests\Type;
 
 use OpenApi\Analysis;
 use OpenApi\Annotations as OA;
+use OpenApi\Builder;
 use OpenApi\Context;
 use OpenApi\Generator;
 use OpenApi\Processors\AugmentSchemas;
@@ -36,6 +37,7 @@ final class TypeResolverTest extends OpenApiTestCase
                 'nullablestringlist' => '{ "type": "array", "items": { "type": "string" }, "nullable": true, "property": "nullableStringList" }',
                 'nullablestringlistunion' => '{ "type": "array", "items": { "type": "string" }, "nullable": true, "property": "nullableStringListUnion" }',
                 'class' => '{ "$ref": "#/components/schemas/DocblockAndTypehintTypes" }',
+                'genericclass' => '{ "$ref": "#/components/schemas/DocblockAndTypehintTypes" }',
                 'nullableclass' => '{ "oneOf": [ { "$ref": "#/components/schemas/DocblockAndTypehintTypes" } ], "nullable": true, "property": "nullableClass" }',
                 'namespacedglobalclass' => '{ "type": "string", "format": "date-time", "property": "namespacedGlobalClass" }',
                 'nullablenamespacedglobalclass' => '{ "type": "string", "format": "date-time", "nullable": true, "property": "nullableNamespacedGlobalClass" }',
@@ -97,6 +99,7 @@ final class TypeResolverTest extends OpenApiTestCase
                 'nullablestringlist' => '{ "type": [ "array", "null" ], "items": { "type": "string" }, "property": "nullableStringList" }',
                 'nullablestringlistunion' => '{ "type": [ "array", "null" ], "items": { "type": "string" }, "property": "nullableStringListUnion" }',
                 'class' => '{ "$ref": "#/components/schemas/DocblockAndTypehintTypes" }',
+                'genericclass' => '{ "$ref": "#/components/schemas/DocblockAndTypehintTypes" }',
                 'nullableclass' => '{ "oneOf": [ { "$ref": "#/components/schemas/DocblockAndTypehintTypes" }, { "type": "null" } ], "property": "nullableClass" }',
                 'namespacedglobalclass' => '{ "type": "string", "format": "date-time", "property": "namespacedGlobalClass" }',
                 'nullablenamespacedglobalclass' => '{ "type": [ "string", "null" ], "format": "date-time", "property": "nullableNamespacedGlobalClass" }',
@@ -202,5 +205,49 @@ final class TypeResolverTest extends OpenApiTestCase
         $typeResolver->augmentSchemaType($analysis, $schema);
 
         $this->assertSpecEquals($schema->toJson(), $expected, $schema->toJson());
+    }
+
+    /**
+     * @return iterable<string, array{TypeResolverInterface}>
+     */
+    public static function typeResolvers(): iterable
+    {
+        foreach (self::getTypeResolvers() as $name => $typeResolver) {
+            yield $name => [$typeResolver];
+        }
+    }
+
+    /**
+     * A short-name docblock resolves against the declaring class's namespace, and only in the
+     * global namespace can that come back with a leading slash. Every `Scratch` fixture is
+     * namespaced, so the case has nowhere else to run.
+     */
+    #[DataProvider('typeResolvers')]
+    public function testGlobalNamespaceClassResolvesWithoutLeadingSlash(TypeResolverInterface $typeResolver): void
+    {
+        $fixture = self::fixture('PHP/GlobalNamespaceTypes.php');
+        require_once $fixture;
+
+        $compiled = (new Builder())
+            ->setMode(Builder\Mode::CLASSIC)
+            ->addSource($fixture)
+            ->withGenerator(fn (Generator $generator): Generator => $generator->setTypeResolver($typeResolver))
+            ->build()
+            ->toArray();
+
+        $properties = (array) $compiled['components']['schemas']['GlobalNamespaceHolder']['properties'];
+
+        $this->assertSame(
+            ['native', 'shortName', 'fullyQualified', 'shortNameGeneric'],
+            array_keys($properties),
+        );
+
+        foreach ($properties as $property => $schema) {
+            $this->assertSame(
+                ['$ref' => '#/components/schemas/GlobalNamespaceTarget'],
+                (array) $schema,
+                $property,
+            );
+        }
     }
 }


### PR DESCRIPTION
## Overview

A property typed `public Target $x` resolves to a `$ref`. Adding `/** @var Target<string> */` above it made the property lose its type altogether — so a generic docblock was worse than writing none, which is the opposite of what a docblock is for.

symfony/type-info handles the generic correctly, returning a `GenericType` that wraps the type being parameterised. `TypeResolver::mapType()` had no arm for it, so it fell through to an empty `SchemaType` and the answer was discarded. Every mode was affected, since `TypeInfoTypeResolver` is the default and the only resolver spec and hybrid use.

A second, narrower one came out of the same code path. In the global namespace a short-name docblock comes back from type-info as `\Target`, while `\Target` itself comes back as `Target`. The leading slash was passed straight through, so the compiled `$ref` reached nothing — `ComponentIndex` keys on `getClassName()`, which never carries one.

## Changes

- `TypeResolver::mapType()` maps a `GenericType` to the type it parameterises. It is matched last, so `array<...>` and `int<...>` keep the arms they already had.
- A class name from an `ObjectType` has any leading slash removed.
- `DocblockGenerics` covers the three docblock forms of one PHP type across all four supported mode/resolver combinations, against a single expected document.
- `GlobalNamespaceTypes` covers the global-namespace case, which no `Scratch` fixture can reach — every one of them is namespaced. It is not autoloadable by design, so phpstan gets it through `scanFiles`.
- Both fixtures are excluded from cs-fixer: `no_superfluous_phpdoc_tags` deletes the short-name docblocks they exist to exercise.
