### PR TITLE
fix(Augmenter): deduplicate allOf refs after resolving class-strings

### DIFF
--- a/docs/guide/spec-attributes.md
+++ b/docs/guide/spec-attributes.md
@@ -541,12 +541,6 @@ create-user:
 
 This is semantically stricter — the schema explicitly declares it must be an object, rather than leaving the type to be inferred from the `allOf` members.
 
-### Duplicate `$ref` deduplication in `allOf`
-
-When a class extends a parent that has its own schema, the `Inheritance` augmenter adds a `$ref` to the parent in `allOf`. If you also declare that same `$ref` explicitly, spec mode deduplicates it — only one entry survives. Classic mode may emit the same `$ref` twice.
-
-Reusing the `CreateUser` example above: it both extends `AbstractUser` and names `abstract-user` in its own `allOf`. In spec mode that `$ref` appears once rather than twice — `Refs::dedupAllOfRefs()` drops the duplicate.
-
 ### Single-element `type` arrays reduced to string
 
 When a schema's `type` is an array with a single element (e.g. `['string']`), spec mode compiles it as a plain string (`type: 'string'`). Classic mode may emit the array form.

--- a/docs/reference/inheritance.md
+++ b/docs/reference/inheritance.md
@@ -70,7 +70,7 @@ User:
 
 ### Duplicate $ref deduplication
 
-If you explicitly declare an `allOf` entry that matches one the augmenter would add (e.g. you extend a class and also manually reference it), the `Refs` augmenter (`dedupAllOfRefs()`) deduplicates — only one `$ref` survives.
+If you explicitly declare an `allOf` entry that matches one the augmenter would add (e.g. you extend a class and also manually reference it), the `Refs` augmenter (`dedupAllOfRefs()`) deduplicates — only one `$ref` survives. Deduplication runs after class-strings are resolved, so `ref: Parent::class` and `#/components/schemas/parent` count as the same entry.
 
 ## PathItem Inheritance
 

--- a/src/Augmenter/Refs.php
+++ b/src/Augmenter/Refs.php
@@ -29,23 +29,33 @@ class Refs implements PipeInterface, LoggerAwareInterface
     public function __invoke(mixed $payload): mixed
     {
         foreach ($payload->schemas as $schema) {
-            $reflector = $schema->getClassReflector();
-            if ($reflector === null) {
+            if ($schema->getClassReflector() === null) {
                 continue;
             }
             $this->mergeAllOf($schema);
-            $this->dedupAllOfRefs($schema);
         }
 
         $index = $payload->buildComponentIndex();
         $refMap = $index->buildRefMap();
 
+        if ($refMap !== []) {
+            $this->resolveRefRefs($payload);
+            $this->resolveFQCNRefs($payload, $refMap);
+        }
+
+        // deduplicate once every ref carries its final value: a FQCN and the component
+        // pointer added by Augmenter\Inheritance name the same schema but differ as strings
+        foreach ($payload->schemas as $schema) {
+            if ($schema->getClassReflector() === null) {
+                continue;
+            }
+            $this->dedupAllOfRefs($schema);
+        }
+
         if ($refMap === []) {
             return null;
         }
 
-        $this->resolveRefRefs($payload);
-        $this->resolveFQCNRefs($payload, $refMap);
         $this->resolveDiscriminatorMappings($payload, $refMap);
         $this->resolveAllOfPropertyRefs($payload);
 

--- a/tests/Fixtures/Scratch/DuplicateRef-spec.php
+++ b/tests/Fixtures/Scratch/DuplicateRef-spec.php
@@ -40,3 +40,16 @@ class AbstractUserSpec
 class CreateUserSpec extends AbstractUserSpec
 {
 }
+
+// the same duplicate written as a FQCN: the inheritance augmenter adds the component
+// pointer, the attribute names the class, and both resolve to `abstract-user`
+#[OA\Schema(
+    schema: 'update-user',
+    allOf: [
+        new OA\Schema(ref: AbstractUserSpec::class),
+        new OA\Schema(required: ['name']),
+    ]
+)]
+class UpdateUserSpec extends AbstractUserSpec
+{
+}

--- a/tests/Fixtures/Scratch/DuplicateRef.php
+++ b/tests/Fixtures/Scratch/DuplicateRef.php
@@ -40,3 +40,16 @@ class AbstractUser
 class CreateUser extends AbstractUser
 {
 }
+
+// the same duplicate written as a FQCN: the inheritance augmenter adds the component
+// pointer, the attribute names the class, and both resolve to `abstract-user`
+#[OAT\Schema(
+    schema: 'update-user',
+    allOf: [
+        new OAT\Schema(ref: AbstractUser::class),
+        new OAT\Schema(required: ['name']),
+    ]
+)]
+class UpdateUser extends AbstractUser
+{
+}

--- a/tests/Fixtures/Scratch/DuplicateRef3.0.0-spec.yaml
+++ b/tests/Fixtures/Scratch/DuplicateRef3.0.0-spec.yaml
@@ -28,3 +28,11 @@ components:
           required:
             - name
             - email
+    update-user:
+      type: object
+      allOf:
+        -
+          $ref: '#/components/schemas/abstract-user'
+        -
+          required:
+            - name

--- a/tests/Fixtures/Scratch/DuplicateRef3.0.0.yaml
+++ b/tests/Fixtures/Scratch/DuplicateRef3.0.0.yaml
@@ -27,3 +27,10 @@ components:
           required:
             - name
             - email
+    update-user:
+      allOf:
+        -
+          $ref: '#/components/schemas/abstract-user'
+        -
+          required:
+            - name

--- a/tests/Fixtures/Scratch/DuplicateRef3.1.0-spec.yaml
+++ b/tests/Fixtures/Scratch/DuplicateRef3.1.0-spec.yaml
@@ -28,3 +28,11 @@ components:
           required:
             - name
             - email
+    update-user:
+      type: object
+      allOf:
+        -
+          $ref: '#/components/schemas/abstract-user'
+        -
+          required:
+            - name

--- a/tests/Fixtures/Scratch/DuplicateRef3.1.0.yaml
+++ b/tests/Fixtures/Scratch/DuplicateRef3.1.0.yaml
@@ -27,3 +27,10 @@ components:
           required:
             - name
             - email
+    update-user:
+      allOf:
+        -
+          $ref: '#/components/schemas/abstract-user'
+        -
+          required:
+            - name

--- a/tests/Fixtures/Scratch/DuplicateRef3.2.0-spec.yaml
+++ b/tests/Fixtures/Scratch/DuplicateRef3.2.0-spec.yaml
@@ -28,3 +28,11 @@ components:
           required:
             - name
             - email
+    update-user:
+      type: object
+      allOf:
+        -
+          $ref: '#/components/schemas/abstract-user'
+        -
+          required:
+            - name

--- a/tests/Fixtures/Scratch/DuplicateRef3.2.0.yaml
+++ b/tests/Fixtures/Scratch/DuplicateRef3.2.0.yaml
@@ -27,3 +27,10 @@ components:
           required:
             - name
             - email
+    update-user:
+      allOf:
+        -
+          $ref: '#/components/schemas/abstract-user'
+        -
+          required:
+            - name


### PR DESCRIPTION
## Overview

A schema that both extends a parent and names that parent with `ref: Parent::class` ends up with the parent referenced twice in its `allOf`. Deduplication compares `$ref` values as strings and runs before class-strings are resolved, so at that point the class-string and the component pointer `Inheritance` adds are not equal — both survive, and both then resolve to the same pointer. Spec and hybrid do this; classic emits one.

Writing the same reference as a pointer rather than a class-string deduplicates correctly, which is why the existing fixture for duplicate refs did not catch it.

## Changes

- `Refs` deduplicates after resolution rather than before, so entries are compared by their final value
- `Scratch/DuplicateRef` covers the class-string form
- The docs no longer list this as a classic/spec difference — classic emits one ref