### PR TITLE
fix(Compiler): compile a schema's examples as the list JSON Schema wants

### DIFF
--- a/src/Compiler/OpenApi31Compiler.php
+++ b/src/Compiler/OpenApi31Compiler.php
@@ -99,6 +99,8 @@ class OpenApi31Compiler implements CompilerInterface
 
         $this->validateNestedNames($specification);
 
+        $this->validateSchemaExamples($specification);
+
         return $this->logger->entries();
     }
 
@@ -586,8 +588,8 @@ class OpenApi31Compiler implements CompilerInterface
             'then' => $schema->then instanceof OA\Schema ? $this->compileSchema($schema->then) : null,
             'else' => $schema->else instanceof OA\Schema ? $this->compileSchema($schema->else) : null,
 
-            // Examples
-            'examples' => $this->compileExamples($schema->examples ?? []),
+            // Examples — the JSON Schema keyword, a list of values rather than a map
+            'examples' => $schema->examples,
 
             // Meta
             'deprecated' => $schema->deprecated,
@@ -774,19 +776,6 @@ class OpenApi31Compiler implements CompilerInterface
     }
 
     /**
-     * `Schema::$examples` only. Every other `examples` is a map of Example Objects and goes
-     * through {@see compileKeyedMap()}; this one is the JSON Schema keyword, and that it
-     * compiles to a map at all is a separate question.
-     *
-     * @param  list<OA\Example>    $examples
-     * @return array<string,mixed>
-     */
-    protected function compileExamples(array $examples): array
-    {
-        return $this->compileNamedMap($examples, 'example', $this->compileExample(...));
-    }
-
-    /**
      * Every component takes its key from one field, and a property from `property`. None can
      * be derived from a method or a non-constructor parameter, so an attribute declared there
      * has to carry its own name — the same requirement classic enforces. `Augmenter\Names`
@@ -853,6 +842,29 @@ class OpenApi31Compiler implements CompilerInterface
                 }
             });
         }
+    }
+
+    /**
+     * `Schema::$examples` is the JSON Schema keyword: a list of values, as its own docblock
+     * says. An Example Object belongs to the `examples` a media type, parameter or header
+     * takes, which is a map. Nothing else catches the mix-up — the property is `?array`, so
+     * `mixed` accepts an Example and the output merely looks odd.
+     */
+    protected function validateSchemaExamples(Specification $specification): void
+    {
+        $specification->getWalker()->visit(OA\Schema::class, function (OA\Schema $schema): void {
+            foreach ($schema->examples ?? [] as $example) {
+                if (!$example instanceof OA\Example) {
+                    continue;
+                }
+
+                $this->logger->warning(sprintf(
+                    'Schema%s: examples takes values, not Example objects, in %s',
+                    $schema->schema !== null ? " \"{$schema->schema}\"" : '',
+                    $example->getSourceLocation(),
+                ));
+            }
+        });
     }
 
     protected function validateSchemas(Specification $specification): void

--- a/src/HybridBridge.php
+++ b/src/HybridBridge.php
@@ -561,6 +561,28 @@ class HybridBridge
         );
     }
 
+    /**
+     * Classic nests `@OA\Examples` under a schema and keys them by name. The spec property is
+     * the JSON Schema keyword, a list of values, so only the value crosses over — an example
+     * carrying an `externalValue` or nothing but a summary has none to give, and a list has
+     * nowhere to put the rest of an Example Object.
+     *
+     * @param  array<Annotations\Examples> $examples
+     * @return list<mixed>
+     */
+    protected function convertSchemaExamples(array $examples): array
+    {
+        $values = [];
+
+        foreach ($examples as $example) {
+            if (!Undefined::isDefault($example->value)) {
+                $values[] = $example->value;
+            }
+        }
+
+        return $values;
+    }
+
     protected function convertSchema(Annotations\Schema $schema): Spec\Schema
     {
         $properties = null;
@@ -615,7 +637,7 @@ class HybridBridge
             example: Undefined::isDefault($schema->example) ? Undefined::UNDEFINED : $schema->example,
             examples: Undefined::isDefault($schema->examples)
                 ? null
-                : array_map($this->convertExample(...), $schema->examples),
+                : $this->convertSchemaExamples($schema->examples),
             deprecated: $this->val($schema->deprecated),
             readOnly: $this->val($schema->readOnly),
             writeOnly: $this->val($schema->writeOnly),

--- a/tests/CompilerTest.php
+++ b/tests/CompilerTest.php
@@ -191,10 +191,11 @@ final class CompilerTest extends TestCase
             'only',
         ];
 
+        // The JSON Schema keyword: a list of values, so it compiles through untouched.
         yield 'examples array' => [
-            new OA\Schema(schema: 'F', type: 'string', examples: [new OA\Example(example: 'foo', value: false)]),
+            new OA\Schema(schema: 'F', type: 'string', examples: [false, 'foo']),
             'examples',
-            ['foo' => ['value' => false]],
+            [false, 'foo'],
         ];
 
         yield 'unevaluatedProperties false' => [

--- a/tests/Fixtures/Scratch/Examples-spec.php
+++ b/tests/Fixtures/Scratch/Examples-spec.php
@@ -8,15 +8,11 @@ namespace OpenApi\Tests\Fixtures\Scratch;
 
 use OpenApi\Spec as OA;
 
+// `Schema::$examples` is the JSON Schema keyword: values, not Example objects. Classic nests
+// `@OA\Examples` here instead and keys them, which is why the two have separate expectations.
 #[OA\Schema(
     schema: 'YoYo',
-    examples: [
-        new OA\Example(
-            example: 'yo',
-            summary: 'the yo',
-            value: 'YoYo'
-        ),
-    ]
+    examples: ['YoYo']
 )]
 class ExampleSchemaSpec
 {

--- a/tests/Fixtures/Scratch/Examples3.0.0-spec.yaml
+++ b/tests/Fixtures/Scratch/Examples3.0.0-spec.yaml
@@ -1,0 +1,36 @@
+openapi: 3.0.0
+info:
+  title: Examples
+  version: '1.0'
+paths:
+  '/endpoint/{name}/{other}':
+    get:
+      operationId: examples
+      parameters:
+        -
+          name: name
+          in: path
+          required: true
+          schema:
+            type: string
+          example: Fritz
+        -
+          name: other
+          in: path
+          required: true
+          schema:
+            type: string
+          examples:
+            o1:
+              summary: 'other example 1'
+              value: ping
+            o2:
+              summary: 'other example 2'
+              value: pong
+      responses:
+        200:
+          description: OK
+components:
+  schemas:
+    YoYo:
+      example: YoYo

--- a/tests/Fixtures/Scratch/Examples3.0.0.yaml
+++ b/tests/Fixtures/Scratch/Examples3.0.0.yaml
@@ -1,0 +1,35 @@
+openapi: 3.0.0
+info:
+  title: Examples
+  version: '1.0'
+paths:
+  '/endpoint/{name}/{other}':
+    get:
+      operationId: examples
+      parameters:
+        -
+          name: name
+          in: path
+          required: true
+          schema:
+            type: string
+          example: Fritz
+        -
+          name: other
+          in: path
+          required: true
+          schema:
+            type: string
+          examples:
+            o1:
+              summary: 'other example 1'
+              value: ping
+            o2:
+              summary: 'other example 2'
+              value: pong
+      responses:
+        '200':
+          description: OK
+components:
+  schemas:
+    YoYo: {}

--- a/tests/Fixtures/Scratch/Examples3.1.0-spec.yaml
+++ b/tests/Fixtures/Scratch/Examples3.1.0-spec.yaml
@@ -1,0 +1,37 @@
+openapi: 3.1.0
+info:
+  title: Examples
+  version: '1.0'
+paths:
+  '/endpoint/{name}/{other}':
+    get:
+      operationId: examples
+      parameters:
+        -
+          name: name
+          in: path
+          required: true
+          schema:
+            type: string
+          example: Fritz
+        -
+          name: other
+          in: path
+          required: true
+          schema:
+            type: string
+          examples:
+            o1:
+              summary: 'other example 1'
+              value: ping
+            o2:
+              summary: 'other example 2'
+              value: pong
+      responses:
+        200:
+          description: OK
+components:
+  schemas:
+    YoYo:
+      examples:
+        - YoYo

--- a/tests/Fixtures/Scratch/Examples3.2.0-spec.yaml
+++ b/tests/Fixtures/Scratch/Examples3.2.0-spec.yaml
@@ -1,0 +1,37 @@
+openapi: 3.2.0
+info:
+  title: Examples
+  version: '1.0'
+paths:
+  '/endpoint/{name}/{other}':
+    get:
+      operationId: examples
+      parameters:
+        -
+          name: name
+          in: path
+          required: true
+          schema:
+            type: string
+          example: Fritz
+        -
+          name: other
+          in: path
+          required: true
+          schema:
+            type: string
+          examples:
+            o1:
+              summary: 'other example 1'
+              value: ping
+            o2:
+              summary: 'other example 2'
+              value: pong
+      responses:
+        200:
+          description: OK
+components:
+  schemas:
+    YoYo:
+      examples:
+        - YoYo

--- a/tests/ScratchTest.php
+++ b/tests/ScratchTest.php
@@ -27,7 +27,9 @@ final class ScratchTest extends OpenApiTestCase
         // Keyed `{fixture}-{version}`, applying to every mode, or `{fixture}-{version}-{mode}`
         // for a diagnostic only one mode raises. Both keys contribute when both are present.
         $expectedLogs = [
-            'Examples-3.0.0' => ['@OA\Schema() is only allowed as of 3.1.0'],
+            'Examples-3.0.0-classic' => ['@OA\Schema::examples is only allowed as of 3.1.0'],
+            'Examples-3.0.0-spec' => ['examples array is not supported in OpenAPI 3.0'],
+            'Examples-3.0.0-hybrid' => ['examples array is not supported in OpenAPI 3.0'],
             'Docblocks-3.0.0-spec' => ['const is not supported in OpenAPI 3.0'],
             'Docblocks-3.0.0-hybrid' => ['const is not supported in OpenAPI 3.0'],
             'Tags-3.2.0-spec' => ['references non-existent parent'],


### PR DESCRIPTION
Part of #1994, which sets out the rule: `Parameter.examples` and `MediaType.examples` are maps of Example Objects, while `Schema.examples` is the JSON Schema keyword and takes an array of literal values. This fixes the spec pipeline; #2176 finishes it in classic and closes the issue.

> Stacked on #2174 — it removes the last caller of `compileExamples()` that PR leaves behind. Review after that merges.

## Overview

`OA\Schema::$examples` is documented as `list<mixed>`, "a list of example values" — the JSON Schema keyword, which takes an array. The compiler ran it through the Example Object map that a media type, parameter and header take, so a schema compiled to:

```yaml
    YoYo:
      examples:
        yo:
          summary: 'the yo'
          value: YoYo
```

Redocly flags that under `struct`, and `.redocly.lint-ignore.yaml` was silencing it, so `composer redocly` passed on a structurally invalid document.

The 3.0 compiler read the property as documented — `$result['example'] = $schema->examples[0]` — so given an Example Object it serialized the whole thing, swagger-php internals included:

```json
"example": { "x": null, "attachables": null, "example": "yo",
             "summary": "the yo", "description": null, "value": "YoYo",
             "externalValue": null, "ref": null }
```

No `Examples3.0.0.yaml` existed, so nothing covered that branch.

## Changes

- `compileSchema()` emits `$schema->examples` as a list. `compileExamples()` had one caller left after #2174 and is gone.
- `validateSchemaExamples()` warns when an element is an `OA\Example`. Nothing else catches it — the property is `?array`, so `mixed` accepts one and the output merely looks odd rather than failing.
- `HybridBridge` maps classic's nested `@OA\Examples` to their value. An example carrying an `externalValue`, or nothing but a summary, has no value to contribute to a list.
- The `Examples` fixture passes values on the spec side, and gains the 3.0 expectations it never had.
- `ScratchTest`'s log declaration for `Examples-3.0.0` named a message that does not exist (`@OA\Schema()` rather than `@OA\Schema::examples`). Never noticed, because with no 3.0 expectation the case never ran. Now declared per mode: classic raises the annotation's version check, spec and hybrid the compiler's.

## Classic keeps its map, for now

Classic nests `@OA\Examples` under a schema deliberately — `Examples::class => ['examples', 'example']` in `Schema::$_nested` — so it still emits the map, and its expectations split from spec's. The two `struct` ignores remain and were checked: removing them makes redocly error on the classic files, so they are load-bearing rather than stale. The new `-spec.yaml` files need no ignore.

A follow-up against `src/Annotations/` would let both ignore entries go and collapse the split. Kept separate because that is an output change in the stable pipeline, and this one is not.

