### PR TITLE
docs(Agents): carve spec-compliance defects out of the classic freeze

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,9 @@ Read the relevant page before working in that part of the tree:
 - `protected` over `private` for methods and properties, so downstream can subclass
 - British spelling in `src/`, US in `docs/` — follow whichever is local to the file
 - New pipeline work goes in `src/Spec/`, `src/Augmenter/`, `src/Compiler/`;
-  `src/Annotations/` and `src/Attributes/` are classic and closed to new features —
+  `src/Annotations/` and `src/Attributes/` are classic and closed to new capabilities,
+  with one carve-out: an OpenAPI construct classic claims to model but cannot express
+  is a spec-compliance defect, and fixing it is in scope —
   [ROADMAP.md](ROADMAP.md) has the v7/v8 plan
 - Repeated docblock unions get a `@phpstan-type` alias, imported with
   `@phpstan-import-type` — see `BuilderSource` on `Builder`


### PR DESCRIPTION
## Overview

Packagist's major-version stats show old majors linger for years — v4 still carries roughly a third of monthly downloads, v3 ~6% — and v6 is the last major where classic is the primary API, so the state classic is in when v7 forks off is what most users will live with for a long time. Under the blanket "closed to new features" rule, gaps where classic cannot express ordinary OpenAPI (a `Header` carrying an example, a `mutualTLS` security scheme) were shielded as features rather than treated as the defects they are.

## Changes

- The classic closed-area rule in `AGENTS.md` gains a carve-out: an OpenAPI construct classic claims to model but cannot express is a spec-compliance defect, and fixing it is in scope