### PR TITLE
fix(Tests): prefer spec expectations for hybrid in ExamplesTest and DocSnippetsTest

### DIFF
--- a/tests/Concerns/UsesExamples.php
+++ b/tests/Concerns/UsesExamples.php
@@ -18,14 +18,23 @@ trait UsesExamples
 
     public static function getSpecFilename(string $name, string $implementation = 'annotations', string $version = '3.0.0', Mode $mode = Mode::CLASSIC): string
     {
+        $basePath = static::examplePath($name);
+
         $specs = [
             "{$name}-{$implementation}-{$mode->value}-{$version}.yaml",
-            "{$name}-{$implementation}-{$version}.yaml",
             "{$name}-{$mode->value}-{$version}.yaml",
-            "{$name}-{$version}.yaml",
         ];
 
-        $basePath = static::examplePath($name);
+        // Hybrid uses spec compilers — prefer the spec expectation before falling
+        // back to the generic (classic) one, same precedence as ScratchTest.
+        if ($mode === Mode::HYBRID) {
+            $specs[] = "{$name}-{$implementation}-spec-{$version}.yaml";
+            $specs[] = "{$name}-spec-{$version}.yaml";
+        }
+
+        $specs[] = "{$name}-{$implementation}-{$version}.yaml";
+        $specs[] = "{$name}-{$version}.yaml";
+
         foreach ($specs as $spec) {
             $specFilename = "{$basePath}/{$spec}";
             if (file_exists($specFilename)) {

--- a/tests/DocSnippetsTest.php
+++ b/tests/DocSnippetsTest.php
@@ -29,7 +29,7 @@ final class DocSnippetsTest extends OpenApiTestCase
 
         foreach ($finder as $file) {
             $key = str_replace('_an', '', $file->getBasename('.php'));
-            $snippet_spec = str_replace('_an.php', '-3.1.0.yaml', $file->getPathname());
+            $basePath = dirname($file->getPathname());
 
             foreach (['an', 'at', 'spec'] as $implementation) {
                 $snippet = str_replace('_an.php', "_{$implementation}.php", $file->getPathname());
@@ -41,12 +41,32 @@ final class DocSnippetsTest extends OpenApiTestCase
                         continue;
                     }
 
+                    $candidates = [
+                        "{$basePath}/{$key}-{$mode->value}-3.1.0.yaml",
+                    ];
+                    if ($mode === Mode::HYBRID) {
+                        $candidates[] = "{$basePath}/{$key}-spec-3.1.0.yaml";
+                    }
+                    $candidates[] = "{$basePath}/{$key}-3.1.0.yaml";
+
+                    $snippet_spec = null;
+                    foreach ($candidates as $candidate) {
+                        if (file_exists($candidate)) {
+                            $snippet_spec = $candidate;
+                            break;
+                        }
+                    }
+
+                    if ($snippet_spec === null) {
+                        continue;
+                    }
+
                     yield "{$key}-{$implementation}-$mode->value" => [
                         $snippet,
                         $implementation,
                         $mode,
                         $snippet_spec,
-                        ];
+                    ];
                 }
             }
         }

--- a/tests/ExamplesTest.php
+++ b/tests/ExamplesTest.php
@@ -59,7 +59,7 @@ final class ExamplesTest extends OpenApiTestCase
                             'mode' => self::modes(),
                         ],
                         [
-                            fn (array $c): bool => $implementation === 'spec' && in_array($c['mode'], [Mode::CLASSIC, Mode::HYBRID], true),
+                            fn (array $c): bool => $implementation === 'spec' && $c['mode'] === Mode::CLASSIC,
                             fn (array $c): bool => $implementation !== 'spec' && $c['mode'] === Mode::SPEC,
                             fn (array $c): bool => $implementation === 'hybrid' && $c['mode'] !== Mode::HYBRID,
                             fn (array $c): bool => $typeResolver instanceof LegacyTypeResolver && $c['mode'] !== Mode::CLASSIC,


### PR DESCRIPTION
## Overview

Hybrid mode was running in both test suites but compared against the
classic baseline without preferring spec expectations — unlike
ScratchTest, which already falls through hybrid → spec → classic.
The spec implementation was also excluded from hybrid mode in
ExamplesTest, even though DocSnippetsTest already runs it.

## Changes

- `getSpecFilename()` fallback chain prefers spec-specific YAML for
  hybrid before falling back to the generic (classic) baseline
- `DocSnippetsTest` provider uses the same mode-aware resolution
- `ExamplesTest` now allows spec sources to run in hybrid mode,
  adding 58 new test cases