### PR TITLE
docs(Contributing): state the commit subject format and the allowed types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,8 @@ Read the relevant page before working in that part of the tree:
 - Repeated docblock unions get a `@phpstan-type` alias, imported with
   `@phpstan-import-type` — see `BuilderSource` on `Builder`
 - Branches are `type/short-description`; commits are `type(Scope): subject`
-  (`feat`, `fix`, `docs`, `chore`, `refactor`)
+  (`feat`, `fix`, `docs`, `test`, `chore`, `refactor`) — [CONTRIBUTING](CONTRIBUTING.md)
+  covers what a message body should contain
 
 ## Before opening a pull request
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,8 +52,9 @@ The prose rules in [Writing documentation](docs/dev/writing-docs.md) apply to de
 and commit messages as well as to pages: state a fact once, do not claim what you have not
 verified, no marketing filler, no volatile values, no line-number citations.
 
-A commit message body documents what the diff does; the reasoning belongs in the pull
-request description.
+Commit subjects follow the same `type(Scope): subject` shape as the title, with `type` one
+of `feat`, `fix`, `docs`, `test`, `chore` or `refactor`. A commit message body documents
+what the diff does; the reasoning belongs in the pull request description.
 
 ## Documentation
 


### PR DESCRIPTION
## Overview

`CONTRIBUTING.md` tells a contributor how to title a pull request but never how to write the
commits inside it. That shape, and the list of allowed types, lived only in `AGENTS.md`, which
is aimed at coding agents. The prose rules for message bodies are already covered — this fills
in the subject line.

## Changes

- `CONTRIBUTING.md` states the commit subject format alongside the pull request title format
- `test` is added to the allowed types in both files — it is in regular use and has been
  through review (#2158, #2165, #2167, #2171), so the list was wrong rather than the practice
- `AGENTS.md` points at `CONTRIBUTING.md` for what a message body should contain
