### PR TITLE
fix(Annotations): accept mutualTLS as a SecurityScheme type

### DIFF
--- a/src/Annotations/Components.php
+++ b/src/Annotations/Components.php
@@ -115,6 +115,26 @@ class Components extends AbstractAnnotation
         Attachable::class => ['attachables'],
     ];
 
+    #[\Override]
+    public function jsonSerialize(): \stdClass
+    {
+        $data = parent::jsonSerialize();
+
+        // mutualTLS security schemes exist as of 3.1
+        if (isset($data->securitySchemes) && $this->_context->isVersion('3.0.x')) {
+            foreach ((array) $data->securitySchemes as $key => $scheme) {
+                if (($scheme->type ?? null) === 'mutualTLS') {
+                    unset($data->securitySchemes->{$key});
+                }
+            }
+            if ((array) $data->securitySchemes === []) {
+                unset($data->securitySchemes);
+            }
+        }
+
+        return $data;
+    }
+
     /**
      * Returns a list of component annotation types.
      *

--- a/src/Annotations/SecurityScheme.php
+++ b/src/Annotations/SecurityScheme.php
@@ -6,6 +6,7 @@
 
 namespace OpenApi\Annotations;
 
+use OpenApi\Analysis;
 use OpenApi\Undefined;
 
 /**
@@ -100,7 +101,7 @@ class SecurityScheme extends AbstractAnnotation
      * @inheritdoc
      */
     public static $_types = [
-        'type' => ['http', 'apiKey', 'oauth2', 'openIdConnect'],
+        'type' => ['http', 'apiKey', 'mutualTLS', 'oauth2', 'openIdConnect'],
         'description' => 'string',
         'name' => 'string',
         'bearerFormat' => 'string',
@@ -121,6 +122,19 @@ class SecurityScheme extends AbstractAnnotation
     public static $_parents = [
         Components::class,
     ];
+
+    #[\Override]
+    public function validate(?Analysis $analysis = null, string $version = OpenApi::DEFAULT_VERSION, ?object $context = null): bool
+    {
+        $isValid = parent::validate($analysis, $version, $context);
+
+        if (OpenApi::versionMatch($version, '3.0.x') && $this->type === 'mutualTLS') {
+            $this->_context->logger->warning('mutualTLS security schemes are not supported in OpenAPI 3.0 and will be omitted: ' . $this->identity() . ' in ' . $this->_context);
+            $isValid = false;
+        }
+
+        return $isValid;
+    }
 
     /**
      * @inheritdoc

--- a/tests/Fixtures/Scratch/Auth-spec.php
+++ b/tests/Fixtures/Scratch/Auth-spec.php
@@ -24,6 +24,12 @@ class AuthHttpSchemesSpec
 {
 }
 
+// mutualTLS exists as of 3.1; the 3.0 document omits it with a warning
+#[OA\Security\Scheme\MutualTls(securityScheme: 'mutualTls', description: 'Client certificate authentication')]
+class AuthMutualTlsSchemeSpec
+{
+}
+
 #[OA\Security\Scheme\OAuth2(
     securityScheme: 'oauth2',
     description: 'All four flows on a single scheme.',

--- a/tests/Fixtures/Scratch/Auth.php
+++ b/tests/Fixtures/Scratch/Auth.php
@@ -25,6 +25,12 @@ class AuthHttpSchemes
 {
 }
 
+// mutualTLS exists as of 3.1; the 3.0 document omits it with a warning
+#[OAT\SecurityScheme(securityScheme: 'mutualTls', type: 'mutualTLS', description: 'Client certificate authentication')]
+class AuthMutualTlsScheme
+{
+}
+
 #[OAT\SecurityScheme(
     securityScheme: 'oauth2',
     type: 'oauth2',

--- a/tests/Fixtures/Scratch/Auth3.0.0.yaml
+++ b/tests/Fixtures/Scratch/Auth3.0.0.yaml
@@ -7,7 +7,7 @@ paths:
     get:
       operationId: getSecured
       responses:
-        '200':
+        200:
           description: 'All good'
       security:
         -
@@ -34,8 +34,8 @@ components:
       scheme: basic
     bearerAuth:
       type: http
-      bearerFormat: JWT
       scheme: bearer
+      bearerFormat: JWT
     oauth2:
       type: oauth2
       description: 'All four flows on a single scheme.'

--- a/tests/Fixtures/Scratch/Auth3.1.0.yaml
+++ b/tests/Fixtures/Scratch/Auth3.1.0.yaml
@@ -7,7 +7,7 @@ paths:
     get:
       operationId: getSecured
       responses:
-        '200':
+        200:
           description: 'All good'
       security:
         -
@@ -34,8 +34,11 @@ components:
       scheme: basic
     bearerAuth:
       type: http
-      bearerFormat: JWT
       scheme: bearer
+      bearerFormat: JWT
+    mutualTls:
+      type: mutualTLS
+      description: 'Client certificate authentication'
     oauth2:
       type: oauth2
       description: 'All four flows on a single scheme.'

--- a/tests/Fixtures/Scratch/Auth3.2.0.yaml
+++ b/tests/Fixtures/Scratch/Auth3.2.0.yaml
@@ -7,7 +7,7 @@ paths:
     get:
       operationId: getSecured
       responses:
-        '200':
+        200:
           description: 'All good'
       security:
         -
@@ -34,8 +34,11 @@ components:
       scheme: basic
     bearerAuth:
       type: http
-      bearerFormat: JWT
       scheme: bearer
+      bearerFormat: JWT
+    mutualTls:
+      type: mutualTLS
+      description: 'Client certificate authentication'
     oauth2:
       type: oauth2
       description: 'All four flows on a single scheme.'

--- a/tests/ScratchTest.php
+++ b/tests/ScratchTest.php
@@ -27,6 +27,7 @@ final class ScratchTest extends OpenApiTestCase
         // Keyed `{fixture}-{version}`, applying to every mode, or `{fixture}-{version}-{mode}`
         // for a diagnostic only one mode raises. Both keys contribute when both are present.
         $expectedLogs = [
+            'Auth-3.0.0' => ['mutualTLS security schemes are not supported in OpenAPI 3.0 and will be omitted'],
             'Examples-3.0.0-classic' => ['@OA\Schema::examples is only allowed as of 3.1.0'],
             'Examples-3.0.0-spec' => ['examples array is not supported in OpenAPI 3.0'],
             'Examples-3.0.0-hybrid' => ['examples array is not supported in OpenAPI 3.0'],


### PR DESCRIPTION
## Overview

`SecurityScheme` validates `type` against http, apiKey, oauth2 and openIdConnect only, so the `mutualTLS` type added in OpenAPI 3.1 cannot be written in classic at all — the spec pipeline has carried it (with a 3.0 warn-and-omit) since the `Auth` scratch fixture was written, and the fixture could never cover it because the classic anchor could not express it. Third fix under the classic spec-compliance carve-out (#2190).

## Changes

- `mutualTLS` joins the `type` enum in `SecurityScheme::$_types`
- `SecurityScheme::validate()` warns at 3.0.x, using the spec compiler's message text so one log expectation covers all three modes
- `Components::jsonSerialize()` drops mutualTLS schemes from 3.0 documents — a scheme cannot remove itself from the parent map
- The `Auth` fixture covers the scheme type in both syntaxes: the 3.0 expectation omits it, 3.1 and 3.2 carry it