### PR TITLE
fix(Annotations): model the full Header Object

### DIFF
--- a/docs/reference/annotations.md
+++ b/docs/reference/annotations.md
@@ -183,7 +183,7 @@ A single encoding definition applied to a single schema property.
 
 #### Allowed in
 ---
-<a href="#additionalproperties">AdditionalProperties</a>, <a href="#components">Components</a>, <a href="#items">Items</a>, <a href="#schema">Schema</a>, <a href="#parameter">Parameter</a>, <a href="#pathparameter">PathParameter</a>, <a href="#property">Property</a>, <a href="#mediatype">MediaType</a>, <a href="#jsoncontent">JsonContent</a>, <a href="#xmlcontent">XmlContent</a>
+<a href="#additionalproperties">AdditionalProperties</a>, <a href="#components">Components</a>, <a href="#items">Items</a>, <a href="#schema">Schema</a>, <a href="#parameter">Parameter</a>, <a href="#pathparameter">PathParameter</a>, <a href="#property">Property</a>, <a href="#mediatype">MediaType</a>, <a href="#header">Header</a>, <a href="#jsoncontent">JsonContent</a>, <a href="#xmlcontent">XmlContent</a>
 
 #### Nested elements
 ---
@@ -329,7 +329,7 @@ A map between the scope name and a short description for it.</p><table class="ta
 
 #### Nested elements
 ---
-<a href="#schema">Schema</a>, <a href="#attachable">Attachable</a>
+<a href="#schema">Schema</a>, <a href="#examples">Examples</a>, <a href="#mediatype">MediaType</a>, <a href="#attachable">Attachable</a>
 
 #### Properties
 ---
@@ -345,6 +345,21 @@ This could contain examples of use.<br />
 CommonMark syntax MAY be used for rich text representation.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>required</strong> : <span style="font-family: monospace;">bool</span></dt>
   <dd><p>No details available.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+  <dt><strong>style</strong> : <span style="font-family: monospace;">string</span></dt>
+  <dd><p>Describes how the header value will be serialized.<br />
+<br />
+Headers support only the "simple" style; it is also the default.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+  <dt><strong>explode</strong> : <span style="font-family: monospace;">bool</span></dt>
+  <dd><p>When this is true, header values of type array or object generate a single header<br />
+whose value is a comma-separated list of the array items or key-value pairs of the map.<br />
+<br />
+The default value is false.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+  <dt><strong>example</strong> : <span style="font-family: monospace;">mixed</span></dt>
+  <dd><p>Example of the header.<br />
+<br />
+The example should match the specified schema if present.<br />
+The example object is mutually exclusive of the examples object.<br />
+Furthermore, if referencing a schema which contains an example, the example value shall override the example provided by the schema.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>deprecated</strong> : <span style="font-family: monospace;">bool</span></dt>
   <dd><p>Specifies that a parameter is deprecated and SHOULD be transitioned out of usage.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>allowEmptyValue</strong> : <span style="font-family: monospace;">bool</span></dt>
@@ -548,7 +563,7 @@ Parameter encodings can be set either here, or on nested `Property` annotations 
 
 #### Allowed in
 ---
-<a href="#response">Response</a>, <a href="#requestbody">RequestBody</a>
+<a href="#response">Response</a>, <a href="#requestbody">RequestBody</a>, <a href="#header">Header</a>
 
 #### Nested elements
 ---

--- a/docs/reference/attributes.md
+++ b/docs/reference/attributes.md
@@ -545,7 +545,7 @@ These will be ignored but can be used for custom processing.</p><table class="ta
 
 #### Allowed in
 ---
-<a href="#additionalproperties">AdditionalProperties</a>, <a href="#components">Components</a>, <a href="#items">Items</a>, <a href="#schema">Schema</a>, <a href="#parameter">Parameter</a>, <a href="#pathparameter">PathParameter</a>, <a href="#property">Property</a>, <a href="#mediatype">MediaType</a>, <a href="#jsoncontent">JsonContent</a>, <a href="#xmlcontent">XmlContent</a>
+<a href="#additionalproperties">AdditionalProperties</a>, <a href="#components">Components</a>, <a href="#items">Items</a>, <a href="#schema">Schema</a>, <a href="#parameter">Parameter</a>, <a href="#pathparameter">PathParameter</a>, <a href="#property">Property</a>, <a href="#mediatype">MediaType</a>, <a href="#header">Header</a>, <a href="#jsoncontent">JsonContent</a>, <a href="#xmlcontent">XmlContent</a>
 
 #### Nested elements
 ---
@@ -842,7 +842,7 @@ These will be ignored but can be used for custom processing.</p><table class="ta
 
 #### Nested elements
 ---
-<a href="#schema">Schema</a>, <a href="#attachable">Attachable</a>
+<a href="#schema">Schema</a>, <a href="#examples">Examples</a>, <a href="#mediatype">MediaType</a>, <a href="#attachable">Attachable</a>
 
 #### Parameters
 ---
@@ -859,7 +859,7 @@ CommonMark syntax MAY be used for rich text representation.</p><table class="tab
   <dt><strong>required</strong> : <span style="font-family: monospace;">bool|null</span></dt>
   <dd><p>No details available.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>schema</strong> : <span style="font-family: monospace;">OpenApi\Attributes\Schema|null</span></dt>
-  <dd><p>Schema object.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>yes</b></td></tr></tbody></table></dd>
+  <dd><p>Schema object.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>deprecated</strong> : <span style="font-family: monospace;">bool|null</span></dt>
   <dd><p>Specifies that a parameter is deprecated and SHOULD be transitioned out of usage.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>allowEmptyValue</strong> : <span style="font-family: monospace;">bool|null</span></dt>
@@ -870,6 +870,34 @@ This is valid only for query parameters and allows sending a parameter with an e
 Default value is false.<br />
 <br />
 If style is used, and if behavior is n/a (cannot be serialized), the value of allowEmptyValue SHALL be ignored.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+  <dt><strong>style</strong> : <span style="font-family: monospace;">string|null</span></dt>
+  <dd><p>Describes how the header value will be serialized.<br />
+<br />
+Headers support only the "simple" style; it is also the default.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+  <dt><strong>explode</strong> : <span style="font-family: monospace;">bool|null</span></dt>
+  <dd><p>When this is true, header values of type array or object generate a single header<br />
+whose value is a comma-separated list of the array items or key-value pairs of the map.<br />
+<br />
+The default value is false.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+  <dt><strong>example</strong> : <span style="font-family: monospace;">mixed|null</span></dt>
+  <dd><p>Example of the header.<br />
+<br />
+The example should match the specified schema if present.<br />
+The example object is mutually exclusive of the examples object.<br />
+Furthermore, if referencing a schema which contains an example, the example value shall override the example provided by the schema.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+  <dt><strong>examples</strong> : <span style="font-family: monospace;">array&lt;Examples&gt;|null</span></dt>
+  <dd><p>Examples of the header.<br />
+<br />
+Each example should match the specified schema if present.<br />
+The examples object is mutually exclusive of the example object.<br />
+Furthermore, if referencing a schema which contains an example, the examples value shall override the example provided by the schema.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
+  <dt><strong>content</strong> : <span style="font-family: monospace;">array&lt;MediaType&gt;|JsonContent|XmlContent|Attachable|null</span></dt>
+  <dd><p>A map containing the representations for the header.<br />
+<br />
+The key is the media type and the value describes it.<br />
+The map must only contain one entry.<br />
+<br />
+The content map is mutually exclusive of the schema property.</p><table class="table-plain"><tbody><tr><td><i>Required</i>:</td><td style="padding-left: 0;"><b>no</b></td></tr></tbody></table></dd>
   <dt><strong>x</strong> : <span style="font-family: monospace;">array&lt;string,mixed&gt;|null</span></dt>
   <dd><p>While the OpenAPI Specification tries to accommodate most use cases, additional data can be added to extend the specification at certain points.<br />
 For further details see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#specificationExtensions<br />
@@ -1520,7 +1548,7 @@ These will be ignored but can be used for custom processing.</p><table class="ta
 
 #### Allowed in
 ---
-<a href="#response">Response</a>, <a href="#requestbody">RequestBody</a>
+<a href="#response">Response</a>, <a href="#requestbody">RequestBody</a>, <a href="#header">Header</a>
 
 #### Nested elements
 ---

--- a/src/Annotations/Examples.php
+++ b/src/Annotations/Examples.php
@@ -88,6 +88,7 @@ class Examples extends AbstractAnnotation
         PathParameter::class,
         Property::class,
         MediaType::class,
+        Header::class,
         JsonContent::class,
         XmlContent::class,
     ];

--- a/src/Annotations/Header.php
+++ b/src/Annotations/Header.php
@@ -5,6 +5,7 @@
 
 namespace OpenApi\Annotations;
 
+use OpenApi\Analysis;
 use OpenApi\Undefined;
 
 /**
@@ -44,11 +45,64 @@ class Header extends AbstractAnnotation
     public $required = Undefined::UNDEFINED;
 
     /**
+     * Describes how the header value will be serialized.
+     *
+     * Headers support only the "simple" style; it is also the default.
+     *
+     * @var string
+     */
+    public $style = Undefined::UNDEFINED;
+
+    /**
+     * When this is true, header values of type array or object generate a single header
+     * whose value is a comma-separated list of the array items or key-value pairs of the map.
+     *
+     * The default value is false.
+     *
+     * @var bool
+     */
+    public $explode = Undefined::UNDEFINED;
+
+    /**
      * Schema object.
      *
      * @var Schema
      */
     public $schema = Undefined::UNDEFINED;
+
+    /**
+     * Example of the header.
+     *
+     * The example should match the specified schema if present.
+     * The example object is mutually exclusive of the examples object.
+     * Furthermore, if referencing a schema which contains an example, the example value shall override the example provided by the schema.
+     *
+     * @var mixed
+     */
+    public $example = Undefined::UNDEFINED;
+
+    /**
+     * Examples of the header.
+     *
+     * Each example should match the specified schema if present.
+     * The examples object is mutually exclusive of the example object.
+     * Furthermore, if referencing a schema which contains an example, the examples value shall override the example provided by the schema.
+     *
+     * @var array<Examples>
+     */
+    public $examples = Undefined::UNDEFINED;
+
+    /**
+     * A map containing the representations for the header.
+     *
+     * The key is the media type and the value describes it.
+     * The map must only contain one entry.
+     *
+     * The content map is mutually exclusive of the schema property.
+     *
+     * @var array<MediaType>|JsonContent|XmlContent|Attachable
+     */
+    public $content = Undefined::UNDEFINED;
 
     /**
      * Specifies that a parameter is deprecated and SHOULD be transitioned out of usage.
@@ -73,7 +127,7 @@ class Header extends AbstractAnnotation
     /**
      * @inheritdoc
      */
-    public static $_required = ['header', 'schema'];
+    public static $_required = ['header'];
 
     /**
      * @inheritdoc
@@ -81,6 +135,8 @@ class Header extends AbstractAnnotation
     public static $_types = [
         'header' => 'string',
         'description' => 'string',
+        'style' => ['simple'],
+        'explode' => 'boolean',
     ];
 
     /**
@@ -88,6 +144,8 @@ class Header extends AbstractAnnotation
      */
     public static $_nested = [
         Schema::class => 'schema',
+        Examples::class => ['examples', 'example'],
+        MediaType::class => ['content', 'mediaType'],
         Attachable::class => ['attachables'],
     ];
 
@@ -99,4 +157,24 @@ class Header extends AbstractAnnotation
         Components::class,
         Response::class,
     ];
+
+    #[\Override]
+    public function validate(?Analysis $analysis = null, string $version = OpenApi::DEFAULT_VERSION, ?object $context = null): bool
+    {
+        $isValid = parent::validate($analysis, $version, $context);
+
+        if (Undefined::isDefault($this->ref)) {
+            $hasSchema = !Undefined::isDefault($this->schema);
+            $hasContent = !Undefined::isDefault($this->content);
+            if ($hasSchema && $hasContent) {
+                $this->_context->logger->warning($this->identity() . ' schema and content are mutually exclusive in ' . $this->_context);
+                $isValid = false;
+            } elseif (!$hasSchema && !$hasContent) {
+                $this->_context->logger->warning($this->identity() . ' requires one of "schema" or "content" in ' . $this->_context);
+                $isValid = false;
+            }
+        }
+
+        return $isValid;
+    }
 }

--- a/src/Annotations/MediaType.php
+++ b/src/Annotations/MediaType.php
@@ -85,6 +85,7 @@ class MediaType extends AbstractAnnotation
     public static $_parents = [
         Response::class,
         RequestBody::class,
+        Header::class,
     ];
 
     protected function encodingCompat($encoding, callable $factory)

--- a/src/Attributes/Header.php
+++ b/src/Attributes/Header.php
@@ -12,9 +12,11 @@ use OpenApi\Undefined;
 class Header extends OA\Header
 {
     /**
-     * @param string|class-string|object|null $ref
-     * @param array<string,mixed>|null        $x
-     * @param list<Attachable>|null           $attachables
+     * @param string|class-string|object|null                         $ref
+     * @param array<Examples>|null                                    $examples
+     * @param array<MediaType>|JsonContent|XmlContent|Attachable|null $content
+     * @param array<string,mixed>|null                                $x
+     * @param list<Attachable>|null                                   $attachables
      */
     public function __construct(
         string|object|null $ref = null,
@@ -24,6 +26,11 @@ class Header extends OA\Header
         ?Schema $schema = null,
         ?bool $deprecated = null,
         ?bool $allowEmptyValue = null,
+        ?string $style = null,
+        ?bool $explode = null,
+        mixed $example = Undefined::UNDEFINED,
+        ?array $examples = null,
+        array|JsonContent|XmlContent|Attachable|null $content = null,
 
         // abstract annotation
         ?array $x = null,
@@ -36,9 +43,12 @@ class Header extends OA\Header
             'required' => $required ?? Undefined::UNDEFINED,
             'deprecated' => $deprecated ?? Undefined::UNDEFINED,
             'allowEmptyValue' => $allowEmptyValue ?? Undefined::UNDEFINED,
+            'style' => $style ?? Undefined::UNDEFINED,
+            'explode' => $explode ?? Undefined::UNDEFINED,
+            'example' => $example,
             'x' => $x ?? Undefined::UNDEFINED,
             'attachables' => $attachables ?? Undefined::UNDEFINED,
-            'value' => $this->combine($schema),
+            'value' => $this->combine($schema, $examples, $content),
         ]);
     }
 }

--- a/src/HybridBridge.php
+++ b/src/HybridBridge.php
@@ -563,7 +563,16 @@ class HybridBridge
             required: $this->val($header->required),
             deprecated: $this->val($header->deprecated),
             ref: $this->val($header->ref),
+            style: $this->val($header->style),
+            explode: $this->val($header->explode),
             schema: Undefined::isDefault($header->schema) ? null : $this->convertSchema($header->schema),
+            example: Undefined::isDefault($header->example) ? Undefined::UNDEFINED : $header->example,
+            examples: Undefined::isDefault($header->examples)
+                ? null
+                : array_map($this->convertExample(...), $header->examples),
+            content: Undefined::isDefault($header->content)
+                ? null
+                : array_map($this->convertMediaType(...), $header->content),
             x: $this->extensions($header),
         );
         $this->copyReflector($header, $result);

--- a/src/Processors/MergeJsonContent.php
+++ b/src/Processors/MergeJsonContent.php
@@ -22,7 +22,7 @@ class MergeJsonContent
 
         foreach ($annotations as $jsonContent) {
             $parent = $jsonContent->_context->nested;
-            if (!($parent instanceof OA\Response) && !($parent instanceof OA\RequestBody) && !($parent instanceof OA\Parameter)) {
+            if (!($parent instanceof OA\Response) && !($parent instanceof OA\RequestBody) && !($parent instanceof OA\Parameter) && !($parent instanceof OA\Header)) {
                 if ($parent) {
                     $jsonContent->_context->logger->warning('Unexpected ' . $jsonContent->identity() . ' in ' . $parent->identity() . ' in ' . $parent->_context);
                 } else {

--- a/src/Processors/MergeXmlContent.php
+++ b/src/Processors/MergeXmlContent.php
@@ -22,7 +22,7 @@ class MergeXmlContent
 
         foreach ($annotations as $xmlContent) {
             $parent = $xmlContent->_context->nested;
-            if (!($parent instanceof OA\Response) && !($parent instanceof OA\RequestBody) && !($parent instanceof OA\Parameter)) {
+            if (!($parent instanceof OA\Response) && !($parent instanceof OA\RequestBody) && !($parent instanceof OA\Parameter) && !($parent instanceof OA\Header)) {
                 if ($parent) {
                     $xmlContent->_context->logger->warning('Unexpected ' . $xmlContent->identity() . ' in ' . $parent->identity() . ' in ' . $parent->_context);
                 } else {

--- a/tests/Fixtures/Scratch/HeaderObject-spec.php
+++ b/tests/Fixtures/Scratch/HeaderObject-spec.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Scratch;
+
+use OpenApi\Spec as OA;
+
+// A spec header becomes a component by merging into a sibling Components; the key is
+// explicit here, inferred from the class name otherwise (ComponentNames covers that).
+#[OA\Components]
+#[OA\Header(
+    header: 'X-Request-Id',
+    required: true,
+    schema: new OA\Schema(type: 'string', format: 'uuid'),
+)]
+class HeaderObjectRequestIdSpec
+{
+}
+
+#[OA\Info(title: 'HeaderObject', version: '1.0')]
+class HeaderObjectControllerSpec
+{
+    // Stacked siblings: the Headers merge into the single Response, which merges
+    // into the Get.
+    #[OA\Operation\Get(path: '/endpoint', operationId: 'endpoint')]
+    #[OA\Response(response: 200, description: 'OK')]
+    #[OA\Header(
+        header: 'X-Rate-Limit-Limit',
+        description: 'The number of allowed requests in the current period',
+        schema: new OA\Schema(type: 'integer'),
+        example: 100,
+    )]
+    #[OA\Header(
+        header: 'X-Expires-After',
+        style: 'simple',
+        explode: true,
+        schema: new OA\Schema(type: 'string', format: 'date-time'),
+        examples: [
+            new OA\Example(example: 'midnight', summary: 'End of day', value: '2027-01-01T00:00:00Z'),
+        ],
+    )]
+    #[OA\Header(
+        header: 'X-Request-Id',
+        ref: '#/components/headers/X-Request-Id',
+    )]
+    #[OA\Header(
+        header: 'X-Complex',
+        content: new OA\MediaType(
+            mediaType: 'application/json',
+            schema: new OA\Schema(type: 'object'),
+        ),
+    )]
+    public function endpoint(): void
+    {
+    }
+}

--- a/tests/Fixtures/Scratch/HeaderObject.php
+++ b/tests/Fixtures/Scratch/HeaderObject.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types=1);
+
+/**
+ * @license Apache 2.0
+ */
+
+namespace OpenApi\Tests\Fixtures\Scratch;
+
+use OpenApi\Attributes as OAT;
+
+#[OAT\Info(title: 'HeaderObject', version: '1.0')]
+#[OAT\Header(
+    header: 'X-Request-Id',
+    required: true,
+    schema: new OAT\Schema(type: 'string', format: 'uuid'),
+)]
+class HeaderObjectController
+{
+    #[OAT\Get(
+        path: '/endpoint',
+        operationId: 'endpoint',
+        responses: [
+            new OAT\Response(
+                response: 200,
+                description: 'OK',
+                headers: [
+                    new OAT\Header(
+                        header: 'X-Rate-Limit-Limit',
+                        description: 'The number of allowed requests in the current period',
+                        schema: new OAT\Schema(type: 'integer'),
+                        example: 100,
+                    ),
+                    new OAT\Header(
+                        header: 'X-Expires-After',
+                        style: 'simple',
+                        explode: true,
+                        schema: new OAT\Schema(type: 'string', format: 'date-time'),
+                        examples: [
+                            new OAT\Examples(example: 'midnight', summary: 'End of day', value: '2027-01-01T00:00:00Z'),
+                        ],
+                    ),
+                    new OAT\Header(
+                        header: 'X-Request-Id',
+                        ref: '#/components/headers/X-Request-Id',
+                    ),
+                    new OAT\Header(
+                        header: 'X-Complex',
+                        content: [
+                            new OAT\MediaType(
+                                mediaType: 'application/json',
+                                schema: new OAT\Schema(type: 'object'),
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )]
+    public function endpoint(): void
+    {
+    }
+}

--- a/tests/Fixtures/Scratch/HeaderObject3.0.0.yaml
+++ b/tests/Fixtures/Scratch/HeaderObject3.0.0.yaml
@@ -1,0 +1,40 @@
+openapi: 3.0.0
+info:
+  title: HeaderObject
+  version: '1.0'
+paths:
+  /endpoint:
+    get:
+      operationId: endpoint
+      responses:
+        200:
+          description: OK
+          headers:
+            X-Rate-Limit-Limit:
+              description: 'The number of allowed requests in the current period'
+              schema:
+                type: integer
+              example: 100
+            X-Expires-After:
+              style: simple
+              explode: true
+              schema:
+                type: string
+                format: date-time
+              examples:
+                midnight:
+                  summary: 'End of day'
+                  value: '2027-01-01T00:00:00Z'
+            X-Request-Id:
+              $ref: '#/components/headers/X-Request-Id'
+            X-Complex:
+              content:
+                application/json:
+                  schema: { type: object }
+components:
+  headers:
+    X-Request-Id:
+      required: true
+      schema:
+        type: string
+        format: uuid

--- a/tests/Fixtures/Scratch/HeaderObject3.1.0.yaml
+++ b/tests/Fixtures/Scratch/HeaderObject3.1.0.yaml
@@ -1,0 +1,40 @@
+openapi: 3.1.0
+info:
+  title: HeaderObject
+  version: '1.0'
+paths:
+  /endpoint:
+    get:
+      operationId: endpoint
+      responses:
+        200:
+          description: OK
+          headers:
+            X-Rate-Limit-Limit:
+              description: 'The number of allowed requests in the current period'
+              schema:
+                type: integer
+              example: 100
+            X-Expires-After:
+              style: simple
+              explode: true
+              schema:
+                type: string
+                format: date-time
+              examples:
+                midnight:
+                  summary: 'End of day'
+                  value: '2027-01-01T00:00:00Z'
+            X-Request-Id:
+              $ref: '#/components/headers/X-Request-Id'
+            X-Complex:
+              content:
+                application/json:
+                  schema: { type: object }
+components:
+  headers:
+    X-Request-Id:
+      required: true
+      schema:
+        type: string
+        format: uuid

--- a/tests/Fixtures/Scratch/HeaderObject3.2.0.yaml
+++ b/tests/Fixtures/Scratch/HeaderObject3.2.0.yaml
@@ -1,0 +1,40 @@
+openapi: 3.2.0
+info:
+  title: HeaderObject
+  version: '1.0'
+paths:
+  /endpoint:
+    get:
+      operationId: endpoint
+      responses:
+        200:
+          description: OK
+          headers:
+            X-Rate-Limit-Limit:
+              description: 'The number of allowed requests in the current period'
+              schema:
+                type: integer
+              example: 100
+            X-Expires-After:
+              style: simple
+              explode: true
+              schema:
+                type: string
+                format: date-time
+              examples:
+                midnight:
+                  summary: 'End of day'
+                  value: '2027-01-01T00:00:00Z'
+            X-Request-Id:
+              $ref: '#/components/headers/X-Request-Id'
+            X-Complex:
+              content:
+                application/json:
+                  schema: { type: object }
+components:
+  headers:
+    X-Request-Id:
+      required: true
+      schema:
+        type: string
+        format: uuid


### PR DESCRIPTION
## Overview

The Header Object has carried `style`, `explode`, `example`, `examples` and `content` since OpenAPI 3.0, but classic declared none of them — a header carrying an example could not be written at all, and the hybrid bridge dropped the fields a spec-mode header could express. First fix under the classic spec-compliance carve-out (#2190): an OpenAPI construct classic claims to model but cannot express is a defect, not a feature.

## Changes

- `Annotations\Header` gains the five Header Object fields; the unconditional schema requirement becomes a schema-XOR-content `validate()`, matching the specification's one-of rule
- `Attributes\Header` takes the new fields as constructor parameters
- `Examples` and `MediaType` list `Header` as a parent, and `MergeJsonContent`/`MergeXmlContent` accept a `Header` parent
- `HybridBridge::convertHeader()` carries the new fields into the spec pipeline
- `Scratch/HeaderObject{,-spec}` pins all five fields in all three modes against one shared expectation per version