### PR TITLE
fix(Augmenter): keep merged member order when expanding traits

### DIFF
--- a/docs/guide/spec-attributes.md
+++ b/docs/guide/spec-attributes.md
@@ -614,10 +614,6 @@ oneOf:
   - { type: 'null' }
 ```
 
-### Trait property ordering
-
-When traits without their own `#[OA\Schema]` are merged inline, the property order in the output may differ between modes. Spec mode orders properties by trait `use` declaration order, which may place trait properties differently than classic mode.
-
 ### Nullable type inference from PHP types
 
 Spec mode consistently infers nullability from PHP type declarations (e.g. `?\DateTime`). For OpenAPI 3.0 this adds `nullable: true`; for 3.1+ it emits `type: ['string', 'null']`. Classic mode may not infer nullability in all cases where the PHP type is nullable.

--- a/docs/reference/inheritance.md
+++ b/docs/reference/inheritance.md
@@ -52,7 +52,9 @@ Only **direct** interfaces of the schema's class are processed. Unlike parents, 
 
 ### Property merging
 
-When an ancestor has no schema, its `#[OA\Property]` members are merged into the current schema. Deduplication is by property name — if the schema already declares a property with the same name, the ancestor's version is skipped. Merged properties are prepended to the schema's property list.
+When an ancestor has no schema, its `#[OA\Property]` members are merged into the current schema. Deduplication is by property name — if the schema already declares a property with the same name, the ancestor's version is skipped.
+
+Everything merged from ancestors is prepended to the schema's own properties as a single block, in the order the augmenter visited it: parents from nearest to root, then the class's direct traits in `use` order, then the traits of each non-schema ancestor, then interfaces. The schema's own properties come last.
 
 ### allOf restructuring
 

--- a/src/Augmenter/Inheritance/Schemas.php
+++ b/src/Augmenter/Inheritance/Schemas.php
@@ -38,9 +38,17 @@ class Schemas
 
             $existingProperties = array_map(fn (OA\Property $property): ?string => $property->property, $schema->properties ?? []);
 
-            $this->expandParents($schema, $reflector, $index, $existingProperties);
-            $this->expandTraits($schema, $reflector, $index, $existingProperties);
-            $this->expandInterfaces($schema, $reflector, $index, $existingProperties);
+            // merged members accumulate in visit order and are prepended once; prepending per
+            // source would emit each group of siblings - traits, most of all - in reverse
+            $merged = [];
+
+            $this->expandParents($schema, $reflector, $index, $existingProperties, $merged);
+            $this->expandTraits($schema, $reflector, $index, $existingProperties, $merged);
+            $this->expandInterfaces($schema, $reflector, $index, $existingProperties, $merged);
+
+            if ($merged !== []) {
+                $schema->properties = [...$merged, ...($schema->properties ?? [])];
+            }
         }
 
         return null;
@@ -49,8 +57,9 @@ class Schemas
     /**
      * @param \ReflectionClass<object> $reflector
      * @param list<string|null>        $existingProperties
+     * @param list<OA\Property>        $merged
      */
-    protected function expandParents(OA\Schema $schema, \ReflectionClass $reflector, ComponentIndex $index, array &$existingProperties): void
+    protected function expandParents(OA\Schema $schema, \ReflectionClass $reflector, ComponentIndex $index, array &$existingProperties, array &$merged): void
     {
         $parent = $reflector->getParentClass();
         while ($parent !== false) {
@@ -60,7 +69,7 @@ class Schemas
                 break;
             }
 
-            $this->mergeMembers($schema, $parent, $existingProperties);
+            $this->mergeMembers($parent, $existingProperties, $merged);
             $parent = $parent->getParentClass();
         }
     }
@@ -68,15 +77,16 @@ class Schemas
     /**
      * @param \ReflectionClass<object> $reflector
      * @param list<string|null>        $existingProperties
+     * @param list<OA\Property>        $merged
      */
-    protected function expandTraits(OA\Schema $schema, \ReflectionClass $reflector, ComponentIndex $index, array &$existingProperties): void
+    protected function expandTraits(OA\Schema $schema, \ReflectionClass $reflector, ComponentIndex $index, array &$existingProperties, array &$merged): void
     {
         foreach ($this->attributeFactory->getDirectTraits($reflector) as $trait) {
             $traitSchema = $index->findSchema($trait->getName());
             if ($traitSchema instanceof OA\Schema) {
                 $this->addAllOfRef($schema, $traitSchema);
             } else {
-                $this->mergeMembers($schema, $trait, $existingProperties);
+                $this->mergeMembers($trait, $existingProperties, $merged);
             }
         }
 
@@ -91,7 +101,7 @@ class Schemas
                 if ($traitSchema instanceof OA\Schema) {
                     $this->addAllOfRef($schema, $traitSchema);
                 } else {
-                    $this->mergeMembers($schema, $trait, $existingProperties);
+                    $this->mergeMembers($trait, $existingProperties, $merged);
                 }
             }
 
@@ -102,8 +112,9 @@ class Schemas
     /**
      * @param \ReflectionClass<object> $reflector
      * @param list<string|null>        $existingProperties
+     * @param list<OA\Property>        $merged
      */
-    protected function expandInterfaces(OA\Schema $schema, \ReflectionClass $reflector, ComponentIndex $index, array &$existingProperties): void
+    protected function expandInterfaces(OA\Schema $schema, \ReflectionClass $reflector, ComponentIndex $index, array &$existingProperties, array &$merged): void
     {
         $ownInterfaces = $this->attributeFactory->getDirectInterfaces($reflector);
 
@@ -112,7 +123,7 @@ class Schemas
             if ($interfaceSchema instanceof OA\Schema) {
                 $this->addAllOfRef($schema, $interfaceSchema);
             } else {
-                $this->mergeMembers($schema, $interface, $existingProperties);
+                $this->mergeMembers($interface, $existingProperties, $merged);
             }
         }
     }
@@ -129,11 +140,11 @@ class Schemas
     /**
      * @param \ReflectionClass<object> $class
      * @param list<string|null>        $existingProperties
+     * @param list<OA\Property>        $merged
      */
-    protected function mergeMembers(OA\Schema $schema, \ReflectionClass $class, array &$existingProperties): void
+    protected function mergeMembers(\ReflectionClass $class, array &$existingProperties, array &$merged): void
     {
         $members = $this->attributeFactory->membersOf($class);
-        $merged = [];
         foreach ($members as $member) {
             if ($member instanceof OA\Property) {
                 // fallback to reflector if name not (yet) set
@@ -143,10 +154,6 @@ class Schemas
                     $merged[] = $member;
                 }
             }
-        }
-
-        if ($merged !== []) {
-            $schema->properties = [...$merged, ...($schema->properties ?? [])];
         }
     }
 }

--- a/tests/Augmenter/InheritanceBcTest.php
+++ b/tests/Augmenter/InheritanceBcTest.php
@@ -31,6 +31,20 @@ final class InheritanceBcTest extends TestCase
         $this->assertCompiledSchemasMatchFile($schemas, self::EXPECTED_FILE, $pipeline);
     }
 
+    /**
+     * Property order carries no meaning in OpenAPI, but reversed `use` order is nobody's
+     * intent - and `assertCompiledSchemasMatchFile()` sorts, so only this pins it.
+     */
+    #[DataProvider('pipelines')]
+    public function testMergedMemberOrderFollowsDeclaration(string $pipeline, array $schemas): void
+    {
+        $this->assertSame(
+            ['parentProp', 'traitProp', 'orderedProp', 'ownProp'],
+            array_keys($schemas['ClassUsingOrderedTraits']['properties'] ?? []),
+            "[{$pipeline}] merged members follow visit order: parent, then traits in `use` order, own properties last",
+        );
+    }
+
     public static function pipelines(): iterable
     {
         yield 'spec' => ['spec', self::buildSpec(__DIR__ . '/../Fixtures/Augmenter/Hierarchy/Spec')];

--- a/tests/Augmenter/InheritanceTest.php
+++ b/tests/Augmenter/InheritanceTest.php
@@ -32,6 +32,7 @@ final class InheritanceTest extends TestCase
             new \ReflectionClass(HierarchyFixtures\PlainParent::class),
             new \ReflectionClass(HierarchyFixtures\ChildOfPlainParent::class),
             new \ReflectionClass(HierarchyFixtures\StandaloneSchema::class),
+            new \ReflectionClass(HierarchyFixtures\ClassUsingOrderedTraits::class),
         );
 
         $spec = $assembler->getSpecification();

--- a/tests/Fixtures/Augmenter/Hierarchy/Classic/ClassUsingOrderedTraits.php
+++ b/tests/Fixtures/Augmenter/Hierarchy/Classic/ClassUsingOrderedTraits.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter\Hierarchy\Classic;
+
+use OpenApi\Attributes as OAT;
+
+#[OAT\Schema]
+class ClassUsingOrderedTraits extends PlainParent
+{
+    use PlainTrait;
+    use OrderedTrait;
+
+    #[OAT\Property(type: 'integer')]
+    public int $ownProp;
+}

--- a/tests/Fixtures/Augmenter/Hierarchy/Classic/OrderedTrait.php
+++ b/tests/Fixtures/Augmenter/Hierarchy/Classic/OrderedTrait.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter\Hierarchy\Classic;
+
+use OpenApi\Attributes as OAT;
+
+trait OrderedTrait
+{
+    #[OAT\Property(type: 'string')]
+    public string $orderedProp;
+}

--- a/tests/Fixtures/Augmenter/Hierarchy/Spec/ClassUsingOrderedTraits.php
+++ b/tests/Fixtures/Augmenter/Hierarchy/Spec/ClassUsingOrderedTraits.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter\Hierarchy\Spec;
+
+use OpenApi\Spec as OA;
+
+#[OA\Schema]
+class ClassUsingOrderedTraits extends PlainParent
+{
+    use PlainTrait;
+    use OrderedTrait;
+
+    #[OA\Property(property: 'ownProp')]
+    #[OA\Schema(type: 'integer')]
+    public int $ownProp;
+}

--- a/tests/Fixtures/Augmenter/Hierarchy/Spec/OrderedTrait.php
+++ b/tests/Fixtures/Augmenter/Hierarchy/Spec/OrderedTrait.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Augmenter\Hierarchy\Spec;
+
+use OpenApi\Spec as OA;
+
+trait OrderedTrait
+{
+    #[OA\Property(property: 'orderedProp')]
+    #[OA\Schema(type: 'string')]
+    public string $orderedProp;
+}

--- a/tests/Fixtures/Augmenter/Hierarchy/expected.yaml
+++ b/tests/Fixtures/Augmenter/Hierarchy/expected.yaml
@@ -16,6 +16,13 @@ ChildOfPlainParent:
         - parentProp
         - childProp
 
+ClassUsingOrderedTraits:
+    properties:
+        - parentProp
+        - traitProp
+        - orderedProp
+        - ownProp
+
 ClassUsingPlainTrait:
     properties:
         - traitProp

--- a/tests/Fixtures/Scratch/MergeTraitsExtended3.0.0-spec.yaml
+++ b/tests/Fixtures/Scratch/MergeTraitsExtended3.0.0-spec.yaml
@@ -19,6 +19,10 @@ components:
       type: object
       description: 'This model can be ignored, it is just used for inheritance.'
       properties:
+        id:
+          type: integer
+          format: int64
+          readOnly: true
         created_at:
           type: string
           format: date-time
@@ -26,10 +30,6 @@ components:
         updated_at:
           type: string
           format: date-time
-          readOnly: true
-        id:
-          type: integer
-          format: int64
           readOnly: true
     Product:
       type: object

--- a/tests/Fixtures/Scratch/MergeTraitsExtended3.1.0-spec.yaml
+++ b/tests/Fixtures/Scratch/MergeTraitsExtended3.1.0-spec.yaml
@@ -19,6 +19,10 @@ components:
       type: object
       description: 'This model can be ignored, it is just used for inheritance.'
       properties:
+        id:
+          type: integer
+          format: int64
+          readOnly: true
         created_at:
           type: string
           format: date-time
@@ -26,10 +30,6 @@ components:
         updated_at:
           type: string
           format: date-time
-          readOnly: true
-        id:
-          type: integer
-          format: int64
           readOnly: true
     Product:
       type: object

--- a/tests/Fixtures/Scratch/MergeTraitsExtended3.2.0-spec.yaml
+++ b/tests/Fixtures/Scratch/MergeTraitsExtended3.2.0-spec.yaml
@@ -19,6 +19,10 @@ components:
       type: object
       description: 'This model can be ignored, it is just used for inheritance.'
       properties:
+        id:
+          type: integer
+          format: int64
+          readOnly: true
         created_at:
           type: string
           format: date-time
@@ -26,10 +30,6 @@ components:
         updated_at:
           type: string
           format: date-time
-          readOnly: true
-        id:
-          type: integer
-          format: int64
           readOnly: true
     Product:
       type: object


### PR DESCRIPTION
## Overview

Properties merged from traits come out in reverse `use` order. `mergeMembers()` prepends its result to the schema's properties, which gives the intended result over a single source — inherited members before the class's own — but it is called once per trait, so each trait lands in front of the one declared before it. Three traits reverse fully. Classic and hybrid emit declaration order.

Map key order carries no meaning in OpenAPI, so no document is wrong, but reverse `use` order is not a choice anyone made, and it is one of the known classic/spec divergences for no reason.

## Changes

- `Inheritance\Schemas` accumulates merged members across parents, traits and interfaces and prepends the block once, in visit order
- `InheritanceBcTest` pins the order for both pipelines — the shared assertion helper sorts before comparing, so nothing else could catch a reversal
- Fixtures and docs updated to the corrected order, and the docs no longer list trait ordering as a classic/spec difference