### PR TITLE
docs(Contributing): set the altitude for a Changes entry

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,9 @@ unless it has a direct bearing on this diff. -->
 
 ## Changes
 
-<!-- Key changes, high level. No code snippets unless genuinely unavoidable. Wrap class
-names, method calls, file paths and other identifiers in backticks. -->
+<!-- Key changes, high level. One line each, naming what moved rather than how it works —
+a condition, a count or a signature is what the diff is for. No code snippets unless
+genuinely unavoidable. Wrap class names, method calls, file paths and other identifiers in
+backticks. -->
 
 -

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,11 @@ implementation — followed by a **Changes** list of the key changes, kept high 
 free of code snippets unless one is genuinely unavoidable. Wrap class names, method calls,
 file paths and other identifiers in backticks.
 
+A **Changes** entry names what moved, in one line; the diff is what says how. A condition,
+a count, a signature or a renamed method's new behaviour is something the reader gets by
+opening the diff, and restating it buries the one or two entries that carry the shape of
+the change. The Overview holds the reasoning, so an entry needs no *because*.
+
 Keep the description to the changes at hand. History that lives elsewhere — earlier
 attempts, abandoned branches, related work in other pull requests — belongs in the issue
 or commit trail, not here, unless it has a direct bearing on the change being reviewed.


### PR DESCRIPTION
## Overview

CONTRIBUTING asked for a **Changes** list "kept high level" without saying what that rules out, so the same detail kept reappearing in descriptions: conditions, counts, and behaviour the diff already shows. Those entries are not wrong, they are just unreadable in bulk — they bury the one or two lines that carry the shape of the change.

The rule now carries a test a writer can apply while drafting.

## Changes

- `CONTRIBUTING.md` states what a **Changes** entry is for
- The pull request template carries the same test where it is read