### PR TITLE
fix(Augmenter): report a response component named after a status code

### DIFF
--- a/docs/reference/augmenters.md
+++ b/docs/reference/augmenters.md
@@ -131,6 +131,9 @@ Removes unreferenced components from the specification.
 Iterates multiple times to catch nested dependencies (a schema only
 referenced by another unused schema should also be removed).
 
+Removal is silent, with one exception: a response component keyed by a status code is
+reported, because it is a response that was meant to nest into an operation.
+
 #### Config settings
 - **cleanup.enabled** : `bool` · default: `true`  
   Enables/disables removal of unreferenced components.

--- a/src/Augmenter/Cleanup.php
+++ b/src/Augmenter/Cleanup.php
@@ -7,6 +7,7 @@
 namespace OpenApi\Augmenter;
 
 use OpenApi\Contracts\AttributeInterface;
+use OpenApi\Spec as OA;
 use OpenApi\Specification;
 use OpenApi\Specification\ComponentName;
 use OpenApi\Utils\Config;
@@ -20,6 +21,9 @@ use Psr\Log\LoggerAwareTrait;
  *
  * Iterates multiple times to catch nested dependencies (a schema only
  * referenced by another unused schema should also be removed).
+ *
+ * Removal is silent, with one exception: a response component keyed by a status code is
+ * reported, because it is a response that was meant to nest into an operation.
  *
  * @implements PipeInterface<Specification>
  */
@@ -98,6 +102,7 @@ class Cleanup implements PipeInterface, LoggerAwareInterface
         foreach ($specification->{$bucket} as $index => $item) {
             $name = ComponentName::of($item);
             if ($name !== null && !isset($usedRefs[JsonPointer::ref('components', $bucket, $name)])) {
+                $this->reportStatusCodeKey($item, $name);
                 unset($specification->{$bucket}[$index]);
                 $removed = true;
             }
@@ -107,5 +112,34 @@ class Cleanup implements PipeInterface, LoggerAwareInterface
         }
 
         return $removed;
+    }
+
+    /**
+     * `Response::$response` is the status code when the response is nested in an operation
+     * and the component name when it is not, and `isRoot()` cannot tell the two apart — it
+     * is true whenever the key is set. So a response that fails to nest becomes a component
+     * named after its status code, which nothing references and this then removes.
+     *
+     * Removing it is right, and silence is not: the response the author wrote disappears
+     * from the document with nothing said. This is the last point at which it is visible.
+     *
+     * A component whose key does not look like a status code is left alone. An unreferenced
+     * reusable response is ordinary — a library may declare more than any one document uses.
+     */
+    protected function reportStatusCodeKey(AttributeInterface $item, string $name): void
+    {
+        if (!$item instanceof OA\Response) {
+            return;
+        }
+
+        if (preg_match(OA\Response::STATUS_CODE_PATTERN, $name) !== 1) {
+            return;
+        }
+
+        $this->logger?->warning(sprintf(
+            'Response "%s" is a component named after a status code; it was most likely meant to nest into an operation in %s',
+            $name,
+            $item->getSourceLocation(),
+        ));
     }
 }

--- a/src/Compiler/OpenApi31Compiler.php
+++ b/src/Compiler/OpenApi31Compiler.php
@@ -30,7 +30,7 @@ class OpenApi31Compiler implements CompilerInterface
      */
     protected const SCHEMA_TYPES = ['string', 'number', 'integer', 'boolean', 'array', 'object', 'null'];
 
-    protected const RESPONSE_KEY = '/^(default|[1-5][0-9]{2}|[1-5]XX)$/';
+    protected const RESPONSE_KEY = OA\Response::STATUS_CODE_PATTERN;
 
     /**
      * Maps nested in another object, as container => [property => the member field keying it].

--- a/src/Spec/Response.php
+++ b/src/Spec/Response.php
@@ -14,6 +14,13 @@ namespace OpenApi\Spec;
 #[\Attribute(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE)]
 class Response extends AbstractAttribute
 {
+    /**
+     * The shape of `$response` when the response is nested in an operation: a status code,
+     * a range, or `default`. In the `responses` bucket the same field is a component name
+     * instead, and matching this there means the response was meant to nest and did not.
+     */
+    public const STATUS_CODE_PATTERN = '/^(default|[1-5][0-9]{2}|[1-5]XX)$/';
+
     /** @var list<MediaType>|null */
     public ?array $content = null;
 

--- a/tests/Augmenter/CleanupTest.php
+++ b/tests/Augmenter/CleanupTest.php
@@ -9,10 +9,13 @@ namespace OpenApi\Tests\Augmenter;
 use OpenApi\Augmenter;
 use OpenApi\Spec as OA;
 use OpenApi\Specification;
+use OpenApi\Tests\Concerns\ExpectsLogEntries;
 use PHPUnit\Framework\TestCase;
 
 final class CleanupTest extends TestCase
 {
+    use ExpectsLogEntries;
+
     public function testRemovesUnreferencedSchema(): void
     {
         $spec = new Specification();
@@ -188,5 +191,69 @@ final class CleanupTest extends TestCase
         (new Augmenter\Cleanup())($spec);
 
         $this->assertCount(1, $spec->securitySchemes);
+    }
+
+    public function testReportsAResponseComponentNamedAfterAStatusCode(): void
+    {
+        $spec = new Specification();
+        $spec->responses = [new OA\Response(response: 200, description: 'OK')];
+
+        $this->expectLogEntry('Response "200" is a component named after a status code', 'warning');
+
+        $cleanup = new Augmenter\Cleanup();
+        $cleanup->setLogger($this->trackingLogger());
+        $cleanup($spec);
+
+        $this->assertSame([], $spec->responses);
+    }
+
+    public function testReportsARangeAndDefaultTheSameWay(): void
+    {
+        $spec = new Specification();
+        $spec->responses = [
+            new OA\Response(response: '2XX', description: 'OK'),
+            new OA\Response(response: 'default', description: 'fallback'),
+        ];
+
+        $this->expectLogEntry('Response "2XX" is a component named after a status code', 'warning');
+        $this->expectLogEntry('Response "default" is a component named after a status code', 'warning');
+
+        $cleanup = new Augmenter\Cleanup();
+        $cleanup->setLogger($this->trackingLogger());
+        $cleanup($spec);
+
+        $this->assertSame([], $spec->responses);
+    }
+
+    /**
+     * An unreferenced reusable response is ordinary — a library may declare more than any
+     * one document uses — so removal is silent unless the key looks like a status code.
+     */
+    public function testRemovesAnUnreferencedNamedResponseWithoutReporting(): void
+    {
+        $spec = new Specification();
+        $spec->responses = [new OA\Response(response: 'NotFound', description: 'nope')];
+
+        $cleanup = new Augmenter\Cleanup();
+        $cleanup->setLogger($this->trackingLogger());
+        $cleanup($spec);
+
+        $this->assertSame([], $spec->responses);
+    }
+
+    public function testKeepsAndDoesNotReportAReferencedStatusCodeKey(): void
+    {
+        $spec = new Specification();
+        $spec->responses = [new OA\Response(response: 200, description: 'OK')];
+
+        $operation = new OA\Operation(path: '/test', method: 'get');
+        $operation->responses = [new OA\Response(response: 404, ref: '#/components/responses/200')];
+        $spec->operations[] = $operation;
+
+        $cleanup = new Augmenter\Cleanup();
+        $cleanup->setLogger($this->trackingLogger());
+        $cleanup($spec);
+
+        $this->assertCount(1, $spec->responses);
     }
 }


### PR DESCRIPTION
## Overview

A response that fails to nest into its operation disappears from the document with nothing
said, in the default configuration.

`Response::$response` carries two meanings: the HTTP status code when the response is nested
in an operation, and the component name when it sits in the `responses` bucket. `isRoot()`
cannot separate them — it is true whenever the key is set. So a response that does not nest
becomes a component named after its status code, nothing references it, `Augmenter\Cleanup`
removes it as unused, and the author's response is gone without a diagnostic.

A reusable response named `200` is a failed merge every time, and it is the only part of
this a user can see. Reporting it turns a silent drop into a pointer.

## Changes

- `Augmenter\Cleanup` warns when the unreferenced component it removes is a `Response` whose
  key looks like a status code, naming the source location. What gets removed is unchanged.
- Keying the check to removal keeps it precise: an unreferenced reusable response is ordinary
  — a library may declare more than any one document uses — so only a status-code-shaped key
  is reported, and a deliberately named component that is referenced stays silent.
- The status-code pattern moves onto `Spec\Response`, so the compiler's `RESPONSE_KEY` and
  the augmenter share one copy instead of carrying the regular expression twice.
- Four tests in `CleanupTest` covering the status code, a range, `default`, a named component
  removed silently, and a referenced status-code key that is kept.

## Note

With `cleanup.enabled` set to `false` nothing warns, because the component survives into the
output where it is at least visible. Extending the compiler's `validateResponses()` to the
components bucket would cover that case too, but the compiler cannot see whether a component
is referenced, so it would also report a deliberately named `200` that an operation `$ref`s.
That is part of the wider question of whether a component key may double as a value, which
also governs `PathItem` and `MediaType`, and is better settled once than guessed at here.
